### PR TITLE
Sanitize external resources to attributions in input file

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -60,6 +60,7 @@ const inputFileContent: ParsedOpossumInputFile = {
   },
   resources: {
     a: 1,
+    folder: {},
   },
   externalAttributions: {
     [externalAttributionUuid]: {
@@ -85,7 +86,10 @@ const inputFileContent: ParsedOpossumInputFile = {
       defaultText: 'MIT license text',
     },
   ],
-  resourcesToAttributions: { '/a': [externalAttributionUuid] },
+  resourcesToAttributions: {
+    '/a': [externalAttributionUuid],
+    '/folder': [externalAttributionUuid],
+  },
 };
 
 const expectedFileContent: ParsedFileContent = {
@@ -93,7 +97,7 @@ const expectedFileContent: ParsedFileContent = {
     ...EMPTY_PROJECT_METADATA,
     projectTitle: 'Test Title',
   },
-  resources: { a: 1 },
+  resources: { a: 1, folder: {} },
   manualAttributions: {
     attributions: {},
     resourcesToAttributions: {},
@@ -118,6 +122,7 @@ const expectedFileContent: ParsedFileContent = {
     },
     resourcesToAttributions: {
       '/a': [externalAttributionUuid],
+      '/folder/': [externalAttributionUuid],
     },
   },
   frequentLicenses: {

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -19,6 +19,7 @@ import {
   parseFrequentLicenses,
   sanitizeRawAttributions,
   sanitizeRawBaseUrlsForSources,
+  sanitizeResourcesToAttributions,
 } from './cleanInputData';
 import { parseOpossumInputFile, parseOpossumOutputFile } from './parseFile';
 import {
@@ -90,6 +91,12 @@ export async function loadJsonFromFilePath(
     parsingResult.frequentLicenses
   );
 
+  log.info('Sanitizing external resources to attributions');
+  const resourcesToExternalAttributions = sanitizeResourcesToAttributions(
+    parsingResult.resources,
+    parsingResult.resourcesToAttributions
+  );
+
   log.info('Converting and cleaning data');
   const parsedFileContent: ParsedFileContent = {
     metadata: parsingResult.metadata,
@@ -106,7 +113,7 @@ export async function loadJsonFromFilePath(
     },
     externalAttributions: {
       attributions: externalAttributions,
-      resourcesToAttributions: parsingResult.resourcesToAttributions,
+      resourcesToAttributions: resourcesToExternalAttributions,
     },
     frequentLicenses: frequentLicenses,
     resolvedExternalAttributions: cleanNonExistentResolvedExternalSignals(


### PR DESCRIPTION
External resources to attributions in the input file might contain faulty paths (folders without trailing slashes). We sanitize the paths of ResourcesToAttributions based on the files and folders contained in the resource tree.