### PR TITLE
Change state for filtering

### DIFF
--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Attributions } from '../../../shared/shared-types';
-import { PackagePanelTitle } from '../../enums/enums';
+import { FilterType, PackagePanelTitle } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
 import {
@@ -21,7 +21,7 @@ import { AttributionList } from '../AttributionList/AttributionList';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { OpossumColors } from '../../shared-styles';
 import { topBarHeight } from '../TopBar/TopBar';
-import { areOnlyFollowUpAttributionsShown } from '../../state/selectors/view-selector';
+import { getActiveFilters } from '../../state/selectors/view-selector';
 
 const countAndSearchOffset = 119;
 
@@ -52,7 +52,8 @@ export function AttributionView(): ReactElement {
   const attributionIdMarkedForReplacement: string = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const filterForFollowUp = useAppSelector(areOnlyFollowUpAttributionsShown);
+  const activeFilters = useAppSelector(getActiveFilters);
+  const filterForFollowUp = activeFilters.has(FilterType.OnlyFollowUp);
 
   const { handleFilterChange, getFilteredAttributions } = provideFollowUpFilter(
     filterForFollowUp,

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -11,7 +11,7 @@ import {
   AttributionsToResources,
   AttributionsWithResources,
 } from '../../../shared/shared-types';
-import { View } from '../../enums/enums';
+import { FilterType, View } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { navigateToView } from '../../state/actions/view-actions/view-actions';
 import {
@@ -25,7 +25,7 @@ import { provideFollowUpFilter } from '../../util/provide-follow-up-filter';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Table } from '../Table/Table';
 import { OpossumColors } from '../../shared-styles';
-import { areOnlyFollowUpAttributionsShown } from '../../state/selectors/view-selector';
+import { getActiveFilters } from '../../state/selectors/view-selector';
 
 const useStyles = makeStyles({
   root: {
@@ -47,7 +47,8 @@ export function ReportView(): ReactElement {
   );
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
   const isFileWithChildren = useAppSelector(getIsFileWithChildren);
-  const filterForFollowUp = useAppSelector(areOnlyFollowUpAttributionsShown);
+  const activeFilters = useAppSelector(getActiveFilters);
+  const filterForFollowUp = activeFilters.has(FilterType.OnlyFollowUp);
   const dispatch = useAppDispatch();
 
   const { handleFilterChange, getFilteredAttributions } = provideFollowUpFilter(

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -58,3 +58,9 @@ export enum ButtonText {
   UnmarkForReplacement = 'Unmark for replacement',
   ShowResources = 'Show resources',
 }
+
+export enum FilterType {
+  OnlyFirstParty = 'Only First Party',
+  HideFirstParty = 'Hide First Party',
+  OnlyFollowUp = 'Only Follow Up',
+}

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View } from '../../../../enums/enums';
+import { FilterType, PopupType, View } from '../../../../enums/enums';
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
+  getActiveFilters,
   getOpenPopup,
   getSelectedView,
   getTargetAttributionId,
@@ -20,6 +21,7 @@ import {
   openPopup,
   openPopupWithTargetAttributionId,
   resetViewState,
+  updateActiveFilters,
   setTargetView,
 } from '../view-actions';
 
@@ -98,16 +100,53 @@ describe('view actions', () => {
     testStore.dispatch(navigateToView(View.Attribution));
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(setTargetView(View.Audit));
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
 
     expect(isAttributionViewSelected(testStore.getState())).toBe(true);
     expect(getTargetView(testStore.getState())).toBe(View.Audit);
     expect(getOpenPopup(testStore.getState())).toBe(PopupType.NotSavedPopup);
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+    ).toBe(true);
 
     testStore.dispatch(resetViewState());
-
     expect(isAttributionViewSelected(testStore.getState())).toBe(false);
     expect(getTargetView(testStore.getState())).toBe(null);
     expect(getOpenPopup(testStore.getState())).toBe(null);
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+    ).toBe(false);
+  });
+
+  test('sets filters correctly', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+    ).toBe(true);
+
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+    ).toBe(false);
+
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    testStore.dispatch(updateActiveFilters(FilterType.HideFirstParty));
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+    ).toBe(false);
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.HideFirstParty)
+    ).toBe(true);
+
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    testStore.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+    ).toBe(true);
+    expect(
+      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+    ).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -3,16 +3,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View } from '../../../enums/enums';
+import { PopupType, View, FilterType } from '../../../enums/enums';
 
 export const ACTION_SET_TARGET_VIEW = 'ACTION_SET_TARGET_VIEW';
 export const ACTION_SET_VIEW = 'ACTION_SET_VIEW';
 export const ACTION_OPEN_POPUP = 'ACTION_OPEN_POPUP';
 export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
