### PR TITLE
Show more indicators for pre-selected attributions

### DIFF
--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -8,12 +8,19 @@ import React, { ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
 import { ToggleButton } from '../ToggleButton/ToggleButton';
 import { ButtonGroup } from '../ButtonGroup/ButtonGroup';
+import MuiTypography from '@material-ui/core/Typography';
 import {
   getContextMenuButtonConfigs,
   getMainButtonConfigs,
 } from './attribution-column-helpers';
 
+const preSelectedLabel = 'Attribution was pre-selected';
+
 const useStyles = makeStyles({
+  preSelectedLabel: {
+    marginLeft: 10,
+    marginTop: 12,
+  },
   buttonRow: {
     position: 'absolute',
     bottom: 0,
@@ -50,35 +57,40 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
   const classes = useStyles();
 
   return (
-    <div className={classes.buttonRow}>
-      {props.showButtonGroup ? (
-        <ButtonGroup
-          isHidden={props.areButtonsHidden}
-          mainButtonConfigs={getMainButtonConfigs(
-            props.temporaryPackageInfo,
-            props.isSavingDisabled,
-            props.onSaveButtonClick,
-            props.onSaveForAllButtonClick,
-            Boolean(props.showSaveForAllButton)
-          )}
-          contextMenuButtonConfigs={getContextMenuButtonConfigs(
-            props.packageInfoWereModified,
-            props.onDeleteButtonClick,
-            props.onDeleteForAllButtonClick,
-            Boolean(props.hideDeleteButtons),
-            props.onUndoButtonClick,
-            Boolean(props.showSaveForAllButton)
-          )}
-        />
-      ) : (
-        <ToggleButton
-          buttonText={'hide'}
-          className={classes.resolveButton}
-          selected={props.selectedPackageIsResolved}
-          handleChange={props.resolvedToggleHandler}
-          ariaLabel={'resolve attribution'}
-        />
-      )}
+    <div className={classes.preSelectedLabel}>
+      {props.temporaryPackageInfo.preSelected ? (
+        <MuiTypography variant={'subtitle1'}>{preSelectedLabel}</MuiTypography>
+      ) : null}
+      <div className={classes.buttonRow}>
+        {props.showButtonGroup ? (
+          <ButtonGroup
+            isHidden={props.areButtonsHidden}
+            mainButtonConfigs={getMainButtonConfigs(
+              props.temporaryPackageInfo,
+              props.isSavingDisabled,
+              props.onSaveButtonClick,
+              props.onSaveForAllButtonClick,
+              Boolean(props.showSaveForAllButton)
+            )}
+            contextMenuButtonConfigs={getContextMenuButtonConfigs(
+              props.packageInfoWereModified,
+              props.onDeleteButtonClick,
+              props.onDeleteForAllButtonClick,
+              Boolean(props.hideDeleteButtons),
+              props.onUndoButtonClick,
+              Boolean(props.showSaveForAllButton)
+            )}
+          />
+        ) : (
+          <ToggleButton
+            buttonText={'hide'}
+            className={classes.resolveButton}
+            selected={props.selectedPackageIsResolved}
+            handleChange={props.resolvedToggleHandler}
+            ariaLabel={'resolve attribution'}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -16,6 +16,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  PreSelectedIcon,
 } from '../Icons/Icons';
 import { AttributionInfo, TableConfig, tableConfigs } from '../Table/Table';
 import { makeStyles } from '@material-ui/core/styles';
@@ -24,19 +25,22 @@ import { PathPredicate } from '../../types/types';
 import { useStylesReportTableHeader } from '../ReportTableHeader/ReportTableHeader';
 import { Source } from '../../../shared/shared-types';
 
+export const reportTableRowHeight = 190;
+const padding = 10;
+
 const useStyles = makeStyles({
   tableData: {
     overflow: 'auto',
     whiteSpace: 'pre-line',
-    padding: 10,
-    height: 140,
+    padding: padding,
+    height: reportTableRowHeight - 2 * padding,
   },
   iconTableData: {
     overflow: 'hidden',
     whiteSpace: 'pre-line',
     paddingTop: 7,
     paddingBottom: 7,
-    height: 140,
+    height: reportTableRowHeight - 2 * padding,
     textAlign: 'center',
   },
   tableCell: {
@@ -78,6 +82,10 @@ const useStyles = makeStyles({
   excludeFromNoticeIcon: {
     border: `2px ${OpossumColors.grey} solid`,
     color: OpossumColors.grey,
+  },
+  preSelectedIcon: {
+    border: `2px ${OpossumColors.brown} solid`,
+    color: OpossumColors.brown,
   },
   markedTableCell: {
     backgroundColor: OpossumColors.lightOrange,
@@ -230,6 +238,14 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
           <>
             <ExcludeFromNoticeIcon
               className={clsx(classes.icon, classes.excludeFromNoticeIcon)}
+            />{' '}
+            <br />
+          </>
+        )}
+        {attributionInfo.preSelected && (
+          <>
+            <PreSelectedIcon
+              className={clsx(classes.icon, classes.preSelectedIcon)}
             />{' '}
             <br />
           </>

--- a/src/Frontend/Components/Table/Table.tsx
+++ b/src/Frontend/Components/Table/Table.tsx
@@ -15,7 +15,10 @@ import {
   useStylesReportTableHeader,
 } from '../ReportTableHeader/ReportTableHeader';
 import { List } from '../List/List';
-import { ReportTableItem } from '../ReportTableItem/ReportTableItem';
+import {
+  ReportTableItem,
+  reportTableRowHeight,
+} from '../ReportTableItem/ReportTableItem';
 import { topBarOffset, useWindowHeight } from '../../util/use-window-height';
 import clsx from 'clsx';
 import { OpossumColors } from '../../shared-styles';
@@ -145,7 +148,7 @@ export function Table(props: TableProps): ReactElement | null {
           <div className={classes.tableWidth}>
             <List
               length={attributionsIds.length}
-              cardVerticalDistance={160}
+              cardVerticalDistance={reportTableRowHeight}
               max={{ height: maxHeight }}
               getListItem={getReportTableItem}
             />

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -30,6 +30,7 @@ export const OpossumColors = {
   red: 'hsl(0, 100%, 45%)',
   lightRed: 'hsl(0, 100%, 60%)',
   green: 'hsl(146, 50%, 45%)',
+  brown: 'hsl(25, 76%, 31%)',
 };
 
 export const resourceBrowserWidthInPixels = 420;


### PR DESCRIPTION
1. Show the new icon in report table view.
(This makes it necessary to increase the row height.)
![Screenshot_20210923_104424](https://user-images.githubusercontent.com/14236667/134488764-65e88ec9-02fb-4e76-b381-ada540cfaf47.png)


2. Show a hint in the attribution details column.
![Screenshot_20210923_112002](https://user-images.githubusercontent.com/14236667/134488738-23c23a0e-10ab-414f-912f-57ad6d5d6b0a.png)


