### PR TITLE
Fix github action for building releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release
-on: release
+on:
+  release:
+    types: [published]
 
 jobs:
   publish_artifact:


### PR DESCRIPTION
Currently, building a release is triggered three times. With this change it should only be triggered once.