### PR TITLE
Add resourceIdMarkedForReplacment to redux state

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
@@ -5,10 +5,12 @@
 
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
+  setAttributionIdMarkedForReplacement,
   setSelectedAttributionId,
   setTargetSelectedAttributionId,
 } from '../attribution-view-simple-actions';
 import {
+  getAttributionIdMarkedForReplacement,
   getSelectedAttributionId,
   getTargetSelectedAttributionId,
 } from '../../../selectors/attribution-view-resource-selectors';
@@ -28,5 +30,15 @@ describe('The load and navigation simple actions', () => {
 
     testStore.dispatch(setTargetSelectedAttributionId('test'));
     expect(getTargetSelectedAttributionId(testStore.getState())).toBe('test');
+  });
+
+  test('sets and gets attributionIdMarkedForReplacement', () => {
+    const testStore = createTestAppStore();
+    expect(getAttributionIdMarkedForReplacement(testStore.getState())).toBe('');
+
+    testStore.dispatch(setAttributionIdMarkedForReplacement('test'));
+    expect(getAttributionIdMarkedForReplacement(testStore.getState())).toBe(
+      'test'
+    );
   });
 });

--- a/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
@@ -4,8 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
   ACTION_SET_SELECTED_ATTRIBUTION_ID,
   ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
+  SetAttributionIdMarkedForReplacement,
   SetSelectedAttributionId,
   SetTargetSelectedAttributionIdAction,
 } from './types';
@@ -25,5 +27,14 @@ export function setTargetSelectedAttributionId(
   return {
     type: ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
     payload: targetSelectedAttributionId,
+  };
+}
+
+export function setAttributionIdMarkedForReplacement(
+  attributionIdMarkedForReplacement: string
+): SetAttributionIdMarkedForReplacement {
+  return {
+    type: ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
+    payload: attributionIdMarkedForReplacement,
   };
 }

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -47,6 +47,8 @@ export const ACTION_SET_DISPLAYED_PANEL_PACKAGE =
   'ACTION_SET_DISPLAYED_PANEL_PACKAGE';
 export const ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID =
   'ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID';
+export const ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT =
+  'ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT';
 export const ACTION_SET_RESOLVED_EXTERNAL_ATTRIBUTIONS =
   'ACTION_SET_RESOLVED_EXTERNAL_ATTRIBUTIONS';
 export const ACTION_ADD_RESOLVED_EXTERNAL_ATTRIBUTION =
@@ -94,6 +96,7 @@ export type ResourceAction =
   | SetProjectMetadata
   | SetFileSearch
   | SetBaseUrlsForSources
+  | SetAttributionIdMarkedForReplacement
   | SetExternalAttributionSources;
 
 export interface ResetResourceStateAction {
@@ -255,4 +258,9 @@ export interface SetBaseUrlsForSources {
 export interface SetExternalAttributionSources {
   type: typeof ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES;
   payload: ExternalAttributionSources;
+}
+
+export interface SetAttributionIdMarkedForReplacement {
+  type: typeof ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT;
+  payload: string;
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -29,6 +29,7 @@ import {
   ACTION_REPLACE_ATTRIBUTION_WITH_MATCHING,
   ACTION_RESET_RESOURCE_STATE,
   ACTION_SET_ATTRIBUTION_BREAKPOINTS,
+  ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
   ACTION_SET_BASE_URLS_FOR_SOURCES,
   ACTION_SET_DISPLAYED_PANEL_PACKAGE,
   ACTION_SET_EXPANDED_IDS,
@@ -95,6 +96,7 @@ export const initialResourceState: ResourceState = {
   attributionView: {
     selectedAttributionId: '',
     targetSelectedAttributionId: '',
+    attributionIdMarkedForReplacement: '',
   },
   fileSearchPopup: {
     fileSearch: '',
@@ -126,6 +128,7 @@ export type ResourceState = {
   attributionView: {
     selectedAttributionId: string;
     targetSelectedAttributionId: string;
+    attributionIdMarkedForReplacement: string;
   };
   fileSearchPopup: {
     fileSearch: string;
@@ -276,6 +279,14 @@ export const resourceState = (
         attributionView: {
           ...state.attributionView,
           targetSelectedAttributionId: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT:
+      return {
+        ...state,
+        attributionView: {
+          ...state.attributionView,
+          attributionIdMarkedForReplacement: action.payload,
         },
       };
     case ACTION_SET_IS_SAVING_DISABLED:

--- a/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
@@ -25,3 +25,7 @@ export function getResourceIdsOfSelectedAttribution(
   }
   return [];
 }
+
+export function getAttributionIdMarkedForReplacement(state: State): string {
+  return state.resourceState.attributionView.attributionIdMarkedForReplacement;
+}


### PR DESCRIPTION
For adding a feature to merge/replace an attribution by another one it is necessary to remember the attribution to be replaced. This attributionId is written to the redux store. For now the feature is only available in the attributionView and therefore placed in the corresponding sub-store.
