### PR TITLE
Add hide button to context menu

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -100,6 +100,9 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   );
   const view = useAppSelector(getSelectedView);
 
+  const selectedPackageId = selectedPackage
+    ? selectedPackage.attributionId
+    : '';
   const {
     isLicenseTextShown,
     setIsLicenseTextShown,
@@ -262,12 +265,12 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       <ButtonRow
         showButtonGroup={props.showManualAttributionData}
         resolvedToggleHandler={getResolvedToggleHandler(
-          selectedPackage,
+          selectedPackageId,
           resolvedExternalAttributions,
           dispatch
         )}
         selectedPackageIsResolved={selectedPackageIsResolved(
-          selectedPackage,
+          selectedPackageId,
           resolvedExternalAttributions
         )}
         areButtonsHidden={props.areButtonsHidden}

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -35,6 +35,7 @@ import {
 import { doNothing } from '../../../util/do-nothing';
 import { AttributionColumn } from '../AttributionColumn';
 import { IpcChannel } from '../../../../shared/ipc-channels';
+import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 
 let originalIpcRenderer: IpcRenderer;
 
@@ -481,6 +482,7 @@ describe('The AttributionColumn', () => {
           onDeleteGloballyButtonClick={doNothing}
         />
       );
+      store.dispatch(setSelectedAttributionId('TestId'));
       store.dispatch(setResources({}));
       store.dispatch(
         setDisplayedPackage({

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackagePanelTitle, View } from '../../../enums/enums';
+import { View } from '../../../enums/enums';
 import {
   getLicenseTextMaxRows,
   getMergeButtonsDisplayState,
@@ -21,31 +21,19 @@ describe('The AttributionColumn helpers', () => {
 
   test('selectedPackageIsResolved returns true', () => {
     expect(
-      selectedPackageIsResolved(
-        {
-          panel: PackagePanelTitle.AllAttributions,
-          attributionId: '123',
-        },
-        new Set<string>().add('123')
-      )
+      selectedPackageIsResolved('123', new Set<string>().add('123'))
     ).toEqual(true);
   });
 
-  test('selectedPackageIsResolved returns false if no selectedpackage', () => {
-    expect(
-      selectedPackageIsResolved(null, new Set<string>().add('123'))
-    ).toEqual(false);
+  test('selectedPackageIsResolved returns false if empty attributionId', () => {
+    expect(selectedPackageIsResolved('', new Set<string>().add('123'))).toEqual(
+      false
+    );
   });
 
   test('selectedPackageIsResolved returns false if id does not match', () => {
     expect(
-      selectedPackageIsResolved(
-        {
-          panel: PackagePanelTitle.AllAttributions,
-          attributionId: '123',
-        },
-        new Set<string>().add('321')
-      )
+      selectedPackageIsResolved('123', new Set<string>().add('321'))
     ).toEqual(false);
   });
 });

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -110,18 +110,16 @@ export function getFirstPartyChangeHandler(
 }
 
 export function getResolvedToggleHandler(
-  selectedPackage: PanelPackage | null,
+  attributionId: string,
   resolvedExternalAttributions: Set<string>,
   dispatch: AppThunkDispatch
 ): () => void {
   return (): void => {
-    if (selectedPackage) {
-      if (resolvedExternalAttributions.has(selectedPackage.attributionId)) {
-        dispatch(
-          removeResolvedExternalAttribution(selectedPackage.attributionId)
-        );
+    if (attributionId) {
+      if (resolvedExternalAttributions.has(attributionId)) {
+        dispatch(removeResolvedExternalAttribution(attributionId));
       } else {
-        dispatch(addResolvedExternalAttribution(selectedPackage.attributionId));
+        dispatch(addResolvedExternalAttribution(attributionId));
       }
       dispatch(saveManualAndResolvedAttributionsToFile());
     }
@@ -129,11 +127,11 @@ export function getResolvedToggleHandler(
 }
 
 export function selectedPackageIsResolved(
-  selectedPackage: PanelPackage | null,
+  attributionId: string,
   resolvedExternalAttributions: Set<string>
 ): boolean {
-  return selectedPackage
-    ? resolvedExternalAttributions.has(selectedPackage.attributionId)
+  return attributionId
+    ? resolvedExternalAttributions.has(attributionId)
     : false;
 }
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -35,14 +35,19 @@ import {
   unlinkAttributionAndSavePackageInfo,
 } from '../../state/actions/resource-actions/save-actions';
 import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
-import { useAppDispatch } from '../../state/hooks';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionIdOfDisplayedPackageInManualPanel,
+  getResolvedExternalAttributions,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
+import {
+  getResolvedToggleHandler,
+  selectedPackageIsResolved,
+} from '../AttributionColumn/attribution-column-helpers';
 
 const useStyles = makeStyles({
   hiddenIcon: {
@@ -87,6 +92,9 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   const manualAttributions = useSelector(getManualAttributions);
   const selectedResourceId = useSelector(getSelectedResourceId);
   const attributionsToResources = useSelector(getManualAttributionsToResources);
+  const resolvedExternalAttributions = useAppSelector(
+    getResolvedExternalAttributions
+  );
 
   const [showAssociatedResourcesPopup, setShowAssociatedResourcesPopup] =
     useState<boolean>(false);
@@ -242,9 +250,18 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           onClick: (): void => setShowAssociatedResourcesPopup(true),
         },
         {
-          buttonText: ButtonText.Hide, //TODO: implement functionality
-          onClick: doNothing,
-          hidden: !isExternalAttribution || true,
+          buttonText: selectedPackageIsResolved(
+            attributionId,
+            resolvedExternalAttributions
+          )
+            ? ButtonText.Unhide
+            : ButtonText.Hide,
+          onClick: getResolvedToggleHandler(
+            attributionId,
+            resolvedExternalAttributions,
+            dispatch
+          ),
+          hidden: !isExternalAttribution,
         },
       ];
 

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -56,5 +56,6 @@ export enum ButtonText {
   ReplaceMarked = 'Replace marked',
   Undo = 'Undo',
   UnmarkForReplacement = 'Unmark for replacement',
+  Unhide = 'Unhide',
   ShowResources = 'Show resources',
 }


### PR DESCRIPTION
### Summary of changes

Adds the implementation for using the hide / unhide function to the context menu for external attributions.

### Context and reason for change

The hide functionality was missing in the context menu for external attributions in the previous version of the context menu. 

### How can the changes be tested

Run the integration tests in package-card-context-menu.test.tsx and / or try it out in the app with example file.

