### PR TITLE
Show PURL if no package type is given in input file

### DIFF
--- a/src/Frontend/util/__tests__/handle-purl.test.ts
+++ b/src/Frontend/util/__tests__/handle-purl.test.ts
@@ -51,7 +51,7 @@ describe('generatePurlFromPackageInfo', () => {
     expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
   });
 
-  test('generates a valid Purl', () => {
+  test('generates a valid Purl without appendix', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
@@ -73,14 +73,15 @@ describe('generatePurlFromPackageInfo', () => {
     expect(generatePurlFromPackageInfo(testPackageInfo)).toBe('');
   });
 
-  test('returns undefined when no packageType is given is given', () => {
+  test('generates Purl with generic type when no packageType is given', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
       packageVersion: 'version',
     };
+    const expectedPurl = 'pkg:generic/namespace/name@version';
 
-    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe('');
+    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
   });
 });
 

--- a/src/Frontend/util/handle-purl.ts
+++ b/src/Frontend/util/handle-purl.ts
@@ -38,9 +38,12 @@ export function parsePurl(potentialPurl: string): ParsedPurl {
 }
 
 export function generatePurlFromPackageInfo(packageInfo: PackageInfo): string {
-  return packageInfo.packageType && packageInfo.packageName
+  return (packageInfo.packageNamespace ||
+    packageInfo.packageType ||
+    packageInfo.packagePURLAppendix) &&
+    packageInfo.packageName
     ? new PackageURL(
-        packageInfo.packageType,
+        packageInfo.packageType ? packageInfo.packageType : 'generic',
         packageInfo?.packageNamespace,
         packageInfo.packageName,
         packageInfo?.packageVersion,


### PR DESCRIPTION
Before this fix, informations like namespace that are present in the PURL were not shown if an attribution did not have a package type. To make these information visible, we now generate a PURL with the type 'generic' that is shown when no type is present.