### PR TITLE
Move link icon to the right side

### DIFF
--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
     paddingLeft: 6,
     height: 24,
     display: 'flex',
-    justifyContent: 'flex-start',
+    justifyContent: 'space-between',
     alignItems: 'center',
     background: OpossumColors.white,
   },
@@ -30,9 +30,6 @@ const useStyles = makeStyles({
     direction: 'rtl',
   },
   tooltip: tooltipStyle,
-  openLinkIcon: {
-    marginLeft: 'auto',
-  },
 });
 
 export function PathBar(): ReactElement | null {
@@ -49,7 +46,7 @@ export function PathBar(): ReactElement | null {
           </bdi>
         </MuiTypography>
       </MuiTooltip>
-      <GoToLinkButton className={classes.openLinkIcon} />
+      <GoToLinkButton />
     </div>
   ) : null;
 }


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes

Move the icon for opening a link in the path bar to the very right

### Context and reason for change

UI consistency.

### How can the changes be tested

In the UI.
