### PR TITLE
Do not include license text for spdx licenses in spdx export

### DIFF
--- a/spdx-tools-ts/package.json
+++ b/spdx-tools-ts/package.json
@@ -8,9 +8,12 @@
   "dependencies": {
     "@types/jest": "^27.0.1",
     "@types/js-yaml": "^4.0.3",
+    "@types/object-hash": "^2.2.1",
     "@types/uuid": "^8.3.1",
     "js-yaml": "^4.1.0",
+    "object-hash": "^2.2.0",
     "packageurl-js": "^0.0.5",
+    "spdx-license-ids": "^3.0.10",
     "typescript": "^4.3.5",
     "uuid": "^8.3.2"
   },

--- a/spdx-tools-ts/src/__tests__/spdxTools.test.ts
+++ b/spdx-tools-ts/src/__tests__/spdxTools.test.ts
@@ -95,7 +95,7 @@ describe('createSpdxDocument', () => {
     });
   });
 
-  it('creates correct document in case of two attributions one without license', () => {
+  it('creates correct document in case of four attributions one without license one spdx license', () => {
     const attribution1: Package = {
       copyright: 'copyright 1',
       license: 'license 1',
@@ -110,21 +110,39 @@ describe('createSpdxDocument', () => {
     };
     const attribution2: Package = {
       copyright: 'copyright 2',
-
       name: 'name 2',
       namespace: 'namespace 2',
       dependencies: [],
       comment: "I'm a comment",
     };
+    const attribution3: Package = {
+      copyright: 'copyright 3',
+      name: 'name 3',
+      namespace: 'namespace 3',
+      dependencies: [],
+      comment: "I'm a comment",
+      license: 'license 1',
+      licenseText: 'license text 1',
+    };
+    const attribution4: Package = {
+      copyright: 'copyright 4',
+      name: 'name 4',
+      namespace: 'namespace 4',
+      dependencies: [],
+      comment: "I'm a comment",
+      license: 'MIT',
+      licenseText: 'license text 4',
+    };
     const spdxDocument = createSpdxDocument('Opossum', {
-      dependencies: [attribution1, attribution2],
+      dependencies: [attribution1, attribution2, attribution3, attribution4],
     });
     expect(spdxDocument).toStrictEqual({
       ...expectedBaseSpdxDocument,
       hasExtractedLicensingInfos: [
         {
           extractedText: 'license text 1',
-          licenseId: 'LicenseRef-license-1-0',
+          licenseId:
+            'LicenseRef-license-1-a1401ff7c639df0803dcc2629a6bc4ac6c03fdec',
           name: 'license 1',
         },
       ],
@@ -144,7 +162,8 @@ describe('createSpdxDocument', () => {
           ],
           filesAnalyzed: false,
           homepage: 'url 1',
-          licenseConcluded: 'LicenseRef-license-1-0',
+          licenseConcluded:
+            'LicenseRef-license-1-a1401ff7c639df0803dcc2629a6bc4ac6c03fdec',
           licenseDeclared: 'NOASSERTION',
           licenseInfoFromFiles: 'NOASSERTION',
           name: 'name 1',
@@ -163,6 +182,33 @@ describe('createSpdxDocument', () => {
           name: 'name 2',
           versionInfo: 'NOASSERTION',
         },
+        {
+          SPDXID: 'SPDXRef-Package-name-3-2',
+          comment: "I'm a comment",
+          copyrightText: 'copyright 3',
+          downloadLocation: 'NOASSERTION',
+          externalRefs: [],
+          filesAnalyzed: false,
+          licenseConcluded:
+            'LicenseRef-license-1-a1401ff7c639df0803dcc2629a6bc4ac6c03fdec',
+          licenseDeclared: 'NOASSERTION',
+          licenseInfoFromFiles: 'NOASSERTION',
+          name: 'name 3',
+          versionInfo: 'NOASSERTION',
+        },
+        {
+          SPDXID: 'SPDXRef-Package-name-4-3',
+          comment: "I'm a comment",
+          copyrightText: 'copyright 4',
+          downloadLocation: 'NOASSERTION',
+          externalRefs: [],
+          filesAnalyzed: false,
+          licenseConcluded: 'MIT',
+          licenseDeclared: 'NOASSERTION',
+          licenseInfoFromFiles: 'NOASSERTION',
+          name: 'name 4',
+          versionInfo: 'NOASSERTION',
+        },
       ],
       relationships: [
         expectedRootRelationship,
@@ -175,6 +221,16 @@ describe('createSpdxDocument', () => {
           relatedSpdxElement: SPDXID_OF_ROOT_PACKAGE,
           relationshipType: 'DEPENDENCY_OF',
           spdxElementId: 'SPDXRef-Package-name-2-1',
+        },
+        {
+          relatedSpdxElement: 'SPDXRef-RootPackage',
+          relationshipType: 'DEPENDENCY_OF',
+          spdxElementId: 'SPDXRef-Package-name-3-2',
+        },
+        {
+          relatedSpdxElement: 'SPDXRef-RootPackage',
+          relationshipType: 'DEPENDENCY_OF',
+          spdxElementId: 'SPDXRef-Package-name-4-3',
         },
       ],
     });

--- a/spdx-tools-ts/src/spdxTools.ts
+++ b/spdx-tools-ts/src/spdxTools.ts
@@ -15,7 +15,7 @@ import {
 } from './types';
 import yaml from 'js-yaml';
 import { PackageURL } from 'packageurl-js';
-import * as spdxLicenseJson from 'spdx-license-ids/index.json';
+import { default as spdxLicenseJson } from 'spdx-license-ids/index.json';
 import hash from 'object-hash';
 
 const DEFAULT_PACKAGE_RELATION = 'DEPENDENCY_OF';
@@ -278,7 +278,5 @@ function isPackageEmpty(pkg: Package): boolean {
 }
 
 function isSpdxLicense(licenseName?: string): boolean {
-  return Boolean(
-    licenseName && Object.values(spdxLicenseJson).includes(licenseName)
-  );
+  return Boolean(licenseName && spdxLicenseJson.includes(licenseName));
 }

--- a/spdx-tools-ts/yarn.lock
+++ b/spdx-tools-ts/yarn.lock
@@ -619,6 +619,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
   integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
 
+"@types/object-hash@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-2.2.1.tgz#67c169f8f033e0b62abbf81df2d00f4598d540b9"
+  integrity sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==
+
 "@types/prettier@^2.1.5":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
@@ -2033,6 +2038,11 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2280,6 +2290,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+spdx-license-ids@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
+  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,6 +2151,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/object-hash@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-2.2.1.tgz#67c169f8f033e0b62abbf81df2d00f4598d540b9"
+  integrity sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -9354,6 +9359,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
@@ -12120,7 +12130,7 @@ spdx-expression-parse@^3.0.0:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"
 
-spdx-license-ids@^3.0.0:
+spdx-license-ids@^3.0.0, spdx-license-ids@^3.0.10:
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
   integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
@@ -12130,9 +12140,12 @@ spdx-license-ids@^3.0.0:
   dependencies:
     "@types/jest" "^27.0.1"
     "@types/js-yaml" "^4.0.3"
+    "@types/object-hash" "^2.2.1"
     "@types/uuid" "^8.3.1"
     js-yaml "^4.1.0"
+    object-hash "^2.2.0"
     packageurl-js "^0.0.5"
+    spdx-license-ids "^3.0.10"
     typescript "^4.3.5"
     uuid "^8.3.2"
 


### PR DESCRIPTION
The spdx export is modified to not include license texts for licenses with spdx license identifier. Furthermore, licenses are deduplicated.