### PR TITLE
Remove @reduxjs/toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.60",
-    "@reduxjs/toolkit": "^1.6.2",
     "clsx": "^1.1.1",
     "electron-devtools-installer": "^3.2.0",
     "electron-is-dev": "^2.0.0",

--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -7,7 +7,6 @@ import MuiPaper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography/Typography';
 import React, { ReactElement } from 'react';
-import { useDispatch } from 'react-redux';
 import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInAccordionPanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -16,6 +15,7 @@ import { FilteredList } from '../FilteredList/FilteredList';
 import { PackagePanelCard } from '../PackagePanelCard/PackagePanelCard';
 import { OpossumColors } from '../../shared-styles';
 import { ListCardConfig } from '../../types/types';
+import { useAppDispatch } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -35,7 +35,7 @@ export function AllAttributionsPanel(
   props: AllAttributionsPanelProps
 ): ReactElement {
   const classes = useStyles();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function getPackagePanelCard(attributionId: string): ReactElement | null {
     const packageInfo = props.attributions && props.attributions[attributionId];

--- a/src/Frontend/Components/App/App.tsx
+++ b/src/Frontend/Components/App/App.tsx
@@ -5,7 +5,6 @@
 
 import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import { View } from '../../enums/enums';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
@@ -15,6 +14,7 @@ import { GlobalPopup } from '../GlobalPopup/GlobalPopup';
 import { AuditView } from '../AuditView/AuditView';
 import { TopBar } from '../TopBar/TopBar';
 import { createTheme } from '@material-ui/core';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -54,7 +54,7 @@ const theme = createTheme({
 
 export function App(): ReactElement {
   const classes = useStyles();
-  const selectedView = useSelector(getSelectedView);
+  const selectedView = useAppSelector(getSelectedView);
 
   function getSelectedViewContainer(): ReactElement {
     switch (selectedView) {

--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -6,7 +6,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+
 import { PackageInfo } from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
@@ -49,6 +49,7 @@ import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { ButtonText, PopupType } from '../../enums/enums';
 import { MainButtonConfig } from '../ButtonGroup/ButtonGroup';
 import { ContextMenuItem } from '../ContextMenu/ContextMenu';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -80,22 +81,24 @@ interface AttributionColumnProps {
 export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const classes = useStyles();
 
-  const dispatch = useDispatch();
-  const initialPackageInfo = useSelector(getPackageInfoOfSelected);
-  const selectedPackage = useSelector(getDisplayedPackage);
-  const resolvedExternalAttributions = useSelector(
+  const dispatch = useAppDispatch();
+  const initialPackageInfo = useAppSelector(getPackageInfoOfSelected);
+  const selectedPackage = useAppSelector(getDisplayedPackage);
+  const resolvedExternalAttributions = useAppSelector(
     getResolvedExternalAttributions
   );
-  const temporaryPackageInfo: PackageInfo = useSelector(
+  const temporaryPackageInfo: PackageInfo = useAppSelector(
     getTemporaryPackageInfo
   );
-  const packageInfoWereModified = useSelector(wereTemporaryPackageInfoModified);
-  const isSavingDisabled = useSelector(getIsSavingDisabled);
-  const selectedAttributionId = useSelector(getSelectedAttributionId);
-  const attributionIdMarkedForReplacement = useSelector(
+  const packageInfoWereModified = useAppSelector(
+    wereTemporaryPackageInfoModified
+  );
+  const isSavingDisabled = useAppSelector(getIsSavingDisabled);
+  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const attributionIdMarkedForReplacement = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const view = useSelector(getSelectedView);
+  const view = useAppSelector(getSelectedView);
 
   const {
     isLicenseTextShown,

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -16,8 +16,8 @@ import { Dropdown } from '../InputElements/Dropdown';
 import { NumberBox } from '../InputElements/NumberBox';
 import { TextBox } from '../InputElements/TextBox';
 import { useAttributionColumnStyles } from './shared-attribution-column-styles';
-import { useSelector } from 'react-redux';
 import { getExternalAttributionSources } from '../../state/selectors/all-views-resource-selectors';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   confidenceDropDown: {
@@ -51,7 +51,7 @@ interface AuditingSubPanelProps {
 
 export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
   const classes = { ...useAttributionColumnStyles(), ...useStyles() };
-  const attributionSources = useSelector(getExternalAttributionSources);
+  const attributionSources = useAppSelector(getExternalAttributionSources);
 
   return (
     <MuiPaper className={classes.panel} elevation={0} square={true}>

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -7,7 +7,6 @@ import MuiPaper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import { PackageInfo } from '../../../shared/shared-types';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
 import { doNothing } from '../../util/do-nothing';
@@ -20,6 +19,7 @@ import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import MuiAccordionDetails from '@material-ui/core/AccordionDetails';
 import { useAttributionColumnStyles } from './shared-attribution-column-styles';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   expansionPanel: {
@@ -65,7 +65,9 @@ interface LicenseSubPanelProps {
 export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
   const classes = { ...useAttributionColumnStyles(), ...useStyles() };
 
-  const frequentLicensesNameOrder = useSelector(getFrequentLicensesNameOrder);
+  const frequentLicensesNameOrder = useAppSelector(
+    getFrequentLicensesNameOrder
+  );
 
   function toggleIsLicenseTextShown(): void {
     props.setIsLicenseTextShown(!props.isLicenseTextShown);

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -6,7 +6,7 @@
 import { View } from '../../enums/enums';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { FollowUp, PackageInfo } from '../../../shared/shared-types';
-import { SimpleThunkDispatch } from '../../state/actions/types';
+import { AppThunkDispatch } from '../../state/types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { PanelPackage } from '../../types/types';
 import {
@@ -55,7 +55,7 @@ export function getLicenseTextMaxRows(
 
 export function getDiscreteConfidenceChangeHandler(
   temporaryPackageInfo: PackageInfo,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<{ value: unknown }>) => void {
   return (event): void => {
     dispatch(
@@ -69,7 +69,7 @@ export function getDiscreteConfidenceChangeHandler(
 
 export function getFollowUpChangeHandler(
   temporaryPackageInfo: PackageInfo,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
     dispatch(
@@ -83,7 +83,7 @@ export function getFollowUpChangeHandler(
 
 export function getExcludeFromNoticeChangeHandler(
   temporaryPackageInfo: PackageInfo,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
     dispatch(
@@ -97,7 +97,7 @@ export function getExcludeFromNoticeChangeHandler(
 
 export function getFirstPartyChangeHandler(
   temporaryPackageInfo: PackageInfo,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
     dispatch(
@@ -112,7 +112,7 @@ export function getFirstPartyChangeHandler(
 export function getResolvedToggleHandler(
   selectedPackage: PanelPackage | null,
   resolvedExternalAttributions: Set<string>,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): () => void {
   return (): void => {
     if (selectedPackage) {
@@ -189,7 +189,7 @@ export function getMergeButtonsDisplayState(
 }
 
 export function usePurl(
-  dispatch: SimpleThunkDispatch,
+  dispatch: AppThunkDispatch,
   packageInfoWereModified: boolean,
   temporaryPackageInfo: PackageInfo,
   displayPackageInfo: PackageInfo,

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -6,7 +6,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography';
 import React, { ReactElement, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { PackageInfo } from '../../../shared/shared-types';
 import { getTemporaryPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
@@ -53,16 +53,16 @@ const useStyles = makeStyles({
 export function AttributionDetailsViewer(): ReactElement | null {
   const classes = useStyles();
 
-  const selectedAttributionId = useSelector(getSelectedAttributionId);
-  const temporaryPackageInfo = useSelector(getTemporaryPackageInfo);
-  const resourceIdsOfSelectedAttributionId: Array<string> = useSelector(
+  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
+  const resourceIdsOfSelectedAttributionId: Array<string> = useAppSelector(
     getResourceIdsOfSelectedAttribution,
     isEqual
   );
 
   const resourceListMaxHeight = useWindowHeight() - 112;
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const saveFileRequestListener = useCallback(() => {
     dispatch(

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -5,7 +5,7 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -44,13 +44,15 @@ const useStyles = makeStyles({
 
 export function AttributionView(): ReactElement {
   const classes = useStyles();
-  const dispatch = useDispatch();
-  const attributions: Attributions = useSelector(getManualAttributions);
-  const selectedAttributionId: string = useSelector(getSelectedAttributionId);
-  const attributionIdMarkedForReplacement: string = useSelector(
+  const dispatch = useAppDispatch();
+  const attributions: Attributions = useAppSelector(getManualAttributions);
+  const selectedAttributionId: string = useAppSelector(
+    getSelectedAttributionId
+  );
+  const attributionIdMarkedForReplacement: string = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const filterForFollowUp = useSelector(areOnlyFollowUpAttributionsShown);
+  const filterForFollowUp = useAppSelector(areOnlyFollowUpAttributionsShown);
 
   const { handleFilterChange, getFilteredAttributions } = provideFollowUpFilter(
     filterForFollowUp,

--- a/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
@@ -4,16 +4,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
 import { getAttributionIdOfDisplayedPackageInManualPanel } from '../../state/selectors/audit-view-resource-selectors';
 
 export function ConfirmDeletionGloballyPopup(): ReactElement {
   const attributionIdOfSelectedPackageInManualPanel: string | null =
-    useSelector(getAttributionIdOfDisplayedPackageInManualPanel);
+    useAppSelector(getAttributionIdOfDisplayedPackageInManualPanel);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function deleteAttributionGlobally(): void {
     if (attributionIdOfSelectedPackageInManualPanel) {

--- a/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import {
@@ -19,13 +19,13 @@ import { getSelectedAttributionId } from '../../state/selectors/attribution-view
 import { View } from '../../enums/enums';
 
 export function ConfirmDeletionPopup(): ReactElement {
-  const view = useSelector(getSelectedView);
-  const selectedResourceId = useSelector(getSelectedResourceId);
-  const selectedAttributionId = useSelector(getSelectedAttributionId);
+  const view = useAppSelector(getSelectedView);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
   const attributionIdOfSelectedPackageInManualPanel: string | null =
-    useSelector(getAttributionIdOfDisplayedPackageInManualPanel);
+    useAppSelector(getAttributionIdOfDisplayedPackageInManualPanel);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function deleteAttributionForResource(): void {
     if (view === View.Audit) {

--- a/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch } from 'react-redux';
 import { ButtonText } from '../../enums/enums';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { useAppDispatch } from '../../state/hooks';
 
 interface ConfirmationPopupProps {
   onConfirmation(): void;
@@ -16,7 +16,7 @@ interface ConfirmationPopupProps {
 }
 
 export function ConfirmationPopup(props: ConfirmationPopupProps): ReactElement {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function handleDeletionClick(): void {
     props.onConfirmation();

--- a/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
+++ b/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
@@ -5,13 +5,13 @@
 
 import React, { ReactElement } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { useDispatch } from 'react-redux';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { useAppDispatch } from '../../state/hooks';
 
 export const TIME_POPUP_IS_DISPLAYED = 1500;
 
 export function ErrorPopup(): ReactElement {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function close(): void {
     dispatch(closePopup());

--- a/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
+++ b/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
@@ -5,15 +5,15 @@
 
 import React, { ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { useDispatch } from 'react-redux';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { ButtonText } from '../../enums/enums';
 import { ResourcesList } from '../ResourcesList/ResourcesList';
 import { FileSearchTextField } from '../FileSearchTextField/FileSearchTextField';
 import { useWindowHeight } from '../../util/use-window-height';
+import { useAppDispatch } from '../../state/hooks';
 
 export function FileSearchPopup(): ReactElement {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const [filteredPaths, setFilteredPaths] = useState<Array<string>>([]);
   const fileSearchPopupOffset = 260;
   const maxPossibleHeightInPx = useWindowHeight() - fileSearchPopupOffset;

--- a/src/Frontend/Components/FileSearchTextField/FileSearchTextField.tsx
+++ b/src/Frontend/Components/FileSearchTextField/FileSearchTextField.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement, useEffect, useMemo, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { setFileSearch } from '../../state/actions/resource-actions/file-search-actions';
 import { getFileSearch } from '../../state/selectors/file-search-selectors';
 import { SearchTextField } from '../SearchTextField/SearchTextField';
@@ -12,6 +11,7 @@ import { getResources } from '../../state/selectors/all-views-resource-selectors
 import { getPathsFromResources } from '../../state/helpers/file-search-helpers';
 import { debounce } from 'lodash';
 import { PathPredicate } from '../../types/types';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 
 interface FileSearchTextFieldProps {
   setFilteredPaths(filteredPaths: Array<string>): void;
@@ -20,9 +20,10 @@ interface FileSearchTextFieldProps {
 export function FileSearchTextField(
   props: FileSearchTextFieldProps
 ): ReactElement {
-  const dispatch = useDispatch();
-  const search = useSelector(getFileSearch);
-  const resources = useSelector(getResources);
+  const dispatch = useAppDispatch();
+  const search = useAppSelector(getFileSearch);
+
+  const resources = useAppSelector(getResources);
   const debounceWaitTimeInMs = 200;
 
   const paths: Array<string> = useMemo(() => {

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import { PopupType } from '../../enums/enums';
 import { getOpenPopup } from '../../state/selectors/view-selector';
 import { NotSavedPopup } from '../NotSavedPopup/NotSavedPopup';
@@ -14,6 +13,7 @@ import { ProjectMetadataPopup } from '../ProjectMetadataPopup/ProjectMetadataPop
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttributionPopup';
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
+import { useAppSelector } from '../../state/hooks';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -37,6 +37,6 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
 }
 
 export function GlobalPopup(): ReactElement | null {
-  const openPopupType = useSelector(getOpenPopup);
+  const openPopupType = useAppSelector(getOpenPopup);
   return getPopupComponent(openPopupType);
 }

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -5,7 +5,6 @@
 
 import React, { ReactElement } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { useSelector } from 'react-redux';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
 import {
   getAttributionBreakpoints,
@@ -17,6 +16,7 @@ import clsx from 'clsx';
 import { getParents } from '../../state/helpers/get-parents';
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { OpenLinkArgs } from '../../../shared/shared-types';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   hidden: {
@@ -30,9 +30,9 @@ interface GoToLinkProps {
 
 export function GoToLinkButton(props: GoToLinkProps): ReactElement {
   const classes = useStyles();
-  const path = useSelector(getSelectedResourceId);
-  const baseUrlsForSources = useSelector(getBaseUrlsForSources);
-  const attributionBreakpoints = useSelector(getAttributionBreakpoints);
+  const path = useAppSelector(getSelectedResourceId);
+  const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
   const isAttributionBreakpoint = getAttributionBreakpointCheck(
     attributionBreakpoints
   );

--- a/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
+++ b/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
@@ -7,7 +7,7 @@ import MuiPaper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInManualPackagePanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -48,20 +48,19 @@ export function ManualPackagePanel(
   props: ManualPackagePanelProps
 ): ReactElement | null {
   const classes = useStyles();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
-  const selectedAttributionId: string | null = useSelector(
+  const selectedAttributionId: string | null = useAppSelector(
     getAttributionIdOfDisplayedPackageInManualPanel
   );
 
-  const attributionIdsOfSelectedResource: Attributions = useSelector(
+  const attributionIdsOfSelectedResource: Attributions = useAppSelector(
     getAttributionsOfSelectedResource
   );
-  const selectedResourceOrClosestParentAttributions: Attributions = useSelector(
-    getAttributionsOfSelectedResourceOrClosestParent
-  );
+  const selectedResourceOrClosestParentAttributions: Attributions =
+    useAppSelector(getAttributionsOfSelectedResourceOrClosestParent);
 
-  const selectedResourceId: string = useSelector(getSelectedResourceId);
+  const selectedResourceId: string = useAppSelector(getSelectedResourceId);
 
   const shownAttributionsOfResource: Attributions = props.overrideParentMode
     ? attributionIdsOfSelectedResource

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ButtonText, View } from '../../enums/enums';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import {
@@ -27,11 +27,13 @@ import { setTargetSelectedAttributionId } from '../../state/actions/resource-act
 import { setTargetSelectedResourceId } from '../../state/actions/resource-actions/audit-view-simple-actions';
 
 export function NotSavedPopup(): ReactElement {
-  const dispatch = useDispatch();
-  const currentAttributionId = useSelector(getAttributionIdToSaveTo);
-  const attributionsToResources = useSelector(getManualAttributionsToResources);
-  const view = useSelector(getSelectedView);
-  const isSavingDisabled = useSelector(getIsSavingDisabled);
+  const dispatch = useAppDispatch();
+  const currentAttributionId = useAppSelector(getAttributionIdToSaveTo);
+  const attributionsToResources = useAppSelector(
+    getManualAttributionsToResources
+  );
+  const view = useAppSelector(getSelectedView);
+  const isSavingDisabled = useAppSelector(getIsSavingDisabled);
   const showSaveGloballyButton =
     view === View.Audit &&
     hasAttributionMultipleResources(

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -6,7 +6,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography/Typography';
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   AttributionIdWithCount,
   Attributions,
@@ -52,17 +52,17 @@ export function PackagePanel(
   props: PackagePanelProps
 ): React.ReactElement | null {
   const classes = useStyles();
-  const selectedPackage = useSelector(getDisplayedPackage);
-  const resolvedExternalAttributionIds = useSelector(
+  const selectedPackage = useAppSelector(getDisplayedPackage);
+  const resolvedExternalAttributionIds = useAppSelector(
     getResolvedExternalAttributions
   );
-  const selectedResourceId = useSelector(getSelectedResourceId);
-  const externalAttributions = useSelector(getExternalAttributions);
-  const resourcesToExternalAttributions = useSelector(
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const externalAttributions = useAppSelector(getExternalAttributions);
+  const resourcesToExternalAttributions = useAppSelector(
     getResourcesToExternalAttributions
   );
-  const attributionSources = useSelector(getExternalAttributionSources);
-  const dispatch = useDispatch();
+  const attributionSources = useAppSelector(getExternalAttributionSources);
+  const dispatch = useAppDispatch();
 
   function getPreSelectedExternalAttributionIdsForSelectedResource(): Array<string> {
     const externalAttributionsForSelectedResource =

--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -7,12 +7,12 @@ import React, { ReactElement } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTypography from '@material-ui/core/Typography';
 import MuiTooltip from '@material-ui/core/Tooltip';
-import { useSelector } from 'react-redux';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
 import { getIsFileWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { GoToLinkButton } from '../GoToLinkButton/GoToLinkButton';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -37,8 +37,8 @@ const useStyles = makeStyles({
 
 export function PathBar(): ReactElement | null {
   const classes = useStyles();
-  const path = useSelector(getSelectedResourceId);
-  const isFileWithChildren = useSelector(getIsFileWithChildren);
+  const path = useAppSelector(getSelectedResourceId);
+  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
 
   return path ? (
     <div className={classes.root}>

--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -6,7 +6,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 import MuiTooltip from '@material-ui/core/Tooltip';
 import React, { ReactElement } from 'react';
-import { useSelector } from 'react-redux';
 import { getProgressBarData } from '../../state/selectors/all-views-resource-selectors';
 import { ProgressBarData } from '../../types/types';
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
@@ -15,6 +14,7 @@ import {
   getProgressBarTooltipText,
   useOnProgressBarClick,
 } from './progress-bar-helpers';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -42,7 +42,7 @@ const useStyles = makeStyles({
 export function ProgressBar(): ReactElement {
   const classes = useStyles();
   const progressBarData: ProgressBarData | null =
-    useSelector(getProgressBarData);
+    useAppSelector(getProgressBarData);
 
   const onProgressBarClick = useOnProgressBarClick(
     progressBarData?.filesWithSignalOnly || []

--- a/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
+++ b/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
@@ -5,7 +5,7 @@
 
 import React, { ReactElement } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 
 import MuiTable from '@material-ui/core/Table';
@@ -26,8 +26,8 @@ const useStyles = makeStyles({
 
 export function ProjectMetadataPopup(): ReactElement {
   const classes = useStyles();
-  const dispatch = useDispatch();
-  const metadata: ProjectMetadata = useSelector(getProjectMetadata);
+  const dispatch = useAppDispatch();
+  const metadata: ProjectMetadata = useAppSelector(getProjectMetadata);
 
   function close(): void {
     dispatch(closePopup());

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ButtonText } from '../../enums/enums';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
@@ -32,10 +32,12 @@ const useStyles = makeStyles({
 export function ReplaceAttributionPopup(): ReactElement {
   const classes = useStyles();
 
-  const dispatch = useDispatch();
-  const attributions = useSelector(getManualAttributions);
-  const markedAttributionId = useSelector(getAttributionIdMarkedForReplacement);
-  const selectedAttributionId = useSelector(getSelectedAttributionId);
+  const dispatch = useAppDispatch();
+  const attributions = useAppSelector(getManualAttributions);
+  const markedAttributionId = useAppSelector(
+    getAttributionIdMarkedForReplacement
+  );
+  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
 
   function handleCancelClick(): void {
     dispatch(closePopup());

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -5,7 +5,7 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   Attributions,
   AttributionsToResources,
@@ -41,14 +41,14 @@ const useStyles = makeStyles({
 
 export function ReportView(): ReactElement {
   const classes = useStyles();
-  const attributions: Attributions = useSelector(getManualAttributions);
-  const attributionsToResources: AttributionsToResources = useSelector(
+  const attributions: Attributions = useAppSelector(getManualAttributions);
+  const attributionsToResources: AttributionsToResources = useAppSelector(
     getManualAttributionsToResources
   );
-  const frequentLicenseTexts = useSelector(getFrequentLicensesTexts);
-  const isFileWithChildren = useSelector(getIsFileWithChildren);
-  const filterForFollowUp = useSelector(areOnlyFollowUpAttributionsShown);
-  const dispatch = useDispatch();
+  const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
+  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
+  const filterForFollowUp = useAppSelector(areOnlyFollowUpAttributionsShown);
+  const dispatch = useAppDispatch();
 
   const { handleFilterChange, getFilteredAttributions } = provideFollowUpFilter(
     filterForFollowUp,

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -6,7 +6,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import remove from 'lodash/remove';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionBreakpoints,
   getExternalAttributions,
@@ -76,33 +76,33 @@ const useStyles = makeStyles({
 export function ResourceBrowser(): ReactElement | null {
   const classes = useStyles();
 
-  const resources = useSelector(getResources);
-  const selectedResourceId = useSelector(getSelectedResourceId);
-  const expandedIds = useSelector(getExpandedIds);
+  const resources = useAppSelector(getResources);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const expandedIds = useAppSelector(getExpandedIds);
 
-  const manualAttributions = useSelector(getManualAttributions);
-  const resourcesToManualAttributions = useSelector(
+  const manualAttributions = useAppSelector(getManualAttributions);
+  const resourcesToManualAttributions = useAppSelector(
     getResourcesToManualAttributions
   );
-  const resourcesWithManualAttributedChildren = useSelector(
+  const resourcesWithManualAttributedChildren = useAppSelector(
     getResourcesWithManualAttributedChildren
   );
 
-  const externalAttributions = useSelector(getExternalAttributions);
-  const resourcesToExternalAttributions = useSelector(
+  const externalAttributions = useAppSelector(getExternalAttributions);
+  const resourcesToExternalAttributions = useAppSelector(
     getResourcesToExternalAttributions
   );
-  const resourcesWithExternalAttributedChildren = useSelector(
+  const resourcesWithExternalAttributedChildren = useAppSelector(
     getResourcesWithExternalAttributedChildren
   );
-  const resolvedExternalAttributions = useSelector(
+  const resolvedExternalAttributions = useAppSelector(
     getResolvedExternalAttributions
   );
 
-  const attributionBreakpoints = useSelector(getAttributionBreakpoints);
-  const filesWithChildren = useSelector(getFilesWithChildren);
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const treeHeight: number = useWindowHeight() - topBarHeight - 4;
 

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
 import {
@@ -42,19 +42,19 @@ interface ResourceDetailsAttributionColumnProps {
 export function ResourceDetailsAttributionColumn(
   props: ResourceDetailsAttributionColumnProps
 ): ReactElement | null {
-  const manualData = useSelector(getManualData);
-  const externalData = useSelector(getExternalData);
+  const manualData = useAppSelector(getManualData);
+  const externalData = useAppSelector(getExternalData);
   const displayedPackage: PanelPackage | null =
-    useSelector(getDisplayedPackage);
-  const selectedResourceId = useSelector(getSelectedResourceId);
+    useAppSelector(getDisplayedPackage);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
   const attributionIdOfSelectedPackageInManualPanel: string | null =
-    useSelector(getAttributionIdOfDisplayedPackageInManualPanel);
-  const temporaryPackageInfo = useSelector(getTemporaryPackageInfo);
-  const selectedResourceIsAttributionBreakpoint = useSelector(
+    useAppSelector(getAttributionIdOfDisplayedPackageInManualPanel);
+  const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
+  const selectedResourceIsAttributionBreakpoint = useAppSelector(
     isAttributionBreakpoint(selectedResourceId)
   );
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   function dispatchUnlinkAttributionAndSavePackageInfo(): void {
     if (attributionIdOfSelectedPackageInManualPanel) {

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
@@ -6,7 +6,7 @@
 import { ChangeEvent } from 'react';
 import { Attributions, PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
-import { SimpleThunkDispatch } from '../../state/actions/types';
+import { AppThunkDispatch } from '../../state/types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { PanelPackage } from '../../types/types';
 
@@ -40,7 +40,7 @@ export function getDisplayPackageInfo(
 }
 
 export function setUpdateTemporaryPackageInfoForCreator(
-  dispatch: SimpleThunkDispatch,
+  dispatch: AppThunkDispatch,
   temporaryPackageInfo: PackageInfo
 ) {
   return (propertyToUpdate: string) => {

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -7,7 +7,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import MuiTabs from '@material-ui/core/Tabs';
 import MuiTab from '@material-ui/core/Tab';
-import { useSelector } from 'react-redux';
 import {
   getExternalData,
   getManualData,
@@ -23,6 +22,7 @@ import {
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { OpossumColors } from '../../shared-styles';
+import { useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   tabsRoot: {
@@ -51,12 +51,13 @@ export function ResourceDetailsTabs(
 ): ReactElement | null {
   const classes = useStyles();
 
-  const manualData = useSelector(getManualData);
-  const externalData = useSelector(getExternalData);
+  const manualData = useAppSelector(getManualData);
+  const externalData = useAppSelector(getExternalData);
 
-  const selectedPackage: PanelPackage | null = useSelector(getDisplayedPackage);
-  const selectedResourceId = useSelector(getSelectedResourceId);
-  const attributionIdsOfSelectedResource: Array<string> = useSelector(
+  const selectedPackage: PanelPackage | null =
+    useAppSelector(getDisplayedPackage);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const attributionIdsOfSelectedResource: Array<string> = useAppSelector(
     getAttributionIdsOfSelectedResource,
     isEqual
   );

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -5,7 +5,6 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import { PanelPackage } from '../../types/types';
 import { ManualPackagePanel } from '../ManualPackagePanel/ManualPackagePanel';
 import { PathBar } from '../PathBar/PathBar';
@@ -26,6 +25,7 @@ import {
   resourceBrowserWidthInPixels,
 } from '../../shared-styles';
 import { isAttributionBreakpoint } from '../../state/selectors/all-views-resource-selectors';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 
 const useStyles = makeStyles({
   root: {
@@ -61,19 +61,19 @@ export function ResourceDetailsViewer(): ReactElement | null {
   const [overrideParentMode, setOverrideParentMode] = useState<boolean>(false);
 
   const displayedPackage: PanelPackage | null =
-    useSelector(getDisplayedPackage);
-  const selectedResourceId = useSelector(getSelectedResourceId);
+    useAppSelector(getDisplayedPackage);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
   const attributionIdsOfSelectedResourceClosestParent: Array<string> =
-    useSelector(getAttributionIdsOfSelectedResourceClosestParent, isEqual);
-  const attributionIdsOfSelectedResource: Array<string> = useSelector(
+    useAppSelector(getAttributionIdsOfSelectedResourceClosestParent, isEqual);
+  const attributionIdsOfSelectedResource: Array<string> = useAppSelector(
     getAttributionIdsOfSelectedResource,
     isEqual
   );
-  const resourceIsAttributionBreakpoint: boolean = useSelector(
+  const resourceIsAttributionBreakpoint: boolean = useAppSelector(
     isAttributionBreakpoint(selectedResourceId)
   );
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     setOverrideParentMode(false);

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -7,7 +7,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { ResourcesList } from '../ResourcesList/ResourcesList';
-import { useSelector } from 'react-redux';
 import {
   getExternalAttributionsToResources,
   getManualAttributionsToResources,
@@ -16,6 +15,7 @@ import { useWindowHeight } from '../../util/use-window-height';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
 import { splitResourceIdsToCurrentAndOtherFolder } from './resource-path-popup-helpers';
 import { ResourcesListBatch } from '../../types/types';
+import { useAppSelector } from '../../state/hooks';
 
 const heightOffset = 300;
 
@@ -38,12 +38,12 @@ interface ResourcePathPopupProps {
 
 export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
   const classes = useStyles();
-  const folderPath = useSelector(getSelectedResourceId);
+  const folderPath = useAppSelector(getSelectedResourceId);
 
-  const externalAttributionsToResources = useSelector(
+  const externalAttributionsToResources = useAppSelector(
     getExternalAttributionsToResources
   );
-  const manualAttributionsToResources = useSelector(
+  const manualAttributionsToResources = useAppSelector(
     getManualAttributionsToResources
   );
   const allResourceIds = props.isExternalAttribution

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -18,16 +18,16 @@ import {
   setExternalData,
   setManualData,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { useDispatch } from 'react-redux';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { screen } from '@testing-library/react';
+import { useAppDispatch } from '../../../state/hooks';
 
 interface HelperComponentProps {
   isExternalAttribution: boolean;
 }
 
 function HelperComponent(props: HelperComponentProps): ReactElement {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const attributions: Attributions = {
     uuid_1: { packageName: 'Test package' },
   };

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -5,7 +5,7 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { navigateToSelectedPathOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { List } from '../List/List';
 import { ListCard } from '../ListCard/ListCard';
@@ -37,8 +37,8 @@ export interface ResourcesListItem {
 export function ResourcesList(props: ResourcesListProps): ReactElement {
   const classes = useStyles();
 
-  const isFileWithChildren = useSelector(getIsFileWithChildren);
-  const dispatch = useDispatch();
+  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
+  const dispatch = useAppDispatch();
   const onClickCallback = props.onClickCallback ?? doNothing;
 
   const resourcesListItems: Array<ResourcesListItem> =

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -9,7 +9,7 @@ import MuiToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import { IpcRendererEvent } from 'electron';
 import pick from 'lodash/pick';
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { IpcChannel } from '../../../shared/ipc-channels';
 import {
   Attributions,
@@ -86,13 +86,13 @@ const useStyles = makeStyles({
 export function TopBar(): ReactElement {
   const classes = useStyles();
 
-  const resources = useSelector(getResources);
-  const manualData = useSelector(getManualData);
-  const selectedView = useSelector(getSelectedView);
-  const attributionBreakpoints = useSelector(getAttributionBreakpoints);
-  const filesWithChildren = useSelector(getFilesWithChildren);
-  const frequentLicenseTexts = useSelector(getFrequentLicensesTexts);
-  const dispatch = useDispatch();
+  const resources = useAppSelector(getResources);
+  const manualData = useAppSelector(getManualData);
+  const selectedView = useAppSelector(getSelectedView);
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+  const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
+  const dispatch = useAppDispatch();
 
   function fileLoadedListener(
     event: IpcRendererEvent,

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -18,7 +18,7 @@ import {
   openResourceInResourceBrowser,
   setSelectedResourceOrAttributionIdToTargetValue,
 } from '../resource-actions/navigation-actions';
-import { SimpleThunkAction, SimpleThunkDispatch } from '../types';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
 import {
   closePopup,
   setTargetView,
@@ -42,8 +42,8 @@ import { getSelectedResourceId } from '../../selectors/audit-view-resource-selec
 
 export function navigateToSelectedPathOrOpenUnsavedPopup(
   resourcePath: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(setTargetSelectedResourceId(resourcePath));
       dispatch(setTargetView(View.Audit));
@@ -56,8 +56,8 @@ export function navigateToSelectedPathOrOpenUnsavedPopup(
 
 export function changeSelectedAttributionIdOrOpenUnsavedPopup(
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const manualAttributions = getManualAttributions(getState());
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(setTargetSelectedAttributionId(attributionId));
@@ -69,10 +69,8 @@ export function changeSelectedAttributionIdOrOpenUnsavedPopup(
   };
 }
 
-export function setViewOrOpenUnsavedPopup(
-  selectedView: View
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function setViewOrOpenUnsavedPopup(selectedView: View): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(setTargetView(selectedView));
       dispatch(setTargetSelectedResourceId(getSelectedResourceId(getState())));
@@ -85,8 +83,8 @@ export function setViewOrOpenUnsavedPopup(
 
 export function setSelectedResourceIdOrOpenUnsavedPopup(
   resourceId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(setTargetSelectedResourceId(resourceId));
       dispatch(openPopup(PopupType.NotSavedPopup));
@@ -99,8 +97,8 @@ export function setSelectedResourceIdOrOpenUnsavedPopup(
 export function selectAttributionInAccordionPanelOrOpenUnsavedPopup(
   packagePanelTitle: PackagePanelTitle,
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
@@ -117,8 +115,8 @@ export function selectAttributionInAccordionPanelOrOpenUnsavedPopup(
 export function selectAttributionInManualPackagePanelOrOpenUnsavedPopup(
   packagePanelTitle: PackagePanelTitle,
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
@@ -132,8 +130,8 @@ export function selectAttributionInManualPackagePanelOrOpenUnsavedPopup(
   };
 }
 
-export function unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId = getSelectedResourceId(getState());
     const attributionId = getAttributionIdToSaveTo(getState()) as string;
     const temporaryPackageInfo = getTemporaryPackageInfo(getState());
@@ -149,8 +147,8 @@ export function unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(): Si
   };
 }
 
-export function saveTemporaryPackageInfoAndNavigateToTargetView(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function saveTemporaryPackageInfoAndNavigateToTargetView(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId = getSelectedResourceId(getState());
     const attributionId = getAttributionIdToSaveTo(getState());
     const temporaryPackageInfo = getTemporaryPackageInfo(getState());
@@ -162,8 +160,8 @@ export function saveTemporaryPackageInfoAndNavigateToTargetView(): SimpleThunkAc
   };
 }
 
-export function navigateToTargetResourceOrAttribution(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function navigateToTargetResourceOrAttribution(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const targetView = getTargetView(getState());
 
     dispatch(setSelectedResourceOrAttributionIdToTargetValue());

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ParsedFileContent } from '../../../../shared/shared-types';
-import { SimpleThunkAction, SimpleThunkDispatch } from '../types';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
 import {
   setAttributionBreakpoints,
   setBaseUrlsForSources,
@@ -21,8 +21,8 @@ import { addResolvedExternalAttribution } from './audit-view-simple-actions';
 
 export function loadFromFile(
   parsedFileContent: ParsedFileContent
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(setResources(parsedFileContent.resources));
 
     dispatch(

--- a/src/Frontend/state/actions/resource-actions/navigation-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/navigation-actions.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AttributionData } from '../../../../shared/shared-types';
-import { SimpleThunkAction, SimpleThunkDispatch } from '../types';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
 import { PanelPackage, State } from '../../../types/types';
 import { PackagePanelTitle, View } from '../../../enums/enums';
 import { getSelectedView, getTargetView } from '../../selectors/view-selector';
@@ -30,8 +30,8 @@ import {
 } from '../../selectors/audit-view-resource-selectors';
 import { getTargetSelectedAttributionId } from '../../selectors/attribution-view-resource-selectors';
 
-export function resetTemporaryPackageInfo(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function resetTemporaryPackageInfo(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const view: View = getSelectedView(getState());
 
     switch (view) {
@@ -55,8 +55,8 @@ export function resetTemporaryPackageInfo(): SimpleThunkAction {
   };
 }
 
-export function setSelectedResourceOrAttributionIdToTargetValue(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function setSelectedResourceOrAttributionIdToTargetValue(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedView = getSelectedView(getState());
     const targetSelectedView = getTargetView(getState());
     if (selectedView === View.Audit) {
@@ -82,8 +82,8 @@ export function setSelectedResourceOrAttributionIdToTargetValue(): SimpleThunkAc
 
 export function openResourceInResourceBrowser(
   resourceId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(setExpandedIds(getParents(resourceId).concat([resourceId])));
     dispatch(setSelectedResourceId(resourceId));
     dispatch(navigateToView(View.Audit));
@@ -92,15 +92,15 @@ export function openResourceInResourceBrowser(
 
 export function setDisplayedPackageAndResetTemporaryPackageInfo(
   panelPackage: PanelPackage
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(setDisplayedPackage(panelPackage));
     dispatch(resetTemporaryPackageInfo());
   };
 }
 
-export function resetSelectedPackagePanelIfContainedAttributionWasRemoved(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function resetSelectedPackagePanelIfContainedAttributionWasRemoved(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId: string = getSelectedResourceId(getState());
     const manualData: AttributionData = getManualData(getState());
     const AttributionIdsOfResource: Array<string> =

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -15,7 +15,7 @@ import {
   SavePackageInfoOperation,
 } from '../../../enums/enums';
 import { packageInfoHasNoSignificantFields } from '../../../util/package-info-has-no-significant-fields';
-import { SimpleThunkAction, SimpleThunkDispatch } from '../types';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
 import {
   getIsSavingDisabled,
   getManualAttributions,
@@ -69,8 +69,8 @@ export function savePackageInfoIfSavingIsNotDisabled(
   resourceId: string | null,
   attributionId: string | null,
   packageInfo: PackageInfo
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (getIsSavingDisabled(getState())) {
       dispatch(openPopup(PopupType.ErrorPopup));
       return;
@@ -83,8 +83,8 @@ export function savePackageInfo(
   resourceId: string | null,
   attributionId: string | null,
   packageInfo: PackageInfo
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const strippedPackageInfo: PackageInfo = getStrippedPackageInfo(
       setConfidenceToDefaultIfNotLowOrHigh(packageInfo)
     );
@@ -160,8 +160,8 @@ function getSavePackageInfoOperation(
   return SavePackageInfoOperation.Update;
 }
 
-export function saveManualAndResolvedAttributionsToFile(): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function saveManualAndResolvedAttributionsToFile(): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const saveFileArgs: SaveFileArgs = {
       manualAttributions: getManualAttributions(getState()),
       resourcesToAttributions: getResourcesToManualAttributions(getState()),
@@ -176,8 +176,8 @@ export function unlinkAttributionAndSavePackageInfo(
   resourceId: string,
   attributionId: string,
   packageInfo: PackageInfo
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
 
@@ -191,8 +191,8 @@ export function unlinkAttributionAndSavePackageInfo(
 
 export function addManualAttributionToSelectedResource(
   packageInfo: PackageInfo
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
@@ -209,8 +209,8 @@ export function addManualAttributionToSelectedResource(
 
 export function addSignalToSelectedResource(
   packageInfo: PackageInfo
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryPackageInfoModified(getState())) {
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
@@ -227,8 +227,8 @@ export function addSignalToSelectedResource(
 
 export function deleteAttributionGloballyAndSave(
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(savePackageInfo(null, attributionId, {}));
   };
 }
@@ -236,8 +236,8 @@ export function deleteAttributionGloballyAndSave(
 export function deleteAttributionAndSave(
   resourceId: string,
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
 
@@ -252,8 +252,8 @@ export function deleteAttributionAndSave(
 function unlinkResourceFromAttributionAndSave(
   resourceId: string,
   attributionId: string
-): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch): void => {
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(unlinkResourceFromAttribution(resourceId, attributionId));
 
     dispatch(resetSelectedPackagePanelIfContainedAttributionWasRemoved());

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -8,7 +8,7 @@ import { PopupType, View } from '../../../enums/enums';
 import { State } from '../../../types/types';
 import { getPackageInfoOfSelectedAttribution } from '../../selectors/all-views-resource-selectors';
 import { getSelectedView } from '../../selectors/view-selector';
-import { SimpleThunkAction, SimpleThunkDispatch } from '../types';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
 import { setTemporaryPackageInfo } from '../resource-actions/all-views-simple-actions';
 import { getAttributionOfDisplayedPackageInManualPanel } from '../../selectors/audit-view-resource-selectors';
 import {
@@ -30,8 +30,8 @@ export function resetViewState(): ResetViewStateAction {
   return { type: ACTION_RESET_VIEW_STATE };
 }
 
-export function navigateToView(view: View): SimpleThunkAction {
-  return (dispatch: SimpleThunkDispatch, getState: () => State): void => {
+export function navigateToView(view: View): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (getSelectedView(getState()) === view) {
       return;
     }

--- a/src/Frontend/state/configure-store.ts
+++ b/src/Frontend/state/configure-store.ts
@@ -3,11 +3,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { createStore, EnhancedStore, applyMiddleware } from '@reduxjs/toolkit';
 import { reducer } from './reducer';
-import thunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
+import { applyMiddleware, createStore, Store } from 'redux';
+import thunk from 'redux-thunk';
 
-export function createAppStore(): EnhancedStore {
+export function createAppStore(): Store {
   return createStore(reducer, composeWithDevTools(applyMiddleware(thunk)));
 }

--- a/src/Frontend/state/hooks.ts
+++ b/src/Frontend/state/hooks.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { State } from '../types/types';
+import { AppThunkDispatch } from './types';
+
+export const useAppDispatch = (): AppThunkDispatch =>
+  useDispatch<AppThunkDispatch>();
+export const useAppSelector: TypedUseSelectorHook<State> = useSelector;

--- a/src/Frontend/state/types.ts
+++ b/src/Frontend/state/types.ts
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { State } from '../../types/types';
+import { State } from '../types/types';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 
-export type SimpleThunkAction = ThunkAction<unknown, State, unknown, Action>;
-export type SimpleThunkDispatch = ThunkDispatch<State, unknown, Action>;
+export type AppThunkAction = ThunkAction<void, State, unknown, Action<string>>;
+
+export type AppThunkDispatch = ThunkDispatch<State, unknown, Action>;

--- a/src/Frontend/test-helpers/render-component-with-store.tsx
+++ b/src/Frontend/test-helpers/render-component-with-store.tsx
@@ -3,27 +3,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EnhancedStore } from '@reduxjs/toolkit';
 import { render, RenderResult } from '@testing-library/react';
 import React, { ReactElement } from 'react';
 import { Provider } from 'react-redux';
-import { AnyAction, Middleware, Store } from 'redux';
-import { SimpleThunkAction } from '../state/actions/types';
+import { Store } from 'redux';
 import { createAppStore } from '../state/configure-store';
-import { State } from '../types/types';
+import { AppThunkDispatch } from '../state/types';
 
-export type EnhancedTestStore = EnhancedStore<
-  State, // @ts-ignore
-  SimpleThunkAction | AnyAction,
-  [Middleware]
->;
+export interface EnhancedTestStore extends Store {
+  dispatch: AppThunkDispatch;
+}
 
 interface RenderResultWithStore extends RenderResult {
   store: EnhancedTestStore;
 }
 
 export function createTestAppStore(): EnhancedTestStore {
-  return createAppStore() as EnhancedTestStore;
+  return createAppStore();
 }
 
 export const renderComponentWithStore = (

--- a/src/Frontend/util/provide-follow-up-filter.ts
+++ b/src/Frontend/util/provide-follow-up-filter.ts
@@ -10,11 +10,11 @@ import {
   PackageInfo,
 } from '../../shared/shared-types';
 import { setFollowUpFilter } from '../state/actions/view-actions/view-actions';
-import { SimpleThunkDispatch } from '../state/actions/types';
+import { AppThunkDispatch } from '../state/types';
 
 export function provideFollowUpFilter(
   filterForFollowUp: boolean,
-  dispatch: SimpleThunkDispatch
+  dispatch: AppThunkDispatch
 ): {
   handleFilterChange: () => void;
   getFilteredAttributions(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,16 +1718,6 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@reduxjs/toolkit@^1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.2.tgz#2f2b5365df77dd6697da28fdf44f33501ed9ba37"
-  integrity sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==
-  dependencies:
-    immer "^9.0.6"
-    redux "^4.1.0"
-    redux-thunk "^2.3.0"
-    reselect "^4.0.0"
-
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -2181,15 +2171,20 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/node@*", "@types/node@^16.11.1":
-  version "16.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
-  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
+"@types/node@*":
+  version "16.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
+  integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
 
 "@types/node@^14.0.1", "@types/node@^14.6.2":
   version "14.17.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.21.tgz#6359d8cf73481e312a43886fa50afc70ce5592c6"
   integrity sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA==
+
+"@types/node@^16.11.1":
+  version "16.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
+  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2275,9 +2270,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "17.0.30"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.30.tgz#2f8e6f5ab6415c091cc5e571942ee9064b17609e"
-  integrity sha512-3Dt/A8gd3TCXi2aRe84y7cK1K8G+N9CZRDG8kDGguOKa0kf/ZkSwTmVIDPsm/KbQOVMaDJXwhBtuOXxqwdpWVg==
+  version "17.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.31.tgz#fe05ebf91ff3ae35bb6b13f6c1b461db8089dff8"
+  integrity sha512-MQSR5EL4JZtdWRvqDgz9kXhSDDoy2zMTYyg7UhP+FZ5ttUOocWyxiqFJiI57sUG0BtaEX7WDXYQlkCYkb3X9vQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -4661,7 +4656,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
@@ -7512,11 +7507,6 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
-immer@^9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
-  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
-
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -8942,9 +8932,9 @@ lazy-val@^1.0.4, lazy-val@^1.0.5:
   integrity sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==
 
 lazystream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
-  integrity sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"
+  integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
   dependencies:
     readable-stream "^2.0.5"
 
@@ -8984,29 +8974,23 @@ lighthouse-logger@^1.0.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
-lilconfig@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.3.tgz#68f3005e921dafbd2a2afb48379986aa6d2579fd"
-  integrity sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 lint-staged@^11.2.5:
-  version "11.2.5"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.5.tgz#afa4c4740fbf874fab1531a846f14504e448e828"
-  integrity sha512-bD6FeKyRtMA3jXcNg/J0fuJmwDN8yaoTdqliFcEl8pFTHiP9NYwQCeZwBoZ8FEXx4lj/pli3oFehr86XYvMNEA==
+  version "11.2.6"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.6.tgz#f477b1af0294db054e5937f171679df63baa4c43"
+  integrity sha512-Vti55pUnpvPE0J9936lKl0ngVeTdSZpEdTNhASbkaWX7J5R9OEifo1INBGQuGW4zmy6OG+TcWPJ3m5yuy5Q8Tg==
   dependencies:
     cli-truncate "2.1.0"
     colorette "^1.4.0"
     commander "^8.2.0"
+    cosmiconfig "^7.0.1"
     debug "^4.3.2"
     enquirer "^2.3.6"
     execa "^5.1.1"
-    js-yaml "^4.1.0"
-    lilconfig "^2.0.3"
     listr2 "^3.12.2"
     micromatch "^4.0.4"
     normalize-path "^3.0.0"
@@ -11819,11 +11803,6 @@ redux-devtools-extension@^2.13.9:
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
   integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
 
-redux-thunk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
-  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
-
 redux-thunk@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.0.tgz#ac89e1d6b9bdb9ee49ce69a69071be41bbd82d67"
@@ -11984,11 +11963,6 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -13651,9 +13625,9 @@ typescript@^4.4.4:
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 ua-parser-js@^0.7.21:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
+  version "0.7.30"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.30.tgz#4cf5170e8b55ac553fe8b38df3a82f0669671f0b"
+  integrity sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==
 
 ua-parser-js@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Summary of changes

The dependency @reduxjs/toolkit is removed and the code adapted accordingly. 

* @reduxjs/toolkit is removed 
* `useAppDispatch` and `useAppSelector` are introduced to improve typing

### Context and reason for change

The reason to remove this dependency is that it is pretty much unused.


