### PR TITLE
allow opening the folder that has the base url attached

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -226,7 +226,7 @@
     "/package.json/"
   ],
   "baseUrlsForSources": {
-    "/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a2",
+    "/": "https://github.com/opossum-tool/OpossumUI/blob/main/src/{path}?test=bla",
     "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4"
   },
   "externalAttributionSources": {

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -38,7 +38,9 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
   );
 
   function getOpenLinkArgs(): OpenLinkArgs {
-    const sortedParents = getParents(path).sort((a, b) => b.length - a.length);
+    const sortedParents = getParents(path)
+      .concat([path])
+      .sort((a, b) => b.length - a.length);
 
     let link = '';
     for (let index = 0; index < sortedParents.length; index++) {


### PR DESCRIPTION
Before this PR it was not possible to navigate to the sources of a file that had a base-url set in the input file. Indeed the corresponding icon triggering this action was not displayed.
Here this issue is fixed such that these files have now the respective icon displayed.
