### PR TITLE
Fix icon distance in report view

### DIFF
--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -67,6 +67,9 @@ const useStyles = makeStyles({
     height: 15,
     margin: 1,
   },
+  iconButton: {
+    marginBottom: 5,
+  },
   editIcon: {
     backgroundColor: OpossumColors.white,
     border: `2px ${OpossumColors.darkBlue} solid`,
@@ -227,6 +230,7 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
           <IconButton
             tooltipTitle="edit"
             placement="left"
+            className={clsx(classes.iconButton)}
             onClick={(): void => {
               props.onIconClick(attributionId);
             }}


### PR DESCRIPTION
### Summary of changes

Add margin-bottom to icon button

### Context and reason for change

The distance between the edit button and the following icon was too small.

### How can the changes be tested

Verify icon distance with example file in report view

