### PR TITLE
Rewrite yarn start for Windows with concurrently.

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "start": "run-script-os",
     "start:darwin:linux": "concurrently \"yarn build:dev; BROWSER=none ESLINT_NO_DEV_ERRORS=true react-scripts start\" \"wait-on http://localhost:3000 && electron .\"",
-    "start:win32": "start /b wait-on http://localhost:3000 ^&^& electron . & yarn build:dev & cross-env BROWSER=none ESLINT_NO_DEV_ERRORS=true react-scripts start",
+    "start:win32": "concurrently \"yarn build:dev & cross-env BROWSER=none ESLINT_NO_DEV_ERRORS=true react-scripts start\" \"wait-on http://localhost:3000 && electron .\"",
     "build:dev": "run-script-os",
     "build:dev:darwin:linux": "yarn generate-notice && DISABLE_ESLINT_PLUGIN=true react-scripts build && tsc -p src/ElectronBackend",
     "build:dev:win32": "yarn generate-notice && cross-env DISABLE_ESLINT_PLUGIN=true react-scripts build && tsc -p src/ElectronBackend",


### PR DESCRIPTION
### Summary of changes

The _start_ script has been rewritten for Windows to use concurrently too.

### Context and reason for change

With the previous implementation _ctrl+C_  didn't work properly in the terminal, when trying to terminate the app.

### How can the changes be tested

Run _yarn start_ on Windows and check that the dev app is correctly started. Afterwards run _ctrl+C_ in the terminal and check that it terminates all app-related processes.

