### PR TITLE
Deactivate devtools in e2e tests

### DIFF
--- a/src/ElectronBackend/main/installExtensionsForDev.ts
+++ b/src/ElectronBackend/main/installExtensionsForDev.ts
@@ -10,7 +10,7 @@ import installExtension, {
 import isDev from 'electron-is-dev';
 
 export function installExtensionsForDev(): void {
-  if (isDev) {
+  if (isDev && !process.env.RUNNING_IN_E2E_TEST) {
     installExtension(REDUX_DEVTOOLS)
       .then((name) => console.log(`Added Extension:  ${name}`))
       .catch((err) => console.log('An error occurred: ', err));

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -17,6 +17,7 @@ export async function getApp(
     timeout: 60000,
     env: {
       DISPLAY: process.env.DISPLAY ?? ':99',
+      RUNNING_IN_E2E_TEST: 'true',
     },
   });
 }


### PR DESCRIPTION
### Summary of changes

Deactivate devtools in e2e tests

### Context and reason for change

Fix flaky windows tests

### How can the changes be tested

