### PR TITLE
Show popup when clicking on the go-to-link button for an invalid link

### DIFF
--- a/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
+++ b/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
@@ -26,6 +26,8 @@ jest.mock('electron', () => ({
   },
 }));
 
+jest.mock('electron-log');
+
 jest.mock('../../input/importFromFile', () => ({
   loadJsonFromFilePath: jest.fn(),
 }));

--- a/src/ElectronBackend/errorHandling/errorHandling.ts
+++ b/src/ElectronBackend/errorHandling/errorHandling.ts
@@ -10,6 +10,7 @@ import {
   MessageBoxReturnValue,
   WebContents,
 } from 'electron';
+import log from 'electron-log';
 import { IpcChannel } from '../../shared/ipc-channels';
 import { loadJsonFromFilePath } from '../input/importFromFile';
 import { getGlobalBackendState } from '../main/globalBackendState';
@@ -25,6 +26,7 @@ export function createListenerCallbackWithErrorHandling(
       await func(...args);
     } catch (error: unknown) {
       if (error instanceof Error) {
+        log.info('Failed executing callback function.\n' + error.message);
         await getMessageBoxForErrors(
           error.message,
           error.stack ?? '',
@@ -32,6 +34,7 @@ export function createListenerCallbackWithErrorHandling(
           true
         );
       } else {
+        log.info('Failed executing callback function.');
         await getMessageBoxForErrors(
           'Unexpected internal error',
           '',

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -39,6 +39,8 @@ jest.mock('electron', () => ({
   app: {
     on: jest.fn(),
     getPath: jest.fn(),
+    getName: jest.fn(),
+    getVersion: jest.fn(),
     whenReady: async (): Promise<unknown> => Promise.resolve(true),
   },
   BrowserWindow: class BrowserWindowMock {
@@ -74,6 +76,8 @@ jest.mock('electron', () => ({
   },
   shell: { showItemInFolder: jest.fn(), openExternal: jest.fn() },
 }));
+
+jest.mock('electron-log');
 
 jest.mock('../../output/writeJsonToFile', () => ({
   writeJsonToFile: jest.fn(),

--- a/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
+++ b/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
@@ -10,7 +10,11 @@ import { useAppDispatch } from '../../state/hooks';
 
 export const TIME_POPUP_IS_DISPLAYED = 1500;
 
-export function ErrorPopup(): ReactElement {
+interface ErrorPopupProps {
+  content: ReactElement | string;
+}
+
+export function ErrorPopup(props: ErrorPopupProps): ReactElement {
   const dispatch = useAppDispatch();
 
   function close(): void {
@@ -21,7 +25,7 @@ export function ErrorPopup(): ReactElement {
 
   return (
     <NotificationPopup
-      content={'Unable to save.'}
+      content={props.content}
       header={'Error'}
       onBackdropClick={close}
       isOpen={true}

--- a/src/Frontend/Components/ErrorPopup/__tests__/ErrorPopup.test.tsx
+++ b/src/Frontend/Components/ErrorPopup/__tests__/ErrorPopup.test.tsx
@@ -10,7 +10,7 @@ import { screen } from '@testing-library/react';
 
 describe('Error popup ', () => {
   test('renders', () => {
-    renderComponentWithStore(<ErrorPopup />);
+    renderComponentWithStore(<ErrorPopup content="Invalid link." />);
 
     expect(screen.getByText('Error')).toBeTruthy();
   });

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -19,8 +19,10 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
     case PopupType.NotSavedPopup:
       return <NotSavedPopup />;
-    case PopupType.ErrorPopup:
-      return <ErrorPopup />;
+    case PopupType.UnableToSavePopup:
+      return <ErrorPopup content="Unable to save." />;
+    case PopupType.InvalidLinkPopup:
+      return <ErrorPopup content="Cannot open link." />;
     case PopupType.FileSearchPopup:
       return <FileSearchPopup />;
     case PopupType.ProjectMetadataPopup:

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -29,7 +29,7 @@ describe('The GlobalPopUp', () => {
 
   test('opens the ErrorPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
-    store.dispatch(openPopup(PopupType.ErrorPopup));
+    store.dispatch(openPopup(PopupType.UnableToSavePopup));
 
     expect(screen.getByText('Error')).toBeTruthy();
   });

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -15,10 +15,12 @@ import clsx from 'clsx';
 import { getParents } from '../../state/helpers/get-parents';
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { OpenLinkArgs } from '../../../shared/shared-types';
-import { useAppSelector } from '../../state/hooks';
 import { IconButton } from '../IconButton/IconButton';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import { clickableIcon } from '../../shared-styles';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
+import { PopupType } from '../../enums/enums';
 
 const useStyles = makeStyles({
   hidden: {
@@ -39,6 +41,7 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
   const isAttributionBreakpoint = getAttributionBreakpointCheck(
     attributionBreakpoints
   );
+  const dispatch = useAppDispatch();
 
   function getOpenLinkArgs(): OpenLinkArgs {
     const sortedParents = getParents(path)
@@ -76,6 +79,16 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
 
   const openLinkArgs = getOpenLinkArgs();
 
+  function onClick(): void {
+    window.ipcRenderer
+      .invoke(IpcChannel.OpenLink, openLinkArgs)
+      .then((result) => {
+        if (result instanceof Error) {
+          dispatch(openPopup(PopupType.InvalidLinkPopup));
+        }
+      });
+  }
+
   return (
     <IconButton
       tooltipTitle={
@@ -84,9 +97,7 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
           : 'open resource in browser'
       }
       placement="right"
-      onClick={(): void => {
-        window.ipcRenderer.invoke(IpcChannel.OpenLink, openLinkArgs);
-      }}
+      onClick={onClick}
       className={!openLinkArgs.link ? classes.hidden : undefined}
       icon={
         <OpenInNewIcon

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -20,10 +20,12 @@ let originalIpcRenderer: IpcRenderer;
 describe('The GoToLinkButton', () => {
   beforeAll(() => {
     originalIpcRenderer = global.window.ipcRenderer;
+    const mockInvoke = jest.fn();
+    mockInvoke.mockReturnValue(Promise.resolve());
     global.window.ipcRenderer = {
       on: jest.fn(),
       removeListener: jest.fn(),
-      invoke: jest.fn(),
+      invoke: mockInvoke,
     } as unknown as IpcRenderer;
   });
 

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -31,10 +31,6 @@ const useStyles = makeStyles({
     ...baseIcon,
     color: OpossumColors.darkBlue,
   },
-  robotArmIcon: {
-    height: 20,
-    transform: 'scale(0.6)',
-  },
   resourceIcon: {
     width: 18,
     height: 18,

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -10,7 +10,8 @@ export enum View {
 }
 
 export enum PopupType {
-  ErrorPopup = 'ErrorPopup',
+  UnableToSavePopup = 'UnableToSavePopup',
+  InvalidLinkPopup = 'InvalidLinkPopup',
   FileSearchPopup = 'FileSearchPopup',
   ProjectMetadataPopup = 'ProjectMetadataPopup',
   NotSavedPopup = 'NotSavedPopup',

--- a/src/Frontend/integration-tests/__tests__/open_file_in_external_link.test.tsx
+++ b/src/Frontend/integration-tests/__tests__/open_file_in_external_link.test.tsx
@@ -35,10 +35,12 @@ function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {
 describe('The go to link button', () => {
   beforeAll(() => {
     originalIpcRenderer = global.window.ipcRenderer;
+    const mockInvoke = jest.fn();
+    mockInvoke.mockReturnValue(Promise.resolve());
     global.window.ipcRenderer = {
       on: jest.fn(),
       removeListener: jest.fn(),
-      invoke: jest.fn(),
+      invoke: mockInvoke,
     } as unknown as IpcRenderer;
   });
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -155,7 +155,9 @@ describe('The savePackageInfo action', () => {
       )
     );
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
-    expect(getOpenPopup(testStore.getState())).toBe(PopupType.ErrorPopup);
+    expect(getOpenPopup(testStore.getState())).toBe(
+      PopupType.UnableToSavePopup
+    );
   });
 
   test('throws an error if resource is a breakpoint', () => {

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -72,7 +72,7 @@ export function savePackageInfoIfSavingIsNotDisabled(
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (getIsSavingDisabled(getState())) {
-      dispatch(openPopup(PopupType.ErrorPopup));
+      dispatch(openPopup(PopupType.UnableToSavePopup));
       return;
     }
     dispatch(savePackageInfo(resourceId, attributionId, packageInfo));

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -21,3 +21,7 @@ export function getApp(commandLineArg?: string): Application {
     },
   });
 }
+
+export function conditionalIt(condition: boolean): jest.It {
+  return condition ? it : it.skip;
+}

--- a/src/e2e-tests/test-resources/opossum_input_e2e.json
+++ b/src/e2e-tests/test-resources/opossum_input_e2e.json
@@ -227,7 +227,9 @@
   ],
   "baseUrlsForSources": {
     "/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a2",
-    "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4"
+    "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4",
+    "/ElectronBackend/": "invalid/link",
+    "/ElectronBackend/Types": "file:///Users/path/to/sources/not/existing/folder"
   },
   "externalAttributionSources": {
     "SC": {


### PR DESCRIPTION
### Summary of changes

Show error popup when clicking on the go-to-link button for an invalid link

### Context and reason for change

Before this fix, an error was thrown in the backend that was not caught. There was no feedback for the user in the OpossumUI.

### How can the changes be tested

Run `yarn test`