### PR TITLE
Fix bug of deleting an marked attribution

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -35,13 +35,19 @@ import {
   getTemporaryPackageInfo,
   wereTemporaryPackageInfoModified,
 } from '../../../selectors/all-views-resource-selectors';
-import { getSelectedAttributionId } from '../../../selectors/attribution-view-resource-selectors';
+import {
+  getAttributionIdMarkedForReplacement,
+  getSelectedAttributionId,
+} from '../../../selectors/attribution-view-resource-selectors';
 import { getAttributionIdOfDisplayedPackageInManualPanel } from '../../../selectors/audit-view-resource-selectors';
 import {
   setResources,
   setTemporaryPackageInfo,
 } from '../all-views-simple-actions';
-import { setSelectedAttributionId } from '../attribution-view-simple-actions';
+import {
+  setAttributionIdMarkedForReplacement,
+  setSelectedAttributionId,
+} from '../attribution-view-simple-actions';
 import {
   addResolvedExternalAttribution,
   setDisplayedPackage,
@@ -921,10 +927,16 @@ describe('The deleteAttributionForAllAndSave action', () => {
         )
       )
     );
+    testStore.dispatch(setSelectedAttributionId('reactUuid'));
+    testStore.dispatch(setAttributionIdMarkedForReplacement('reactUuid'));
 
     testStore.dispatch(deleteAttributionForAllAndSave('reactUuid'));
     expect(getManualData(testStore.getState())).toEqual(expectedManualData);
     expect(getTemporaryPackageInfo(testStore.getState())).toEqual({});
+    expect(getSelectedAttributionId(testStore.getState())).toEqual('');
+    expect(getAttributionIdMarkedForReplacement(testStore.getState())).toEqual(
+      ''
+    );
   });
 });
 

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -366,27 +366,29 @@ export const resourceState = (
         },
       };
     case ACTION_DELETE_ATTRIBUTION:
+      const attributionToDeleteId = action.payload;
       const manualDataAfterDeletion: AttributionData = deleteManualAttribution(
         state.allViews.manualData,
-        action.payload,
+        attributionToDeleteId,
         getAttributionBreakpointCheckForResourceState(state)
       );
 
       const newDisplayedPanelPackage: PanelPackage | null =
         state.auditView.displayedPanelPackage?.panel ===
           PackagePanelTitle.ManualPackages &&
-        state.auditView.displayedPanelPackage.attributionId === action.payload
+        state.auditView.displayedPanelPackage.attributionId ===
+          attributionToDeleteId
           ? { ...state.auditView.displayedPanelPackage, attributionId: '' }
           : state.auditView.displayedPanelPackage;
 
       const newSelectedAttributionId: string =
-        state.attributionView.selectedAttributionId === action.payload
+        state.attributionView.selectedAttributionId === attributionToDeleteId
           ? ''
           : state.attributionView.selectedAttributionId;
 
       const newAttributionIdMarkedForReplacement: string =
         state.attributionView.attributionIdMarkedForReplacement ===
-        action.payload
+        attributionToDeleteId
           ? ''
           : state.attributionView.attributionIdMarkedForReplacement;
 

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -384,6 +384,12 @@ export const resourceState = (
           ? ''
           : state.attributionView.selectedAttributionId;
 
+      const newAttributionIdMarkedForReplacement: string =
+        state.attributionView.attributionIdMarkedForReplacement ===
+        action.payload
+          ? ''
+          : state.attributionView.attributionIdMarkedForReplacement;
+
       return {
         ...state,
         allViews: {
@@ -406,6 +412,8 @@ export const resourceState = (
         attributionView: {
           ...state.attributionView,
           selectedAttributionId: newSelectedAttributionId,
+          attributionIdMarkedForReplacement:
+            newAttributionIdMarkedForReplacement,
         },
       };
     case ACTION_REPLACE_ATTRIBUTION_WITH_MATCHING:


### PR DESCRIPTION
The following bug is fixed: If an attribution is marked and then deleted, subsequently replacing by marked throws.