### PR TITLE
keep comments when promoting signal

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -398,6 +398,7 @@ describe('Test of loading function', () => {
           [manualAttributionUuid]: {
             packageName: 'my app',
             packageVersion: '1.2.3',
+            comment: 'some comment',
             copyright: '(c) first party',
             preSelected: true,
             attributionConfidence: 17,

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -24,8 +24,8 @@ import {
 import { parseOpossumInputFile, parseOpossumOutputFile } from './parseFile';
 import {
   GlobalBackendState,
-  OpossumOutputFile,
   JsonParsingError,
+  OpossumOutputFile,
   ParsedOpossumInputFile,
 } from '../types/types';
 import { WebContents } from 'electron';
@@ -171,7 +171,6 @@ function createOutputFileIfItDoesNotExist(
     const preselectedExternalAttributions = Object.fromEntries(
       Object.entries(externalAttributionsCopy).filter(([, packageInfo]) => {
         delete packageInfo.source;
-        delete packageInfo.comment;
         return Boolean(packageInfo.preSelected);
       })
     );

--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -10,7 +10,7 @@ import React, { ReactElement } from 'react';
 import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInAccordionPanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import { addManualAttributionToSelectedResource } from '../../state/actions/resource-actions/save-actions';
+import { addToSelectedResource } from '../../state/actions/resource-actions/save-actions';
 import { FilteredList } from '../FilteredList/FilteredList';
 import { PackagePanelCard } from '../PackagePanelCard/PackagePanelCard';
 import { OpossumColors } from '../../shared-styles';
@@ -50,7 +50,7 @@ export function AllAttributionsPanel(
     }
 
     function onAddClick(): void {
-      dispatch(addManualAttributionToSelectedResource(packageInfo));
+      dispatch(addToSelectedResource(packageInfo));
     }
 
     const cardConfig: ListCardConfig = {

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -20,7 +20,6 @@ import PlusIcon from '@material-ui/icons/Add';
 import clsx from 'clsx';
 import { ContextMenu, ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { ButtonText, PopupType, View } from '../../enums/enums';
-import { doNothing } from '../../util/do-nothing';
 import { useSelector } from 'react-redux';
 import {
   getManualAttributions,
@@ -105,7 +104,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     <IconButton
       tooltipTitle="add"
       placement="left"
-      onClick={props.onIconClick ? props.onIconClick : doNothing}
+      onClick={props.onIconClick}
       key={getKey('add-icon', props.cardContent)}
       icon={
         <PlusIcon

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -13,10 +13,7 @@ import {
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInAccordionPanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import {
-  addManualAttributionToSelectedResource,
-  addSignalToSelectedResource,
-} from '../../state/actions/resource-actions/save-actions';
+import { addToSelectedResource } from '../../state/actions/resource-actions/save-actions';
 import {
   getDisplayedPackage,
   getResolvedExternalAttributions,
@@ -92,16 +89,10 @@ export function PackagePanel(
     switch (props.title) {
       case PackagePanelTitle.ExternalPackages:
       case PackagePanelTitle.ContainedExternalPackages:
-        dispatch(
-          addSignalToSelectedResource(props.attributions[attributionId])
-        );
+        dispatch(addToSelectedResource(props.attributions[attributionId]));
         break;
       case PackagePanelTitle.ContainedManualPackages:
-        dispatch(
-          addManualAttributionToSelectedResource(
-            props.attributions[attributionId]
-          )
-        );
+        dispatch(addToSelectedResource(props.attributions[attributionId]));
         break;
     }
   }

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -244,8 +244,7 @@ describe('The App in Audit View', () => {
     clickAddIconOnCardInAttributionList(screen, 'React, 16.5.0');
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
-    expectValueNotInTextBox(screen, 'Comment', 'React comment');
-    expectValueInTextBox(screen, 'Comment', '');
+    expectValueInTextBox(screen, 'Comment', 'React comment');
     expectValueInTextBox(screen, 'Name', 'React');
     clickOnButton(screen, ButtonText.Save);
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -55,8 +55,7 @@ import {
 } from '../audit-view-simple-actions';
 import { loadFromFile } from '../load-actions';
 import {
-  addManualAttributionToSelectedResource,
-  addSignalToSelectedResource,
+  addToSelectedResource,
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
   saveManualAndResolvedAttributionsToFile,
@@ -948,7 +947,7 @@ describe('The deleteAttributionGloballyAndSave action', () => {
   });
 });
 
-describe('The addManualAttributionToSelectedResource action', () => {
+describe('The addToSelectedResource action', () => {
   let originalIpcRenderer: IpcRenderer;
 
   beforeAll(() => {
@@ -984,9 +983,7 @@ describe('The addManualAttributionToSelectedResource action', () => {
       ]
     ).toEqual(['/root/src/something.js']);
 
-    testStore.dispatch(
-      addManualAttributionToSelectedResource(testTemporaryPackageInfo)
-    );
+    testStore.dispatch(addToSelectedResource(testTemporaryPackageInfo));
     const manualData: AttributionData = getManualData(testStore.getState());
     expect(manualData.resourcesToAttributions['/root/']).toEqual([
       testManualAttributionUuid_1,
@@ -1019,29 +1016,8 @@ describe('The addManualAttributionToSelectedResource action', () => {
     ).toEqual(['/root/src/something.js']);
 
     testStore.dispatch(setTemporaryPackageInfo({ packageName: 'modified' }));
-    testStore.dispatch(
-      addManualAttributionToSelectedResource(testTemporaryPackageInfo)
-    );
+    testStore.dispatch(addToSelectedResource(testTemporaryPackageInfo));
     expect(getOpenPopup(testStore.getState())).toEqual('NotSavedPopup');
-  });
-});
-
-describe('The addSignalToSelectedResource action', () => {
-  let originalIpcRenderer: IpcRenderer;
-
-  beforeAll(() => {
-    originalIpcRenderer = global.window.ipcRenderer;
-    global.window.ipcRenderer = {
-      on: jest.fn(),
-      invoke: jest.fn(),
-    } as unknown as IpcRenderer;
-  });
-
-  beforeEach(() => jest.clearAllMocks());
-
-  afterAll(() => {
-    // Important to restore the original value.
-    global.window.ipcRenderer = originalIpcRenderer;
   });
 
   test('adds a signal to the selected resource', () => {
@@ -1067,7 +1043,7 @@ describe('The addSignalToSelectedResource action', () => {
       copyright: 'test copyright',
       comment: 'Comment of signal',
     };
-    testStore.dispatch(addSignalToSelectedResource(testPackageInfo));
+    testStore.dispatch(addToSelectedResource(testPackageInfo));
 
     const manualData: AttributionData = getManualData(testStore.getState());
     expect(manualData.resourcesToAttributions['/root/'].length).toEqual(1);
@@ -1084,6 +1060,7 @@ describe('The addSignalToSelectedResource action', () => {
       licenseText: ' test License text',
       url: 'test url',
       copyright: 'test copyright',
+      comment: 'Comment of signal',
     };
     expect(manualData.attributions[uuidNewAttribution]).toEqual(
       expectedModifiedPackageInfo
@@ -1092,33 +1069,6 @@ describe('The addSignalToSelectedResource action', () => {
       expectedModifiedPackageInfo
     );
     expect(getOpenPopup(testStore.getState())).toBe(null);
-  });
-
-  test('opens popup', () => {
-    const testStore = createTestAppStore();
-    testStore.dispatch(
-      loadFromFile(
-        getParsedInputFileEnrichedWithTestData({
-          resources: testResources,
-          manualAttributions: testManualAttributions,
-          resourcesToManualAttributions: testResourcesToManualAttributions,
-        })
-      )
-    );
-    testStore.dispatch(setSelectedResourceId('/root/'));
-    testStore.dispatch(setTemporaryPackageInfo({ packageName: 'modified' }));
-    const testPackageInfo: PackageInfo = {
-      attributionConfidence: 30,
-      packageVersion: '1.0',
-      packageName: 'test Package',
-      licenseName: 'test License name',
-      licenseText: ' test License text',
-      url: 'test url',
-      copyright: 'test copyright',
-      comment: 'Comment of signal',
-    };
-    testStore.dispatch(addSignalToSelectedResource(testPackageInfo));
-    expect(getOpenPopup(testStore.getState())).toEqual('NotSavedPopup');
   });
 
   test('saves resolved external signals', () => {

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -23,7 +23,6 @@ import {
   getResourcesToManualAttributions,
   wereTemporaryPackageInfoModified,
 } from '../../selectors/all-views-resource-selectors';
-import omit from 'lodash/omit';
 import { IpcChannel } from '../../../../shared/ipc-channels';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
@@ -189,7 +188,7 @@ export function unlinkAttributionAndSavePackageInfo(
   };
 }
 
-export function addManualAttributionToSelectedResource(
+export function addToSelectedResource(
   packageInfo: PackageInfo
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
@@ -201,24 +200,6 @@ export function addManualAttributionToSelectedResource(
           getSelectedResourceId(getState()),
           null,
           setConfidenceToDefault(packageInfo)
-        )
-      );
-    }
-  };
-}
-
-export function addSignalToSelectedResource(
-  packageInfo: PackageInfo
-): AppThunkAction {
-  return (dispatch: AppThunkDispatch, getState: () => State): void => {
-    if (wereTemporaryPackageInfoModified(getState())) {
-      dispatch(openPopup(PopupType.NotSavedPopup));
-    } else {
-      dispatch(
-        savePackageInfo(
-          getSelectedResourceId(getState()),
-          null,
-          omit(setConfidenceToDefault(packageInfo), 'comment')
         )
       );
     }

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -85,7 +85,7 @@ export function savePackageInfo(
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const strippedPackageInfo: PackageInfo = getStrippedPackageInfo(
-      setConfidenceToDefaultIfNotLowOrHigh(packageInfo)
+      getPackageInfoWithDefaultConfidenceIfNotLowOrHigh(packageInfo)
     );
     const state = getState();
 
@@ -199,7 +199,7 @@ export function addToSelectedResource(
         savePackageInfo(
           getSelectedResourceId(getState()),
           null,
-          setConfidenceToDefault(packageInfo)
+          getPackageInfoWithDefaultConfidence(packageInfo)
         )
       );
     }
@@ -300,7 +300,9 @@ function unlinkResourceFromAttribution(
   };
 }
 
-function setConfidenceToDefault(packageInfo: PackageInfo): PackageInfo {
+function getPackageInfoWithDefaultConfidence(
+  packageInfo: PackageInfo
+): PackageInfo {
   return isEmpty(packageInfo)
     ? packageInfo
     : {
@@ -309,7 +311,7 @@ function setConfidenceToDefault(packageInfo: PackageInfo): PackageInfo {
       };
 }
 
-function setConfidenceToDefaultIfNotLowOrHigh(
+function getPackageInfoWithDefaultConfidenceIfNotLowOrHigh(
   packageInfo: PackageInfo
 ): PackageInfo {
   return packageInfo.attributionConfidence &&
@@ -318,5 +320,5 @@ function setConfidenceToDefaultIfNotLowOrHigh(
       DiscreteConfidence.High.valueOf(),
     ].includes(packageInfo.attributionConfidence)
     ? packageInfo
-    : setConfidenceToDefault(packageInfo);
+    : getPackageInfoWithDefaultConfidence(packageInfo);
 }


### PR DESCRIPTION


### Summary of changes

keep comments when promoting signal

### Context and reason for change

In the past we removed the comment of a signal when it was promoted to an attribution. This behaviour is modified to keep the comment in this case.

