### PR TITLE
Fix display of invalid package urls

### DIFF
--- a/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
+++ b/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
@@ -25,7 +25,7 @@ export const useAttributionColumnStyles = makeStyles({
     marginLeft: 8,
   },
   textBoxInvalidInput: {
-    '& textarea': {
+    '& textarea, input': {
       color: OpossumColors.orange,
     },
   },


### PR DESCRIPTION
### Summary of changes

Invalid purls are supposed to be displayed in red.

### Context and reason for change

Before this fix, the text color was black.

### How can the changes be tested

Enter an invalid text in the PURL field in the attribution column of OpossumUI

