### PR TITLE
Show more icons in package cards

### DIFF
--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -58,6 +58,7 @@ export function AllAttributionsPanel(
       isPreSelected: Boolean(packageInfo.preSelected),
       firstParty: packageInfo.firstParty,
       excludeFromNotice: packageInfo.excludeFromNotice,
+      followUp: Boolean(packageInfo.followUp),
     };
 
     return (

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -53,6 +53,7 @@ export function AttributionList(props: AttributionListProps): ReactElement {
       isPreSelected: Boolean(attribution.preSelected),
       firstParty: attribution.firstParty,
       excludeFromNotice: attribution.excludeFromNotice,
+      followUp: Boolean(attribution.followUp),
     };
 
     return (

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -10,12 +10,14 @@ import React, { ReactElement } from 'react';
 import { OpossumColors } from '../../shared-styles';
 import { ListCardConfig } from '../../types/types';
 
+const defaultCardHeight = 40;
+
 const useStyles = makeStyles({
   root: {
     flex: 1,
     display: 'flex',
     alignItems: 'center',
-    height: 40,
+    height: defaultCardHeight,
     '&:hover': {
       cursor: 'pointer',
     },
@@ -88,12 +90,17 @@ const useStyles = makeStyles({
     height: 19,
     width: 26,
     textAlign: 'center',
+    writingMode: 'horizontal-tb',
   },
   iconColumn: {
-    flexDirection: 'column',
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'start',
     alignItems: 'flex-end',
+    flexWrap: 'wrap-reverse',
+    // fix for width of column flexbox container not growing after wrap
+    // -> use row flexbox with vertical writing mode
+    writingMode: 'vertical-lr',
+    height: defaultCardHeight,
   },
   textLines: {
     margin: '0 6px 0 0',
@@ -107,9 +114,6 @@ const useStyles = makeStyles({
     '&.MuiTypography-body2': {
       fontSize: '0.85rem',
     },
-  },
-  excludeFromNotice: {
-    color: OpossumColors.darkBlue,
   },
 });
 
@@ -150,8 +154,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
           ? props.cardConfig.isSelected
             ? classes.preSelectedAndSelected
             : classes.preSelected
-          : null,
-        props.cardConfig.excludeFromNotice && classes.excludeFromNotice
+          : null
       )}
       onClick={props.onClick}
     >

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -60,6 +60,7 @@ export function ManualAttributionList(
       isPreSelected: Boolean(attribution.preSelected),
       firstParty: attribution.firstParty,
       excludeFromNotice: attribution.excludeFromNotice,
+      followUp: Boolean(attribution.followUp),
     };
 
     return (

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -4,15 +4,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { AddIcon, FirstPartyIcon } from '../Icons/Icons';
+import {
+  AddIcon,
+  ExcludeFromNoticeIcon,
+  FirstPartyIcon,
+  FollowUpIcon,
+} from '../Icons/Icons';
 import { ListCard } from '../ListCard/ListCard';
 import { getCardLabels } from './package-card-helpers';
 import { makeStyles } from '@material-ui/core/styles';
 import { ListCardConfig, ListCardContent } from '../../types/types';
+import { OpossumColors } from '../../shared-styles';
 
 const useStyles = makeStyles({
   hiddenIcon: {
     visibility: 'hidden',
+  },
+  followUpIcon: {
+    color: OpossumColors.lightRed,
+  },
+  excludeFromNoticeIcon: {
+    color: OpossumColors.grey,
   },
 });
 
@@ -25,6 +37,16 @@ interface PackageCardProps {
   openResourcesIcon?: JSX.Element;
 }
 
+function getKey(
+  prefix: string,
+  cardContent: ListCardContent,
+  packageLabels: Array<string>
+): string {
+  return `${prefix}-${cardContent.name}-${cardContent.packageVersion}-${
+    packageLabels[0] || ''
+  }`;
+}
+
 export function PackageCard(props: PackageCardProps): ReactElement | null {
   const classes = useStyles();
   const packageLabels = getCardLabels(props.cardContent);
@@ -33,25 +55,36 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       className={props.cardConfig.isResolved ? classes.hiddenIcon : undefined}
       onClick={props.onIconClick}
       label={packageLabels[0] || ''}
-      key={`add-icon-${props.cardContent.name}-${
-        props.cardContent.packageVersion
-      }-${packageLabels[0] || ''}`}
+      key={getKey('add-icon', props.cardContent, packageLabels)}
     />
   ) : undefined;
 
-  const firstPartyIcon = props.cardConfig.firstParty ? (
-    <FirstPartyIcon
-      key={`first-party-icon-${props.cardContent.name}-${
-        props.cardContent.packageVersion
-      }-${packageLabels[0] || ''}`}
-    />
-  ) : undefined;
   const rightIcons: Array<JSX.Element> = [];
   if (props.openResourcesIcon) {
     rightIcons.push(props.openResourcesIcon);
   }
-  if (firstPartyIcon) {
-    rightIcons.push(firstPartyIcon);
+  if (props.cardConfig.firstParty) {
+    rightIcons.push(
+      <FirstPartyIcon
+        key={getKey('first-party-icon', props.cardContent, packageLabels)}
+      />
+    );
+  }
+  if (props.cardConfig.excludeFromNotice) {
+    rightIcons.push(
+      <ExcludeFromNoticeIcon
+        key={getKey('exclude-icon', props.cardContent, packageLabels)}
+        className={classes.excludeFromNoticeIcon}
+      />
+    );
+  }
+  if (props.cardConfig.followUp) {
+    rightIcons.push(
+      <FollowUpIcon
+        key={getKey('follow-up-icon', props.cardContent, packageLabels)}
+        className={classes.followUpIcon}
+      />
+    );
   }
 
   return (

--- a/src/Frontend/Components/PackageList/PackageList.tsx
+++ b/src/Frontend/Components/PackageList/PackageList.tsx
@@ -63,6 +63,7 @@ export function PackageList(props: PackageListProps): ReactElement {
       isExternalAttribution: props.isExternalAttribution,
       firstParty: packageInfo.firstParty,
       excludeFromNotice: packageInfo.excludeFromNotice,
+      followUp: Boolean(packageInfo.followUp),
     };
 
     function onIconClick(): void {

--- a/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
+++ b/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
@@ -16,36 +16,60 @@ import {
 import { ListCardConfig, ListCardContent } from '../../../types/types';
 
 const testCardContent: ListCardContent = { name: 'Test' };
-const testcardConfig: ListCardConfig = { firstParty: true };
+const testCardConfig: ListCardConfig = { firstParty: true };
+const testCardWithManyIconsConfig: ListCardConfig = {
+  firstParty: true,
+  followUp: true,
+  excludeFromNotice: true,
+};
 
 describe('The PackagePanelCard', () => {
-  test('renders', () => {
+  test('renders content', () => {
     const { getByText } = renderComponentWithStore(
       <PackagePanelCard
         onClick={doNothing}
         cardContent={testCardContent}
         attributionId={'/'}
-        cardConfig={testcardConfig}
+        cardConfig={testCardConfig}
       />
     );
 
     expect(getByText('Test'));
   });
-  test('renders firstParty Icon and show resources Icon', () => {
+
+  test('renders only first party icon and show resources icon', () => {
+    const { getByLabelText, queryByLabelText } = renderComponentWithStore(
+      <PackagePanelCard
+        onClick={doNothing}
+        cardContent={testCardContent}
+        attributionId={'/'}
+        cardConfig={testCardConfig}
+      />
+    );
+
+    expect(getByLabelText('show resources'));
+    expect(getByLabelText('First party icon'));
+    expect(queryByLabelText('Exclude from notice icon')).toBeFalsy();
+    expect(queryByLabelText('Follow-up icon')).toBeFalsy();
+  });
+
+  test('renders many icons at once', () => {
     const { getByLabelText } = renderComponentWithStore(
       <PackagePanelCard
         onClick={doNothing}
         cardContent={testCardContent}
         attributionId={'/'}
-        cardConfig={testcardConfig}
+        cardConfig={testCardWithManyIconsConfig}
       />
     );
 
-    expect(getByLabelText('First party icon'));
     expect(getByLabelText('show resources'));
+    expect(getByLabelText('First party icon'));
+    expect(getByLabelText('Exclude from notice icon'));
+    expect(getByLabelText('Follow-up icon'));
   });
 
-  test('has working resources Icon', () => {
+  test('has working resources icon', () => {
     const manualAttributions: Attributions = {
       uuid_1: { packageName: 'Test package' },
     };
@@ -58,7 +82,7 @@ describe('The PackagePanelCard', () => {
         onClick={doNothing}
         cardContent={testCardContent}
         attributionId={'uuid_1'}
-        cardConfig={testcardConfig}
+        cardConfig={testCardConfig}
       />
     );
     store.dispatch(setManualData(manualAttributions, resourcesToAttributions));

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -28,6 +28,7 @@ export const OpossumColors = {
   disabledGrey: 'hsla(0, 0%, 0%, 0.26)',
   disabledButtonGrey: 'hsla(0, 0%, 0%, 0.13)',
   red: 'hsl(0, 100%, 45%)',
+  lightRed: 'hsl(0, 100%, 60%)',
   green: 'hsl(146, 50%, 45%)',
 };
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -61,6 +61,7 @@ export interface ListCardConfig {
   isPreSelected?: boolean;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
+  followUp?: boolean;
 }
 
 export interface PathPredicate {


### PR DESCRIPTION
To make signals and attributions that are marked as follow-up or
as excluded more notable, we add the icons that are already used
in the report view table also in the other two views.

- Add a grid of icons to package cards with two icons per column
- Remove blue text color for excluded attributions

![Screenshot_20210922_134539](https://user-images.githubusercontent.com/14236667/134346119-e4c30933-eaed-487b-abda-bcc634f4cf36.png)