### PR TITLE
Add icon to hide multiselect in attribution view

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -255,9 +255,9 @@ the `Audit View` and has two main components:
 All existing attributions are listed and can be selected. **Pre-selected**
 attributions are signaled by an `P` icon. They can be confirmed, which converts them into attributions
 in all views and in the progress bar. However, that is not a requirement. **Pre-selected** and manual
-attributions are both written in the output file. On top there is a dropdown list with filters that allows
-for filtering for attributions marked for follow-up, first party and not first party. The last two are mutually
-exclusive.
+attributions are both written in the output file. On top there is an icon for openning the filter section. By clicking
+on it, a dropdown will be shown with filters that allows for filtering for attributions marked for follow-up, first
+party and not first party. The last two are mutually exclusive.
 
 #### Selected Attribution Panel
 

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -33,6 +33,7 @@ interface AttributionListProps {
   maxHeight: number;
   title: string;
   topRightElement?: JSX.Element;
+  filterElement?: JSX.Element;
 }
 
 export function AttributionList(props: AttributionListProps): ReactElement {
@@ -93,6 +94,7 @@ export function AttributionList(props: AttributionListProps): ReactElement {
         <MuiTypography className={classes.title}>{props.title}</MuiTypography>
         {props.topRightElement}
       </div>
+      {props.filterElement}
       <FilteredList
         attributions={props.attributions}
         attributionIds={attributionIds}

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import makeStyles from '@mui/styles/makeStyles';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
@@ -18,9 +18,16 @@ import { useFilters } from '../../util/use-filters';
 import { useWindowHeight } from '../../util/use-window-height';
 import { AttributionDetailsViewer } from '../AttributionDetailsViewer/AttributionDetailsViewer';
 import { AttributionList } from '../AttributionList/AttributionList';
-import { OpossumColors } from '../../shared-styles';
+import {
+  OpossumColors,
+  clickableIcon,
+  disabledIcon,
+} from '../../shared-styles';
 import { topBarHeight } from '../TopBar/TopBar';
 import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import { IconButton } from '../IconButton/IconButton';
+import { getActiveFilters } from '../../state/selectors/view-selector';
 
 const countAndSearchOffset = 119;
 
@@ -33,6 +40,11 @@ const useStyles = makeStyles({
   attributionList: {
     width: '30%',
     margin: 5,
+  },
+  disabledIcon,
+  clickableIcon,
+  hiddenFilter: {
+    display: 'none',
   },
 });
 
@@ -56,6 +68,14 @@ export function AttributionView(): ReactElement {
     Object.keys(attributions).length
   })`;
 
+  const activeFilters = Array.from(useAppSelector(getActiveFilters));
+
+  const [showMultiSelect, setShowMultiselect] = useState<boolean>(false);
+
+  if (activeFilters.length != 0 && !showMultiSelect) {
+    setShowMultiselect(!showMultiSelect);
+  }
+
   return (
     <div className={classes.root}>
       <AttributionList
@@ -66,7 +86,29 @@ export function AttributionView(): ReactElement {
         className={classes.attributionList}
         maxHeight={useWindowHeight() - topBarHeight - countAndSearchOffset}
         title={title}
-        topRightElement={<FilterMultiSelect />}
+        topRightElement={
+          <IconButton
+            tooltipTitle="Filters"
+            placement="right"
+            onClick={(): void => setShowMultiselect(!showMultiSelect)}
+            disabled={activeFilters.length != 0}
+            icon={
+              <FilterAltIcon
+                aria-label={'Filter icon'}
+                className={
+                  activeFilters.length != 0
+                    ? classes.disabledIcon
+                    : classes.clickableIcon
+                }
+              />
+            }
+          />
+        }
+        filterElement={
+          <FilterMultiSelect
+            className={showMultiSelect ? undefined : classes.hiddenFilter}
+          />
+        }
       />
       <AttributionDetailsViewer />
     </div>

--- a/src/Frontend/Components/SearchTextField/SearchTextField.tsx
+++ b/src/Frontend/Components/SearchTextField/SearchTextField.tsx
@@ -12,6 +12,7 @@ import { OpossumColors } from '../../shared-styles';
 
 const useStyles = makeStyles({
   searchField: {
+    marginTop: 4,
     marginBottom: 8,
     '& div': {
       borderRadius: 0,


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Add an icon in attribution view to hide or show the multiselect filter

### Context and reason for change
- The multiselect component is too prominent and is not used so frequently

### How can the changes be tested
- The icon can be tested in the UI