-export const ACTION_SET_FOLLOW_UP_FILTER = 'ACTION_SET_FOLLOW_UP_FILTER';
 export const ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID =
   'ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID';
+export const ACTION_UPDATE_ACTIVE_FILTERS = 'ACTION_UPDATE_ACTIVE_FILTERS';
 
 export type ViewAction =
   | SetView
@@ -20,8 +20,8 @@ export type ViewAction =
   | ClosePopupAction
   | ResetViewStateAction
   | OpenPopupAction
-  | SetFollowUpFilter
-  | OpenPopupWithTargetAttributionIdAction;
+  | OpenPopupWithTargetAttributionIdAction
+  | UpdateActiveFilters;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -51,9 +51,9 @@ export interface OpenPopupAction {
   payload: OpenPopupActionPopupType;
 }
 
-export interface SetFollowUpFilter {
-  type: typeof ACTION_SET_FOLLOW_UP_FILTER;
-  payload: boolean;
+export interface UpdateActiveFilters {
+  type: typeof ACTION_UPDATE_ACTIVE_FILTERS;
+  payload: FilterType;
 }
 
 interface OpenPopupWithTargetAttributionIdActionPayload {

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PackageInfo } from '../../../../shared/shared-types';
-import { PopupType, View } from '../../../enums/enums';
+import { FilterType, PopupType, View } from '../../../enums/enums';
 import { State } from '../../../types/types';
 import { getPackageInfoOfSelectedAttribution } from '../../selectors/all-views-resource-selectors';
 import { getSelectedView } from '../../selectors/view-selector';
@@ -16,17 +16,17 @@ import {
   ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
-  ACTION_SET_FOLLOW_UP_FILTER,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
+  ACTION_UPDATE_ACTIVE_FILTERS,
   ClosePopupAction,
   OpenPopupWithTargetAttributionIdAction,
   OpenPopupAction,
   ResetViewStateAction,
-  SetFollowUpFilter,
   SetTargetView,
   SetView,
   OpenPopupActionPopupType,
+  UpdateActiveFilters,
 } from './types';
 
 export function resetViewState(): ResetViewStateAction {
@@ -74,10 +74,13 @@ export function closePopup(): ClosePopupAction {
   return { type: ACTION_CLOSE_POPUP };
 }
 
-export function setFollowUpFilter(
-  filterForFollowUp: boolean
-): SetFollowUpFilter {
-  return { type: ACTION_SET_FOLLOW_UP_FILTER, payload: filterForFollowUp };
+export function updateActiveFilters(
+  filterType: FilterType
+): UpdateActiveFilters {
+  return {
+    type: ACTION_UPDATE_ACTIVE_FILTERS,
+    payload: filterType,
+  };
 }
 
 export function openPopupWithTargetAttributionId(

--- a/src/Frontend/state/helpers/__tests__/set-filters.test.ts
+++ b/src/Frontend/state/helpers/__tests__/set-filters.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FilterType } from '../../../enums/enums';
+import { getFiltersToRemove, getUpdatedFilters } from '../set-filters';
+
+describe('The getUpdatedFilters function', () => {
+  test('adds non-existing filter', () => {
+    const activeFilters = new Set([FilterType.OnlyFollowUp]);
+    const expectedFilters = new Set([
+      FilterType.OnlyFollowUp,
+      FilterType.HideFirstParty,
+    ]);
+    expect(getUpdatedFilters(activeFilters, FilterType.HideFirstParty)).toEqual(
+      expectedFilters
+    );
+  });
+
+  test('remove existing filter', () => {
+    const activeFilters = new Set([
+      FilterType.OnlyFollowUp,
+      FilterType.HideFirstParty,
+    ]);
+    const expectedFilters = new Set([FilterType.OnlyFollowUp]);
+    expect(getUpdatedFilters(activeFilters, FilterType.HideFirstParty)).toEqual(
+      expectedFilters
+    );
+  });
+});
+
+describe('The getFiltersToRemove function', () => {
+  test('returns only first party filter when the new filter is hide first party', () => {
+    const filtersToRemove = new Set([FilterType.OnlyFirstParty]);
+    expect(getFiltersToRemove(FilterType.HideFirstParty)).toEqual(
+      filtersToRemove
+    );
+  });
+
+  test('returns hide first party filter when the new filter is only first party', () => {
+    const filtersToRemove = new Set([FilterType.HideFirstParty]);
+    expect(getFiltersToRemove(FilterType.OnlyFirstParty)).toEqual(
+      filtersToRemove
+    );
+  });
+
+  test('returns no filter when the new filter is only follow up', () => {
+    const filtersToRemove = new Set();
+    expect(getFiltersToRemove(FilterType.OnlyFollowUp)).toEqual(
+      filtersToRemove
+    );
+  });
+});

--- a/src/Frontend/state/helpers/set-filters.ts
+++ b/src/Frontend/state/helpers/set-filters.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FilterType } from '../../enums/enums';
+const mutuallyExclusiveFilters = [
+  [FilterType.OnlyFirstParty, FilterType.HideFirstParty],
+];
+
+export function getUpdatedFilters(
+  activeFilters: Set<FilterType>,
+  newFilter: FilterType
+): Set<FilterType> {
+  const currentFilters = new Set(activeFilters);
+  if (currentFilters.has(newFilter)) {
+    currentFilters.delete(newFilter);
+  } else {
+    const filtersToRemove = getFiltersToRemove(newFilter);
+    if (filtersToRemove.size !== 0) {
+      filtersToRemove.forEach((element) => currentFilters.delete(element));
+    }
+    currentFilters.add(newFilter);
+  }
+  return currentFilters;
+}
+
+export function getFiltersToRemove(newFilter: FilterType): Set<FilterType> {
+  return new Set(
+    mutuallyExclusiveFilters
+      .filter((filterPair) => filterPair.includes(newFilter))
+      .map((filterPair) =>
+        filterPair.indexOf(newFilter) ? filterPair[0] : filterPair[1]
+      )
+  );
+}

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -3,32 +3,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View } from '../../enums/enums';
+import { PopupType, View, FilterType } from '../../enums/enums';
 import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
-  ACTION_SET_FOLLOW_UP_FILTER,
+  ACTION_UPDATE_ACTIVE_FILTERS,
   ViewAction,
   ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID,
 } from '../actions/view-actions/types';
