### PR TITLE
Add feature to set base url

### DIFF
--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -13,7 +13,7 @@ import {
   ExportType,
 } from '../../../shared/shared-types';
 import { loadJsonFromFilePath } from '../../input/importFromFile';
-import { openFileDialog } from '../openFileDialog';
+import { openFileDialog, selectBaseURLDialog } from '../dialogs';
 import { writeCsvToFile } from '../../output/writeCsvToFile';
 import { writeJsonToFile } from '../../output/writeJsonToFile';
 import { createWindow } from '../createWindow';
@@ -24,6 +24,7 @@ import {
   getOpenFileListener,
   getOpenLinkListener,
   getSaveFileListener,
+  getSelectBaseURLListener,
 } from '../listeners';
 
 import * as MockDate from 'mockdate';
@@ -90,8 +91,9 @@ jest.mock('../../input/importFromFile', () => ({
   loadJsonFromFilePath: jest.fn(),
 }));
 
-jest.mock('../openFileDialog', () => ({
+jest.mock('../dialogs', () => ({
   openFileDialog: jest.fn(),
+  selectBaseURLDialog: jest.fn(),
 }));
 
 const mockDate = 1603976726737;
@@ -218,6 +220,25 @@ describe('getOpenFileListener', () => {
 
     expect(openFileDialog).toBeCalled();
     expect(mainWindow.setTitle).toBeCalledWith('Test Title');
+  });
+});
+
+describe('getSelectBaseURLListener', () => {
+  test('opens base url dialog and sends selected path to frontend', () => {
+    const mockCallback = jest.fn();
+    const webContents = { send: mockCallback as unknown } as WebContents;
+    const baseURL = '/Users/path/to/sources';
+    const expectedFormattedBaseURL = 'file:///Users/path/to/sources/{path}';
+
+    // @ts-ignore
+    selectBaseURLDialog.mockReturnValueOnce([baseURL]);
+
+    getSelectBaseURLListener(webContents)();
+
+    expect(selectBaseURLDialog).toBeCalled();
+    expect(webContents.send).toBeCalledWith(IpcChannel.SetBaseURLForRoot, {
+      baseURLForRoot: expectedFormattedBaseURL,
+    });
   });
 });
 

--- a/src/ElectronBackend/main/dialogs.ts
+++ b/src/ElectronBackend/main/dialogs.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { dialog, BrowserWindow } from 'electron';
+import { BrowserWindow, dialog } from 'electron';
 
 export function openFileDialog(): Array<string> | undefined {
   const window = BrowserWindow.getFocusedWindow();
@@ -13,6 +13,17 @@ export function openFileDialog(): Array<string> | undefined {
         filters: [
           { name: 'Opossum Input File', extensions: ['json', 'json.gz'] },
         ],
+      })
+    : undefined;
+}
+
+export function selectBaseURLDialog(): Array<string> | undefined {
+  const window = BrowserWindow.getFocusedWindow();
+  return window
+    ? dialog.showOpenDialogSync(window, {
+        buttonLabel: 'Select',
+        properties: ['openDirectory'],
+        title: 'Path to Sources',
       })
     : undefined;
 }

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -5,7 +5,7 @@
 
 import { app, BrowserWindow, Menu, shell } from 'electron';
 import { IpcChannel } from '../../shared/ipc-channels';
-import { getOpenFileListener } from './listeners';
+import { getOpenFileListener, getSelectBaseURLListener } from './listeners';
 import { getGlobalBackendState } from './globalBackendState';
 import {
   getPathOfChromiumNoticeDocument,
@@ -94,6 +94,12 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
                 showProjectMetadataPopup: true,
               });
             }
+          },
+        },
+        {
+          label: 'Set Path to Sources',
+          click(): void {
+            getSelectBaseURLListener(webContents)();
           },
         },
         {

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -67,12 +67,17 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
     return { link };
   }
 
