### PR TITLE
Disable multiline for some fields

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -121,7 +121,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
               props.displayPackageInfo.source.name,
               attributionSources
             )}
-            maxRows={1}
+            multiline={false}
             handleChange={doNothing}
           />
         ) : null}
@@ -133,6 +133,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
         text={props.displayPackageInfo.comment}
         minRows={props.commentRows}
         maxRows={props.commentRows}
+        multiline={true}
         handleChange={props.setUpdateTemporaryPackageInfoFor('comment')}
       />
     </MuiPaper>

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -121,7 +121,6 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
               props.displayPackageInfo.source.name,
               attributionSources
             )}
-            multiline={false}
             handleChange={doNothing}
           />
         ) : null}

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -32,6 +32,7 @@ export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
           text={props.displayPackageInfo.copyright}
           minRows={props.copyrightRows}
           maxRows={props.copyrightRows}
+          multiline={true}
           handleChange={props.setUpdateTemporaryPackageInfoFor('copyright')}
         />
       </div>

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -115,6 +115,7 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
             className={clsx(classes.licenseTextBox, classes.licenseText)}
             minRows={props.licenseTextRows}
             maxRows={props.licenseTextRows}
+            multiline={true}
             title={getLicenseTextLabelText(
               props.displayPackageInfo.licenseName,
               props.isEditable,

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -55,7 +55,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           className={clsx(classes.textBox)}
           title={'Name'}
           text={props.displayPackageInfo.packageName}
-          maxRows={1}
+          multiline={false}
           handleChange={props.setUpdateTemporaryPackageInfoFor('packageName')}
           isEditable={props.nameAndVersionAreEditable}
         />
@@ -63,7 +63,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           className={clsx(classes.textBox, classes.rightTextBox)}
           title={'Version'}
           text={props.displayPackageInfo.packageVersion}
-          maxRows={1}
+          multiline={false}
           handleChange={props.setUpdateTemporaryPackageInfoFor(
             'packageVersion'
           )}
@@ -77,14 +77,14 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
         )}
         title={'PURL'}
         text={props.temporaryPurl}
-        maxRows={1}
+        multiline={false}
         handleChange={props.handlePurlChange}
         isEditable={props.isEditable}
       />
       <TextBox
         isEditable={props.isEditable}
         className={clsx(classes.textBox)}
-        maxRows={1}
+        multiline={false}
         title={'URL'}
         text={props.displayPackageInfo.url}
         handleChange={props.setUpdateTemporaryPackageInfoFor('url')}

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -55,7 +55,6 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           className={clsx(classes.textBox)}
           title={'Name'}
           text={props.displayPackageInfo.packageName}
-          multiline={false}
           handleChange={props.setUpdateTemporaryPackageInfoFor('packageName')}
           isEditable={props.nameAndVersionAreEditable}
         />
@@ -63,7 +62,6 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           className={clsx(classes.textBox, classes.rightTextBox)}
           title={'Version'}
           text={props.displayPackageInfo.packageVersion}
-          multiline={false}
           handleChange={props.setUpdateTemporaryPackageInfoFor(
             'packageVersion'
           )}
@@ -77,14 +75,12 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
         )}
         title={'PURL'}
         text={props.temporaryPurl}
-        multiline={false}
         handleChange={props.handlePurlChange}
         isEditable={props.isEditable}
       />
       <TextBox
         isEditable={props.isEditable}
         className={clsx(classes.textBox)}
-        multiline={false}
         title={'URL'}
         text={props.displayPackageInfo.url}
         handleChange={props.setUpdateTemporaryPackageInfoFor('url')}

