### PR TITLE
add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/typescript-node/.devcontainer/base.Dockerfile
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"runArgs": ["--init"],
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			"VARIANT": "16-bullseye"
+		}
+	},
+
+	"settings": {},
+
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// "forwardPorts": [],
+
+	"postCreateCommand": "yarn install",
+
+	"remoteUser": "node",
+	"features": {
+		"git": "latest",
+		"desktop-lite": "latest",
+		"python": "latest"
+	}
+}


### PR DESCRIPTION
This adds [devcontainer](https://code.visualstudio.com/docs/remote/containers) support for developing containerized within vscode.

This should also allow to use GitHub Codespaces.
