### PR TITLE
Add option to run all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "compile-all": "tsc -p ./ && tsc --noEmit -p src/ElectronBackend",
     "test:unit": "react-scripts test --watchAll=false --testPathIgnorePatterns=src/e2e-tests --testPathIgnorePatterns=src/Frontend/integration-tests",
     "test:local": "react-scripts test --watchAll=false src/ --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__tests__/**/*.ts?(x)\" ]",
+    "test:all": "react-scripts test --watchAll=false src/ --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ] && yarn test:e2e",
     "test:integration-ci": "react-scripts test --watchAll=false src/Frontend/integration-tests --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ]",
     "test:e2e": "run-script-os",
     "test:e2e:darwin:linux": "concurrently -s first -k true \"yarn build:dev; BROWSER=none react-scripts start\" \"wait-on http://localhost:3000 && react-scripts test --watchAll=false --detectOpenHandles --forceExit src/e2e-tests\"",


### PR DESCRIPTION
### Summary of changes

`yarn test:all` executes all tests (i.e. unit, all integration, and e2e tests).

### Context and reason for change

It is sometimes convenient to run all tests locally with just one command.

### How can the changes be tested

run `yarn test:all` from terminal and OpossumUI directory.

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

