### PR TITLE
remove show resources icon

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -69,7 +69,6 @@ interface PackageCardProps {
   cardConfig: ListCardConfig;
   onClick(): void;
   onIconClick?(): void;
-  openResourcesIcon?: JSX.Element;
   hideContextMenu?: boolean;
   hideResourceSpecificButtons?: boolean;
 }
@@ -121,9 +120,6 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   ) : undefined;
   const rightIcons: Array<JSX.Element> = [];
 
-  if (props.openResourcesIcon) {
-    rightIcons.push(props.openResourcesIcon);
-  }
   if (props.cardConfig.firstParty) {
     rightIcons.push(
       <FirstPartyIcon key={getKey('first-party-icon', props.cardContent)} />

--- a/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
+++ b/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
@@ -61,7 +61,6 @@ describe('The PackagePanel', () => {
 
     expect(screen.getByText('React, 16.5.0'));
     expect(screen.getByText('JQuery'));
-    expect(screen.getAllByLabelText('show resources'));
   });
 
   test('groups by source and prettifies known sources', () => {

--- a/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
+++ b/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
@@ -8,14 +8,6 @@ import { getCardLabels } from '../PackageCard/package-card-helpers';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { ListCardConfig, ListCardContent } from '../../types/types';
-import { IconButton } from '../IconButton/IconButton';
-import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
-import { makeStyles } from '@material-ui/styles';
-import { clickableIcon } from '../../shared-styles';
-
-const useStyles = makeStyles({
-  clickableIcon,
-});
 
 interface PackagePanelCardProps {
   cardContent: ListCardContent;
@@ -30,8 +22,6 @@ interface PackagePanelCardProps {
 export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
   const [showAssociatedResourcesPopup, setShowAssociatedResourcesPopup] =
     useState<boolean>(false);
-
-  const classes = useStyles();
 
   return (
     <div>
@@ -50,22 +40,6 @@ export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
         cardConfig={props.cardConfig}
         packageCount={props.packageCount}
         hideResourceSpecificButtons={props.hideResourceSpecificButtons}
-        openResourcesIcon={
-          <IconButton
-            tooltipTitle="show resources"
-            placement="right"
-            onClick={(): void => {
-              setShowAssociatedResourcesPopup(true);
-            }}
-            key={`open-resources-icon-${props.cardContent.name}-${props.cardContent.packageVersion}`}
-            icon={
-              <OpenInBrowserIcon
-                className={classes.clickableIcon}
-                aria-label={'show resources'}
-              />
-            }
-          />
-        }
       />
     </div>
   );

--- a/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
+++ b/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import {
   createTestAppStore,
@@ -11,14 +11,10 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 import { doNothing } from '../../../util/do-nothing';
 import { PackagePanelCard } from '../PackagePanelCard';
-import {
-  Attributions,
-  ResourcesToAttributions,
-} from '../../../../shared/shared-types';
+import { Attributions } from '../../../../shared/shared-types';
 import { ListCardConfig, ListCardContent } from '../../../types/types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/test-helpers';
-import { ButtonText } from '../../../enums/enums';
 
 const testCardContent: ListCardContent = { id: '1', name: 'Test' };
 const testCardConfig: ListCardConfig = { firstParty: true };
@@ -61,7 +57,7 @@ describe('The PackagePanelCard', () => {
     expect(screen.getByText('Test'));
   });
 
-  test('renders only first party icon and show resources icon', () => {
+  test('renders only first party icon', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -80,7 +76,6 @@ describe('The PackagePanelCard', () => {
       { store: testStore }
     );
 
-    expect(screen.getByLabelText('show resources'));
     expect(screen.getByLabelText('First party icon'));
     expect(screen.queryByLabelText('Exclude from notice icon')).toBeFalsy();
     expect(screen.queryByLabelText('Follow-up icon')).toBeFalsy();
@@ -106,7 +101,6 @@ describe('The PackagePanelCard', () => {
       { store: testStore }
     );
 
-    expect(screen.getByLabelText('show resources'));
     expect(screen.getByLabelText('First party icon'));
     expect(screen.getByLabelText('Exclude from notice icon'));
     expect(screen.getByLabelText('Follow-up icon'));
@@ -131,43 +125,6 @@ describe('The PackagePanelCard', () => {
       { store: testStore }
     );
 
-    expect(screen.getByLabelText('show resources'));
     expect(screen.getByLabelText('Pre-selected icon'));
-  });
-
-  test('has working resources icon', () => {
-    const manualAttributions: Attributions = {
-      uuid_1: { packageName: 'Test package' },
-    };
-    const resourcesToAttributions: ResourcesToAttributions = {
-      '/thirdParty': ['uuid_1'],
-    };
-    const testStore = createTestAppStore();
-    testStore.dispatch(
-      loadFromFile(
-        getParsedInputFileEnrichedWithTestData({
-          manualAttributions,
-          resourcesToManualAttributions: resourcesToAttributions,
-        })
-      )
-    );
-    renderComponentWithStore(
-      <PackagePanelCard
-        onClick={doNothing}
-        cardContent={testCardContent}
-        attributionId={'uuid_1'}
-        cardConfig={testCardConfig}
-      />,
-      { store: testStore }
-    );
-
-    expect(screen.getByLabelText('show resources'));
-    expect(screen.queryByLabelText('Resources for signal')).toBeNull();
-
-    fireEvent.click(screen.getByLabelText('show resources'));
-    expect(screen.getByText('Resources for selected attribution'));
-
-    fireEvent.click(screen.getByText(ButtonText.Close));
-    expect(screen.queryByLabelText('Resources for selected signal')).toBeNull();
   });
 });

--- a/src/Frontend/integration-tests/__tests__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/__tests__/other-popups.test.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { IpcRenderer } from 'electron';
 import React from 'react';
 import { IpcChannel } from '../../../shared/ipc-channels';
@@ -17,21 +17,17 @@ import {
   clickOnButton,
   clickOnCardInAttributionList,
   clickOnElementInResourceBrowser,
-  clickOnPathInPopupWithResources,
   clickOnTab,
   EMPTY_PARSED_FILE_CONTENT,
   expectButton,
   expectButtonInHamburgerMenu,
   expectErrorPopupIsNotShown,
   expectErrorPopupIsShown,
-  expectPackageInPackagePanel,
-  expectPackagePanelShown,
   expectUnsavedChangesPopupIsNotShown,
   expectUnsavedChangesPopupIsShown,
   expectValueInAddToAttributionList,
   expectValueInTextBox,
   expectValueNotInTextBox,
-  getOpenResourcesIconForPackagePanel,
   insertValueIntoTextBox,
   mockElectronIpcRendererOn,
   TEST_TIMEOUT,
@@ -40,8 +36,6 @@ import { App } from '../../Components/App/App';
 
 import { TIME_POPUP_IS_DISPLAYED } from '../../Components/ErrorPopup/ErrorPopup';
 import { ButtonText, DiscreteConfidence } from '../../enums/enums';
-import { setExternalAttributionSources } from '../../state/actions/resource-actions/all-views-simple-actions';
-import { ATTRIBUTION_SOURCES } from '../../../shared/shared-constants';
 
 let originalIpcRenderer: IpcRenderer;
 
@@ -256,51 +250,6 @@ describe('Other popups of the app', () => {
     expectUnsavedChangesPopupIsNotShown(screen);
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
-  });
-
-  test('opens working popup with file list when clicking on show resources icon', () => {
-    const mockChannelReturn: ParsedFileContent = {
-      ...EMPTY_PARSED_FILE_CONTENT,
-      resources: {
-        root: { src: { file_2: 1 } },
-        file: 1,
-        directory_manual: { subdirectory_manual: { file_manual: 1 } },
-      },
-      manualAttributions: {
-        attributions: {
-          uuid_1: { packageName: 'React' },
-        },
-        resourcesToAttributions: {
-          '/directory_manual/subdirectory_manual/': ['uuid_1'],
-        },
-      },
-      externalAttributions: {
-        attributions: {
-          uuid_1: {
-            source: {
-              name: 'HC',
-              documentConfidence: 99.0,
-            },
-            packageName: 'JQuery',
-          },
-        },
-        resourcesToAttributions: {
-          '/root/src/': ['uuid_1'],
-        },
-      },
-    };
-    mockElectronBackend(mockChannelReturn);
-    const { store } = renderComponentWithStore(<App />);
-    store.dispatch(setExternalAttributionSources(ATTRIBUTION_SOURCES));
-
-    clickOnElementInResourceBrowser(screen, '/');
-
-    expectPackagePanelShown(screen, 'Signals in Folder Content');
-    expectPackageInPackagePanel(screen, 'JQuery', 'Signals in Folder Content');
-
-    fireEvent.click(getOpenResourcesIconForPackagePanel(screen, 'JQuery'));
-    clickOnPathInPopupWithResources(screen, '/root/src/');
-    expectPackageInPackagePanel(screen, 'JQuery', 'High Compute');
   });
 
   jest.useFakeTimers();

--- a/src/Frontend/test-helpers/test-helpers.ts
+++ b/src/Frontend/test-helpers/test-helpers.ts
@@ -171,17 +171,6 @@ export function getPopupWithResources(screen: Screen): HTMLElement {
     .parentElement as HTMLElement;
 }
 
-export function getOpenResourcesIconForPackagePanel(
-  screen: Screen,
-  packageName: string
-): HTMLElement {
-  // eslint-disable-next-line testing-library/prefer-screen-queries
-  return getByLabelText(
-    getPackagePanel(screen, packageName),
-    'show resources'
-  ) as HTMLElement;
-}
-
 export function getPackagePanel(
   screen: Screen,
   packagePanelName: string


### PR DESCRIPTION


### Summary of changes

remove show resources icon

### Context and reason for change

The show resources popup is now available in the context menu. Therefore, the respective icon that was displayed for signals is removed.



