### PR TITLE
Fix flaky e2e-tests

### DIFF
--- a/src/ElectronBackend/main/installExtensionsForDev.ts
+++ b/src/ElectronBackend/main/installExtensionsForDev.ts
@@ -10,7 +10,7 @@ import installExtension, {
 import isDev from 'electron-is-dev';
 
 export function installExtensionsForDev(): void {
-  if (isDev) {
+  if (isDev && !process.env.RUNNING_IN_SPECTRON) {
     installExtension(REDUX_DEVTOOLS)
       .then((name) => console.log(`Added Extension:  ${name}`))
       .catch((err) => console.log('An error occurred: ', err));

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -6,7 +6,7 @@
 import { Application } from 'spectron';
 import path from 'path';
 
-export const INTEGRATION_TEST_TIMEOUT = 35000;
+export const INTEGRATION_TEST_TIMEOUT = 60000;
 
 export function getApp(commandLineArg?: string): Application {
   const app = 'build/ElectronBackend/app.js';


### PR DESCRIPTION
### Summary of changes

- increase the timeout for e2e tests to 60s.
- do not install tests for e2e tests

### Context and reason for change

The tests running on macos in the CI seem to be flaky. Hopefully increasing the timeout helps.

### How can the changes be tested

`yarn e2e-test`
