### PR TITLE
Fix notice files generation under Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "update-commit-hash:win32": "echo {\"commitInfo\" : \"unknown-version\" } > \"src\\commitInfo.json\"",
     "generate-notice": "run-script-os",
     "generate-notice:darwin:linux": "mkdir -p notices && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",
-    "generate-notice:win32": "if not exist notices mkdir notices && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",
+    "generate-notice:win32": "(if not exist notices (mkdir notices)) && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",
     "ship-linux": "yarn build && electron-builder --linux --x64 --publish never && mkdir -p release/linux && mv 'release/OpossumUI-0.1.0.AppImage' 'release/linux/OpossumUI-for-linux.AppImage'",
     "ship-win": "run-script-os",
     "ship-win:darwin:linux": "yarn build && electron-builder --win --x64 --publish never && mkdir -p release/win && mv \"release/OpossumUI Setup 0.1.0.exe\" \"release/win/OpossumUI-for-win.exe\"",


### PR DESCRIPTION
Signed-off-by: Leslie Lazzarino <leslie.lazzarino@tngtech.com>

### Summary of changes

Now when running ship-win on Windows the notice files are always recreated, as it should be.

### Context and reason for change

The existing generate-notice:win32 script in package.json worked only if the folder where the notice files are written did not exist. 

### How can the changes be tested

Run _yarn generate-notice_ or _yarn ship-win_ on Windows when you have already notice files present. Check that afterwards the "Date modified" value has changed (the Chromium notice is just downloaded: the "Date modified" will remain that of the last change in the original file in the cloud, not that of the copy on the local system). 

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

