### PR TITLE
Update readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Prettier is used as a code formatter.
 The following software is required for working on the repository:
 
 - [git](https://git-scm.com/),
-- [node.js](https://nodejs.org/) 16+,
+- [node.js](https://nodejs.org/) 16 (version 17 is currently not supported),
 - [yarn](https://yarnpkg.com/en/),
 - [reuse.software](https://reuse.software/) (to check that copyright information is provided),
 - [wine](https://www.winehq.org/) (only to build the Windows version).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,5 +22,5 @@ SPDX-License-Identifier: CC0-1.0
 * **[Sebastian Thomas](https://github.com/sebathomas)** (<sebastian.thomas@tngtech.com>)
 
 
-[Full contributors list](https://github.com/opossum-tool/OpossumUI/contributors).
+[Contributors list on GitHub](https://github.com/opossum-tool/OpossumUI/contributors).
 


### PR DESCRIPTION
### Summary of changes

Information regarding required node versions is updated.
Formulation in CONTRIBUTORS.md is improved.

### Context and reason for change

Readme is updated. Node 17 is currently not supported. Therefore, the version requirement 16+ is wrong.


