### PR TITLE
Update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Prettier is used as a code formatter.
 The following software is required for working on the repository:
 
 - [git](https://git-scm.com/),
-- [node.js](https://nodejs.org/) 16 (version 17 is currently not supported),
+- [node.js](https://nodejs.org/) 16+,
 - [yarn](https://yarnpkg.com/en/),
 - [reuse.software](https://reuse.software/) (to check that copyright information is provided),
 - [wine](https://www.winehq.org/) (only to build the Windows version).


### PR DESCRIPTION
### Summary of changes

Update docs

### Context and reason for change

We now also support yarn 17. The docs are updated accordingly.



