### PR TITLE
Add e2e test to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
+      - name: Increase watchers
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -48,5 +51,9 @@ jobs:
       - run: yarn lint-check
       - run: yarn compile-all
       - run: yarn test
-
+      - name: Run end2end tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn e2e-test
+        if: matrix.os != 'windows-latest'
       - run: yarn ${{ matrix.SHIP }}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build": "yarn generate-notice && react-scripts build && tsc -p src/ElectronBackend",
     "compile-all": "tsc -p ./ && tsc --noEmit -p src/ElectronBackend",
     "test": "react-scripts test --watchAll=false --testPathIgnorePatterns=src/e2e-tests",
-    "e2e-test": "concurrently \"yarn build; BROWSER=none react-scripts start\" \"wait-on http://localhost:3000 && react-scripts test --watchAll=false src/e2e-tests\"",
+    "e2e-test": "concurrently -s first -k true \"yarn build; BROWSER=none react-scripts start\" \"wait-on http://localhost:3000 && react-scripts test --watchAll=false --detectOpenHandles --forceExit src/e2e-tests\"",
     "lint": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
     "lint-check": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\"",
     "copyright-lint-check": "reuse lint",


### PR DESCRIPTION
### Summary of changes

Adds a step to the CI which executes the CI for linux and mac. The trick is to tell concurrently to stop when jest exits and persist jests exit code upwards. Also force jest to exit when tests are done.
Increase file watchers for linux. The end2end tests currently do not work under windows yet.

### Context and reason for change

We recently added e2e-tests, but the tests were not running in the CI yet.

### How can the changes be tested

`yarn e2e-test`

