### PR TITLE
Do not show 'marked for replacement' label in Audit View

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -187,7 +187,8 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const displayTexts = getDisplayTexts(
     temporaryPackageInfo,
     selectedAttributionId,
-    attributionIdMarkedForReplacement
+    attributionIdMarkedForReplacement,
+    view
   );
 
   function listener(event: IpcRendererEvent, resetState: boolean): void {

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -26,13 +26,17 @@ const MARKED_FOR_REPLACEMENT_LABEL = 'Attribution is marked for replacement';
 export function getDisplayTexts(
   temporaryPackageInfo: PackageInfo,
   selectedAttributionId: string,
-  attributionIdMarkedForReplacement: string
+  attributionIdMarkedForReplacement: string,
+  view: View
 ): Array<string> {
   const displayTexts = [];
   if (temporaryPackageInfo.preSelected) {
     displayTexts.push(PRE_SELECTED_LABEL);
   }
-  if (selectedAttributionId === attributionIdMarkedForReplacement) {
+  if (
+    view === 'Attribution' &&
+    selectedAttributionId === attributionIdMarkedForReplacement
+  ) {
     displayTexts.push(MARKED_FOR_REPLACEMENT_LABEL);
   }
   return displayTexts;


### PR DESCRIPTION
The check was broken because it is based on variables of the
Attribution View that are constant while the user is using the
Audit View.

Signed-off-by: Sebastian Thomas <sebastian.thomas@tngtech.com>