### PR TITLE
Only highlight file and folder names in tree, not the background

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -46,7 +46,6 @@ const useStyles = makeStyles({
     height: '100%',
   },
   treeItemLabel: {
-    flex: 1,
     height: 19,
     whiteSpace: 'nowrap',
     '&:hover': {


### PR DESCRIPTION
For very long paths, the highlighting in the tree became
inconsistent. This bug can be avoided by only highlighting the
selected resource names, just like many other file browsers.

![Screenshot_20211004_154758](https://user-images.githubusercontent.com/14236667/135863499-d98d044e-a890-4666-8dbd-ed1237e70ab5.png)

![Screenshot_20211004_154822](https://user-images.githubusercontent.com/14236667/135863524-5f5d66fb-b994-4a7a-bd28-24e0279d7a83.png)