### PR TITLE
Highlight attribution to replace

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -63,7 +63,6 @@ interface AttributionColumnProps {
   showParentAttributions?: boolean;
   showManualAttributionData: boolean;
   resetViewIfThisIdChanges?: string;
-  selectedAttributionIsMarkedForReplacement?: boolean;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
@@ -234,9 +233,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
           resolvedExternalAttributions
         )}
         selectedPackageIsMarkedForReplacement={
-          props.selectedAttributionIsMarkedForReplacement
-            ? props.selectedAttributionIsMarkedForReplacement
-            : false
+          selectedAttributionId === attributionIdMarkedForReplacement
         }
         onUndoButtonClick={(): void => {
           dispatch(setTemporaryPackageInfo(initialPackageInfo));

--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -63,6 +63,7 @@ interface AttributionColumnProps {
   showParentAttributions?: boolean;
   showManualAttributionData: boolean;
   resetViewIfThisIdChanges?: string;
+  selectedAttributionIsMarkedForReplacement?: boolean;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
@@ -232,6 +233,11 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
           selectedPackage,
           resolvedExternalAttributions
         )}
+        selectedPackageIsMarkedForReplacement={
+          props.selectedAttributionIsMarkedForReplacement
+            ? props.selectedAttributionIsMarkedForReplacement
+            : false
+        }
         onUndoButtonClick={(): void => {
           dispatch(setTemporaryPackageInfo(initialPackageInfo));
         }}

--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -15,11 +15,12 @@ import {
 } from './attribution-column-helpers';
 
 const preSelectedLabel = 'Attribution was pre-selected';
+const markedForReplacementLabel = 'Attribution is marked for replacement';
 
 const useStyles = makeStyles({
   preSelectedLabel: {
     marginLeft: 10,
-    marginTop: 12,
+    marginTop: 5,
   },
   buttonRow: {
     position: 'absolute',
@@ -49,6 +50,7 @@ interface ButtonRowProps {
   hideUnmarkForReplacementButton: boolean;
   hideOnReplaceMarkedByButton: boolean;
   deactivateReplaceMarkedByButton: boolean;
+  selectedPackageIsMarkedForReplacement: boolean;
   onSaveButtonClick(): void;
   onSaveForAllButtonClick(): void;
   onDeleteButtonClick(): void;
@@ -67,6 +69,11 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
     <div className={classes.preSelectedLabel}>
       {props.temporaryPackageInfo.preSelected ? (
         <MuiTypography variant={'subtitle1'}>{preSelectedLabel}</MuiTypography>
+      ) : null}
+      {props.selectedPackageIsMarkedForReplacement ? (
+        <MuiTypography variant={'subtitle1'}>
+          {markedForReplacementLabel}
+        </MuiTypography>
       ) : null}
       <div className={classes.buttonRow}>
         {props.showButtonGroup ? (

--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -14,8 +14,8 @@ import {
   getMainButtonConfigs,
 } from './attribution-column-helpers';
 
-const preSelectedLabel = 'Attribution was pre-selected';
-const markedForReplacementLabel = 'Attribution is marked for replacement';
+const PRE_SELECTED_LABEL = 'Attribution was pre-selected';
+const MARKED_FOR_REPLACEMENT_LABEL = 'Attribution is marked for replacement';
 
 const useStyles = makeStyles({
   preSelectedLabel: {
@@ -68,11 +68,13 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
   return (
     <div className={classes.preSelectedLabel}>
       {props.temporaryPackageInfo.preSelected ? (
-        <MuiTypography variant={'subtitle1'}>{preSelectedLabel}</MuiTypography>
+        <MuiTypography variant={'subtitle1'}>
+          {PRE_SELECTED_LABEL}
+        </MuiTypography>
       ) : null}
       {props.selectedPackageIsMarkedForReplacement ? (
         <MuiTypography variant={'subtitle1'}>
-          {markedForReplacementLabel}
+          {MARKED_FOR_REPLACEMENT_LABEL}
         </MuiTypography>
       ) : null}
       <div className={classes.buttonRow}>

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../state/actions/resource-actions/save-actions';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
+  getAttributionIdMarkedForReplacement,
   getResourceIdsOfSelectedAttribution,
   getSelectedAttributionId,
 } from '../../state/selectors/attribution-view-resource-selectors';
@@ -57,6 +58,10 @@ export function AttributionDetailsViewer(): ReactElement | null {
     getResourceIdsOfSelectedAttribution,
     isEqual
   );
+  const attributionIdMarkedForReplacement: string = useSelector(
+    getAttributionIdMarkedForReplacement
+  );
+
   const resourceListMaxHeight = useWindowHeight() - 86;
 
   const dispatch = useDispatch();
@@ -109,6 +114,9 @@ export function AttributionDetailsViewer(): ReactElement | null {
           dispatch(setTemporaryPackageInfo(packageInfo));
         }}
         saveFileRequestListener={saveFileRequestListener}
+        selectedAttributionIsMarkedForReplacement={
+          selectedAttributionId === attributionIdMarkedForReplacement
+        }
       />
     </div>
   ) : null;

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../state/actions/resource-actions/save-actions';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
-  getAttributionIdMarkedForReplacement,
   getResourceIdsOfSelectedAttribution,
   getSelectedAttributionId,
 } from '../../state/selectors/attribution-view-resource-selectors';
@@ -57,9 +56,6 @@ export function AttributionDetailsViewer(): ReactElement | null {
   const resourceIdsOfSelectedAttributionId: Array<string> = useSelector(
     getResourceIdsOfSelectedAttribution,
     isEqual
-  );
-  const attributionIdMarkedForReplacement: string = useSelector(
-    getAttributionIdMarkedForReplacement
   );
 
   const resourceListMaxHeight = useWindowHeight() - 86;
@@ -114,9 +110,6 @@ export function AttributionDetailsViewer(): ReactElement | null {
           dispatch(setTemporaryPackageInfo(packageInfo));
         }}
         saveFileRequestListener={saveFileRequestListener}
-        selectedAttributionIsMarkedForReplacement={
-          selectedAttributionId === attributionIdMarkedForReplacement
-        }
       />
     </div>
   ) : null;

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
 interface AttributionListProps {
   attributions: Attributions;
   selectedAttributionId: string | null;
-  attributionIdMarkedForReplacement: string | null;
+  attributionIdMarkedForReplacement: string;
   onCardClick(attributionId: string, isButton?: boolean): void;
   className?: string;
   maxHeight: number;

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles({
 interface AttributionListProps {
   attributions: Attributions;
   selectedAttributionId: string | null;
+  attributionIdMarkedForReplacement: string | null;
   onCardClick(attributionId: string, isButton?: boolean): void;
   className?: string;
   maxHeight: number;
@@ -44,12 +45,17 @@ export function AttributionList(props: AttributionListProps): ReactElement {
       return attributionId === props.selectedAttributionId;
     }
 
+    function isMarkedForReplacement(): boolean {
+      return attributionId === props.attributionIdMarkedForReplacement;
+    }
+
     function onClick(): void {
       props.onCardClick(attributionId);
     }
 
     const cardConfig: ListCardConfig = {
       isSelected: isSelected(),
+      isMarkedForReplacement: isMarkedForReplacement(),
       isPreSelected: Boolean(attribution.preSelected),
       firstParty: attribution.firstParty,
       excludeFromNotice: attribution.excludeFromNotice,

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -33,6 +33,7 @@ describe('The AttributionList', () => {
       <AttributionList
         attributions={packages}
         selectedAttributionId={''}
+        attributionIdMarkedForReplacement={''}
         onCardClick={mockCallback}
         maxHeight={1000}
         title={'title'}
@@ -47,6 +48,7 @@ describe('The AttributionList', () => {
       <AttributionList
         attributions={packages}
         selectedAttributionId={''}
+        attributionIdMarkedForReplacement={''}
         onCardClick={doNothing}
         maxHeight={1000}
         title={'title'}
@@ -61,6 +63,7 @@ describe('The AttributionList', () => {
       <AttributionList
         attributions={packages}
         selectedAttributionId={''}
+        attributionIdMarkedForReplacement={''}
         onCardClick={mockCallback}
         maxHeight={1000}
         title={'title'}
@@ -94,6 +97,7 @@ describe('The AttributionList', () => {
       <AttributionList
         attributions={testPackages}
         selectedAttributionId={''}
+        attributionIdMarkedForReplacement={''}
         onCardClick={mockCallback}
         maxHeight={1000}
         title={'title'}

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -10,7 +10,10 @@ import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
-import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
+import {
+  getAttributionIdMarkedForReplacement,
+  getSelectedAttributionId,
+} from '../../state/selectors/attribution-view-resource-selectors';
 import { useFollowUpFilter } from '../../util/use-follow-up-filter';
 import { topBarOffset, useWindowHeight } from '../../util/use-window-height';
 import { AttributionDetailsViewer } from '../AttributionDetailsViewer/AttributionDetailsViewer';
@@ -42,6 +45,9 @@ export function AttributionView(): ReactElement {
   const dispatch = useDispatch();
   const attributions: Attributions = useSelector(getManualAttributions);
   const selectedAttributionId: string = useSelector(getSelectedAttributionId);
+  const attributionIdMarkedForReplacement: string = useSelector(
+    getAttributionIdMarkedForReplacement
+  );
 
   const { filterForFollowUp, handleFilterChange, getFilteredAttributions } =
     useFollowUpFilter();
@@ -64,6 +70,7 @@ export function AttributionView(): ReactElement {
       <AttributionList
         attributions={filteredAttributions}
         selectedAttributionId={selectedAttributionId}
+        attributionIdMarkedForReplacement={attributionIdMarkedForReplacement}
         onCardClick={onCardClick}
         className={classes.attributionList}
         maxHeight={useWindowHeight() - topBarOffset - countAndSearchOffset}

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -48,6 +48,12 @@ const useStyles = makeStyles({
       background: OpossumColors.middleBlueOnHover,
     },
   },
+  markedForReplacement: {
+    borderRightWidth: 'medium',
+    borderRightColor: OpossumColors.brown,
+    background: OpossumColors.lightGrey,
+    color: OpossumColors.grey,
+  },
   resolved: {
     opacity: 0.5,
   },
@@ -137,6 +143,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
         props.cardConfig.isResource ? classes.resource : classes.package,
         props.cardConfig.isExternalAttribution && classes.externalAttribution,
         props.cardConfig.isSelected && classes.selected,
+        props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
         props.cardConfig.isResolved && classes.resolved
       )}
       onClick={props.onClick}

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -24,6 +24,7 @@ export const OpossumColors = {
   pastelRed: 'hsl(0, 70%, 70%)',
   lightOrange: 'hsl(27, 100%, 94%)',
   orange: 'hsl(16, 100%, 50%)',
+  lightGrey: 'hsla(0, 0%, 0%, 0.16)',
   grey: 'hsla(0, 0%, 0%, 0.52)',
   disabledGrey: 'hsla(0, 0%, 0%, 0.26)',
   disabledButtonGrey: 'hsla(0, 0%, 0%, 0.13)',

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -58,6 +58,7 @@ export interface ListCardConfig {
   isResource?: true;
   isExternalAttribution?: boolean;
   isSelected?: boolean;
+  isMarkedForReplacement?: boolean;
   isResolved?: boolean;
   isPreSelected?: boolean;
   excludeFromNotice?: boolean;


### PR DESCRIPTION
Attributions that are selected to be replaced are greyed out and highlighted with a brown border on the right side.


![Screenshot 2021-09-28 at 16 16 36](https://user-images.githubusercontent.com/48415604/135105360-fb0a0883-0dcb-4e77-8b5f-866e87959c43.png)

![Screenshot 2021-09-28 at 16 56 42](https://user-images.githubusercontent.com/48415604/135118440-c0d66714-ca67-4994-98de-410a3cd9584b.png)

![Screenshot 2021-09-28 at 16 56 59](https://user-images.githubusercontent.com/48415604/135118468-b63dab30-ae24-48dd-ad62-ec41d6958a3f.png)

Signed-off-by: Anton Bauhofer <anton.bauhofer@tngtech.com>