+import { getUpdatedFilters } from '../helpers/set-filters';
 
 export interface ViewState {
   view: View;
   targetView: View | null;
   openPopup: PopupType | null;
-  filterForFollowUp: boolean;
   targetAttributionId: string;
+  activeFilters: Set<FilterType>;
 }
 
 export const initialViewState: ViewState = {
   view: View.Audit,
   targetView: null,
   openPopup: null,
-  filterForFollowUp: false,
   targetAttributionId: '',
+  activeFilters: new Set<FilterType>(),
 };
 
 export function viewState(
@@ -58,10 +59,10 @@ export function viewState(
         ...state,
         openPopup: action.payload,
       };
-    case ACTION_SET_FOLLOW_UP_FILTER:
+    case ACTION_UPDATE_ACTIVE_FILTERS:
       return {
         ...state,
-        filterForFollowUp: action.payload,
+        activeFilters: getUpdatedFilters(state.activeFilters, action.payload),
       };
     case ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID:
       return {

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View } from '../../enums/enums';
+import { FilterType, PopupType, View } from '../../enums/enums';
 import { State } from '../../types/types';
 
 export function isAttributionViewSelected(state: State): boolean {
@@ -30,8 +30,8 @@ export function getOpenPopup(state: State): null | PopupType {
   return state.viewState.openPopup;
 }
 
-export function areOnlyFollowUpAttributionsShown(state: State): boolean {
-  return state.viewState.filterForFollowUp;
+export function getActiveFilters(state: State): Set<FilterType> {
+  return state.viewState.activeFilters;
 }
 
 export function getTargetAttributionId(state: State): string {

--- a/src/Frontend/util/provide-follow-up-filter.ts
+++ b/src/Frontend/util/provide-follow-up-filter.ts
@@ -9,7 +9,8 @@ import {
   AttributionsWithResources,
   PackageInfo,
 } from '../../shared/shared-types';
-import { setFollowUpFilter } from '../state/actions/view-actions/view-actions';
+import { FilterType } from '../enums/enums';
+import { updateActiveFilters } from '../state/actions/view-actions/view-actions';
 import { AppThunkDispatch } from '../state/types';
 
 export function provideFollowUpFilter(
@@ -22,7 +23,7 @@ export function provideFollowUpFilter(
   ): AttributionsWithResources | Attributions;
 } {
   function handleFilterChange(): void {
-    dispatch(setFollowUpFilter(!filterForFollowUp));
+    dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
   }
   function getFilteredAttributions(
     attributions: AttributionsWithResources | Attributions


### PR DESCRIPTION
### Summary of changes
- create 3 filters as enum: only 1st party , hide 1st party, only follow-up 
- save active filters in state
- update the follow-up action and selector
- add logic enforces only 1st party or hide 1st party filter can be active at once
- fix follow up filtering logic, to use the new state

### Context and reason for change
- new filters for show only first party and hide first party are required

### How can the changes be tested
run `yarn test:unit`


