### PR TITLE
Update browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,14 +138,10 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "Chrome 91"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "Chrome 91"
     ]
   },
   "lint-staged": {


### PR DESCRIPTION
### Summary of changes

Update browserslist

### Context and reason for change

So far we supported many old browsers. However, we run on electron. Therefore, there is no need to do that.

