### PR TITLE
Fix bug when selecting frequent licenses

### DIFF
--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -46,8 +46,8 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
 
   const inputValue = props.text || '';
   const inputValueIndexInOptions: number = props.options
-    .map((name) => name.toLowerCase())
-    .indexOf(inputValue.toLowerCase());
+    .map((name) => name)
+    .indexOf(inputValue);
   const isInputValueInOptions: boolean = inputValueIndexInOptions > -1;
 
   return (
@@ -58,11 +58,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
         options={props.options}
         disableClearable={true}
         disabled={!props.isEditable}
-        inputValue={
-          isInputValueInOptions
-            ? props.options[inputValueIndexInOptions]
-            : inputValue
-        }
+        inputValue={inputValue}
         onInputChange={onInputChange}
         renderInput={(params): ReactElement => {
           const paramsWithAdornment = props.endAdornmentText

--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -45,9 +45,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
   }
 
   const inputValue = props.text || '';
-  const inputValueIndexInOptions: number = props.options
-    .map((name) => name)
-    .indexOf(inputValue);
+  const inputValueIndexInOptions: number = props.options.indexOf(inputValue);
   const isInputValueInOptions: boolean = inputValueIndexInOptions > -1;
 
   return (


### PR DESCRIPTION
There was some hidden magic that converted the license name the user wrote to uppercase letters if there was a match with a frequent license. This logic is removed and the user has to actively choose the frequent license now.
Only in the case of a perfect match (user input: MIT, frequent license: MIT) the frequent license is automatically chosen.
Also removed some formatting, which was confusing for the user and added an integration test.
