### PR TITLE
Sort package cards by displayed title

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -11,7 +11,7 @@ import {
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { ListCard } from '../ListCard/ListCard';
-import { getCardLabels } from './package-card-helpers';
+import { getCardLabels } from '../../util/get-card-labels';
 import makeStyles from '@mui/styles/makeStyles';
 import { ListCardConfig, ListCardContent } from '../../types/types';
 import { clickableIcon, OpossumColors } from '../../shared-styles';

--- a/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
+++ b/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement, useState } from 'react';
-import { getCardLabels } from '../PackageCard/package-card-helpers';
+import { getCardLabels } from '../../util/get-card-labels';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { ListCardConfig, ListCardContent } from '../../types/types';

--- a/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
+++ b/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
@@ -7,7 +7,7 @@ import { Attributions } from '../../../shared/shared-types';
 import { getAlphabeticalComparer } from '../get-alphabetical-comparer';
 
 describe('getAlphabeticalComparer', () => {
-  test('sorts alphabetically', () => {
+  test('sorts alphabetically by list card title', () => {
     const testAttributions: Attributions = {
       '1': {
         packageName: 'zz Test package',
@@ -21,7 +21,59 @@ describe('getAlphabeticalComparer', () => {
         licenseText: 'Some license text',
       },
       '3': {
+        comment: 'Example comment',
+      },
+      '4': {
+        packageName: 'JQuery',
+        packageVersion: '1.0',
+      },
+      '5': {
+        attributionConfidence: 0,
+        packageName: 'JQuery',
+        licenseText: 'Some license text',
+      },
+    };
+    const sortedAttributionIds = Object.keys(testAttributions).sort(
+      getAlphabeticalComparer(testAttributions)
+    );
+
+    expect(sortedAttributionIds).toEqual(['3', '5', '4', '2', '1']);
+  });
+
+  test('sorts empty attributions to the end of the list', () => {
+    const testAttributions: Attributions = {
+      '1': {},
+      '2': {
+        attributionConfidence: 0,
+        comment: 'Some comment',
+        copyright: 'Copyright John Doe',
+        licenseText: 'Some license text',
+      },
+      '3': {
         copyright: '(C) Copyright John Doe',
+      },
+    };
+    const sortedAttributionIds = Object.keys(testAttributions).sort(
+      getAlphabeticalComparer(testAttributions)
+    );
+
+    expect(sortedAttributionIds).toEqual(['2', '3', '1']);
+  });
+
+  test('sorts non-alphabetical chars behind alphabetical chars', () => {
+    const testAttributions: Attributions = {
+      '1': {
+        packageName: 'Test package',
+        packageVersion: '1.0',
+      },
+      '2': {
+        attributionConfidence: 0,
+        comment: 'Some comment',
+        copyright: 'Copyright John Doe',
+        licenseText: 'Some license text',
+      },
+      '3': {
+        copyright: 'John Doe',
       },
     };
     const sortedAttributionIds = Object.keys(testAttributions).sort(

--- a/src/Frontend/util/__tests__/get-card-labels-test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels-test.ts
@@ -8,8 +8,8 @@ import {
   addPreambleToCopyright,
   addSecondLineOfPackageLabelFromAttribute,
   getCardLabels,
-} from '../package-card-helpers';
-import { ListCardContent } from '../../../types/types';
+} from '../get-card-labels';
+import { ListCardContent } from '../../types/types';
 
 describe('Test getPackageLabel', () => {
   const testProps: ListCardContent = {

--- a/src/Frontend/util/get-alphabetical-comparer.ts
+++ b/src/Frontend/util/get-alphabetical-comparer.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Attributions } from '../../shared/shared-types';
+import { getCardLabels } from './get-card-labels';
 
 export function getAlphabeticalComparer(attributions: Attributions) {
   return function compareFunction(
@@ -11,11 +12,53 @@ export function getAlphabeticalComparer(attributions: Attributions) {
     otherElement: string
   ): number {
     const defaultName = '\u10FFFF'; // largest unicode character
-    const packageName = attributions[element].packageName || defaultName;
-    const otherPackageName =
-      attributions[otherElement].packageName || defaultName;
-    return packageName.localeCompare(otherPackageName, undefined, {
+
+    const elementCardLabels = getCardLabels({
+      id: element,
+      name: attributions[element].packageName,
+      ...attributions[element],
+    });
+    const elementTitle = getElementTitle(elementCardLabels, defaultName);
+    const elementTitleIsAlphabetical = isElementTitleAlphabetical(
+      elementTitle,
+      defaultName
+    );
+
+    const otherElementCardLabels = getCardLabels({
+      id: otherElement,
+      name: attributions[otherElement].packageName,
+      ...attributions[otherElement],
+    });
+    const otherElementTitle = getElementTitle(
+      otherElementCardLabels,
+      defaultName
+    );
+    const otherElementTitleIsAlphabetical = isElementTitleAlphabetical(
+      otherElementTitle,
+      defaultName
+    );
+
+    if (!elementTitleIsAlphabetical && otherElementTitleIsAlphabetical)
+      return 1;
+    if (elementTitleIsAlphabetical && !otherElementTitleIsAlphabetical)
+      return -1;
+
+    return elementTitle.localeCompare(otherElementTitle, undefined, {
       sensitivity: 'base',
     });
   };
+}
+
+function getElementTitle(
+  elementCardLabels: Array<string>,
+  defaultName: string
+): string {
+  return elementCardLabels.length > 0 ? elementCardLabels[0] : defaultName;
+}
+
+function isElementTitleAlphabetical(
+  elementTitle: string,
+  defaultName: string
+): boolean {
+  return elementTitle.localeCompare('a') >= 0 && elementTitle !== defaultName;
 }

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ListCardContent } from '../../types/types';
+import { ListCardContent } from '../types/types';
 
 const prioritizedPackageInfoAttributes: Array<
   'name' | 'copyright' | 'licenseName' | 'licenseText' | 'comment' | 'url'


### PR DESCRIPTION
### Summary of changes

Change package card sorting to sort by displayed title (first line).

### Context and reason for change

The sorting in the attribution lists only compared the package names of the attribution to sort the attributions. This was confusing for the user, because the card displays additional / different information, depending on the available information (e.g. package name and package version combined, only the comment, ...). This commit adds a sorting by the first line that is displayed in the package card. Empty attributions are sorted to the bottom.

### How can the changes be tested

Run tests in get-alphabetical-comparer.test.tsx or test with input file.

