### PR TITLE
Fix app name

### DIFF
--- a/.circleci/build_opossum_frontend.sh
+++ b/.circleci/build_opossum_frontend.sh
@@ -17,11 +17,11 @@ yarn ship-linux
 yarn ship-mac
 yarn ship-win
 cd release/macOS/
-zip -r -q "opossum-ui-mac.zip" "opossum-ui-darwin-x64/"
+zip -r -q "OpossumUI-mac.zip" "OpossumUI-darwin-x64/"
 mkdir "/home/circleci/project/release/builds"
-mv "/home/circleci/project/release/linux_and_windows/opossum-ui-0.1.0.AppImage" "/home/circleci/project/release/builds/opossum-ui-linux-${commit}.AppImage"
-mv "/home/circleci/project/release/macOS/opossum-ui-mac.zip" "/home/circleci/project/release/builds/opossum-ui-mac-${commit}.zip"
-mv "/home/circleci/project/release/linux_and_windows/opossum-ui Setup 0.1.0.exe" "/home/circleci/project/release/builds/opossum-ui-windows-${commit}.exe"
-test -e "/home/circleci/project/release/builds/opossum-ui-linux-${commit}.AppImage"
-test -e "/home/circleci/project/release/builds/opossum-ui-mac-${commit}.zip"
-test -e "/home/circleci/project/release/builds/opossum-ui-windows-${commit}.exe"
+mv "/home/circleci/project/release/linux_and_windows/OpossumUI-0.1.0.AppImage" "/home/circleci/project/release/builds/OpossumUI-linux-${commit}.AppImage"
+mv "/home/circleci/project/release/macOS/OpossumUI-mac.zip" "/home/circleci/project/release/builds/OpossumUI-mac-${commit}.zip"
+mv "/home/circleci/project/release/linux_and_windows/OpossumUI Setup 0.1.0.exe" "/home/circleci/project/release/builds/OpossumUI-windows-${commit}.exe"
+test -e "/home/circleci/project/release/builds/OpossumUI-linux-${commit}.AppImage"
+test -e "/home/circleci/project/release/builds/OpossumUI-mac-${commit}.zip"
+test -e "/home/circleci/project/release/builds/OpossumUI-windows-${commit}.exe"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
                 path: /home/circleci/project/README.md
             - store_artifacts:
                 path: /home/circleci/project/release/builds
-                destination: opossum-ui
+                destination: OpossumUI
 
 workflows:
   workflow:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
         include:
           - os: ubuntu-latest
             SHIP: ship-linux
-            FILE: release/linux_and_windows/opossum-ui-*.AppImage
+            FILE: release/linux_and_windows/OpossumUI-*.AppImage
           - os: macos-latest
             SHIP: ship-mac
-            FILE: release/macOS/opossum-ui-darwin-x64.zip
+            FILE: release/macOS/OpossumUI-darwin-x64.zip
           - os: windows-latest
             SHIP: ship-win
-            FILE: release/linux_and_windows/opossum-ui Setup*.exe
+            FILE: release/linux_and_windows/OpossumUI Setup*.exe
 
     steps:
       - name: Check out git repository

--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ supported.
 
 #### Linux
 
-Run the executable _opossum-ui-0.1.0.AppImage_
+Run the executable _OpossumUI-0.1.0.AppImage_
 
 #### macOS
 
-Run _opossum-ui_ in _opossum-ui-darwin-x64/_.
+Run _OpossumUI_ in _OpossumUI-darwin-x64/_.
 
 #### Windows
 
-Run _opossum-ui Setup 0.1.0.exe_ to install the OpossumUI. Then open _opossum-ui_ from the start menu.
+Run _OpossumUI Setup 0.1.0.exe_ to install the OpossumUI. Then open _OpossumUI_ from the start menu.
 
 ## Working with OpossumUI
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -50,15 +50,15 @@ supported.
 
 #### Linux
 
-Run the executable *opossum-ui-0.1.0.AppImage*
+Run the executable *OpossumUI-0.1.0.AppImage*
 
 #### macOS
 
-Run *opossum-ui* in *opossum-ui-darwin-x64/*.
+Run *OpossumUI* in *OpossumUI-darwin-x64/*.
 
 #### Windows
 
-Run *opossum-ui Setup 0.1.0.exe* to install the OpossumUI. Then open *opossum-ui* from the start menu.
+Run *OpossumUI Setup 0.1.0.exe* to install the OpossumUI. Then open *OpossumUI* from the start menu.
 
 ## Working with OpossumUI
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opossum-ui",
+  "name": "OpossumUI",
   "description": "The OpossumUI enables the editing of attribution information that is assigned to a resource tree.",
   "license": "Apache-2.0",
   "version": "0.1.0",
@@ -95,7 +95,7 @@
     "generate-notice:win32": "if not exist notices mkdir notices && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",
     "ship-linux": "yarn build && electron-builder --linux --x64 --publish never",
     "ship-win": "yarn build && electron-builder --win --x64 --publish never",
-    "ship-mac": "yarn build && electron-packager . opossum-ui --ignore=^/release --ignore=^/src --ignore=^/example-files --ignore=^/run_precommit.sh --ignore=^/README.md --ignore=__tests__ --platform=darwin arch=x64 --overwrite --out=release/macOS --icon src/ElectronBackend/logo/icon.icns && zip -r -q 'release/macOS/opossum-ui-darwin-x64.zip' 'release/macOS/opossum-ui-darwin-x64/'",
+    "ship-mac": "yarn build && electron-packager . OpossumUI --ignore=^/release --ignore=^/src --ignore=^/example-files --ignore=^/run_precommit.sh --ignore=^/README.md --ignore=__tests__ --platform=darwin arch=x64 --overwrite --out=release/macOS --icon src/ElectronBackend/logo/icon.icns && zip -r -q 'release/macOS/OpossumUI-darwin-x64.zip' 'release/macOS/OpossumUI-darwin-x64/'",
     "ship": "yarn ship-linux && yarn ship-win && yarn ship-mac",
     "clean": "rm -rf ./build/ ./release/"
   },


### PR DESCRIPTION
Before this fix, the name of the built app was shown as 'opossum-ui'. With the fix, it is shown as 'OpossumUI'. This fixes the name of the executables and the name shown when the app is running.