### PR TITLE
Remove statement for e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ yarn test:unit
 yarn test:integration-ci
 ```
 
-End to end test are available (currently only linux and mac) and can be run using:
+End to end test are available and can be run using:
 ```
 yarn test:e2e
 ```


### PR DESCRIPTION
### Summary of changes

Remove statement from the documentation claiming that e2e tests only work on MacOS and Linux.

### Context and reason for change

We changed the framework for e2e tests, added support for Windows and forgot to fix the documentation.

