### PR TITLE
enforce object shorthand notation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 2,
     '@typescript-eslint/await-thenable': 2,
     '@typescript-eslint/require-await': 2,
+    'object-shorthand': 2,
     'react/prop-types': 'off',
     'testing-library/no-node-access': 'off', // TODO: remove this line and fix warnings
     'testing-library/no-await-sync-query': 'off', // TODO: remove this line and fix warnings

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -117,7 +117,7 @@ export async function loadJsonFromFilePath(
       attributions: externalAttributions,
       resourcesToAttributions: resourcesToExternalAttributions,
     },
-    frequentLicenses: frequentLicenses,
+    frequentLicenses,
     resolvedExternalAttributions: cleanNonExistentResolvedExternalSignals(
       webContents,
       opossumOutputData.resolvedExternalAttributions,
@@ -195,7 +195,7 @@ function createOutputFileIfItDoesNotExist(
 
     const attributionJSON: OpossumOutputFile = {
       metadata: {
-        projectId: projectId,
+        projectId,
         fileCreationDate: String(Date.now()),
       },
       manualAttributions: preselectedAttributions,

--- a/src/ElectronBackend/output/writeCsvToFile.ts
+++ b/src/ElectronBackend/output/writeCsvToFile.ts
@@ -153,7 +153,7 @@ function writeAttributionWithResources(
       ...attributionWithResource,
       licenseText: shortenedLicenseText,
       resources: shortenedResources,
-      attributionNumber: attributionNumber,
+      attributionNumber,
     });
   } else {
     attributionWithResource.resources.forEach((resource) => {
@@ -165,12 +165,12 @@ function writeAttributionWithResources(
           ...attributionWithResource,
           licenseText: shortenedLicenseText,
           resources: resource,
-          attributionNumber: attributionNumber,
+          attributionNumber,
         });
       } else {
         csvStream.write({
           resources: resource,
-          attributionNumber: attributionNumber,
+          attributionNumber,
         });
       }
     });
@@ -190,7 +190,7 @@ function writeAttribution(
   csvStream.write({
     ...attributionWithResource,
     licenseText: shortenedLicenseText,
-    attributionNumber: attributionNumber,
+    attributionNumber,
   });
 }
 

--- a/src/ElectronBackend/spdxTools/spdxTools.ts
+++ b/src/ElectronBackend/spdxTools/spdxTools.ts
@@ -82,9 +82,9 @@ export function createSpdxDocument(
       creators: [`Tool: ${creatorTool}`],
     },
     documentDescribes: [ROOT_PACKAGE_SPDX_ID], // c.f. https://github.com/spdx/spdx-spec/issues/395
-    dataLicense: dataLicense,
+    dataLicense,
     ...(documentName && { name: documentName }),
-    documentNamespace: documentNamespace,
+    documentNamespace,
     ...spdxAttributions,
   };
 }

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
   hidden: {
     visibility: 'hidden',
   },
