### PR TITLE
Remove white border at the bottom of the resources list

### DIFF
--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -58,7 +58,7 @@ export function AttributionDetailsViewer(): ReactElement | null {
     isEqual
   );
 
-  const resourceListMaxHeight = useWindowHeight() - 86;
+  const resourceListMaxHeight = useWindowHeight() - 112;
 
   const dispatch = useDispatch();
 

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -8,6 +8,15 @@ import { FixedSizeList as VirtualizedList } from 'react-window';
 import { Height, NumberOfDisplayedItems } from '../../types/types';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
+import { OpossumColors } from '../../shared-styles';
+
+const useStyles = makeStyles({
+  root: {
+    backgroundColor: OpossumColors.white,
+  },
+  paddingBottomScrollbar: { paddingBottom: 18 },
+  horizontalScrollbarFix: { overflowX: 'scroll' },
+});
 
 interface ListProps {
   length: number;
@@ -19,11 +28,6 @@ interface ListProps {
   allowHorizontalScrolling?: boolean;
 }
 
-const useStyles = makeStyles({
-  paddingBottomScrollbar: { paddingBottom: 18 },
-  horizontalScrollbarFix: { overflowX: 'scroll' },
-});
-
 function maxHeightWasGiven(
   max: NumberOfDisplayedItems | Height
 ): max is Height {
@@ -33,17 +37,16 @@ function maxHeightWasGiven(
 export function List(props: ListProps): ReactElement {
   const classes = useStyles();
   const cardHeight = props.cardVerticalDistance || 24;
-  const minHeight = cardHeight + 6;
   const maxHeight = maxHeightWasGiven(props.max)
     ? props.max.height
     : props.max.numberOfDisplayedItems * (cardHeight + 1);
   const currentHeight = props.length * (cardHeight + 1);
   const listHeight = props.alwaysShowHorizontalScrollBar
-    ? maxHeight + 1
-    : Math.min(currentHeight, maxHeight) + 1;
+    ? maxHeight
+    : Math.min(currentHeight, maxHeight);
 
   return (
-    <div style={{ minHeight }}>
+    <div className={classes.root} style={{ maxHeight: currentHeight }}>
       <VirtualizedList
         height={listHeight}
         width={'vertical'}
@@ -66,7 +69,11 @@ export function List(props: ListProps): ReactElement {
           <div
             style={
               props.allowHorizontalScrolling
-                ? { ...style, minWidth: '100%', width: 'fit-content' }
+                ? {
+                    ...style,
+                    minWidth: '100%',
+                    width: 'fit-content',
+                  }
                 : style
             }
           >

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -57,7 +57,7 @@ export function List(props: ListProps): ReactElement {
             : null,
           props.addPaddingBottom ? classes.paddingBottomScrollbar : null
         )}
-        style={currentHeight < maxHeight ? { overflowY: 'hidden' } : {}}
+        style={currentHeight < maxHeight ? { overflow: 'auto hidden' } : {}}
       >
         {({
           index,

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -8,14 +8,13 @@ import { FixedSizeList as VirtualizedList } from 'react-window';
 import { Height, NumberOfDisplayedItems } from '../../types/types';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
-import { OpossumColors } from '../../shared-styles';
 
 const useStyles = makeStyles({
-  root: {
-    backgroundColor: OpossumColors.white,
-  },
   paddingBottomScrollbar: { paddingBottom: 18 },
   horizontalScrollbarFix: { overflowX: 'scroll' },
+  deactivateScrollbar: {
+    overflowY: 'hidden',
+  },
 });
 
 interface ListProps {
@@ -46,7 +45,7 @@ export function List(props: ListProps): ReactElement {
     : Math.min(currentHeight, maxHeight);
 
   return (
-    <div className={classes.root} style={{ maxHeight: currentHeight }}>
+    <div style={{ maxHeight: currentHeight }}>
       <VirtualizedList
         height={listHeight}
         width={'vertical'}
@@ -58,6 +57,7 @@ export function List(props: ListProps): ReactElement {
             : null,
           props.addPaddingBottom ? classes.paddingBottomScrollbar : null
         )}
+        style={currentHeight < maxHeight ? { overflowY: 'hidden' } : {}}
       >
         {({
           index,

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -20,6 +20,9 @@ const useStyles = makeStyles({
   header: {
     whiteSpace: 'nowrap',
   },
+  resourceListContainer: {
+    overflowY: 'hidden',
+  },
 });
 
 interface ResourcePathPopupProps {
@@ -56,10 +59,12 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
       onBackdropClick={props.closePopup}
       onEscapeKeyDown={props.closePopup}
       content={
-        <ResourcesList
-          resourceIds={resourceIds}
-          maxHeight={useWindowHeight() - heightOffset}
-        />
+        <div className={classes.resourceListContainer}>
+          <ResourcesList
+            resourceIds={resourceIds}
+            maxHeight={useWindowHeight() - heightOffset}
+          />
+        </div>
       }
       isOpen={props.isOpen}
       fullWidth={true}

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -17,7 +17,6 @@ import { OpossumColors } from '../../shared-styles';
 const useStyles = makeStyles({
   root: {
     marginTop: 6,
-    marginBottom: 4,
     backgroundColor: OpossumColors.white,
   },
 });


### PR DESCRIPTION
Before this fix, the resources list in the attribution view had a white border when horizontal scrolling was deactivated.

Signed-off-by: Anton Bauhofer <anton.bauhofer@tngtech.com>