### PR TITLE
Add icon for pre-selected attributions, remove gradients

### DIFF
--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -68,6 +68,7 @@ export function AllAttributionsPanel(
         cardConfig={cardConfig}
         key={`PackageCard-${packageInfo.packageName}-${attributionId}`}
         cardContent={{
+          id: `all-attributions-${attributionId}`,
           name: packageInfo.packageName,
           packageVersion: packageInfo.packageVersion,
           copyright: packageInfo.copyright,

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -62,6 +62,7 @@ export function AttributionList(props: AttributionListProps): ReactElement {
         cardConfig={cardConfig}
         key={`AttributionCard-${attribution.packageName}-${attributionId}`}
         cardContent={{
+          id: `attribution-list-${attributionId}`,
           name: attribution.packageName,
           packageVersion: attribution.packageVersion,
           copyright: attribution.copyright,

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -18,10 +18,11 @@ import WidgetsIcon from '@material-ui/icons/Widgets';
 import FolderOutlinedIcon from '@material-ui/icons/Folder';
 import DescriptionIcon from '@material-ui/icons/Description';
 import IndeterminateCheckBoxIcon from '@material-ui/icons/IndeterminateCheckBox';
+import FolderOpenIcon from '@material-ui/icons/FolderOpen';
 import ReplayIcon from '@material-ui/icons/Replay';
+import LocalParkingIcon from '@material-ui/icons/LocalParking';
 import clsx from 'clsx';
 import React, { ReactElement } from 'react';
-import FolderOpenIcon from '@material-ui/icons/FolderOpen';
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
 
 const useStyles = makeStyles({
@@ -324,5 +325,17 @@ export function FileIcon({
         className ?? classes.resourceDefaultColor
       )}
     />
+  );
+}
+
+export function PreSelectedIcon(props: IconProps): ReactElement {
+  const classes = useStyles();
+  return (
+    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="was pre-selected">
+      <LocalParkingIcon
+        aria-label={'Pre-selected icon'}
+        className={clsx(classes.nonClickableIcon, props.className)}
+      />
+    </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -48,18 +48,6 @@ const useStyles = makeStyles({
       background: OpossumColors.middleBlueOnHover,
     },
   },
-  preSelected: {
-    background: `linear-gradient(to right, ${OpossumColors.almostWhiteBlue}, ${OpossumColors.lighterBlue})`,
-    '&:hover': {
-      background: `linear-gradient(to right, ${OpossumColors.lighterBlue}, ${OpossumColors.lightBlueOnHover})`,
-    },
-  },
-  preSelectedAndSelected: {
-    background: `linear-gradient(to right, ${OpossumColors.lightestBlue}, ${OpossumColors.middleBlue})`,
-    '&:hover': {
-      background: `linear-gradient(to right, ${OpossumColors.lightBlue}, ${OpossumColors.middleBlueOnHover})`,
-    },
-  },
   resolved: {
     opacity: 0.5,
   },
@@ -149,12 +137,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
         props.cardConfig.isResource ? classes.resource : classes.package,
         props.cardConfig.isExternalAttribution && classes.externalAttribution,
         props.cardConfig.isSelected && classes.selected,
-        props.cardConfig.isResolved && classes.resolved,
-        props.cardConfig.isPreSelected
-          ? props.cardConfig.isSelected
-            ? classes.preSelectedAndSelected
-            : classes.preSelected
-          : null
+        props.cardConfig.isResolved && classes.resolved
       )}
       onClick={props.onClick}
     >

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -14,6 +14,7 @@ const addNewAttributionButtonTitle = 'Add new attribution';
 const addNewAttributionButtonId = 'ADD_NEW_ATTRIBUTION_ID';
 
 interface ManualAttributionListProps {
+  selectedResourceId: string;
   attributions: Attributions;
   selectedAttributionId: string | null;
   onCardClick(attributionId: string, isButton?: boolean): void;
@@ -69,6 +70,7 @@ export function ManualAttributionList(
         cardConfig={cardConfig}
         key={`AttributionCard-${attribution.packageName}-${attributionId}`}
         cardContent={{
+          id: `manual-${props.selectedResourceId}-${attributionId}`,
           name: attribution.packageName,
           packageVersion: attribution.packageVersion,
           copyright: attribution.copyright,

--- a/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
+++ b/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
@@ -31,6 +31,7 @@ describe('The ManualAttributionList', () => {
   test('renders', () => {
     const { getByText } = render(
       <ManualAttributionList
+        selectedResourceId="/folder/"
         attributions={packages}
         selectedAttributionId={''}
         onCardClick={mockCallback}
@@ -43,6 +44,7 @@ describe('The ManualAttributionList', () => {
   test('renders first party icon', () => {
     const { getByText, getByLabelText } = render(
       <ManualAttributionList
+        selectedResourceId="/folder/"
         attributions={packages}
         selectedAttributionId={''}
         onCardClick={doNothing}
@@ -55,6 +57,7 @@ describe('The ManualAttributionList', () => {
   test('renders button', () => {
     const { getByText } = render(
       <ManualAttributionList
+        selectedResourceId="/folder/"
         attributions={packages}
         selectedAttributionId={''}
         isAddNewAttributionItemShown={true}
@@ -69,6 +72,7 @@ describe('The ManualAttributionList', () => {
   test('sets selectedAttributionId on click', () => {
     const { getByText } = render(
       <ManualAttributionList
+        selectedResourceId="/folder/"
         attributions={packages}
         selectedAttributionId={''}
         onCardClick={mockCallback}
@@ -100,6 +104,7 @@ describe('The ManualAttributionList', () => {
     };
     const { container } = render(
       <ManualAttributionList
+        selectedResourceId="/folder/"
         attributions={testPackages}
         selectedAttributionId={''}
         onCardClick={mockCallback}

--- a/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
+++ b/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
@@ -15,6 +15,7 @@ import {
   getAttributionIdOfDisplayedPackageInManualPanel,
   getAttributionsOfSelectedResource,
   getAttributionsOfSelectedResourceOrClosestParent,
+  getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { Button } from '../Button/Button';
 import { ManualAttributionList } from '../ManualAttributionList/ManualAttributionList';
@@ -60,6 +61,8 @@ export function ManualPackagePanel(
     getAttributionsOfSelectedResourceOrClosestParent
   );
 
+  const selectedResourceId: string = useSelector(getSelectedResourceId);
+
   const shownAttributionsOfResource: Attributions = props.overrideParentMode
     ? attributionIdsOfSelectedResource
     : selectedResourceOrClosestParentAttributions;
@@ -87,6 +90,7 @@ export function ManualPackagePanel(
           : 'Attributions'}
       </MuiTypography>
       <ManualAttributionList
+        selectedResourceId={selectedResourceId}
         attributions={shownAttributionsOfResource}
         selectedAttributionId={selectedAttributionId}
         isAddNewAttributionItemShown={props.showAddNewAttributionButton}

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -9,6 +9,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  PreSelectedIcon,
 } from '../Icons/Icons';
 import { ListCard } from '../ListCard/ListCard';
 import { getCardLabels } from './package-card-helpers';
@@ -37,14 +38,8 @@ interface PackageCardProps {
   openResourcesIcon?: JSX.Element;
 }
 
-function getKey(
-  prefix: string,
-  cardContent: ListCardContent,
-  packageLabels: Array<string>
-): string {
-  return `${prefix}-${cardContent.name}-${cardContent.packageVersion}-${
-    packageLabels[0] || ''
-  }`;
+function getKey(prefix: string, cardContent: ListCardContent): string {
+  return `${prefix}-${cardContent.id}`;
 }
 
 export function PackageCard(props: PackageCardProps): ReactElement | null {
@@ -55,7 +50,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       className={props.cardConfig.isResolved ? classes.hiddenIcon : undefined}
       onClick={props.onIconClick}
       label={packageLabels[0] || ''}
-      key={getKey('add-icon', props.cardContent, packageLabels)}
+      key={getKey('add-icon', props.cardContent)}
     />
   ) : undefined;
 
@@ -65,15 +60,13 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   }
   if (props.cardConfig.firstParty) {
     rightIcons.push(
-      <FirstPartyIcon
-        key={getKey('first-party-icon', props.cardContent, packageLabels)}
-      />
+      <FirstPartyIcon key={getKey('first-party-icon', props.cardContent)} />
     );
   }
   if (props.cardConfig.excludeFromNotice) {
     rightIcons.push(
       <ExcludeFromNoticeIcon
-        key={getKey('exclude-icon', props.cardContent, packageLabels)}
+        key={getKey('exclude-icon', props.cardContent)}
         className={classes.excludeFromNoticeIcon}
       />
     );
@@ -81,9 +74,14 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   if (props.cardConfig.followUp) {
     rightIcons.push(
       <FollowUpIcon
-        key={getKey('follow-up-icon', props.cardContent, packageLabels)}
+        key={getKey('follow-up-icon', props.cardContent)}
         className={classes.followUpIcon}
       />
+    );
+  }
+  if (props.cardConfig.isPreSelected) {
+    rightIcons.push(
+      <PreSelectedIcon key={getKey('pre-selected-icon', props.cardContent)} />
     );
   }
 

--- a/src/Frontend/Components/PackageCard/__tests__/package-card-helpers-test.ts
+++ b/src/Frontend/Components/PackageCard/__tests__/package-card-helpers-test.ts
@@ -13,6 +13,7 @@ import { ListCardContent } from '../../../types/types';
 
 describe('Test getPackageLabel', () => {
   const testProps: ListCardContent = {
+    id: '1',
     name: 'Test package name',
     packageVersion: '1.2',
     copyright: '(c) Test copyright',
@@ -22,6 +23,7 @@ describe('Test getPackageLabel', () => {
     licenseName: 'Test license name',
   };
   const testPropsWithoutVersion: ListCardContent = {
+    id: '2',
     name: 'Test package name',
     copyright: 'Test copyright',
     licenseText: 'Test license text',
@@ -30,6 +32,7 @@ describe('Test getPackageLabel', () => {
     licenseName: 'Test license name',
   };
   const testPropsWithUndefinedName: ListCardContent = {
+    id: '3',
     name: undefined,
     copyright: 'Test copyright',
     licenseText: 'Test license text',
@@ -38,6 +41,7 @@ describe('Test getPackageLabel', () => {
     licenseName: 'Test license name',
   };
   const testPropsWithoutName: ListCardContent = {
+    id: '4',
     copyright: 'Test copyright',
     licenseText: 'Test license text',
     comment: 'Test comment',
@@ -45,18 +49,22 @@ describe('Test getPackageLabel', () => {
     licenseName: 'Test license name',
   };
   const testPropsCopyrightLicenseTextAndComment: ListCardContent = {
+    id: '5',
     copyright: 'Test copyright',
     licenseText: 'Test license text',
     comment: 'Test comment',
   };
   const testPropsWithLicenseTextAndComment: ListCardContent = {
+    id: '6',
     licenseText: 'Test license text',
     comment: 'Test comment',
   };
   const testPropsJustComment: ListCardContent = {
+    id: '7',
     comment: 'Test comment',
   };
   const testPropsJustUrlAndCopyright: ListCardContent = {
+    id: '8',
     copyright: 'Test copyright',
     url: 'Test url',
   };
@@ -101,7 +109,7 @@ describe('Test getPackageLabel', () => {
     expect(getCardLabels(testPropsJustComment)).toEqual(['Test comment']);
   });
   test('finds label for empty package', () => {
-    expect(getCardLabels({})).toEqual([]);
+    expect(getCardLabels({ id: '9' })).toEqual([]);
   });
   test('finds label for package with just url and copyright', () => {
     expect(getCardLabels(testPropsJustUrlAndCopyright)).toEqual([
@@ -113,6 +121,7 @@ describe('Test getPackageLabel', () => {
 
 describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
   const testProps: ListCardContent = {
+    id: '10',
     name: 'Test package name',
     packageVersion: '1.2',
     copyright: 'Test copyright',
@@ -122,6 +131,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     licenseName: 'Test license name',
   };
   const testPropsWithoutVersion: ListCardContent = {
+    id: '11',
     name: 'Test package name',
     copyright: 'Test copyright',
     licenseText: 'Test license text',
@@ -170,6 +180,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
 
 describe('Test addSecondLineOfPackageLabelFromAttribute', () => {
   const testProps: ListCardContent = {
+    id: '12',
     name: 'Test package name',
     packageVersion: '1.2',
     copyright: 'Test copyright',

--- a/src/Frontend/Components/PackageList/PackageList.tsx
+++ b/src/Frontend/Components/PackageList/PackageList.tsx
@@ -25,6 +25,7 @@ interface PackageListProps {
   isExternalAttribution: boolean;
   preSelectedExternalAttributionIdsForSelectedResource: Array<string>;
   isAddToPackageEnabled: boolean;
+  selectedResourceId: string;
 }
 
 export function PackageList(props: PackageListProps): ReactElement {
@@ -53,12 +54,14 @@ export function PackageList(props: PackageListProps): ReactElement {
       (attributionIdWithCount) =>
         attributionIdWithCount.attributionId === attributionId
     )[0].childrenWithAttributionCount;
+    const isPreselected = props.isExternalAttribution
+      ? props.preSelectedExternalAttributionIdsForSelectedResource.includes(
+          attributionId
+        )
+      : packageInfo.preSelected;
     const cardConfig: ListCardConfig = {
       isSelected: attributionId === props.selectedAttributionId,
-      isPreSelected:
-        props.preSelectedExternalAttributionIdsForSelectedResource.includes(
-          attributionId
-        ),
+      isPreSelected: isPreselected,
       isResolved: props.resolvedAttributionIds.has(attributionId),
       isExternalAttribution: props.isExternalAttribution,
       firstParty: packageInfo.firstParty,
@@ -77,6 +80,7 @@ export function PackageList(props: PackageListProps): ReactElement {
         key={`PackageCard-${packageInfo.packageName}-${index}`}
         packageCount={packageCount}
         cardContent={{
+          id: `package-${props.selectedResourceId}-${attributionId}`,
           name: packageInfo.packageName,
           packageVersion: packageInfo.packageVersion,
           copyright: packageInfo.copyright,

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -141,6 +141,7 @@ export function PackagePanel(
               props.title === PackagePanelTitle.ContainedExternalPackages
             }
             isAddToPackageEnabled={props.isAddToPackageEnabled}
+            selectedResourceId={selectedResourceId}
           />
         </div>
       ))}

--- a/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
+++ b/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
@@ -15,12 +15,15 @@ import {
 } from '../../../../shared/shared-types';
 import { ListCardConfig, ListCardContent } from '../../../types/types';
 
-const testCardContent: ListCardContent = { name: 'Test' };
+const testCardContent: ListCardContent = { id: '1', name: 'Test' };
 const testCardConfig: ListCardConfig = { firstParty: true };
 const testCardWithManyIconsConfig: ListCardConfig = {
   firstParty: true,
   followUp: true,
   excludeFromNotice: true,
+};
+const testCardWithPreSelectedConfig: ListCardConfig = {
+  isPreSelected: true,
 };
 
 describe('The PackagePanelCard', () => {
@@ -51,6 +54,7 @@ describe('The PackagePanelCard', () => {
     expect(getByLabelText('First party icon'));
     expect(queryByLabelText('Exclude from notice icon')).toBeFalsy();
     expect(queryByLabelText('Follow-up icon')).toBeFalsy();
+    expect(queryByLabelText('Pre-selected icon')).toBeFalsy();
   });
 
   test('renders many icons at once', () => {
@@ -67,6 +71,20 @@ describe('The PackagePanelCard', () => {
     expect(getByLabelText('First party icon'));
     expect(getByLabelText('Exclude from notice icon'));
     expect(getByLabelText('Follow-up icon'));
+  });
+
+  test('renders pre-selected icon', () => {
+    const { getByLabelText } = renderComponentWithStore(
+      <PackagePanelCard
+        onClick={doNothing}
+        cardContent={testCardContent}
+        attributionId={'/'}
+        cardConfig={testCardWithPreSelectedConfig}
+      />
+    );
+
+    expect(getByLabelText('show resources'));
+    expect(getByLabelText('Pre-selected icon'));
   });
 
   test('has working resources icon', () => {

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -44,6 +44,7 @@ export interface Height {
 export type KeysOfPackageInfo = keyof PackageInfo;
 
 export interface ListCardContent {
+  id: string;
   name?: string;
   packageVersion?: string;
   copyright?: string;


### PR DESCRIPTION
The gradients were hard to understand and their visibility was
not ideal. This adds an icon with hover text instead.

Additionally, we add a unique ID to the package card to avoid
duplicate key errors, which were probably already a problem
before but have become more likely since we now have many more
icons.

![Screenshot_20210923_102546](https://user-images.githubusercontent.com/14236667/134476144-7962512a-b053-44ec-91a8-eb7da6a8f150.png)