### PR TITLE
fix confirm in context menu

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -196,13 +196,17 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
         ? temporaryPackageInfo
         : manualAttributions[attributionId];
 
-    dispatch(
-      unlinkAttributionAndSavePackageInfo(
-        selectedResourceId,
-        attributionId,
-        packageInfo
-      )
-    );
+    if (attributionsToResources[attributionId].length === 1) {
+      confirmAttributionGlobally();
+    } else {
+      dispatch(
+        unlinkAttributionAndSavePackageInfo(
+          selectedResourceId,
+          attributionId,
+          packageInfo
+        )
+      );
+    }
   }
 
   function confirmAttributionGlobally(): void {

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { doNothing } from '../../../util/do-nothing';
+import { PackageCard } from '../PackageCard';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import {
+  Attributions,
+  Resources,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { ButtonText } from '../../../enums/enums';
+import { clickOnButtonInPackageContextMenu } from '../../../test-helpers/context-menu-test-helpers';
+import { IpcRenderer } from 'electron';
+
+const testResources: Resources = {
+  thirdParty: {
+    'package_1.tr.gz': 1,
+    'package_2.tr.gz': 1,
+    'jQuery.js': 1,
+  },
+};
+const testAttributionId = 'attributionId';
+const testAttributions: Attributions = {
+  [testAttributionId]: { packageName: 'pkg', preSelected: true },
+  anotherAttributionId: { packageName: 'pkg', preSelected: true },
+};
+
+let originalIpcRenderer: IpcRenderer;
+
+describe('The PackageCard', () => {
+  beforeAll(() => {
+    originalIpcRenderer = global.window.ipcRenderer;
+    global.window.ipcRenderer = {
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      invoke: jest.fn(),
+    } as unknown as IpcRenderer;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  afterAll(() => {
+    // Important to restore the original value.
+    global.window.ipcRenderer = originalIpcRenderer;
+  });
+
+  test('has working confirm button', () => {
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      'package_1.tr.gz': [testAttributionId],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    renderComponentWithStore(
+      <PackageCard
+        attributionId={testAttributionId}
+        cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
+        cardContent={{
+          id: 'some_id',
+          name: 'packageName',
+        }}
+        onClick={doNothing}
+      />,
+      { store: testStore }
+    );
+
+    expect(screen.getByText('packageName'));
+
+    expect(
+      testStore.getState().resourceState.allViews.manualData.attributions[
+        testAttributionId
+      ]
+    ).toEqual(testAttributions[testAttributionId]);
+    clickOnButtonInPackageContextMenu(
+      screen,
+      'packageName',
+      ButtonText.Confirm
+    );
+    expect(
+      testStore.getState().resourceState.allViews.manualData.attributions[
+        testAttributionId
+      ]
+    ).toEqual({
+      ...testAttributions[testAttributionId],
+      attributionConfidence: 80,
+      preSelected: undefined,
+    });
+  });
+
+  test('has working confirm globally button', () => {
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      'package_1.tr.gz': [testAttributionId],
+      'package_2.tr.gz': [testAttributionId],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    renderComponentWithStore(
+      <PackageCard
+        attributionId={testAttributionId}
+        cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
+        cardContent={{
+          id: 'some_id',
+          name: 'packageName',
+        }}
+        onClick={doNothing}
+      />,
+      { store: testStore }
+    );
+
+    expect(screen.getByText('packageName'));
+
+    expect(
+      testStore.getState().resourceState.allViews.manualData.attributions[
+        testAttributionId
+      ]
+    ).toEqual(testAttributions[testAttributionId]);
+    clickOnButtonInPackageContextMenu(
+      screen,
+      'packageName',
+      ButtonText.ConfirmGlobally
+    );
+    expect(
+      testStore.getState().resourceState.allViews.manualData.attributions[
+        testAttributionId
+      ]
+    ).toEqual({
+      ...testAttributions[testAttributionId],
+      attributionConfidence: 80,
+      preSelected: undefined,
+    });
+  });
+});


### PR DESCRIPTION
### Summary of changes

fix confirm in context menu

### Context and reason for change

So far pre-selected attributions were duplicated when confirming via
context menu. This is fixed in this diff.