-  clickableIcon: clickableIcon,
+  clickableIcon,
 });
 
 interface GoToLinkProps {

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../shared-styles';
 
 const useStyles = makeStyles({
-  clickableIcon: clickableIcon,
+  clickableIcon,
   nonClickableIcon: {
     ...baseIcon,
     color: OpossumColors.darkBlue,

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles({
   excludeFromNoticeIcon: {
     color: OpossumColors.grey,
   },
-  clickableIcon: clickableIcon,
+  clickableIcon,
 });
 
 interface PackageCardProps {

--- a/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
+++ b/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
@@ -14,7 +14,7 @@ import { makeStyles } from '@material-ui/styles';
 import { clickableIcon } from '../../shared-styles';
 
 const useStyles = makeStyles({
-  clickableIcon: clickableIcon,
+  clickableIcon,
 });
 
 interface PackagePanelCardProps {

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles({
   tableData: {
     overflow: 'auto',
     whiteSpace: 'pre-line',
-    padding: padding,
+    padding,
     height: reportTableRowHeight - 2 * padding,
   },
   iconTableData: {
@@ -100,7 +100,7 @@ const useStyles = makeStyles({
   containerWithoutLineBreak: {
     whiteSpace: 'nowrap',
   },
-  clickableIcon: clickableIcon,
+  clickableIcon,
 });
 
 type CellData = number | string | Source;

--- a/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
@@ -101,7 +101,7 @@ describe('The table helpers', () => {
       };
 
       const testAttributionInfo: AttributionInfo = {
-        followUp: followUp,
+        followUp,
         resources: ['1'],
       };
 

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
@@ -56,7 +56,7 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
     loadFromFile(
       getParsedInputFileEnrichedWithTestData({
         manualAttributions,
-        resourcesToManualAttributions: resourcesToManualAttributions,
+        resourcesToManualAttributions,
       })
     )
   );

--- a/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
@@ -63,7 +63,7 @@ function getExternalAttributionIdsWithCount(
   attributionIds: Array<string>
 ): Array<AttributionIdWithCount> {
   return attributionIds.map((attributionId) => ({
-    attributionId: attributionId,
+    attributionId,
   }));
 }
 

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -168,8 +168,8 @@ describe('The ResourceDetailsViewer', () => {
     store.dispatch(
       loadFromFile(
         getParsedInputFileEnrichedWithTestData({
-          externalAttributions: externalAttributions,
-          resourcesToExternalAttributions: resourcesToExternalAttributions,
+          externalAttributions,
+          resourcesToExternalAttributions,
         })
       )
     );
@@ -200,8 +200,8 @@ describe('The ResourceDetailsViewer', () => {
     store.dispatch(
       loadFromFile(
         getParsedInputFileEnrichedWithTestData({
-          externalAttributions: externalAttributions,
-          resourcesToExternalAttributions: resourcesToExternalAttributions,
+          externalAttributions,
+          resourcesToExternalAttributions,
         })
       )
     );

--- a/src/Frontend/integration-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/__tests__/audit-view.test.tsx
@@ -679,7 +679,7 @@ describe('The App in Audit View', () => {
         resourcesToManualAttributions: testResourcesToManualAttributions,
         externalAttributions: testExternalAttributions,
         resourcesToExternalAttributions: testResourcesToExternalAttributions,
-        attributionBreakpoints: attributionBreakpoints,
+        attributionBreakpoints,
       })
     );
 

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -105,7 +105,7 @@ export function selectAttributionInAccordionPanelOrOpenUnsavedPopup(
       dispatch(
         setDisplayedPackageAndResetTemporaryPackageInfo({
           panel: packagePanelTitle,
-          attributionId: attributionId,
+          attributionId,
         })
       );
     }
@@ -123,7 +123,7 @@ export function selectAttributionInManualPackagePanelOrOpenUnsavedPopup(
       dispatch(
         setDisplayedPackageAndResetTemporaryPackageInfo({
           panel: packagePanelTitle,
-          attributionId: attributionId,
+          attributionId,
         })
       );
     }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -577,7 +577,7 @@ export const resourceState = (
           ),
           externalData: {
             ...state.allViews.externalData,
-            resourcesWithAttributedChildren: resourcesWithAttributedChildren,
+            resourcesWithAttributedChildren,
           },
         },
         auditView: {

--- a/src/Frontend/util/handle-purl.ts
+++ b/src/Frontend/util/handle-purl.ts
@@ -29,7 +29,7 @@ export function parsePurl(potentialPurl: string): ParsedPurl {
         packageNamespace:
           packageURL && packageURL.namespace ? packageURL.namespace : undefined,
         packageType: packageURL ? packageURL.type : undefined,
-        packagePURLAppendix: packagePURLAppendix,
+        packagePURLAppendix,
       },
     };
   } catch {


### PR DESCRIPTION


### Summary of changes

Introduce new lint rule to enforce use of object shorthand notation

### Context and reason for change

We had this rule implicitly. However, automation is better than manual curation.