--- a/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
@@ -104,7 +104,7 @@ describe('The AttributionDetailsViewer', () => {
     store.dispatch(navigateToView(View.Attribution));
     store.dispatch(setSelectedAttributionId('uuid_1'));
     store.dispatch(setTemporaryPackageInfo(expectedPackageInfo));
-    expect(screen.getByText('React'));
+    expect(screen.getByDisplayValue('React'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }) as Element);
     expect(getManualAttributions(store.getState()).uuid_1).toEqual(

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -82,7 +82,7 @@ describe('The Attribution View', () => {
     expect(screen.getByText('Test other package, 2.0'));
 
     fireEvent.click(screen.getByText('Test package, 1.0') as Element);
-    expect(screen.getByText('Test package'));
+    expect(screen.getByDisplayValue('Test package'));
     expect(screen.getByRole('button', { name: 'Save' }));
     expect(screen.getByText('test resource'));
   });

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -14,6 +14,7 @@ interface TextProps extends InputElementProps {
   minRows?: number;
   maxRows?: number;
   endIcon?: ReactElement;
+  multiline?: boolean;
 }
 
 export function TextBox(props: TextProps): ReactElement {
@@ -35,7 +36,7 @@ export function TextBox(props: TextProps): ReactElement {
             </MuiInputAdornment>
           ),
         }}
-        multiline
+        multiline={props.multiline}
         minRows={props.minRows ? props.minRows : 1}
         maxRows={props.maxRows ? props.maxRows : 1}
         variant="outlined"

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
@@ -145,9 +145,9 @@ describe('The ResourceDetailsAttributionColumn', () => {
       testTemporaryPackageInfo
     );
 
-    expect(screen.getByText('React'));
-    expect(screen.getByText('16.5.0'));
-    expect(screen.getByText(testManualLicense));
+    expect(screen.getByDisplayValue('React'));
+    expect(screen.getByDisplayValue('16.5.0'));
+    expect(screen.getByDisplayValue(testManualLicense));
   });
 
   test('does not show parent attribution if overrideParentMode is false', () => {

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -221,7 +221,7 @@ describe('The ResourceDetailsViewer', () => {
     const externalAttributions = {
       uuid_2: {
         source: { name: 'HC', documentConfidence: 1 },
-        packageName: 'JQuery',
+        packageName: 'React',
         licenseText: testExternalLicense,
       },
     };
@@ -241,9 +241,9 @@ describe('The ResourceDetailsViewer', () => {
     );
 
     fireEvent.click(screen.getByText('jQuery, 16.5.0') as Element);
-    expect(screen.getByText('jQuery'));
-    expect(screen.getByText('16.5.0'));
-    expect(screen.getByText('JQuery'));
+    expect(screen.getByDisplayValue('jQuery'));
+    expect(screen.getByDisplayValue('16.5.0'));
+    expect(screen.getByText('React'));
     expectValueInTextBox(
       screen,
       'License Text (to appear in attribution document)',
@@ -255,7 +255,7 @@ describe('The ResourceDetailsViewer', () => {
       testExternalLicense
     );
 
-    fireEvent.click(screen.getByText('JQuery') as Element);
+    fireEvent.click(screen.getByText('React') as Element);
     expectValueNotInTextBox(
       screen,
       'License Text (to appear in attribution document)',
@@ -445,8 +445,8 @@ describe('The ResourceDetailsViewer', () => {
       testTemporaryPackageInfo
     );
 
-    expect(screen.getByText('jQuery'));
-    expect(screen.getByText('16.5.0'));
+    expect(screen.getByDisplayValue('jQuery'));
+    expect(screen.getByDisplayValue('16.5.0'));
     expectValueInTextBox(
       screen,
       'License Text (to appear in attribution document)',
@@ -462,8 +462,8 @@ describe('The ResourceDetailsViewer', () => {
       testTemporaryPackageInfo2
     );
 
-    expect(screen.getByText('Vue.js'));
-    expect(screen.getByText('2.6.11'));
+    expect(screen.getByDisplayValue('Vue.js'));
+    expect(screen.getByDisplayValue('2.6.11'));
     expectValueInTextBox(
       screen,
       'License Text (to appear in attribution document)',

--- a/src/Frontend/integration-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/__tests__/audit-view.test.tsx
@@ -32,10 +32,12 @@ import {
   expectPackagePanelShown,
   expectResourceBrowserIsNotShown,
   expectValueInAddToAttributionList,
+  expectValueInConfidenceField,
   expectValueInManualPackagePanel,
   expectValueInManualPackagePanelForParentAttribution,
   expectValueInTextBox,
   expectValueNotInAddToAttributionList,
+  expectValueNotInConfidenceField,
   expectValueNotInManualPackagePanel,
   expectValueNotInTextBox,
   getCardInAttributionList,
@@ -279,28 +281,19 @@ describe('The App in Audit View', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'withExternalAttribution.js');
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
 
     clickOnPackageInPackagePanel(screen, 'React, 16.5.0', 'Signals');
     expect(screen.queryAllByDisplayValue('10').length).toEqual(1);
-    expectValueNotInTextBox(
+    expectValueNotInConfidenceField(
       screen,
-      'Confidence',
       `High (${DiscreteConfidence.High})`
     );
 
     clickAddIconOnCardInAttributionList(screen, 'React, 16.5.0');
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectValueNotInTextBox(screen, 'Comment', 'React comment');
     expectValueInTextBox(screen, 'Comment', '');
     expectValueInTextBox(screen, 'Name', 'React');
@@ -308,20 +301,12 @@ describe('The App in Audit View', () => {
 
     clickOnElementInResourceBrowser(screen, 'withManualAttribution.js');
     expectValueInTextBox(screen, 'Name', 'Vue');
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
 
     clickOnElementInResourceBrowser(screen, 'withoutAttribution.js');
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
   });
 
   test('allows to switch between resources by clicking the progress bar', () => {
@@ -503,11 +488,7 @@ describe('The App in Audit View', () => {
         'Permission is not granted'
       );
       expectValueInTextBox(screen, 'Name', 'Vue');
-      expectValueInTextBox(
-        screen,
-        'Confidence',
-        `Low (${DiscreteConfidence.Low})`
-      );
+      expectValueInConfidenceField(screen, `Low (${DiscreteConfidence.Low})`);
       clickAddIconOnCardInAttributionList(screen, 'Angular, 10');
 
       expectValueInAddToAttributionList(screen, 'React, 16.5.0');
@@ -519,11 +500,7 @@ describe('The App in Audit View', () => {
         'Permission is maybe granted.'
       );
       expectValueInTextBox(screen, 'Name', 'Angular');
-      expectValueInTextBox(
-        screen,
-        'Confidence',
-        `High (${DiscreteConfidence.High})`
-      );
+      expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     }
   );
 

--- a/src/Frontend/integration-tests/__tests__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/__tests__/save-attributions.test.tsx
@@ -22,8 +22,10 @@ import {
   expectButtonIsNotShown,
   expectElementsInAutoCompleteAndSelectFirst,
   expectResourceBrowserIsNotShown,
+  expectValueInConfidenceField,
   expectValueInManualPackagePanel,
   expectValueInTextBox,
+  expectValueNotInConfidenceField,
   expectValueNotInTextBox,
   expectValuesInProgressbarTooltip,
   goToView,
@@ -267,59 +269,45 @@ describe('The App in Audit View', () => {
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
-    expectValueInTextBox(screen, 'Confidence', '10');
+    expectValueInConfidenceField(screen, '10');
     expectValuesInProgressbarTooltip(screen, 4, 0, 4, 0);
     expectButton(screen, ButtonText.Confirm);
     expectButton(screen, ButtonText.ConfirmGlobally);
 
     clickOnButton(screen, ButtonText.Confirm);
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectValuesInProgressbarTooltip(screen, 4, 1, 3, 0);
     expectButtonInContextMenuIsNotShown(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
-    expectValueInTextBox(screen, 'Confidence', '10');
-    expectValueNotInTextBox(
+    expectValueInConfidenceField(screen, '10');
+    expectValueNotInConfidenceField(
       screen,
-      'Confidence',
       `High (${DiscreteConfidence.High})`
     );
     expectButton(screen, ButtonText.Confirm);
     expectButton(screen, ButtonText.ConfirmGlobally);
 
     clickOnButton(screen, ButtonText.ConfirmGlobally);
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectValuesInProgressbarTooltip(screen, 4, 3, 1, 0);
     expectButtonInContextMenuIsNotShown(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 
     clickOnElementInResourceBrowser(screen, 'thirdResource.js');
-    expectValueNotInTextBox(screen, 'Confidence', '10');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '10');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectButtonIsNotShown(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 
     clickOnElementInResourceBrowser(screen, 'fourthResource.js');
-    expectValueInTextBox(screen, 'Confidence', '90');
-    expectValueNotInTextBox(
+    expectValueInConfidenceField(screen, '90');
+    expectValueNotInConfidenceField(
       screen,
-      'Confidence',
       `High (${DiscreteConfidence.High})`
     );
     expectValueInTextBox(screen, 'Name', 'Vue');
@@ -327,12 +315,8 @@ describe('The App in Audit View', () => {
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 
     clickOnButton(screen, ButtonText.Confirm);
-    expectValueNotInTextBox(screen, 'Confidence', '90');
-    expectValueInTextBox(
-      screen,
-      'Confidence',
-      `High (${DiscreteConfidence.High})`
-    );
+    expectValueNotInConfidenceField(screen, '90');
+    expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectValuesInProgressbarTooltip(screen, 4, 4, 0, 0);
     expectButtonIsNotShown(screen, ButtonText.Confirm);
   });
@@ -379,7 +363,7 @@ describe('The App in Audit View', () => {
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
-    expectValueInTextBox(screen, 'Confidence', '10');
+    expectValueInConfidenceField(screen, '10');
     expectValuesInProgressbarTooltip(screen, 5, 5, 0, 0);
 
     expectButtonInContextMenu(screen, ButtonText.Delete);
@@ -466,7 +450,7 @@ describe('The App in Audit View', () => {
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
-    expectValueInTextBox(screen, 'Confidence', '10');
+    expectValueInConfidenceField(screen, '10');
     expectValuesInProgressbarTooltip(screen, 5, 0, 5, 0);
 
     expectButtonInContextMenu(screen, ButtonText.Delete);

--- a/src/Frontend/test-helpers/test-helpers.ts
+++ b/src/Frontend/test-helpers/test-helpers.ts
@@ -395,6 +395,24 @@ export function insertValueIntoTextBox(
   });
 }
 
+export function expectValueInConfidenceField(
+  screen: Screen,
+  value: string
+): void {
+  const numberBox = screen.getByLabelText('Confidence');
+  // eslint-disable-next-line testing-library/prefer-screen-queries
+  getByText(numberBox, value);
+}
+
+export function expectValueNotInConfidenceField(
+  screen: Screen,
+  value: string
+): void {
+  const numberBox = screen.getByLabelText('Confidence');
+  // eslint-disable-next-line testing-library/prefer-screen-queries
+  expect(queryByText(numberBox, value)).not.toBeTruthy();
+}
+
 export function expectValueInTextBox(
   screen: Screen,
   textBoxLabel: string,
@@ -402,7 +420,7 @@ export function expectValueInTextBox(
 ): void {
   const textBox = screen.getByLabelText(textBoxLabel);
   // eslint-disable-next-line testing-library/prefer-screen-queries
-  getByText(textBox, value);
+  expect(textBox).toHaveValue(value);
 }
 
 export function expectValueNotInTextBox(


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes

- Add new property multiline for Textbox
- Disable multiline for name, version, purl and url
- Add new test helper functions for confidence fields

### Context and reason for change

Name, version, purl and url should only be one line

### How can the changes be tested

Run `yarn test` and test in the UI
