### PR TITLE
Include resources into detailed component list

### DIFF
--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -411,26 +411,28 @@ describe('getExportBomListener', () => {
       detailedBomFilePath: '/somefile.csv',
     });
 
-    const attributions: Attributions = {
+    const attributionsWithResources: AttributionsWithResources = {
       key1: {
         followUp: undefined,
         licenseText: 'license text',
         firstParty: true,
+        resources: ['/somefile.csv'],
       },
       key2: {
         packageName: 'license text',
+        resources: ['/a', '/b'],
       },
     };
 
     await listener(IpcChannel.ExportFile, {
       type: ExportType.DetailedBom,
-      bomAttributions: attributions,
+      bomAttributionsWithResources: attributionsWithResources,
     });
 
     expect(writeCsvToFile).toHaveBeenNthCalledWith(
       1,
       '/somefile.csv',
-      attributions,
+      attributionsWithResources,
       [
         'packageName',
         'packageVersion',
@@ -441,6 +443,7 @@ describe('getExportBomListener', () => {
         'copyright',
         'licenseName',
         'licenseText',
+        'resources',
       ]
     );
   });

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -292,11 +292,12 @@ async function createDetailedBom(
     'copyright',
     'licenseName',
     'licenseText',
+    'resources',
   ];
 
   await writeCsvToFile(
     detailedBomFilePath,
-    args.bomAttributions,
+    args.bomAttributionsWithResources,
     detailedBomColumnOrder
   );
 }

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -12,7 +12,6 @@ import React, { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { IpcChannel } from '../../../shared/ipc-channels';
 import {
-  AttributionData,
   Attributions,
   ExportSpdxDocumentJsonArgs,
   ExportSpdxDocumentYamlArgs,
@@ -33,6 +32,7 @@ import {
 import { getSelectedView } from '../../state/selectors/view-selector';
 import {
   getAttributionsWithAllChildResourcesWithoutFolders,
+  getAttributionsWithResources,
   removeSlashesFromFilesWithChildren,
 } from '../../util/get-attributions-with-resources';
 import { useIpcRenderer } from '../../util/use-ipc-renderer';
@@ -181,26 +181,39 @@ export function TopBar(): ReactElement {
   }
 
   function getDetailedBomExportListener(): void {
+    const bomAttributions = getBomAttributions(manualData.attributions);
+
+    const bomAttributionsWithResources = getAttributionsWithResources(
+      bomAttributions,
+      manualData.attributionsToResources
+    );
+
+    const bomAttributionsWithFormattedResources =
+      removeSlashesFromFilesWithChildren(
+        bomAttributionsWithResources,
+        getFileWithChildrenCheck(filesWithChildren)
+      );
+
     window.ipcRenderer.invoke(IpcChannel.ExportFile, {
       type: ExportType.DetailedBom,
-      bomAttributions: getBomAttributions(manualData),
+      bomAttributionsWithResources: bomAttributionsWithFormattedResources,
     });
   }
 
   function getCompactBomExportListener(): void {
     window.ipcRenderer.invoke(IpcChannel.ExportFile, {
       type: ExportType.CompactBom,
-      bomAttributions: getBomAttributions(manualData),
+      bomAttributions: getBomAttributions(manualData.attributions),
     });
   }
 
-  function getBomAttributions(manualData: AttributionData): Attributions {
+  function getBomAttributions(attributions: Attributions): Attributions {
     return pick(
-      manualData.attributions,
-      Object.keys(manualData.attributions).filter(
+      attributions,
+      Object.keys(attributions).filter(
         (attributionId) =>
-          !manualData.attributions[attributionId].followUp &&
-          !manualData.attributions[attributionId].firstParty
+          !attributions[attributionId].followUp &&
+          !attributions[attributionId].firstParty
       )
     );
   }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -140,7 +140,7 @@ export interface ExportCompactBomArgs {
 
 export interface ExportDetailedBomArgs {
   type: ExportType.DetailedBom;
-  bomAttributions: Attributions;
+  bomAttributionsWithResources: AttributionsWithResources;
 }
 
 export interface ExportSpdxDocumentYamlArgs {


### PR DESCRIPTION
### Summary of changes

Include resources into the detailed component list export, that are directly linked to the respective attributions.

### Context and reason for change

In an earlier pull request, the resources were removed to enhance performance. Here, resources are reintroduced, but without the recursive scanning of the tree that was causing the performance issues. To fix this, only the resources, that are directly linked to the respective attributions are included (vs all children that get the attributions from the parents).

### How can the changes be tested

Build the app and do a detailed component list export to check the performance.

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

