### PR TITLE
Split ResourcePathPopup resource list in current and other folders

### DIFF
--- a/src/ElectronBackend/input/cleanInputData.ts
+++ b/src/ElectronBackend/input/cleanInputData.ts
@@ -57,7 +57,10 @@ export function sanitizeResourcesToAttributions(
 
   return Object.fromEntries(
     Object.entries(rawResourcesToAttributions).reduce(
-      (accumulatedResult: Array<[string, string[]]>, [path, attributions]) => {
+      (
+        accumulatedResult: Array<[string, Array<string>]>,
+        [path, attributions]
+      ) => {
         const pathWithSlashes = addTrailingSlashIfAbsent(path);
 
         if (allResourcePaths.has(path)) {

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -92,7 +92,9 @@ export function AttributionDetailsViewer(): ReactElement | null {
           Linked Resources
         </MuiTypography>
         <ResourcesList
-          resourceIds={resourceIdsOfSelectedAttributionId}
+          resourcesListBatches={[
+            { resourceIds: resourceIdsOfSelectedAttributionId },
+          ]}
           maxHeight={resourceListMaxHeight}
         />
       </div>

--- a/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
+++ b/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
@@ -28,7 +28,7 @@ export function FileSearchPopup(): ReactElement {
     <>
       <FileSearchTextField setFilteredPaths={setFilteredPaths} />
       <ResourcesList
-        resourceIds={filteredPaths}
+        resourcesListBatches={[{ resourceIds: filteredPaths }]}
         maxHeight={resourceListMaxHeightInPx}
         onClickCallback={close}
       />

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -18,6 +18,8 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     height: defaultCardHeight,
+  },
+  hover: {
     '&:hover': {
       cursor: 'pointer',
     },
@@ -108,6 +110,20 @@ const useStyles = makeStyles({
       fontSize: '0.85rem',
     },
   },
+  excludeFromNotice: {
+    color: OpossumColors.darkBlue,
+  },
+  header: {
+    background: OpossumColors.white,
+    '&.MuiTypography-body2': {
+      fontWeight: 'bold',
+    },
+    height: 20,
+    textAlign: 'left',
+    '&:hover': {
+      background: OpossumColors.white,
+    },
+  },
 });
 
 interface ListCardProps {
@@ -141,6 +157,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
         classes.root,
         props.cardConfig.isResource ? classes.resource : classes.package,
         props.cardConfig.isExternalAttribution && classes.externalAttribution,
+        props.cardConfig.isHeader ? classes.header : classes.hover,
         props.cardConfig.isSelected && classes.selected,
         props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
         props.cardConfig.isResolved && classes.resolved
@@ -164,7 +181,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
         <MuiTypography
           variant={'body2'}
           className={clsx(
-            classes.textLine,
+            props.cardConfig.isHeader ? classes.header : classes.textLine,
             props.cardConfig.isResource
               ? classes.textShortenedFromLeftSide
               : classes.textShortened
@@ -190,9 +207,9 @@ export function ListCard(props: ListCardProps): ReactElement | null {
           </MuiTypography>
         ) : null}
       </div>
-      <div className={classes.iconColumn}>
-        {props.rightIcons ? props.rightIcons : null}
-      </div>
+      {props.rightIcons ? (
+        <div className={classes.iconColumn}>{props.rightIcons}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../state/selectors/all-views-resource-selectors';
 import { useWindowHeight } from '../../util/use-window-height';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
-import { splitResourceItToCurrentAndOtherFolder } from './resource-path-popup-helpers';
+import { splitResourceIdsToCurrentAndOtherFolder } from './resource-path-popup-helpers';
 import { ResourcesListBatch } from '../../types/types';
 
 const heightOffset = 300;
@@ -51,22 +51,27 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
     ? externalAttributionsToResources[props.attributionId]
     : manualAttributionsToResources[props.attributionId];
 
-  const resourcesListBatches: Array<ResourcesListBatch> = [];
-
-  const { currentFolderResourceIds, otherFolderResourceIds } =
-    splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
-
   const header = `Resources for selected ${
     props.isExternalAttribution ? 'signal' : 'attribution'
   }`;
 
-  resourcesListBatches.push({ resourceIds: currentFolderResourceIds });
-  if (otherFolderResourceIds.length > 0) {
-    resourcesListBatches.push({
-      header: 'Resources in Other Folders',
-      resourceIds: otherFolderResourceIds,
-    });
+  function getResourcesListBatches(): Array<ResourcesListBatch> {
+    const resourcesListBatches: Array<ResourcesListBatch> = [];
+
+    const { currentFolderResourceIds, otherFolderResourceIds } =
+      splitResourceIdsToCurrentAndOtherFolder(allResourceIds, folderPath);
+
+    resourcesListBatches.push({ resourceIds: currentFolderResourceIds });
+    if (otherFolderResourceIds.length > 0) {
+      resourcesListBatches.push({
+        header: 'Resources in Other Folders',
+        resourceIds: otherFolderResourceIds,
+      });
+    }
+    return resourcesListBatches;
   }
+
+  const resourcesListBatches = getResourcesListBatches();
 
   return (
     <NotificationPopup

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -4,7 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
 import { doNothing } from '../../../util/do-nothing';
 import { ResourcePathPopup } from '../ResourcePathPopup';
 import {
@@ -16,6 +19,7 @@ import {
   setManualData,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { useDispatch } from 'react-redux';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { screen } from '@testing-library/react';
 
 interface HelperComponentProps {
@@ -32,6 +36,7 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
   };
   const resourcesToExternalAttributions: ResourcesToAttributions = {
     '/firstParty': ['uuid_1'],
+    '/folder/anotherFirstParty': ['uuid_1'],
   };
 
   dispatch(setExternalData(attributions, resourcesToExternalAttributions));
@@ -62,5 +67,28 @@ describe('ResourcePathPopup', () => {
 
     expect(screen.queryByText('Resources for selected signal')).toBeTruthy();
     expect(screen.queryByText('/firstParty')).toBeTruthy();
+  });
+
+  test('renders subheader, if resources in other folders exist', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId('/folder/anotherFirstParty'));
+    renderComponentWithStore(<HelperComponent isExternalAttribution={true} />, {
+      store: testStore,
+    });
+    expect(screen.queryByText('Resources in Other Folders')).toBeTruthy();
+
+    expect(screen.queryByText('/firstParty')).toBeTruthy();
+    expect(screen.queryByText('/folder/anotherFirstParty')).toBeTruthy();
+  });
+
+  test('renders no subheader, if no resources in other folders exist', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+    renderComponentWithStore(
+      <HelperComponent isExternalAttribution={false} />,
+      { store: testStore }
+    );
+    expect(screen.queryByText('Resources in Other Folders')).toBeFalsy();
+    expect(screen.queryByText('/thirdParty')).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -53,6 +53,8 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
 }
 
 describe('ResourcePathPopup', () => {
+  const resourcesInOtherFoldersHeader = 'Resources in Other Folders';
+
   test('renders resources for manual Attributions', () => {
     renderComponentWithStore(<HelperComponent isExternalAttribution={false} />);
 
@@ -75,8 +77,8 @@ describe('ResourcePathPopup', () => {
     renderComponentWithStore(<HelperComponent isExternalAttribution={true} />, {
       store: testStore,
     });
-    expect(screen.queryByText('Resources in Other Folders')).toBeTruthy();
 
+    expect(screen.queryByText(resourcesInOtherFoldersHeader)).toBeTruthy();
     expect(screen.queryByText('/firstParty')).toBeTruthy();
     expect(screen.queryByText('/folder/anotherFirstParty')).toBeTruthy();
   });
@@ -88,7 +90,7 @@ describe('ResourcePathPopup', () => {
       <HelperComponent isExternalAttribution={false} />,
       { store: testStore }
     );
-    expect(screen.queryByText('Resources in Other Folders')).toBeFalsy();
+    expect(screen.queryByText(resourcesInOtherFoldersHeader)).toBeFalsy();
     expect(screen.queryByText('/thirdParty')).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -3,44 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  insertHeaderForOtherFolderResourceIds,
-  splitResourceItToCurrentAndOtherFolder,
-} from '../resource-path-popup-helpers';
-
-describe('insertHeaderForOtherFolderResourceIds', () => {
-  test('inserts headers if resources in other folders present', () => {
-    const currentFolderResourceIds = ['resource_1'];
-    const otherFolderResourceIds = ['resource_2', 'resource_3'];
-
-    const headerIndices = insertHeaderForOtherFolderResourceIds(
-      currentFolderResourceIds,
-      otherFolderResourceIds
-    );
-
-    expect(headerIndices).toStrictEqual([1, 2]);
-    expect(currentFolderResourceIds).toStrictEqual([
-      'resource_1',
-      '',
-      'Resources in Other Folders',
-    ]);
-    expect(otherFolderResourceIds).toStrictEqual(['resource_2', 'resource_3']);
-  });
-
-  test('inserts no headers if no resources in other folders present', () => {
-    const currentFolderResourceIds = ['resource_1'];
-    const otherFolderResourceIds: string[] = [];
-
-    const headerIndices = insertHeaderForOtherFolderResourceIds(
-      currentFolderResourceIds,
-      otherFolderResourceIds
-    );
-
-    expect(headerIndices).toStrictEqual([]);
-    expect(currentFolderResourceIds).toStrictEqual(['resource_1']);
-    expect(otherFolderResourceIds).toStrictEqual([]);
-  });
-});
+import { splitResourceItToCurrentAndOtherFolder } from '../resource-path-popup-helpers';
 
 describe('splitResourceItToCurrentAndOtherFolder', () => {
   test('splits resource ids correctly', () => {
@@ -51,7 +14,7 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
     ];
     const folderPath = '/folder_1/';
 
-    const [currentFolderResourceIds, otherFolderResourceIds] =
+    const { currentFolderResourceIds, otherFolderResourceIds } =
       splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
 
     expect(currentFolderResourceIds).toStrictEqual([
@@ -65,7 +28,7 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
     const allResourceIds = undefined;
     const folderPath = '/folder_1/';
 
-    const [currentFolderResourceIds, otherFolderResourceIds] =
+    const { currentFolderResourceIds, otherFolderResourceIds } =
       // @ts-ignore
       splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
 

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  insertHeaderForOtherFolderResourceIds,
+  splitResourceItToCurrentAndOtherFolder,
+} from '../resource-path-popup-helpers';
+
+describe('insertHeaderForOtherFolderResourceIds', () => {
+  test('inserts headers if resources in other folders present', () => {
+    const currentFolderResourceIds = ['resource_1'];
+    const otherFolderResourceIds = ['resource_2', 'resource_3'];
+
+    const headerIndices = insertHeaderForOtherFolderResourceIds(
+      currentFolderResourceIds,
+      otherFolderResourceIds
+    );
+
+    expect(headerIndices).toStrictEqual([1, 2]);
+    expect(currentFolderResourceIds).toStrictEqual([
+      'resource_1',
+      '',
+      'Resources in Other Folders',
+    ]);
+    expect(otherFolderResourceIds).toStrictEqual(['resource_2', 'resource_3']);
+  });
+
+  test('inserts no headers if no resources in other folders present', () => {
+    const currentFolderResourceIds = ['resource_1'];
+    const otherFolderResourceIds: string[] = [];
+
+    const headerIndices = insertHeaderForOtherFolderResourceIds(
+      currentFolderResourceIds,
+      otherFolderResourceIds
+    );
+
+    expect(headerIndices).toStrictEqual([]);
+    expect(currentFolderResourceIds).toStrictEqual(['resource_1']);
+    expect(otherFolderResourceIds).toStrictEqual([]);
+  });
+});
+
+describe('splitResourceItToCurrentAndOtherFolder', () => {
+  test('splits resource ids correctly', () => {
+    const allResourceIds = [
+      '/folder_1/',
+      '/folder_1/resource_1',
+      '/folder_2/resource_3',
+    ];
+    const folderPath = '/folder_1/';
+
+    const [currentFolderResourceIds, otherFolderResourceIds] =
+      splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
+
+    expect(currentFolderResourceIds).toStrictEqual([
+      '/folder_1/',
+      '/folder_1/resource_1',
+    ]);
+    expect(otherFolderResourceIds).toStrictEqual(['/folder_2/resource_3']);
+  });
+
+  test('handles undefined allResourceIds correctly', () => {
+    const allResourceIds = undefined;
+    const folderPath = '/folder_1/';
+
+    const [currentFolderResourceIds, otherFolderResourceIds] =
+      // @ts-ignore
+      splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
+
+    expect(currentFolderResourceIds).toStrictEqual([]);
+    expect(otherFolderResourceIds).toStrictEqual([]);
+  });
+});

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { splitResourceItToCurrentAndOtherFolder } from '../resource-path-popup-helpers';
+import { splitResourceIdsToCurrentAndOtherFolder } from '../resource-path-popup-helpers';
 
 describe('splitResourceItToCurrentAndOtherFolder', () => {
   test('splits resource ids correctly', () => {
@@ -14,14 +14,21 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
     ];
     const folderPath = '/folder_1/';
 
-    const { currentFolderResourceIds, otherFolderResourceIds } =
-      splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
-
-    expect(currentFolderResourceIds).toStrictEqual([
+    const expectedOtherFolderResourceIds = ['/folder_2/resource_3'];
+    const expectedCurrentFolderResourceIds = [
       '/folder_1/',
       '/folder_1/resource_1',
-    ]);
-    expect(otherFolderResourceIds).toStrictEqual(['/folder_2/resource_3']);
+    ];
+
+    const { currentFolderResourceIds, otherFolderResourceIds } =
+      splitResourceIdsToCurrentAndOtherFolder(allResourceIds, folderPath);
+
+    expect(currentFolderResourceIds).toStrictEqual(
+      expectedCurrentFolderResourceIds
+    );
+    expect(otherFolderResourceIds).toStrictEqual(
+      expectedOtherFolderResourceIds
+    );
   });
 
   test('handles undefined allResourceIds correctly', () => {
@@ -30,7 +37,7 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
 
     const { currentFolderResourceIds, otherFolderResourceIds } =
       // @ts-ignore
-      splitResourceItToCurrentAndOtherFolder(allResourceIds, folderPath);
+      splitResourceIdsToCurrentAndOtherFolder(allResourceIds, folderPath);
 
     expect(currentFolderResourceIds).toStrictEqual([]);
     expect(otherFolderResourceIds).toStrictEqual([]);

--- a/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
+++ b/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export function splitResourceItToCurrentAndOtherFolder(
+export function splitResourceIdsToCurrentAndOtherFolder(
   allResourceIds: Array<string>,
   folderPath: string
 ): {
@@ -13,12 +13,11 @@ export function splitResourceItToCurrentAndOtherFolder(
   const currentFolderResourceIds: Array<string> = [];
   const otherFolderResourceIds: Array<string> = [];
 
-  (allResourceIds ?? []).forEach((resourceId) => {
+  allResourceIds?.forEach((resourceId) => {
     resourceId.startsWith(folderPath)
       ? currentFolderResourceIds.push(resourceId)
       : otherFolderResourceIds.push(resourceId);
   });
-  currentFolderResourceIds.sort();
   return {
     currentFolderResourceIds: currentFolderResourceIds,
     otherFolderResourceIds: otherFolderResourceIds,

--- a/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
+++ b/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function insertHeaderForOtherFolderResourceIds(
+  currentFolderResourceIds: string[],
+  otherFolderResourceIds: string[]
+): number[] {
+  const headerIndices: number[] = [];
+  const otherFolderResourceIdsHeader = 'Resources in Other Folders';
+
+  if (otherFolderResourceIds.length > 0) {
+    headerIndices.push(
+      currentFolderResourceIds.length,
+      currentFolderResourceIds.length + 1
+    );
+
+    currentFolderResourceIds.push('', otherFolderResourceIdsHeader);
+    otherFolderResourceIds.sort();
+  }
+  return headerIndices;
+}
+
+export function splitResourceItToCurrentAndOtherFolder(
+  allResourceIds: string[],
+  folderPath: string
+): [string[], string[]] {
+  const currentFolderResourceIds: string[] = [];
+  const otherFolderResourceIds: string[] = [];
+
+  (allResourceIds ?? []).forEach((resourceId) => {
+    resourceId.startsWith(folderPath)
+      ? currentFolderResourceIds.push(resourceId)
+      : otherFolderResourceIds.push(resourceId);
+  });
+  currentFolderResourceIds.sort();
+  return [currentFolderResourceIds, otherFolderResourceIds];
+}
+
+export function mergeCurrentAndOtherFolderResourceIds(
+  currentFolderResourceIds: string[],
+  otherFolderResourceIds: string[]
+): string[] {
+  const allResourceIds = [];
+  for (const resourceId of currentFolderResourceIds)
+    allResourceIds.push(resourceId);
+
+  for (const resourceId of otherFolderResourceIds)
+    allResourceIds.push(resourceId);
+  return allResourceIds;
+}

--- a/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
+++ b/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
@@ -3,31 +3,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export function insertHeaderForOtherFolderResourceIds(
-  currentFolderResourceIds: string[],
-  otherFolderResourceIds: string[]
-): number[] {
-  const headerIndices: number[] = [];
-  const otherFolderResourceIdsHeader = 'Resources in Other Folders';
-
-  if (otherFolderResourceIds.length > 0) {
-    headerIndices.push(
-      currentFolderResourceIds.length,
-      currentFolderResourceIds.length + 1
-    );
-
-    currentFolderResourceIds.push('', otherFolderResourceIdsHeader);
-    otherFolderResourceIds.sort();
-  }
-  return headerIndices;
-}
-
 export function splitResourceItToCurrentAndOtherFolder(
-  allResourceIds: string[],
+  allResourceIds: Array<string>,
   folderPath: string
-): [string[], string[]] {
-  const currentFolderResourceIds: string[] = [];
-  const otherFolderResourceIds: string[] = [];
+): {
+  currentFolderResourceIds: Array<string>;
+  otherFolderResourceIds: Array<string>;
+} {
+  const currentFolderResourceIds: Array<string> = [];
+  const otherFolderResourceIds: Array<string> = [];
 
   (allResourceIds ?? []).forEach((resourceId) => {
     resourceId.startsWith(folderPath)
@@ -35,18 +19,8 @@ export function splitResourceItToCurrentAndOtherFolder(
       : otherFolderResourceIds.push(resourceId);
   });
   currentFolderResourceIds.sort();
-  return [currentFolderResourceIds, otherFolderResourceIds];
-}
-
-export function mergeCurrentAndOtherFolderResourceIds(
-  currentFolderResourceIds: string[],
-  otherFolderResourceIds: string[]
-): string[] {
-  const allResourceIds = [];
-  for (const resourceId of currentFolderResourceIds)
-    allResourceIds.push(resourceId);
-
-  for (const resourceId of otherFolderResourceIds)
-    allResourceIds.push(resourceId);
-  return allResourceIds;
+  return {
+    currentFolderResourceIds: currentFolderResourceIds,
+    otherFolderResourceIds: otherFolderResourceIds,
+  };
 }

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles({
 
 interface ResourcesListProps {
   resourceIds: Array<string>;
+  headerIndices?: Array<number>;
   maxHeight?: number;
   onClickCallback?: () => void;
 }
@@ -32,7 +33,9 @@ export function ResourcesList(props: ResourcesListProps): ReactElement {
 
   const isFileWithChildren = useSelector(getIsFileWithChildren);
   const dispatch = useDispatch();
-  const sortedResourcePaths = props.resourceIds.sort();
+  const sortedResourcePaths = props.headerIndices
+    ? props.resourceIds
+    : props.resourceIds.sort();
   const onClickCallback = props.onClickCallback ?? doNothing;
 
   function getResourceCard(index: number): ReactElement {
@@ -41,6 +44,16 @@ export function ResourcesList(props: ResourcesListProps): ReactElement {
     function onPathClick(): void {
       dispatch(navigateToSelectedPathOrOpenUnsavedPopup(resourcePath));
       onClickCallback();
+    }
+
+    if (props.headerIndices && props.headerIndices.includes(index)) {
+      return (
+        <ListCard
+          text={resourcePath}
+          onClick={doNothing}
+          cardConfig={{ isHeader: true }}
+        />
+      );
     }
 
     return (

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -13,8 +13,8 @@ import { doNothing } from '../../util/do-nothing';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
 import { getIsFileWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { OpossumColors } from '../../shared-styles';
-import { ResourcesListBatch, ResourcesListItem } from '../../types/types';
 import { convertResourcesListBatchesToResourcesListItems } from './resource-list-helpers';
+import { ResourcesListBatch } from '../../types/types';
 
 const useStyles = makeStyles({
   root: {
@@ -29,6 +29,11 @@ interface ResourcesListProps {
   onClickCallback?: () => void;
 }
 
+export interface ResourcesListItem {
+  text: string;
+  isHeader?: boolean;
+}
+
 export function ResourcesList(props: ResourcesListProps): ReactElement {
   const classes = useStyles();
 
@@ -36,15 +41,16 @@ export function ResourcesList(props: ResourcesListProps): ReactElement {
   const dispatch = useDispatch();
   const onClickCallback = props.onClickCallback ?? doNothing;
 
-  props.resourcesListBatches.forEach((resourcesListBatch) => {
-    resourcesListBatch.resourceIds.sort();
-  });
-
   const resourcesListItems: Array<ResourcesListItem> =
     convertResourcesListBatchesToResourcesListItems(props.resourcesListBatches);
 
   function getResourceCard(index: number): ReactElement {
     const cardText: string = resourcesListItems[index].text;
+    const isHeader = resourcesListItems[index].isHeader;
+
+    const formattedText = isHeader
+      ? cardText
+      : removeTrailingSlashIfFileWithChildren(cardText, isFileWithChildren);
 
     function onPathClick(): void {
       dispatch(navigateToSelectedPathOrOpenUnsavedPopup(cardText));
@@ -53,20 +59,9 @@ export function ResourcesList(props: ResourcesListProps): ReactElement {
 
     return (
       <ListCard
-        text={
-          resourcesListItems[index].isHeader
-            ? cardText
-            : removeTrailingSlashIfFileWithChildren(
-                cardText,
-                isFileWithChildren
-              )
-        }
-        onClick={resourcesListItems[index].isHeader ? doNothing : onPathClick}
-        cardConfig={
-          resourcesListItems[index].isHeader
-            ? { isHeader: true }
-            : { isResource: true }
-        }
+        text={formattedText}
+        onClick={isHeader ? doNothing : onPathClick}
+        cardConfig={isHeader ? { isHeader: true } : { isResource: true }}
       />
     );
   }

--- a/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
+++ b/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
@@ -15,6 +15,7 @@ import {
   getSelectedResourceId,
 } from '../../../state/selectors/audit-view-resource-selectors';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { ResourcesListBatch } from '../../../types/types';
 
 describe('The ResourcesList', () => {
   const resourceIdsOfSelectedAttributionId = [
@@ -22,13 +23,20 @@ describe('The ResourcesList', () => {
     'resource_2',
   ];
 
+  const resourcesListBatches: Array<ResourcesListBatch> = [
+    { resourceIds: resourceIdsOfSelectedAttributionId },
+  ];
+
+  const expectedExpandedIds = [
+    '/',
+    '/folder1/',
+    '/folder1/folder2/',
+    '/folder1/folder2/resource_1',
+  ];
+
   test('component renders', () => {
     renderComponentWithStore(
-      <ResourcesList
-        resourcesListBatches={[
-          { resourceIds: resourceIdsOfSelectedAttributionId },
-        ]}
-      />
+      <ResourcesList resourcesListBatches={resourcesListBatches} />
     );
     expect(screen.getByText('/folder1/folder2/resource_1')).toBeTruthy();
     expect(screen.getByText('resource_2')).toBeTruthy();
@@ -36,71 +44,56 @@ describe('The ResourcesList', () => {
 
   test('clicking on a path changes the view, selectedResourceId and expandedResources without user callback', () => {
     const { store } = renderComponentWithStore(
-      <ResourcesList
-        resourcesListBatches={[
-          { resourceIds: resourceIdsOfSelectedAttributionId },
-        ]}
-      />
+      <ResourcesList resourcesListBatches={resourcesListBatches} />
     );
     store.dispatch(navigateToView(View.Attribution));
+    const examplePath = '/folder1/folder2/resource_1';
 
-    fireEvent.click(screen.getByText('/folder1/folder2/resource_1'));
+    fireEvent.click(screen.getByText(examplePath));
 
-    expect(getSelectedResourceId(store.getState())).toBe(
-      '/folder1/folder2/resource_1'
-    );
+    expect(getSelectedResourceId(store.getState())).toBe(examplePath);
     expect(getSelectedView(store.getState())).toBe(View.Audit);
-    expect(getExpandedIds(store.getState())).toMatchObject([
-      '/',
-      '/folder1/',
-      '/folder1/folder2/',
-      '/folder1/folder2/resource_1',
-    ]);
+    expect(getExpandedIds(store.getState())).toMatchObject(expectedExpandedIds);
   });
 
   test('clicking on a path changes the view, selectedResourceId and expandedResources with user callback', () => {
     const onClickCallback = jest.fn();
     const { store } = renderComponentWithStore(
       <ResourcesList
-        resourcesListBatches={[
-          { resourceIds: resourceIdsOfSelectedAttributionId },
-        ]}
+        resourcesListBatches={resourcesListBatches}
         onClickCallback={onClickCallback}
       />
     );
     store.dispatch(navigateToView(View.Attribution));
+    const examplePath = '/folder1/folder2/resource_1';
 
-    fireEvent.click(screen.getByText('/folder1/folder2/resource_1'));
+    fireEvent.click(screen.getByText(examplePath));
 
     expect(onClickCallback).toHaveBeenCalled();
-    expect(getSelectedResourceId(store.getState())).toBe(
-      '/folder1/folder2/resource_1'
-    );
+    expect(getSelectedResourceId(store.getState())).toBe(examplePath);
     expect(getSelectedView(store.getState())).toBe(View.Audit);
-    expect(getExpandedIds(store.getState())).toMatchObject([
-      '/',
-      '/folder1/',
-      '/folder1/folder2/',
-      '/folder1/folder2/resource_1',
-    ]);
+    expect(getExpandedIds(store.getState())).toMatchObject(expectedExpandedIds);
   });
 
   test('clicking on a header does nothing', () => {
     const onClickCallback = jest.fn();
+    const resourcesListBatchesWithHeader: Array<ResourcesListBatch> = [
+      {
+        header: 'Header',
+        resourceIds: [
+          ...resourceIdsOfSelectedAttributionId,
+          '/folder3/folder4/',
+        ],
+      },
+    ];
+
     const { store } = renderComponentWithStore(
       <ResourcesList
-        resourcesListBatches={[
-          {
-            header: 'Header',
-            resourceIds: [
-              ...resourceIdsOfSelectedAttributionId,
-              '/folder3/folder4/',
-            ],
-          },
-        ]}
+        resourcesListBatches={resourcesListBatchesWithHeader}
         onClickCallback={onClickCallback}
       />
     );
+
     store.dispatch(navigateToView(View.Attribution));
     store.dispatch(setSelectedResourceId('/'));
 

--- a/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
+++ b/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
@@ -24,14 +24,23 @@ describe('The ResourcesList', () => {
 
   test('component renders', () => {
     renderComponentWithStore(
-      <ResourcesList resourceIds={resourceIdsOfSelectedAttributionId} />
+      <ResourcesList
+        resourcesListBatches={[
+          { resourceIds: resourceIdsOfSelectedAttributionId },
+        ]}
+      />
     );
     expect(screen.getByText('/folder1/folder2/resource_1')).toBeTruthy();
     expect(screen.getByText('resource_2')).toBeTruthy();
   });
+
   test('clicking on a path changes the view, selectedResourceId and expandedResources without user callback', () => {
     const { store } = renderComponentWithStore(
-      <ResourcesList resourceIds={resourceIdsOfSelectedAttributionId} />
+      <ResourcesList
+        resourcesListBatches={[
+          { resourceIds: resourceIdsOfSelectedAttributionId },
+        ]}
+      />
     );
     store.dispatch(navigateToView(View.Attribution));
 
@@ -48,11 +57,14 @@ describe('The ResourcesList', () => {
       '/folder1/folder2/resource_1',
     ]);
   });
+
   test('clicking on a path changes the view, selectedResourceId and expandedResources with user callback', () => {
     const onClickCallback = jest.fn();
     const { store } = renderComponentWithStore(
       <ResourcesList
-        resourceIds={resourceIdsOfSelectedAttributionId}
+        resourcesListBatches={[
+          { resourceIds: resourceIdsOfSelectedAttributionId },
+        ]}
         onClickCallback={onClickCallback}
       />
     );
@@ -77,13 +89,16 @@ describe('The ResourcesList', () => {
     const onClickCallback = jest.fn();
     const { store } = renderComponentWithStore(
       <ResourcesList
-        resourceIds={[
-          ...resourceIdsOfSelectedAttributionId,
-          'Header',
-          '/folder3/folder4/',
+        resourcesListBatches={[
+          {
+            header: 'Header',
+            resourceIds: [
+              ...resourceIdsOfSelectedAttributionId,
+              '/folder3/folder4/',
+            ],
+          },
         ]}
         onClickCallback={onClickCallback}
-        headerIndices={[resourceIdsOfSelectedAttributionId.length]}
       />
     );
     store.dispatch(navigateToView(View.Attribution));

--- a/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
+++ b/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
@@ -14,6 +14,7 @@ import {
   getExpandedIds,
   getSelectedResourceId,
 } from '../../../state/selectors/audit-view-resource-selectors';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
 describe('The ResourcesList', () => {
   const resourceIdsOfSelectedAttributionId = [
@@ -70,5 +71,28 @@ describe('The ResourcesList', () => {
       '/folder1/folder2/',
       '/folder1/folder2/resource_1',
     ]);
+  });
+
+  test('clicking on a header does nothing', () => {
+    const onClickCallback = jest.fn();
+    const { store } = renderComponentWithStore(
+      <ResourcesList
+        resourceIds={[
+          ...resourceIdsOfSelectedAttributionId,
+          'Header',
+          '/folder3/folder4/',
+        ]}
+        onClickCallback={onClickCallback}
+        headerIndices={[resourceIdsOfSelectedAttributionId.length]}
+      />
+    );
+    store.dispatch(navigateToView(View.Attribution));
+    store.dispatch(setSelectedResourceId('/'));
+
+    fireEvent.click(screen.getByText('Header'));
+
+    expect(onClickCallback).toHaveBeenCalledTimes(0);
+    expect(getSelectedResourceId(store.getState())).toBe('/');
+    expect(getSelectedView(store.getState())).toBe(View.Attribution);
   });
 });

--- a/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
+++ b/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { convertResourcesListBatchesToResourcesListItems } from '../resource-list-helpers';
+
+describe('convertResourceListBatchesToResourceListItems', () => {
+  test('inserts headers correctly', () => {
+    const resourcesListBatches = [
+      { resourceIds: ['resource_1'] },
+      {
+        resourceIds: ['resource_2', 'resource_3'],
+        header: 'Resources in Other Folders',
+      },
+    ];
+
+    const resourcesListItems =
+      convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
+
+    expect(resourcesListItems).toStrictEqual([
+      { text: 'resource_1' },
+      { text: '', isHeader: true },
+      { text: 'Resources in Other Folders', isHeader: true },
+      { text: 'resource_2' },
+      { text: 'resource_3' },
+    ]);
+  });
+
+  test('inserts no empty line for header at start of table', () => {
+    const resourcesListBatches = [
+      { resourceIds: ['resource_1'], header: 'Header' },
+    ];
+
+    const resourcesListItems =
+      convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
+
+    expect(resourcesListItems).toStrictEqual([
+      { text: 'Header', isHeader: true },
+      { text: 'resource_1' },
+    ]);
+  });
+});

--- a/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
+++ b/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { convertResourcesListBatchesToResourcesListItems } from '../resource-list-helpers';
+import { ResourcesListItem } from '../ResourcesList';
+import { ResourcesListBatch } from '../../../types/types';
 
 describe('convertResourceListBatchesToResourceListItems', () => {
   test('inserts headers correctly', () => {
-    const resourcesListBatches = [
+    const resourcesListBatches: Array<ResourcesListBatch> = [
       { resourceIds: ['resource_1'] },
       {
         resourceIds: ['resource_2', 'resource_3'],
@@ -15,29 +17,57 @@ describe('convertResourceListBatchesToResourceListItems', () => {
       },
     ];
 
-    const resourcesListItems =
-      convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
-
-    expect(resourcesListItems).toStrictEqual([
+    const expectedResourcesListItems: Array<ResourcesListItem> = [
       { text: 'resource_1' },
       { text: '', isHeader: true },
       { text: 'Resources in Other Folders', isHeader: true },
       { text: 'resource_2' },
       { text: 'resource_3' },
-    ]);
-  });
-
-  test('inserts no empty line for header at start of table', () => {
-    const resourcesListBatches = [
-      { resourceIds: ['resource_1'], header: 'Header' },
     ];
 
     const resourcesListItems =
       convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
 
-    expect(resourcesListItems).toStrictEqual([
+    expect(resourcesListItems).toStrictEqual(expectedResourcesListItems);
+  });
+
+  test('executes case insensitive sort on resourceIds of each batch', () => {
+    const resourcesListBatches: Array<ResourcesListBatch> = [
+      { resourceIds: ['README.md', 'package.json'] },
+      {
+        resourceIds: ['resource_3', 'resource_2'],
+        header: 'Resources in Other Folders',
+      },
+    ];
+
+    const expectedResourcesListItems: Array<ResourcesListItem> = [
+      { text: 'package.json' },
+      { text: 'README.md' },
+      { text: '', isHeader: true },
+      { text: 'Resources in Other Folders', isHeader: true },
+      { text: 'resource_2' },
+      { text: 'resource_3' },
+    ];
+
+    const resourcesListItems =
+      convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
+
+    expect(resourcesListItems).toStrictEqual(expectedResourcesListItems);
+  });
+
+  test('inserts no empty line for header at start of table', () => {
+    const resourcesListBatches: Array<ResourcesListBatch> = [
+      { resourceIds: ['resource_1'], header: 'Header' },
+    ];
+
+    const expectedResourcesListItems: Array<ResourcesListItem> = [
       { text: 'Header', isHeader: true },
       { text: 'resource_1' },
-    ]);
+    ];
+
+    const resourcesListItems =
+      convertResourcesListBatchesToResourcesListItems(resourcesListBatches);
+
+    expect(resourcesListItems).toStrictEqual(expectedResourcesListItems);
   });
 });

--- a/src/Frontend/Components/ResourcesList/resource-list-helpers.ts
+++ b/src/Frontend/Components/ResourcesList/resource-list-helpers.ts
@@ -3,12 +3,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesListBatch, ResourcesListItem } from '../../types/types';
+import { ResourcesListItem } from './ResourcesList';
+import { ResourcesListBatch } from '../../types/types';
 
 export function convertResourcesListBatchesToResourcesListItems(
   resourcesListBatches: Array<ResourcesListBatch>
 ): Array<ResourcesListItem> {
   const resourcesListItems: Array<ResourcesListItem> = [];
+
+  resourcesListBatches.forEach((resourcesListBatch) => {
+    resourcesListBatch.resourceIds.sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: 'base' })
+    );
+  });
+
   resourcesListBatches.forEach((resourcesListBatch) => {
     if (resourcesListBatch.header) {
       if (resourcesListItems.length > 0) {

--- a/src/Frontend/Components/ResourcesList/resource-list-helpers.ts
+++ b/src/Frontend/Components/ResourcesList/resource-list-helpers.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourcesListBatch, ResourcesListItem } from '../../types/types';
+
+export function convertResourcesListBatchesToResourcesListItems(
+  resourcesListBatches: Array<ResourcesListBatch>
+): Array<ResourcesListItem> {
+  const resourcesListItems: Array<ResourcesListItem> = [];
+  resourcesListBatches.forEach((resourcesListBatch) => {
+    if (resourcesListBatch.header) {
+      if (resourcesListItems.length > 0) {
+        resourcesListItems.push({ text: '', isHeader: true });
+      }
+      resourcesListItems.push({
+        text: resourcesListBatch.header,
+        isHeader: true,
+      });
+    }
+    resourcesListBatch.resourceIds.forEach((resourceId) => {
+      resourcesListItems.push({
+        text: resourceId,
+      });
+    });
+  });
+  return resourcesListItems;
+}

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -105,7 +105,7 @@ export function addUnresolvedAttributionsToResourcesWithAttributedChildren(
 
 export function removeResolvedAttributionsFromResourcesWithAttributedChildren(
   resourcesWithAttributedChildren: ResourcesWithAttributedChildren,
-  resourceIds: string[]
+  resourceIds: Array<string>
 ): void {
   resourceIds.forEach((resourceId) => {
     deleteChildrenFromAttributedResources(

--- a/src/Frontend/state/helpers/file-search-helpers.ts
+++ b/src/Frontend/state/helpers/file-search-helpers.ts
@@ -24,7 +24,10 @@ function getPathsFromResourcesHelper(
     }`;
     paths.push(path);
     if (canHaveChildren(resource)) {
-      const newPaths: string[] = getPathsFromResourcesHelper(resource, path);
+      const newPaths: Array<string> = getPathsFromResourcesHelper(
+        resource,
+        path
+      );
       // Do not replace with spread operator (can lead to stack overflow exception)
       newPaths.forEach((path) => {
         paths.push(path);

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -64,6 +64,7 @@ export interface ListCardConfig {
   excludeFromNotice?: boolean;
   firstParty?: boolean;
   followUp?: boolean;
+  isHeader?: boolean;
 }
 
 export interface PathPredicate {

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -70,3 +70,13 @@ export interface ListCardConfig {
 export interface PathPredicate {
   (path: string): boolean;
 }
+
+export interface ResourcesListBatch {
+  resourceIds: Array<string>;
+  header?: string;
+}
+
+export interface ResourcesListItem {
+  text: string;
+  isHeader?: boolean;
+}

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -75,8 +75,3 @@ export interface ResourcesListBatch {
   resourceIds: Array<string>;
   header?: string;
 }
-
-export interface ResourcesListItem {
-  text: string;
-  isHeader?: boolean;
-}


### PR DESCRIPTION
If resources in other folders exist, the resource list shows the resources in the current folder at the top and the resources in other folders underneath, separated by a new header.

Signed-off-by: Jonas Tai <jonas.tai@tngtech.com>