### PR TITLE
Fix jump-to-signal logic in progress bar

### DIFF
--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -45,9 +45,7 @@ export function ProgressBar(): ReactElement {
     useSelector(getProgressBarData);
 
   const onProgressBarClick = useOnProgressBarClick(
-    // HERE:
-    // PASS ONLY FILES THAT REALLY HAVE A SIGNAL AND NOT ONLY PARENT SIGNAL
-    progressBarData?.filesWithSignalOnly || []
+    progressBarData?.filesWithNonInheritedSignalOnly || []
   );
 
   return (

--- a/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
@@ -87,7 +87,7 @@ describe('ProgressBar helpers', () => {
       filesWithManualAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 3,
       filesWithOnlyExternalAttributionCount: 3,
-      filesWithSignalOnly: ['file1', 'file2', 'file3'],
+      filesWithNonInheritedSignalOnly: ['file1', 'file2', 'file3'],
     };
     const expectedProgressBarBackground: string =
       'linear-gradient(to right,' +

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -253,7 +253,7 @@ describe('The load and navigation simple actions', () => {
       filesWithManualAttributionCount: 4,
       filesWithOnlyExternalAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: ['/folder2/file2'],
+      filesWithNonInheritedSignalOnly: ['/folder2/file2'],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -205,14 +205,17 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 0,
       filesWithOnlyExternalAttributionCount: 2,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: ['/root/src/something.js', '/root/readme.md'],
+      filesWithNonInheritedSignalOnly: [
+        '/root/src/something.js',
+        '/root/readme.md',
+      ],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 4,
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: ['/root/readme.md'],
+      filesWithNonInheritedSignalOnly: ['/root/readme.md'],
     };
 
     const testStore = createTestAppStore();
@@ -276,7 +279,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
     testStore.dispatch(
       loadFromFile({
@@ -367,14 +370,14 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: ['/root/src/something.js'],
+      filesWithNonInheritedSignalOnly: ['/root/src/something.js'],
     };
     const emptyTestTemporaryPackageInfo: PackageInfo = {};
 
@@ -588,7 +591,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
 
     const testStore = createTestAppStore();
@@ -661,14 +664,14 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: ['/folder/somethingElse.js'],
+      filesWithNonInheritedSignalOnly: ['/folder/somethingElse.js'],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -74,7 +74,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(2);
-    expect(progressBarData.filesWithSignalOnly).toEqual([
+    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
       '/thirdParty/package_1.tr.gz',
       '/thirdParty/package_2.tr.gz',
     ]);
@@ -140,7 +140,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(1);
-    expect(progressBarData.filesWithSignalOnly).toEqual([
+    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
       '/thirdParty/package_1.tr.gz',
     ]);
   });
@@ -231,7 +231,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(5);
-    expect(progressBarData.filesWithSignalOnly).toEqual([
+    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
       '/folder1/breakpoint1/file1',
       '/folder2/breakpoint2/file3',
       '/folder3/breakpoint3/file5',
@@ -285,7 +285,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(0);
-    expect(progressBarData.filesWithSignalOnly).toEqual([]);
+    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([]);
   });
 
   test('resourceHasOnlyPreSelectedAttributions with only pre-selected attributions', () => {
@@ -318,7 +318,7 @@ describe('The getUpdatedProgressBarData function', () => {
       filesWithManualAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
       filesWithOnlyExternalAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
     const resources: Resources = {
       dir1: { subdir1: { file1: 1 } },
@@ -341,7 +341,7 @@ describe('The getUpdatedProgressBarData function', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
-      filesWithSignalOnly: [],
+      filesWithNonInheritedSignalOnly: [],
     };
 
     updateProgressBarDataForResources(

--- a/src/Frontend/state/helpers/progress-bar-data-helpers.ts
+++ b/src/Frontend/state/helpers/progress-bar-data-helpers.ts
@@ -25,7 +25,7 @@ export function getUpdatedProgressBarData(
     filesWithManualAttributionCount: 0,
     filesWithOnlyPreSelectedAttributionCount: 0,
     filesWithOnlyExternalAttributionCount: 0,
-    filesWithSignalOnly: [],
+    filesWithNonInheritedSignalOnly: [],
   };
 
   updateProgressBarDataForResources(
@@ -98,7 +98,7 @@ export function updateProgressBarDataForResources(
     const hasManualAttribution: boolean =
       hasParentManualAttribution ||
       Boolean(resourcesToManualAttributions[path]);
-    const hasExternalAttribution = Boolean(
+    const hasNonInheritedExternalAttributions = Boolean(
       resourcesToExternalAttributions[path]
     );
     const resourceCanHaveChildren = canHaveChildren(resource);
@@ -109,9 +109,9 @@ export function updateProgressBarDataForResources(
         progressBarData.filesWithOnlyPreSelectedAttributionCount++;
       } else if (hasManualAttribution) {
         progressBarData.filesWithManualAttributionCount++;
-      } else if (hasExternalAttribution) {
+      } else if (hasNonInheritedExternalAttributions) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
-        progressBarData.filesWithSignalOnly.push(path);
+        progressBarData.filesWithNonInheritedSignalOnly.push(path);
       } else if (hasParentExternalAttribution) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
       }
@@ -130,7 +130,7 @@ export function updateProgressBarDataForResources(
         path,
         hasManualAttribution && !isBreakpoint,
         hasOnlyPreselectedAttribution && !isBreakpoint,
-        hasExternalAttribution && !isBreakpoint
+        hasNonInheritedExternalAttributions && !isBreakpoint
       );
     }
   }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -25,7 +25,7 @@ export interface ProgressBarData {
   filesWithManualAttributionCount: number;
   filesWithOnlyPreSelectedAttributionCount: number;
   filesWithOnlyExternalAttributionCount: number;
-  filesWithSignalOnly: Array<string>;
+  filesWithNonInheritedSignalOnly: Array<string>;
 }
 
 export interface PanelPackage {


### PR DESCRIPTION
### Summary of changes

The jump-to-signal logic in progress bar is adjusted so that only navigation to resources that have non-inherited signals (i.e. parent signals are not considered) is allowed.

### Context and reason for change

Before this fix, sometimes when clicking on the progress bar one was navigated to a resource that had no signal.

### How can the changes be tested

Run tests with `yarn test`

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

