### PR TITLE
Fix hidden signals in Signals in Folder Content tab

### DIFF
--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -19,6 +19,7 @@ import { getPanelData, PanelData } from './resource-details-tabs-helpers';
 import {
   getAttributionIdsOfSelectedResource,
   getDisplayedPackage,
+  getResolvedExternalAttributions,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { OpossumColors } from '../../shared-styles';
@@ -66,6 +67,9 @@ export function ResourceDetailsTabs(
     getAttributionIdsOfSelectedResource,
     isEqual
   );
+  const resolvedExternalAttributions: Set<string> = useAppSelector(
+    getResolvedExternalAttributions
+  );
 
   enum Tabs {
     SignalsAndContent = 0,
@@ -77,7 +81,13 @@ export function ResourceDetailsTabs(
   }, [selectedResourceId, Tabs.SignalsAndContent]);
 
   const panelData: Array<PanelData> = useMemo(
-    () => getPanelData(selectedResourceId, manualData, externalData),
+    () =>
+      getPanelData(
+        selectedResourceId,
+        manualData,
+        externalData,
+        resolvedExternalAttributions
+      ),
     /*
       manualData is excluded from dependencies on purpose to avoid recalculation when
       it changes. Usually this is not an issue as the displayed data remains correct.
@@ -88,7 +98,7 @@ export function ResourceDetailsTabs(
     */
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedResourceId, externalData, manualData.attributionsToResources]
+    [selectedResourceId, externalData, resolvedExternalAttributions]
   );
 
   const assignableAttributionIds: Array<string> = remove(

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -14,7 +14,7 @@ import {
 import { PanelPackage } from '../../types/types';
 import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
 import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
-import { remove, isEqual } from 'lodash';
+import { isEqual, remove } from 'lodash';
 import { getPanelData, PanelData } from './resource-details-tabs-helpers';
 import {
   getAttributionIdsOfSelectedResource,
@@ -98,7 +98,12 @@ export function ResourceDetailsTabs(
     */
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedResourceId, externalData, resolvedExternalAttributions]
+    [
+      selectedResourceId,
+      externalData,
+      resolvedExternalAttributions,
+      manualData.attributionsToResources,
+    ]
   );
 
   const assignableAttributionIds: Array<string> = remove(

--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/resource-details-tabs-helpers.test.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/resource-details-tabs-helpers.test.ts
@@ -18,22 +18,22 @@ import { PackagePanelTitle } from '../../../enums/enums';
 import { EMPTY_ATTRIBUTION_DATA } from '../../../shared-constants';
 
 describe('computeAggregatedAttributionsFromChildren', () => {
-  test('selects aggregated children and sorts correctly', () => {
-    const testAttributions: Attributions = {
-      uuid_1: { packageName: 'test Package', licenseText: 'test license text' },
-      uuid_2: { packageName: 'second test Package' },
-      uuid_3: { comment: 'test comment', copyright: 'test copyright' },
-      uuid_4: { packageName: 'test Package' },
-    };
-    const testResourcesToAttributions: ResourcesToAttributions = {
-      'samplepath/subfolder': ['uuid_1', 'uuid_2'],
-      'samplepath2/subfolder/subsubfolder': ['uuid_3', 'uuid_2'],
-      'samplepath3/subfolder': ['uuid_4'],
-    };
-    const testAttributedChildren: Set<string> = new Set<string>()
-      .add('samplepath/subfolder')
-      .add('samplepath2/subfolder/subsubfolder');
+  const testAttributions: Attributions = {
+    uuid_1: { packageName: 'test Package', licenseText: 'test license text' },
+    uuid_2: { packageName: 'second test Package' },
+    uuid_3: { comment: 'test comment', copyright: 'test copyright' },
+    uuid_4: { packageName: 'test Package' },
+  };
+  const testResourcesToAttributions: ResourcesToAttributions = {
+    'samplepath/subfolder': ['uuid_1', 'uuid_2'],
+    'samplepath2/subfolder/subsubfolder': ['uuid_3', 'uuid_2'],
+    'samplepath3/subfolder': ['uuid_4'],
+  };
+  const testAttributedChildren: Set<string> = new Set<string>()
+    .add('samplepath/subfolder')
+    .add('samplepath2/subfolder/subsubfolder');
 
+  test('selects aggregated children and sorts correctly', () => {
     const expectedResult: Array<AttributionIdWithCount> = [
       {
         childrenWithAttributionCount: 2,
@@ -54,6 +54,31 @@ describe('computeAggregatedAttributionsFromChildren', () => {
         testAttributions,
         testResourcesToAttributions,
         testAttributedChildren
+      );
+    expect(result).toEqual(expectedResult);
+  });
+
+  test('filters resolved attributions correctly', () => {
+    const expectedResult: Array<AttributionIdWithCount> = [
+      {
+        childrenWithAttributionCount: 2,
+        attributionId: 'uuid_2',
+      },
+      {
+        childrenWithAttributionCount: 1,
+        attributionId: 'uuid_3',
+      },
+    ];
+
+    const testResolvedExternalAttributions = new Set<string>();
+    testResolvedExternalAttributions.add('uuid_1');
+
+    const result: Array<AttributionIdWithCount> =
+      computeAggregatedAttributionsFromChildren(
+        testAttributions,
+        testResourcesToAttributions,
+        testAttributedChildren,
+        testResolvedExternalAttributions
       );
     expect(result).toEqual(expectedResult);
   });
@@ -144,7 +169,8 @@ describe('getPanelData', () => {
     const panelData: Array<PanelData> = getPanelData(
       '/file.txt',
       EMPTY_ATTRIBUTION_DATA,
-      EMPTY_ATTRIBUTION_DATA
+      EMPTY_ATTRIBUTION_DATA,
+      new Set<string>()
     );
     expect(panelData.length).toBe(1);
     expect(panelData[0].title).toBe(PackagePanelTitle.ExternalPackages);
@@ -154,7 +180,8 @@ describe('getPanelData', () => {
     const panelData: Array<PanelData> = getPanelData(
       '/folder/',
       EMPTY_ATTRIBUTION_DATA,
-      EMPTY_ATTRIBUTION_DATA
+      EMPTY_ATTRIBUTION_DATA,
+      new Set<string>()
     );
     expect(panelData.length).toBe(3);
     expect(panelData[0].title).toBe(PackagePanelTitle.ExternalPackages);

--- a/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
@@ -108,12 +108,15 @@ export function computeAggregatedAttributionsFromChildren(
   attributions: Attributions,
   resourcesToAttributions: ResourcesToAttributions,
   attributedChildren: Set<string>,
-  resolvedExternalAttributions = new Set<string>()
+  resolvedExternalAttributions?: Set<string>
 ): Array<AttributionIdWithCount> {
   const attributionCount: { [attributionId: string]: number } = {};
   attributedChildren.forEach((child: string) => {
     resourcesToAttributions[child].forEach((attributionId: string) => {
-      if (!resolvedExternalAttributions.has(attributionId)) {
+      if (
+        !resolvedExternalAttributions ||
+        !resolvedExternalAttributions.has(attributionId)
+      ) {
         attributionCount[attributionId] =
           (attributionCount[attributionId] || 0) + 1;
       }

--- a/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
@@ -23,7 +23,8 @@ export interface PanelData {
 export function getPanelData(
   selectedResourceId: string,
   manualData: AttributionData,
-  externalData: AttributionData
+  externalData: AttributionData,
+  resolvedExternalAttributions: Set<string>
 ): Array<PanelData> {
   let panelData: Array<PanelData> = [
     {
@@ -41,7 +42,8 @@ export function getPanelData(
         title: PackagePanelTitle.ContainedExternalPackages,
         attributionIdsWithCount: getContainedExternalPackages(
           selectedResourceId,
-          externalData
+          externalData,
+          resolvedExternalAttributions
         ),
         attributions: externalData.attributions,
       },
@@ -69,7 +71,8 @@ function getExternalAttributionIdsWithCount(
 
 function getContainedExternalPackages(
   selectedResourceId: string,
-  externalData: AttributionData
+  externalData: AttributionData,
+  resolvedExternalAttributions: Set<string>
 ): Array<AttributionIdWithCount> {
   const externalAttributedChildren = getAttributedChildren(
     externalData.resourcesWithAttributedChildren,
@@ -79,7 +82,8 @@ function getContainedExternalPackages(
   return computeAggregatedAttributionsFromChildren(
     externalData.attributions,
     externalData.resourcesToAttributions,
-    externalAttributedChildren
+    externalAttributedChildren,
+    resolvedExternalAttributions
   );
 }
 
@@ -103,13 +107,16 @@ function getContainedManualPackages(
 export function computeAggregatedAttributionsFromChildren(
   attributions: Attributions,
   resourcesToAttributions: ResourcesToAttributions,
-  attributedChildren: Set<string>
+  attributedChildren: Set<string>,
+  resolvedExternalAttributions = new Set<string>()
 ): Array<AttributionIdWithCount> {
   const attributionCount: { [attributionId: string]: number } = {};
   attributedChildren.forEach((child: string) => {
     resourcesToAttributions[child].forEach((attributionId: string) => {
-      attributionCount[attributionId] =
-        (attributionCount[attributionId] || 0) + 1;
+      if (!resolvedExternalAttributions.has(attributionId)) {
+        attributionCount[attributionId] =
+          (attributionCount[attributionId] || 0) + 1;
+      }
     });
   });
 


### PR DESCRIPTION
### Summary of changes

Add filter for resolved attributions to 'Signals in Folder Content' tab.

### Context and reason for change

Hiding a signal should remove it from the 'Signals in Folder Content' tab and make it only visible through the 'Signals' tab of the resources, the signal is attached to. So far, the signal stayed greyed out in the 'Signals in Folder Content' tab, if at least one resource, to which the signal was attached to, had one or more other non-hidden signals. This commit fixes this behavior by adding a filter for resolved attributions to the 'Signals in Folder Content' tab.

### How can the changes be tested

Run tests and / or use example file to hide a signal that is attached to a resource with at least one other non-hidden signal. Verify that the signal is not visible in the 'Signals in Folder Content' tab after hiding it

