### PR TITLE
catch frontend errors that are not caught at error boundary

### DIFF
--- a/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
@@ -25,7 +25,7 @@ const styles = createStyles({
 // it's known to fire twice in dev mode: https://github.com/facebook/react/issues/19613
 window.addEventListener('error', (event): void => {
   sendErrorInfo(event.error, {
-    componentStack: event.error.stack || '',
+    componentStack: event.error.stack,
   });
 });
 

--- a/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -61,7 +61,7 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
 
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(2);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
       IpcChannel['SendErrorInformation'],
       expect.anything()


### PR DESCRIPTION
In the past only frontend errors that were thrown during render were caught. Now we catch all errors in order to signal the user that something went wrong.
Note: in dev mode both, the error boundary and the event listener, are called in event of errors. In prod, however, this is not the case.

To test: -> test with build app
- create one error in render
-  create one error not in render