+  function isLocalLink(link: string): boolean {
+    return link.startsWith('file://');
+  }
+
   const openLinkArgs = getOpenLinkArgs();
 
   return (
     <GoToLinkIcon
       className={clsx(!openLinkArgs.link && classes.hidden, props.className)}
       label={'link to open'}
+      linkIsLocal={isLocalLink(openLinkArgs.link)}
       onClick={(): void => {
         window.ipcRenderer.invoke(IpcChannel.OpenLink, openLinkArgs);
       }}

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -56,7 +56,7 @@ describe('The GoToLinkButton', () => {
       store.dispatch(setBaseUrlsForSources(testBaseUrlsForSources));
 
       expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(0);
-      expect(screen.getByLabelText('open link in browser'));
+      expect(screen.getByLabelText('open link'));
       clickGoToLinkButton(screen);
 
       expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -78,6 +78,12 @@ interface ClickableIconProps extends IconProps {
   onClick: () => void;
 }
 
+interface GoToLinkIconProps extends IconProps {
+  label: string;
+  linkIsLocal: boolean;
+  onClick: () => void;
+}
+
 export function OpenFileIcon(props: ClickableIconProps): ReactElement {
   const classes = useStyles();
 
@@ -120,13 +126,13 @@ export function FolderIcon(props: ClickableIconProps): ReactElement {
   );
 }
 
-export function GoToLinkIcon(props: ClickableIconProps): ReactElement {
+export function GoToLinkIcon(props: GoToLinkIconProps): ReactElement {
   const classes = useStyles();
 
   return (
     <MuiTooltip
       classes={{ tooltip: classes.tooltip }}
-      title="open link in browser"
+      title={props.linkIsLocal ? 'open file' : 'open resource in browser'}
       placement={'right'}
     >
       <OpenInNewIcon
@@ -135,7 +141,7 @@ export function GoToLinkIcon(props: ClickableIconProps): ReactElement {
           event.stopPropagation();
           props.onClick();
         }}
-        aria-label={'open link in browser'}
+        aria-label={'open link'}
       />
     </MuiTooltip>
   );

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -60,9 +60,15 @@ describe('The Icons', () => {
   });
 
   test('renders GoToLinkIcon', () => {
-    render(<GoToLinkIcon onClick={doNothing} label={'test_label'} />);
+    render(
+      <GoToLinkIcon
+        onClick={doNothing}
+        linkIsLocal={false}
+        label={'test_label'}
+      />
+    );
 
-    expect(screen.getByLabelText('open link in browser'));
+    expect(screen.getByLabelText('open link'));
   });
 
   test('renders CommentIcon', () => {

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -17,13 +17,18 @@ import {
   ExportSpdxDocumentYamlArgs,
   ExportType,
   ParsedFileContent,
+  BaseURLForRootArgs,
 } from '../../../shared/shared-types';
 import { PopupType, View } from '../../enums/enums';
 import { setViewOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import { resetResourceState } from '../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  resetResourceState,
+  setBaseUrlsForSources,
+} from '../../state/actions/resource-actions/all-views-simple-actions';
 import { loadFromFile } from '../../state/actions/resource-actions/load-actions';
 import {
   getAttributionBreakpoints,
+  getBaseUrlsForSources,
   getFilesWithChildren,
   getFrequentLicensesTexts,
   getManualData,
@@ -92,6 +97,7 @@ export function TopBar(): ReactElement {
   const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
+  const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
   const dispatch = useAppDispatch();
 
   function fileLoadedListener(
@@ -251,6 +257,20 @@ export function TopBar(): ReactElement {
     }
   }
 
+  function setBaseURLForRootListener(
+    event: IpcRendererEvent,
+    baseURLForRootArgs: BaseURLForRootArgs
+  ): void {
+    if (baseURLForRootArgs?.baseURLForRoot) {
+      dispatch(
+        setBaseUrlsForSources({
+          ...baseUrlsForSources,
+          '/': baseURLForRootArgs.baseURLForRoot,
+        })
+      );
+    }
+  }
+
   useIpcRenderer(IpcChannel.FileLoaded, fileLoadedListener, [dispatch]);
   useIpcRenderer(IpcChannel.ResetLoadedFile, resetLoadedFileListener, [
     dispatch,
@@ -264,6 +284,10 @@ export function TopBar(): ReactElement {
     showProjectMetadataPopupListener,
     [dispatch]
   );
+  useIpcRenderer(IpcChannel.SetBaseURLForRoot, setBaseURLForRootListener, [
+    dispatch,
+    baseUrlsForSources,
+  ]);
   useIpcRenderer(IpcChannel.ExportFileRequest, getExportFileRequestListener, [
     manualData,
     attributionBreakpoints,

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -37,7 +37,7 @@ describe('TopBar', () => {
 
   test('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(6);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(7);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel['FileLoaded'],
       expect.anything()
@@ -60,6 +60,10 @@ describe('TopBar', () => {
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel['ShowProjectMetadataPopup'],
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel['SetBaseURLForRoot'],
       expect.anything()
     );
 

--- a/src/Frontend/test-helpers/test-helpers.ts
+++ b/src/Frontend/test-helpers/test-helpers.ts
@@ -637,7 +637,7 @@ export function expectValuesInProgressbarTooltip(
 }
 
 export function getGoToLinkButton(screen: Screen): HTMLElement {
-  return screen.getByLabelText('open link in browser');
+  return screen.getByLabelText('open link');
 }
 
 export function expectGoToLinkButtonIsVisible(screen: Screen): void {

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -5,7 +5,11 @@
 
 import { IpcRendererEvent } from 'electron';
 import { useEffect } from 'react';
-import { ExportType, ParsedFileContent } from '../../shared/shared-types';
+import {
+  ExportType,
+  ParsedFileContent,
+  BaseURLForRootArgs,
+} from '../../shared/shared-types';
 
 type ResetStateListener = (
   event: IpcRendererEvent,
@@ -24,11 +28,17 @@ type ExportFileRequestListener = (
 
 type LoggingListener = (event: IpcRendererEvent, logging: string) => void;
 
+type SetBaseURLForRootListener = (
+  event: IpcRendererEvent,
+  baseURLForRootArgs: BaseURLForRootArgs
+) => void;
+
 type Listener =
   | ResetStateListener
   | SetStateListener
   | LoggingListener
-  | ExportFileRequestListener;
+  | ExportFileRequestListener
+  | SetBaseURLForRootListener;
 
 export function useIpcRenderer(
   channel: string,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -17,4 +17,5 @@ export enum IpcChannel {
   SendErrorInformation = 'send-error-information',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
+  SetBaseURLForRoot = 'set-base-url-for-root',
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -164,6 +164,10 @@ export interface OpenLinkArgs {
   link: string;
 }
 
+export interface BaseURLForRootArgs {
+  baseURLForRoot: string;
+}
+
 export interface ExternalAttributionSources {
   [source: string]: {
     name: string;


### PR DESCRIPTION
### Summary of changes

This enables the user to set a local base url for the root of the resources.

### Context and reason for change

Before this, the base url could only be provided through an input file. Now, the user can set a base url through OpossumUI.

### How can the changes be tested

Open an input file in OpossumUI that contains resources that are located in the local file system. Click the new entry in the electron menu and select the directory in which the files are located. Select the corresponding file in the resource browser and click on the link button in the path bar to test if the file is opened.

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

