### PR TITLE
Fix a bug in the github action triggered upon release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             SHIP: ship-linux
@@ -33,7 +32,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
-      - run: yarn install
+      - run: yarn install --network-timeout 560000
       - run: yarn ${{ matrix.SHIP }}
       - name: Upload release asset
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The action triggered 3 runs with 3 build and publish steps (9 jobs in total) due to a problem with matrix definition.
Furthermore, the timeout for yarn install was increased (similar as in build.yml).