### PR TITLE
Fix horizontal scrolling in resources list

### DIFF
--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -16,6 +16,7 @@ interface ListProps {
   cardVerticalDistance?: number;
   alwaysShowHorizontalScrollBar?: boolean;
   addPaddingBottom?: boolean;
+  allowHorizontalScrolling?: boolean;
 }
 
 const useStyles = makeStyles({
@@ -26,10 +27,7 @@ const useStyles = makeStyles({
 function maxHeightWasGiven(
   max: NumberOfDisplayedItems | Height
 ): max is Height {
-  if ((max as Height).height) {
-    return true;
-  }
-  return false;
+  return !!(max as Height).height;
 }
 
 export function List(props: ListProps): ReactElement {
@@ -64,7 +62,17 @@ export function List(props: ListProps): ReactElement {
         }: {
           index: number;
           style: CSSProperties;
-        }): ReactElement => <div style={style}>{props.getListItem(index)}</div>}
+        }): ReactElement => (
+          <div
+            style={
+              props.allowHorizontalScrolling
+                ? { ...style, minWidth: '100%', width: 'fit-content' }
+                : style
+            }
+          >
+            {props.getListItem(index)}
+          </div>
+        )}
       </VirtualizedList>
     </div>
   );

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles({
 function maxHeightWasGiven(
   max: NumberOfDisplayedItems | Height
 ): max is Height {
-  return !!(max as Height).height;
+  return Boolean((max as Height).height);
 }
 
 export function List(props: ListProps): ReactElement {

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -12,12 +12,13 @@ import { ListCard } from '../ListCard/ListCard';
 import { doNothing } from '../../util/do-nothing';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
 import { getIsFileWithChildren } from '../../state/selectors/all-views-resource-selectors';
+import { OpossumColors } from '../../shared-styles';
 
 const useStyles = makeStyles({
   root: {
-    flex: 1,
     marginTop: 6,
     marginBottom: 4,
+    backgroundColor: OpossumColors.white,
   },
 });
 
@@ -66,6 +67,7 @@ export function ResourcesList(props: ResourcesListProps): ReactElement {
         max={max}
         length={sortedResourcePaths.length}
         addPaddingBottom={true}
+        allowHorizontalScrolling={true}
       />
     </div>
   );


### PR DESCRIPTION
Before this fix, the background color and the highlighting color of the resources list were not coherent for long paths.