### PR TITLE
Add cache for node modules in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,19 @@ jobs:
         with:
           node-version: 16
 
-      - run: yarn install
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ matrix.os }}-yarn-opossumUI-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-yarn-opossumUI
+
+      - run: yarn install --network-timeout 560000
       - run: yarn lint-check
       - run: yarn compile-all
       - if: ${{ matrix.os != 'windows-latest' }}


### PR DESCRIPTION
The CI fails regulary for windows and mac while downloading the node modules. Using a cache should dramatically reduce the problem.
