### PR TITLE
Add replace attribution to context menu and audit view

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -123,15 +123,14 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       ? selectedPackageId
       : '';
 
-  const mergeButtonDisplayState = getMergeButtonsDisplayState(
-    view,
+  const mergeButtonDisplayState = getMergeButtonsDisplayState({
     attributionIdMarkedForReplacement,
-    currentViewSelectedAttributionId,
-    currentViewSelectedAttributionId,
+    targetAttributionId: currentViewSelectedAttributionId,
+    selectedAttributionId: currentViewSelectedAttributionId,
     packageInfoWereModified,
-    Boolean(temporaryPackageInfo.preSelected),
-    false
-  );
+    targetAttributionIsPreSelected: Boolean(temporaryPackageInfo.preSelected),
+    targetAttributionIsExternalAttribution: false,
+  });
 
   const mainButtonConfigs: Array<MainButtonConfig> = [
     {
@@ -199,7 +198,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
           )
         );
       },
-      hidden: mergeButtonDisplayState.hideOnReplaceMarkedByButton,
+      hidden: mergeButtonDisplayState.hideReplaceMarkedByButton,
     },
   ];
 

--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -10,6 +10,7 @@ import React, { ChangeEvent, ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
+  getAttributionIdMarkedForReplacement,
   getIsSavingDisabled,
   getPackageInfoOfSelected,
   getTemporaryPackageInfo,
@@ -41,12 +42,9 @@ import { LicenseSubPanel } from './LicenseSubPanel';
 import { AuditingSubPanel } from './AuditingSubPanel';
 import { ButtonRow } from './ButtonRow';
 import { setAttributionIdMarkedForReplacement } from '../../state/actions/resource-actions/attribution-view-simple-actions';
-import {
-  getAttributionIdMarkedForReplacement,
-  getSelectedAttributionId,
-} from '../../state/selectors/attribution-view-resource-selectors';
-import { openPopup } from '../../state/actions/view-actions/view-actions';
-import { ButtonText, PopupType } from '../../enums/enums';
+import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
+import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
+import { ButtonText, PopupType, View } from '../../enums/enums';
 import { MainButtonConfig } from '../ButtonGroup/ButtonGroup';
 import { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
@@ -118,13 +116,21 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     selectedPackage
   );
   const nameAndVersionAreEditable = props.isEditable && temporaryPurl === '';
+  const currentViewSelectedAttributionId =
+    view === View.Attribution
+      ? selectedAttributionId
+      : view === View.Audit
+      ? selectedPackageId
+      : '';
 
   const mergeButtonDisplayState = getMergeButtonsDisplayState(
     view,
     attributionIdMarkedForReplacement,
-    selectedAttributionId,
+    currentViewSelectedAttributionId,
+    currentViewSelectedAttributionId,
     packageInfoWereModified,
-    Boolean(temporaryPackageInfo.preSelected)
+    Boolean(temporaryPackageInfo.preSelected),
+    false
   );
 
   const mainButtonConfigs: Array<MainButtonConfig> = [
@@ -169,7 +175,9 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     {
       buttonText: ButtonText.MarkForReplacement,
       onClick: (): void => {
-        dispatch(setAttributionIdMarkedForReplacement(selectedAttributionId));
+        dispatch(
+          setAttributionIdMarkedForReplacement(currentViewSelectedAttributionId)
+        );
       },
       hidden: mergeButtonDisplayState.hideMarkForReplacementButton,
     },
@@ -184,7 +192,12 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       buttonText: ButtonText.ReplaceMarked,
       disabled: mergeButtonDisplayState.deactivateReplaceMarkedByButton,
       onClick: (): void => {
-        dispatch(openPopup(PopupType.ReplaceAttributionPopup));
+        dispatch(
+          openPopupWithTargetAttributionId(
+            PopupType.ReplaceAttributionPopup,
+            currentViewSelectedAttributionId
+          )
+        );
       },
       hidden: mergeButtonDisplayState.hideOnReplaceMarkedByButton,
     },

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -39,146 +39,128 @@ describe('The AttributionColumn helpers', () => {
 });
 
 describe('getMergeButtonsDisplayState', () => {
-  it('does not show buttons when in table view', () => {
-    expect(
-      getMergeButtonsDisplayState(View.Audit, '', '', '', false, false, false)
-    ).toStrictEqual({
-      hideMarkForReplacementButton: true,
-      hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: true,
-      deactivateReplaceMarkedByButton: false,
-    });
-  });
-
   it('does not show buttons when external attribution', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Audit,
-        '',
-        'attr',
-        '',
-        false,
-        false,
-        true
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: '',
+        targetAttributionId: 'attr',
+        selectedAttributionId: '',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: true,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: true,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: true,
+      hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
     });
   });
 
   it('does show markForReplacementButton when another attribution is selected for replacement', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        'other_attr',
-        'attr',
-        'attr',
-        false,
-        false,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'other_attr',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: false,
+      hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: false,
     });
   });
 
   it('shows unMarkForReplacementButton when attribution is already selected for replacement', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        'attr',
-        'attr',
-        'attr',
-        false,
-        false,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: true,
       hideUnmarkForReplacementButton: false,
-      hideOnReplaceMarkedByButton: true,
+      hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
     });
   });
 
   it('does not show unMarkForReplacementButton when attribution is not selected', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        '',
-        'attr',
-        'attr',
-        false,
-        false,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: '',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: true,
+      hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
     });
   });
 
   it('deactivates ReplaceMarkedByButton when selectedAttribution part of replacement and packageInfo were modified', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        'attr2',
-        'attr',
-        'attr',
-        true,
-        false,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: true,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: false,
+      hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: true,
     });
   });
 
   it('enables ReplaceMarkedByButton when selectedAttribution not part of replacement and packageInfo were modified', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        'attr2',
-        'attr1',
-        'attr',
-        true,
-        false,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr1',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: true,
+        targetAttributionIsPreSelected: false,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: false,
+      hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: false,
     });
   });
 
   it('deactivates ReplaceMarkedByButton when attribution is preselected', () => {
     expect(
-      getMergeButtonsDisplayState(
-        View.Attribution,
-        'attr2',
-        'attr',
-        'attr',
-        false,
-        true,
-        false
-      )
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: true,
+        targetAttributionIsExternalAttribution: false,
+      })
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
-      hideOnReplaceMarkedByButton: false,
+      hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: true,
     });
   });

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -39,9 +39,28 @@ describe('The AttributionColumn helpers', () => {
 });
 
 describe('getMergeButtonsDisplayState', () => {
-  it('does not show buttons when outside of attribution view', () => {
+  it('does not show buttons when in table view', () => {
     expect(
-      getMergeButtonsDisplayState(View.Audit, '', '', false, false)
+      getMergeButtonsDisplayState(View.Audit, '', '', '', false, false, false)
+    ).toStrictEqual({
+      hideMarkForReplacementButton: true,
+      hideUnmarkForReplacementButton: true,
+      hideOnReplaceMarkedByButton: true,
+      deactivateReplaceMarkedByButton: false,
+    });
+  });
+
+  it('does not show buttons when external attribution', () => {
+    expect(
+      getMergeButtonsDisplayState(
+        View.Audit,
+        '',
+        'attr',
+        '',
+        false,
+        false,
+        true
+      )
     ).toStrictEqual({
       hideMarkForReplacementButton: true,
       hideUnmarkForReplacementButton: true,
@@ -56,6 +75,8 @@ describe('getMergeButtonsDisplayState', () => {
         View.Attribution,
         'other_attr',
         'attr',
+        'attr',
+        false,
         false,
         false
       )
@@ -73,6 +94,8 @@ describe('getMergeButtonsDisplayState', () => {
         View.Attribution,
         'attr',
         'attr',
+        'attr',
+        false,
         false,
         false
       )
@@ -86,7 +109,15 @@ describe('getMergeButtonsDisplayState', () => {
 
   it('does not show unMarkForReplacementButton when attribution is not selected', () => {
     expect(
-      getMergeButtonsDisplayState(View.Attribution, '', 'attr', false, false)
+      getMergeButtonsDisplayState(
+        View.Attribution,
+        '',
+        'attr',
+        'attr',
+        false,
+        false,
+        false
+      )
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
@@ -95,13 +126,15 @@ describe('getMergeButtonsDisplayState', () => {
     });
   });
 
-  it('deactivates ReplaceMarkedByButton when packageInfo were modified', () => {
+  it('deactivates ReplaceMarkedByButton when selectedAttribution part of replacement and packageInfo were modified', () => {
     expect(
       getMergeButtonsDisplayState(
         View.Attribution,
         'attr2',
         'attr',
+        'attr',
         true,
+        false,
         false
       )
     ).toStrictEqual({
@@ -112,14 +145,35 @@ describe('getMergeButtonsDisplayState', () => {
     });
   });
 
+  it('enables ReplaceMarkedByButton when selectedAttribution not part of replacement and packageInfo were modified', () => {
+    expect(
+      getMergeButtonsDisplayState(
+        View.Attribution,
+        'attr2',
+        'attr1',
+        'attr',
+        true,
+        false,
+        false
+      )
+    ).toStrictEqual({
+      hideMarkForReplacementButton: false,
+      hideUnmarkForReplacementButton: true,
+      hideOnReplaceMarkedByButton: false,
+      deactivateReplaceMarkedByButton: false,
+    });
+  });
+
   it('deactivates ReplaceMarkedByButton when attribution is preselected', () => {
     expect(
       getMergeButtonsDisplayState(
         View.Attribution,
         'attr2',
         'attr',
+        'attr',
         false,
-        true
+        true,
+        false
       )
     ).toStrictEqual({
       hideMarkForReplacementButton: false,

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -150,7 +150,7 @@ export function getLicenseTextLabelText(
     : 'License Text (to appear in attribution document)';
 }
 
-interface MergeButtonDisplayState {
+export interface MergeButtonDisplayState {
   hideMarkForReplacementButton: boolean;
   hideUnmarkForReplacementButton: boolean;
   hideOnReplaceMarkedByButton: boolean;
@@ -160,29 +160,39 @@ interface MergeButtonDisplayState {
 export function getMergeButtonsDisplayState(
   currentView: View,
   attributionIdMarkedForReplacement: string,
+  targetAttributionId: string,
   selectedAttributionId: string,
   packageInfoWereModified: boolean,
-  attributionIsPreSelected: boolean
+  targetAttributionIsPreSelected: boolean,
+  isExternalAttribution: boolean
 ): MergeButtonDisplayState {
-  const isAttributionView = currentView === View.Attribution;
+  const isTableView = currentView === View.Report;
   const anyAttributionMarkedForReplacement =
     attributionIdMarkedForReplacement !== '';
-  const selectedAttributionIsMarkedForReplacement =
-    selectedAttributionId === attributionIdMarkedForReplacement;
+  const targetAttributionIsMarkedForReplacement =
+    targetAttributionId === attributionIdMarkedForReplacement;
+  const selectedAttributionIsPartOfMerge =
+    selectedAttributionId === attributionIdMarkedForReplacement ||
+    selectedAttributionId === targetAttributionId;
 
   return {
     hideMarkForReplacementButton:
-      !isAttributionView || selectedAttributionIsMarkedForReplacement,
+      isExternalAttribution ||
+      isTableView ||
+      targetAttributionIsMarkedForReplacement,
     hideUnmarkForReplacementButton:
-      !isAttributionView ||
+      isExternalAttribution ||
+      isTableView ||
       !anyAttributionMarkedForReplacement ||
-      !selectedAttributionIsMarkedForReplacement,
+      !targetAttributionIsMarkedForReplacement,
     hideOnReplaceMarkedByButton:
-      !isAttributionView ||
+      isExternalAttribution ||
+      isTableView ||
       !anyAttributionMarkedForReplacement ||
-      selectedAttributionIsMarkedForReplacement,
+      targetAttributionIsMarkedForReplacement,
     deactivateReplaceMarkedByButton:
-      packageInfoWereModified || attributionIsPreSelected,
+      (selectedAttributionIsPartOfMerge && packageInfoWereModified) ||
+      targetAttributionIsPreSelected,
   };
 }
 

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -153,46 +153,44 @@ export function getLicenseTextLabelText(
 export interface MergeButtonDisplayState {
   hideMarkForReplacementButton: boolean;
   hideUnmarkForReplacementButton: boolean;
-  hideOnReplaceMarkedByButton: boolean;
+  hideReplaceMarkedByButton: boolean;
   deactivateReplaceMarkedByButton: boolean;
 }
 
-export function getMergeButtonsDisplayState(
-  currentView: View,
-  attributionIdMarkedForReplacement: string,
-  targetAttributionId: string,
-  selectedAttributionId: string,
-  packageInfoWereModified: boolean,
-  targetAttributionIsPreSelected: boolean,
-  isExternalAttribution: boolean
-): MergeButtonDisplayState {
-  const isTableView = currentView === View.Report;
+export function getMergeButtonsDisplayState(currentState: {
+  attributionIdMarkedForReplacement: string;
+  targetAttributionId: string;
+  selectedAttributionId: string;
+  packageInfoWereModified: boolean;
+  targetAttributionIsPreSelected: boolean;
+  targetAttributionIsExternalAttribution: boolean;
+}): MergeButtonDisplayState {
   const anyAttributionMarkedForReplacement =
-    attributionIdMarkedForReplacement !== '';
+    currentState.attributionIdMarkedForReplacement !== '';
   const targetAttributionIsMarkedForReplacement =
-    targetAttributionId === attributionIdMarkedForReplacement;
+    currentState.targetAttributionId ===
+    currentState.attributionIdMarkedForReplacement;
   const selectedAttributionIsPartOfMerge =
-    selectedAttributionId === attributionIdMarkedForReplacement ||
-    selectedAttributionId === targetAttributionId;
+    currentState.selectedAttributionId ===
+      currentState.attributionIdMarkedForReplacement ||
+    currentState.selectedAttributionId === currentState.targetAttributionId;
 
   return {
     hideMarkForReplacementButton:
-      isExternalAttribution ||
-      isTableView ||
+      currentState.targetAttributionIsExternalAttribution ||
       targetAttributionIsMarkedForReplacement,
     hideUnmarkForReplacementButton:
-      isExternalAttribution ||
-      isTableView ||
+      currentState.targetAttributionIsExternalAttribution ||
       !anyAttributionMarkedForReplacement ||
       !targetAttributionIsMarkedForReplacement,
-    hideOnReplaceMarkedByButton:
-      isExternalAttribution ||
-      isTableView ||
+    hideReplaceMarkedByButton:
+      currentState.targetAttributionIsExternalAttribution ||
       !anyAttributionMarkedForReplacement ||
       targetAttributionIsMarkedForReplacement,
     deactivateReplaceMarkedByButton:
-      (selectedAttributionIsPartOfMerge && packageInfoWereModified) ||
-      targetAttributionIsPreSelected,
+      (selectedAttributionIsPartOfMerge &&
+        currentState.packageInfoWereModified) ||
+      currentState.targetAttributionIsPreSelected,
   };
 }
 

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -9,11 +9,11 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Attributions } from '../../../shared/shared-types';
 import { FilterType, PackagePanelTitle } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
 import {
   getAttributionIdMarkedForReplacement,
-  getSelectedAttributionId,
-} from '../../state/selectors/attribution-view-resource-selectors';
+  getManualAttributions,
+} from '../../state/selectors/all-views-resource-selectors';
+import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
 import { provideFollowUpFilter } from '../../util/provide-follow-up-filter';
 import { useWindowHeight } from '../../util/use-window-height';
 import { AttributionDetailsViewer } from '../AttributionDetailsViewer/AttributionDetailsViewer';

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -8,10 +8,16 @@ import {
   openPopup,
   openPopupWithTargetAttributionId,
 } from '../../../state/actions/view-actions/view-actions';
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
 import { GlobalPopup } from '../GlobalPopup';
 import { PopupType } from '../../../enums/enums';
 import { screen } from '@testing-library/react';
+import { Attributions } from '../../../../shared/shared-types';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 
 describe('The GlobalPopUp', () => {
   test('does not open by default', () => {
@@ -49,8 +55,27 @@ describe('The GlobalPopUp', () => {
   });
 
   test('opens the ReplaceAttributionPopup', () => {
-    const { store } = renderComponentWithStore(<GlobalPopup />);
-    store.dispatch(openPopup(PopupType.ReplaceAttributionPopup));
+    const testAttributions: Attributions = {
+      uuid1: { packageName: 'name 1' },
+    };
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          manualAttributions: testAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<GlobalPopup />, {
+      store: testStore,
+    });
+    testStore.dispatch(
+      openPopupWithTargetAttributionId(
+        PopupType.ReplaceAttributionPopup,
+        'uuid1'
+      )
+    );
 
     expect(
       screen.getByText('This removes the following attribution')

--- a/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
+++ b/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
@@ -5,7 +5,11 @@
 
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-import { Attributions } from '../../../../shared/shared-types';
+import {
+  Attributions,
+  Resources,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
 import { doNothing } from '../../../util/do-nothing';
 import { ManualAttributionList } from '../ManualAttributionList';
 import {
@@ -15,6 +19,14 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import {
+  clickOnButtonInPackageContextMenu,
+  expectButtonInPackageContextMenu,
+  expectContextMenuForNotPreSelectedAttributionMultipleResources,
+  expectContextMenuForNotPreSelectedAttributionSingleResource,
+  testCorrectMarkAndUnmarkForReplacementInContextMenu,
+} from '../../../test-helpers/context-menu-test-helpers';
+import { ButtonText } from '../../../enums/enums';
 
 function getTestStore(manualAttributions: Attributions): EnhancedTestStore {
   const store = createTestAppStore();
@@ -141,6 +153,84 @@ describe('The ManualAttributionList', () => {
     );
     expect(container.childNodes[0].textContent).toContain(
       '(C) Copyright John Doe 2'
+    );
+  });
+
+  test('shows correct replace attribution buttons in the context menu', () => {
+    const testResources: Resources = {
+      root: { src: { file_1: 1, file_2: 1 } },
+      file: 1,
+    };
+    const testManualAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'jQuery',
+        packageVersion: '16.0.0',
+        comment: 'ManualPackage',
+      },
+      uuid_2: {
+        packageName: 'React',
+        packageVersion: '16.0.0',
+        comment: 'ManualPackage',
+      },
+      uuid_3: {
+        packageName: 'Vue',
+        packageVersion: '16.0.0',
+        comment: 'ManualPackage',
+        preSelected: true,
+      },
+    };
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      '/root/src/file_1': ['uuid_1', 'uuid_2', 'uuid_3'],
+      '/root/src/file_2': ['uuid_2'],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testManualAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    renderComponentWithStore(
+      <ManualAttributionList
+        selectedResourceId="/root/src/file_1"
+        attributions={testManualAttributions}
+        selectedAttributionId={''}
+        onCardClick={mockCallback}
+      />,
+      { store: testStore }
+    );
+
+    expectContextMenuForNotPreSelectedAttributionSingleResource(
+      screen,
+      'jQuery, 16.0.0'
+    );
+
+    testCorrectMarkAndUnmarkForReplacementInContextMenu(
+      screen,
+      'jQuery, 16.0.0'
+    );
+
+    clickOnButtonInPackageContextMenu(
+      screen,
+      'jQuery, 16.0.0',
+      ButtonText.MarkForReplacement
+    );
+
+    expectButtonInPackageContextMenu(
+      screen,
+      'Vue, 16.0.0',
+      ButtonText.ReplaceMarked,
+      true
+    );
+
+    expectContextMenuForNotPreSelectedAttributionMultipleResources(
+      screen,
+      'React, 16.0.0',
+      true
     );
   });
 });

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -225,15 +225,14 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     ) ||
       hideResourceSpecificButtons);
   const mergeButtonDisplayState: MergeButtonDisplayState =
-    getMergeButtonsDisplayState(
-      selectedView,
+    getMergeButtonsDisplayState({
       attributionIdMarkedForReplacement,
-      attributionId,
+      targetAttributionId: attributionId,
       selectedAttributionId,
       packageInfoWereModified,
-      isPreselected,
-      isExternalAttribution
-    );
+      targetAttributionIsPreSelected: isPreselected,
+      targetAttributionIsExternalAttribution: isExternalAttribution,
+    });
   const isMarkedForReplacement =
     Boolean(attributionId) &&
     attributionId === attributionIdMarkedForReplacement;
@@ -307,7 +306,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
               )
             );
           },
-          hidden: mergeButtonDisplayState.hideOnReplaceMarkedByButton,
+          hidden: mergeButtonDisplayState.hideReplaceMarkedByButton,
         },
       ];
 

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -12,13 +12,13 @@ import { doNothing } from '../../util/do-nothing';
 import MuiTypography from '@material-ui/core/Typography';
 import {
   getAttributionIdMarkedForReplacement,
-  getSelectedAttributionId,
-} from '../../state/selectors/attribution-view-resource-selectors';
-import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
+  getManualAttributions,
+} from '../../state/selectors/all-views-resource-selectors';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { makeStyles } from '@material-ui/core/styles';
 import { savePackageInfo } from '../../state/actions/resource-actions/save-actions';
 import { setAttributionIdMarkedForReplacement } from '../../state/actions/resource-actions/attribution-view-simple-actions';
+import { getTargetAttributionId } from '../../state/selectors/view-selector';
 
 const useStyles = makeStyles({
   typography: {
@@ -37,7 +37,7 @@ export function ReplaceAttributionPopup(): ReactElement {
   const markedAttributionId = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const targetAttributionId = useAppSelector(getTargetAttributionId);
 
   function handleCancelClick(): void {
     dispatch(closePopup());
@@ -48,7 +48,7 @@ export function ReplaceAttributionPopup(): ReactElement {
       savePackageInfo(
         null,
         markedAttributionId,
-        attributions[selectedAttributionId]
+        attributions[targetAttributionId]
       )
     );
     dispatch(setAttributionIdMarkedForReplacement(''));
@@ -87,7 +87,7 @@ export function ReplaceAttributionPopup(): ReactElement {
       <MuiTypography className={classes.typography}>
         and links its resources to the current attribution
       </MuiTypography>
-      {getAttributionCard(selectedAttributionId)}
+      {getAttributionCard(targetAttributionId)}
     </div>
   );
 

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -85,7 +85,7 @@ export function ReplaceAttributionPopup(): ReactElement {
       </MuiTypography>
       {getAttributionCard(markedAttributionId)}
       <MuiTypography className={classes.typography}>
-        and links its resources to the current attribution
+        and links its resources to the attribution
       </MuiTypography>
       {getAttributionCard(targetAttributionId)}
     </div>

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup';
-import { openPopup } from '../../../state/actions/view-actions/view-actions';
+import { openPopupWithTargetAttributionId } from '../../../state/actions/view-actions/view-actions';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
@@ -41,9 +41,14 @@ function setupTestState(store: EnhancedTestStore): void {
     'package_2.tr.gz': ['test_marked_id'],
   };
 
-  store.dispatch(openPopup(PopupType.ReplaceAttributionPopup));
   store.dispatch(setSelectedAttributionId('test_selected_id'));
   store.dispatch(setAttributionIdMarkedForReplacement('test_marked_id'));
+  store.dispatch(
+    openPopupWithTargetAttributionId(
+      PopupType.ReplaceAttributionPopup,
+      'test_selected_id'
+    )
+  );
   store.dispatch(
     loadFromFile(
       getParsedInputFileEnrichedWithTestData({

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -77,9 +77,9 @@ export function ResourceDetailsTabs(
       manualData is excluded from dependencies on purpose to avoid recalculation when
       it changes. Usually this is not an issue as the displayed data remains correct.
       In consequence, the panelData is eventually consistent.
-      Only manualData.attributionsToResources in dependencies to update panelData, when replaceAttributionPopup
-      was called in AuditView for manual attributions in attributions in folder content panel, but not update them
-      after every save click.
+      We still need manualData.attributionsToResources in the dependencies to update panelData, when
+      replaceAttributionPopup was called. This is relevant for manual attributions in the attributions in folder
+      content panel.
     */
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -73,12 +73,17 @@ export function ResourceDetailsTabs(
 
   const panelData: Array<PanelData> = useMemo(
     () => getPanelData(selectedResourceId, manualData, externalData),
-    // manualData is excluded from dependencies on purpose to avoid recalculation when
-    // it changes. Usually this is not an issue as the displayed data remains correct.
-    // In consequence, the panelData is eventually consistent.
+    /*
+      manualData is excluded from dependencies on purpose to avoid recalculation when
+      it changes. Usually this is not an issue as the displayed data remains correct.
+      In consequence, the panelData is eventually consistent.
+      Only manualData.attributionsToResources in dependencies to update panelData, when replaceAttributionPopup
+      was called in AuditView for manual attributions in attributions in folder content panel, but not update them
+      after every save click.
+    */
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedResourceId, externalData]
+    [selectedResourceId, externalData, manualData.attributionsToResources]
   );
 
   const assignableAttributionIds: Array<string> = remove(

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -26,7 +26,6 @@ import {
   expectContextMenuForPreSelectedAttributionMultipleResources,
   expectGlobalOnlyContextMenuForNotPreselectedAttribution,
   expectGlobalOnlyContextMenuForPreselectedAttribution,
-  expectUnmarkForReplacementInContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
 import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
@@ -41,8 +40,6 @@ import {
   expectPackagePanelShown,
 } from '../../../test-helpers/package-panel-helpers';
 import {
-  expectButtonInHamburgerMenu,
-  expectButtonInHamburgerMenuIsNotShown,
   expectValueInTextBox,
   expectValueNotInTextBox,
 } from '../../../test-helpers/attribution-column-test-helpers';
@@ -433,72 +430,5 @@ describe('The ContextMenu', () => {
     expectShowResourcesPopupVisible(screen);
     clickOnPathInPopupWithResources(screen, '/secondResource.js');
     expectValueInTextBox(screen, 'Name', 'Vue');
-  });
-
-  test('replace attributions buttons are synced with hamburger menu buttons', () => {
-    const testResources: Resources = {
-      root: { src: { file_1: 1, file_2: 1 } },
-      file: 1,
-    };
-    const testManualAttributions: Attributions = {
-      uuid_1: {
-        packageName: 'jQuery',
-        packageVersion: '16.0.0',
-        comment: 'ManualPackage',
-      },
-      uuid_2: {
-        packageName: 'React',
-        packageVersion: '16.0.0',
-        comment: 'ManualPackage',
-      },
-      uuid_3: {
-        packageName: 'Vue',
-        packageVersion: '16.0.0',
-        comment: 'ManualPackage',
-        preSelected: true,
-      },
-    };
-    const testResourcesToManualAttributions: ResourcesToAttributions = {
-      '/root/src/file_1': ['uuid_1'],
-      '/root/src/file_2': ['uuid_2', 'uuid_3'],
-    };
-
-    mockElectronBackend(
-      getParsedInputFileEnrichedWithTestData({
-        resources: testResources,
-        manualAttributions: testManualAttributions,
-        resourcesToManualAttributions: testResourcesToManualAttributions,
-      })
-    );
-    renderComponentWithStore(<App />);
-
-    clickOnElementInResourceBrowser(screen, 'root');
-    clickOnElementInResourceBrowser(screen, 'src');
-    clickOnButtonInPackageContextMenu(
-      screen,
-      'jQuery, 16.0.0',
-      ButtonText.MarkForReplacement
-    );
-
-    clickOnElementInResourceBrowser(screen, 'file_1');
-    expectUnmarkForReplacementInContextMenu(screen, 'jQuery, 16.0.0');
-    expectButtonInHamburgerMenu(screen, ButtonText.UnmarkForReplacement);
-    expectButtonInHamburgerMenuIsNotShown(
-      screen,
-      ButtonText.MarkForReplacement
-    );
-
-    clickOnElementInResourceBrowser(screen, 'file_2');
-    clickOnTab(screen, 'All Attributions Tab');
-    expectUnmarkForReplacementInContextMenu(screen, 'jQuery, 16.0.0');
-
-    goToView(screen, View.Attribution);
-    expectUnmarkForReplacementInContextMenu(screen, 'jQuery, 16.0.0');
-    clickOnCardInAttributionList(screen, 'jQuery, 16.0.0');
-    expectButtonInHamburgerMenu(screen, ButtonText.UnmarkForReplacement);
-    expectButtonInHamburgerMenuIsNotShown(
-      screen,
-      ButtonText.MarkForReplacement
-    );
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -21,15 +21,12 @@ import { App } from '../../../Components/App/App';
 import {
   clickOnButtonInPackageContextMenu,
   clickOnButtonInPackageInPackagePanelContextMenu,
-  expectButtonInPackageContextMenu,
-  expectButtonInPackageInPackagePanelContextMenu,
   expectContextMenuForExternalAttributionInPackagePanel,
   expectContextMenuForHiddenExternalAttributionInPackagePanel,
   expectContextMenuForNotPreSelectedAttributionMultipleResources,
   expectContextMenuForNotPreSelectedAttributionSingleResource,
   expectContextMenuForPreSelectedAttributionMultipleResources,
   expectContextMenuIsNotShown,
-  expectCorrectMarkAndUnmarkForReplacementInContextMenu,
   expectGlobalOnlyContextMenuForNotPreselectedAttribution,
   expectGlobalOnlyContextMenuForPreselectedAttribution,
   expectNoConfirmationButtonsShown,
@@ -295,7 +292,7 @@ describe('In Audit View the ContextMenu', () => {
     expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
   });
 
-  describe('replace attribution buttons', () => {
+  describe('replaces attributions', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {
         uuid_2: {
@@ -343,7 +340,7 @@ describe('In Audit View the ContextMenu', () => {
       '/root/src/file_2': ['uuid_2', 'uuid_3'],
     };
 
-    test('replace attributions in Package panel', () => {
+    test('in the package panel', () => {
       mockElectronBackend(
         getParsedInputFileEnrichedWithTestData({
           resources: testResources,
@@ -357,34 +354,14 @@ describe('In Audit View the ContextMenu', () => {
       clickOnElementInResourceBrowser(screen, 'src');
       clickOnElementInResourceBrowser(screen, 'file_1');
       expectValueInTextBox(screen, 'Name', 'jQuery');
-      expectContextMenuForNotPreSelectedAttributionSingleResource(
-        screen,
-        'jQuery, 16.0.0'
-      );
 
-      expectCorrectMarkAndUnmarkForReplacementInContextMenu(
-        screen,
-        'jQuery, 16.0.0'
-      );
       clickOnButtonInPackageContextMenu(
         screen,
         'jQuery, 16.0.0',
         ButtonText.MarkForReplacement
       );
-
       clickOnElementInResourceBrowser(screen, 'file_2');
-      expectButtonInPackageContextMenu(
-        screen,
-        'Vue, 16.0.0',
-        ButtonText.ReplaceMarked,
-        true
-      );
 
-      expectContextMenuForNotPreSelectedAttributionSingleResource(
-        screen,
-        'React, 16.0.0',
-        true
-      );
       handleReplaceMarkedAttributionViaContextMenu(
         screen,
         'React, 16.0.0',
@@ -417,7 +394,7 @@ describe('In Audit View the ContextMenu', () => {
       ]);
     });
 
-    test('replace attributions in attributions in folder content panel', () => {
+    test('in the attributions in folder content panel', () => {
       mockElectronBackend(
         getParsedInputFileEnrichedWithTestData({
           resources: testResources,
@@ -429,33 +406,10 @@ describe('In Audit View the ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'root');
       clickOnElementInResourceBrowser(screen, 'src');
-      expectGlobalOnlyContextMenuForNotPreselectedAttribution(
-        screen,
-        'jQuery, 16.0.0'
-      );
-
-      expectCorrectMarkAndUnmarkForReplacementInContextMenu(
-        screen,
-        'jQuery, 16.0.0'
-      );
       clickOnButtonInPackageContextMenu(
         screen,
         'jQuery, 16.0.0',
         ButtonText.MarkForReplacement
-      );
-
-      expectButtonInPackageInPackagePanelContextMenu(
-        screen,
-        'Vue, 16.0.0',
-        'Attributions in Folder Content',
-        ButtonText.ReplaceMarked,
-        true
-      );
-
-      expectGlobalOnlyContextMenuForNotPreselectedAttribution(
-        screen,
-        'React, 16.0.0',
-        true
       );
 
       handleReplaceMarkedAttributionViaContextMenu(

--- a/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
@@ -10,10 +10,10 @@ import {
   setTargetSelectedAttributionId,
 } from '../attribution-view-simple-actions';
 import {
-  getAttributionIdMarkedForReplacement,
   getSelectedAttributionId,
   getTargetSelectedAttributionId,
 } from '../../../selectors/attribution-view-resource-selectors';
+import { getAttributionIdMarkedForReplacement } from '../../../selectors/all-views-resource-selectors';
 
 describe('The load and navigation simple actions', () => {
   test('sets and gets selectedAttributionId', () => {

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../../test-helpers/general-test-helpers';
 import { ProgressBarData } from '../../../../types/types';
 import {
+  getAttributionIdMarkedForReplacement,
   getManualAttributions,
   getManualAttributionsToResources,
   getManualData,
@@ -35,10 +36,7 @@ import {
   getTemporaryPackageInfo,
   wereTemporaryPackageInfoModified,
 } from '../../../selectors/all-views-resource-selectors';
-import {
-  getAttributionIdMarkedForReplacement,
-  getSelectedAttributionId,
-} from '../../../selectors/attribution-view-resource-selectors';
+import { getSelectedAttributionId } from '../../../selectors/attribution-view-resource-selectors';
 import { getAttributionIdOfDisplayedPackageInManualPanel } from '../../../selectors/audit-view-resource-selectors';
 import {
   setResources,

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -43,7 +43,9 @@ export interface ClosePopupAction {
 
 export type OpenPopupActionPopupType = Exclude<
   PopupType,
-  PopupType.ConfirmDeletionPopup | PopupType.ConfirmDeletionGloballyPopup
+  | PopupType.ConfirmDeletionPopup
+  | PopupType.ConfirmDeletionGloballyPopup
+  | PopupType.ReplaceAttributionPopup
 >;
 
 export interface OpenPopupAction {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -85,6 +85,7 @@ export const initialResourceState: ResourceState = {
     metadata: EMPTY_PROJECT_METADATA,
     baseUrlsForSources: {},
     externalAttributionSources: {},
+    attributionIdMarkedForReplacement: '',
   },
   auditView: {
     selectedResourceId: '',
@@ -96,7 +97,6 @@ export const initialResourceState: ResourceState = {
   attributionView: {
     selectedAttributionId: '',
     targetSelectedAttributionId: '',
-    attributionIdMarkedForReplacement: '',
   },
   fileSearchPopup: {
     fileSearch: '',
@@ -117,6 +117,7 @@ export type ResourceState = {
     metadata: ProjectMetadata;
     baseUrlsForSources: BaseUrlsForSources;
     externalAttributionSources: ExternalAttributionSources;
+    attributionIdMarkedForReplacement: string;
   };
   auditView: {
     selectedResourceId: string;
@@ -128,7 +129,6 @@ export type ResourceState = {
   attributionView: {
     selectedAttributionId: string;
     targetSelectedAttributionId: string;
-    attributionIdMarkedForReplacement: string;
   };
   fileSearchPopup: {
     fileSearch: string;
@@ -284,8 +284,8 @@ export const resourceState = (
     case ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT:
       return {
         ...state,
-        attributionView: {
-          ...state.attributionView,
+        allViews: {
+          ...state.allViews,
           attributionIdMarkedForReplacement: action.payload,
         },
       };
@@ -387,10 +387,10 @@ export const resourceState = (
           : state.attributionView.selectedAttributionId;
 
       const newAttributionIdMarkedForReplacement: string =
-        state.attributionView.attributionIdMarkedForReplacement ===
+        state.allViews.attributionIdMarkedForReplacement ===
         attributionToDeleteId
           ? ''
-          : state.attributionView.attributionIdMarkedForReplacement;
+          : state.allViews.attributionIdMarkedForReplacement;
 
       return {
         ...state,
@@ -406,6 +406,8 @@ export const resourceState = (
             getAttributionBreakpointCheckForResourceState(state),
             getFileWithChildrenCheckForResourceState(state)
           ),
+          attributionIdMarkedForReplacement:
+            newAttributionIdMarkedForReplacement,
         },
         auditView: {
           ...state.auditView,
@@ -414,8 +416,6 @@ export const resourceState = (
         attributionView: {
           ...state.attributionView,
           selectedAttributionId: newSelectedAttributionId,
-          attributionIdMarkedForReplacement:
-            newAttributionIdMarkedForReplacement,
         },
       };
     case ACTION_REPLACE_ATTRIBUTION_WITH_MATCHING:

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -199,3 +199,7 @@ export function getExternalAttributionSources(
 ): ExternalAttributionSources {
   return state.resourceState.allViews.externalAttributionSources;
 }
+
+export function getAttributionIdMarkedForReplacement(state: State): string {
+  return state.resourceState.allViews.attributionIdMarkedForReplacement;
+}

--- a/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
@@ -25,7 +25,3 @@ export function getResourceIdsOfSelectedAttribution(
   }
   return [];
 }
-
-export function getAttributionIdMarkedForReplacement(state: State): string {
-  return state.resourceState.attributionView.attributionIdMarkedForReplacement;
-}

--- a/src/Frontend/test-helpers/context-menu-test-helpers.ts
+++ b/src/Frontend/test-helpers/context-menu-test-helpers.ts
@@ -90,7 +90,6 @@ export function expectContextMenuForNotPreSelectedAttributionMultipleResources(
     ButtonText.Confirm,
     ButtonText.ConfirmGlobally,
     ButtonText.UnmarkForReplacement,
-    ButtonText.ReplaceMarked,
   ];
 
   if (showReplaceMarked) {
@@ -210,7 +209,7 @@ export function expectContextMenuForHiddenExternalAttributionInPackagePanel(
   );
 }
 
-export function expectCorrectMarkAndUnmarkForReplacementInContextMenu(
+export function testCorrectMarkAndUnmarkForReplacementInContextMenu(
   screen: Screen,
   packageName: string
 ): void {

--- a/src/Frontend/test-helpers/context-menu-test-helpers.ts
+++ b/src/Frontend/test-helpers/context-menu-test-helpers.ts
@@ -4,28 +4,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  clickOnButton,
   expectButtonIsNotShown,
   getButton,
   getPackagePanel,
 } from './general-test-helpers';
 import { fireEvent, getByText, Screen } from '@testing-library/react';
 import { ButtonText } from '../enums/enums';
+import {
+  expectReplaceAttributionPopupIsNotShown,
+  expectReplaceAttributionPopupIsShown,
+} from './popup-test-helpers';
 
 export function expectGlobalOnlyContextMenuForNotPreselectedAttribution(
   screen: Screen,
-  cardLabel: string
+  cardLabel: string,
+  showReplaceMarked = false
 ): void {
+  const shownButtons = [
+    ButtonText.ShowResources,
+    ButtonText.DeleteGlobally,
+    ButtonText.MarkForReplacement,
+  ];
+  const hiddenButtons = [
+    ButtonText.Hide,
+    ButtonText.Unhide,
+    ButtonText.Delete,
+    ButtonText.Confirm,
+    ButtonText.ConfirmGlobally,
+    ButtonText.UnmarkForReplacement,
+  ];
+
+  if (showReplaceMarked) {
+    shownButtons.push(ButtonText.ReplaceMarked);
+  } else {
+    hiddenButtons.push(ButtonText.ReplaceMarked);
+  }
+
   expectCorrectButtonsInContextMenu(
     screen,
     cardLabel,
-    [ButtonText.ShowResources, ButtonText.DeleteGlobally],
-    [
-      ButtonText.Hide,
-      ButtonText.Unhide,
-      ButtonText.Delete,
-      ButtonText.Confirm,
-      ButtonText.ConfirmGlobally,
-    ]
+    shownButtons,
+    hiddenButtons
   );
 }
 
@@ -40,25 +60,50 @@ export function expectGlobalOnlyContextMenuForPreselectedAttribution(
       ButtonText.ShowResources,
       ButtonText.DeleteGlobally,
       ButtonText.ConfirmGlobally,
+      ButtonText.MarkForReplacement,
     ],
-    [ButtonText.Hide, ButtonText.Unhide, ButtonText.Delete, ButtonText.Confirm]
+    [
+      ButtonText.Hide,
+      ButtonText.Unhide,
+      ButtonText.Delete,
+      ButtonText.Confirm,
+      ButtonText.UnmarkForReplacement,
+      ButtonText.ReplaceMarked,
+    ]
   );
 }
 
 export function expectContextMenuForNotPreSelectedAttributionMultipleResources(
   screen: Screen,
-  cardLabel: string
+  cardLabel: string,
+  showReplaceMarked = false
 ): void {
+  const shownButtons = [
+    ButtonText.ShowResources,
+    ButtonText.Delete,
+    ButtonText.DeleteGlobally,
+    ButtonText.MarkForReplacement,
+  ];
+  const hiddenButtons = [
+    ButtonText.Hide,
+    ButtonText.Unhide,
+    ButtonText.Confirm,
+    ButtonText.ConfirmGlobally,
+    ButtonText.UnmarkForReplacement,
+    ButtonText.ReplaceMarked,
+  ];
+
+  if (showReplaceMarked) {
+    shownButtons.push(ButtonText.ReplaceMarked);
+  } else {
+    hiddenButtons.push(ButtonText.ReplaceMarked);
+  }
+
   expectCorrectButtonsInContextMenu(
     screen,
     cardLabel,
-    [ButtonText.ShowResources, ButtonText.Delete, ButtonText.DeleteGlobally],
-    [
-      ButtonText.Hide,
-      ButtonText.Unhide,
-      ButtonText.Confirm,
-      ButtonText.ConfirmGlobally,
-    ]
+    shownButtons,
+    hiddenButtons
   );
 }
 
@@ -75,8 +120,47 @@ export function expectContextMenuForPreSelectedAttributionMultipleResources(
       ButtonText.DeleteGlobally,
       ButtonText.Confirm,
       ButtonText.ConfirmGlobally,
+      ButtonText.MarkForReplacement,
     ],
-    [ButtonText.Hide, ButtonText.Unhide]
+    [
+      ButtonText.Hide,
+      ButtonText.Unhide,
+      ButtonText.UnmarkForReplacement,
+      ButtonText.ReplaceMarked,
+    ]
+  );
+}
+
+export function expectContextMenuForNotPreSelectedAttributionSingleResource(
+  screen: Screen,
+  cardLabel: string,
+  showReplaceMarked = false
+): void {
+  const shownButtons = [
+    ButtonText.ShowResources,
+    ButtonText.Delete,
+    ButtonText.MarkForReplacement,
+  ];
+  const hiddenButtons = [
+    ButtonText.Hide,
+    ButtonText.Unhide,
+    ButtonText.Confirm,
+    ButtonText.ConfirmGlobally,
+    ButtonText.DeleteGlobally,
+    ButtonText.UnmarkForReplacement,
+  ];
+
+  if (showReplaceMarked) {
+    shownButtons.push(ButtonText.ReplaceMarked);
+  } else {
+    hiddenButtons.push(ButtonText.ReplaceMarked);
+  }
+
+  expectCorrectButtonsInContextMenu(
+    screen,
+    cardLabel,
+    shownButtons,
+    hiddenButtons
   );
 }
 
@@ -96,8 +180,87 @@ export function expectContextMenuForExternalAttributionInPackagePanel(
       ButtonText.DeleteGlobally,
       ButtonText.Confirm,
       ButtonText.ConfirmGlobally,
+      ButtonText.UnmarkForReplacement,
+      ButtonText.ReplaceMarked,
+      ButtonText.MarkForReplacement,
     ]
   );
+}
+
+export function expectContextMenuForHiddenExternalAttributionInPackagePanel(
+  screen: Screen,
+  packageName: string,
+  packagePanelName: string
+): void {
+  expectCorrectButtonsInPackageInPackagePanelContextMenu(
+    screen,
+    packageName,
+    packagePanelName,
+    [ButtonText.ShowResources, ButtonText.Unhide],
+    [
+      ButtonText.Hide,
+      ButtonText.Delete,
+      ButtonText.DeleteGlobally,
+      ButtonText.Confirm,
+      ButtonText.ConfirmGlobally,
+      ButtonText.MarkForReplacement,
+      ButtonText.ReplaceMarked,
+      ButtonText.UnmarkForReplacement,
+    ]
+  );
+}
+
+export function expectCorrectMarkAndUnmarkForReplacementInContextMenu(
+  screen: Screen,
+  packageName: string
+): void {
+  clickOnButtonInPackageContextMenu(
+    screen,
+    packageName,
+    ButtonText.MarkForReplacement
+  );
+  expectUnmarkForReplacementInContextMenu(screen, packageName);
+  clickOnButtonInPackageContextMenu(
+    screen,
+    packageName,
+    ButtonText.UnmarkForReplacement
+  );
+  expectButtonInPackageContextMenu(
+    screen,
+    packageName,
+    ButtonText.MarkForReplacement
+  );
+}
+
+export function expectUnmarkForReplacementInContextMenu(
+  screen: Screen,
+  packageName: string
+): void {
+  expectButtonInPackageContextMenu(
+    screen,
+    packageName,
+    ButtonText.UnmarkForReplacement
+  );
+  expectButtonInPackageContextMenuIsNotShown(
+    screen,
+    packageName,
+    ButtonText.MarkForReplacement
+  );
+}
+
+export function handleReplaceMarkedAttributionViaContextMenu(
+  screen: Screen,
+  packageName: string,
+  responseButtonText: ButtonText.Cancel | ButtonText.Replace
+): void {
+  clickOnButtonInPackageContextMenu(
+    screen,
+    packageName,
+    ButtonText.ReplaceMarked
+  );
+  expectReplaceAttributionPopupIsShown(screen);
+  clickOnButton(screen, responseButtonText);
+  expectReplaceAttributionPopupIsNotShown(screen);
 }
 
 export function expectContextMenuIsNotShown(
@@ -151,7 +314,7 @@ export function expectCorrectButtonsInContextMenu(
   hiddenButtons: Array<ButtonText>
 ): void {
   shownButtons.forEach((buttonText) => {
-    expectEnabledButtonInPackageContextMenu(screen, cardLabel, buttonText);
+    expectButtonInPackageContextMenu(screen, cardLabel, buttonText);
   });
 
   hiddenButtons.forEach((buttonText) => {
@@ -159,16 +322,17 @@ export function expectCorrectButtonsInContextMenu(
   });
 }
 
-function expectEnabledButtonInPackageContextMenu(
+export function expectButtonInPackageContextMenu(
   screen: Screen,
   cardLabel: string,
-  buttonLabel: ButtonText
+  buttonLabel: ButtonText,
+  disabled = false
 ): void {
   openContextMenuOnCardPackageCard(screen, cardLabel);
   const button = getButton(screen, buttonLabel);
   const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
 
-  expect(buttonAttribute && buttonAttribute.value).toBe('false');
+  expect(buttonAttribute && buttonAttribute.value).toBe(String(disabled));
 }
 
 function expectButtonInPackageContextMenuIsNotShown(
@@ -207,7 +371,7 @@ export function expectCorrectButtonsInPackageInPackagePanelContextMenu(
   hiddenButtons: Array<ButtonText>
 ): void {
   shownButtons.forEach((buttonText) => {
-    expectEnabledButtonInPackageInPackagePanelContextMenu(
+    expectButtonInPackageInPackagePanelContextMenu(
       screen,
       packageName,
       packagePanelName,
@@ -225,17 +389,18 @@ export function expectCorrectButtonsInPackageInPackagePanelContextMenu(
   });
 }
 
-function expectEnabledButtonInPackageInPackagePanelContextMenu(
+export function expectButtonInPackageInPackagePanelContextMenu(
   screen: Screen,
   packageName: string,
   packagePanelName: string,
-  buttonLabel: ButtonText
+  buttonLabel: ButtonText,
+  disabled = false
 ): void {
   openContextMenuOnPackageInPackagePanel(screen, packageName, packagePanelName);
   const button = getButton(screen, buttonLabel);
   const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
 
-  expect(buttonAttribute && buttonAttribute.value).toBe('false');
+  expect(buttonAttribute && buttonAttribute.value).toBe(String(disabled));
 }
 
 function expectButtonInPackageInPackagePanelContextMenuIsNotShown(


### PR DESCRIPTION
### Summary of changes

This commit adds the replace attribution function to the context menu and to the hamburger menu in audit view.

### Context and reason for change

Replacing attributions was only possible in attribution view so far and not available in the context menu. This adds these functionalities and allows the user to replace attributions with the context of the file tree and to switch between views while replacing attributions.

### How can the changes be tested

Run the context menu integration tests (part of the frontend ci integration tests) and / or test replace attributions with example file with context menu and in audit view.

