### PR TITLE
Adjust style to align icons in the package list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "stream-json": "^1.7.2",
     "upath": "^2.0.1",
     "uuid": "^8.3.0",
-    "write-file-atomic": "^3.0.3"
+    "write-file-atomic": "^3.0.3",
+    "react-scrollbar-size": "4.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^8.11.1",

--- a/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles({
     padding: '0 12px',
   },
   disabledAccordion: {},
-  expansionPanelDetails: { height: '100%', padding: '0 12px 16px' },
+  expansionPanelDetails: { height: '100%', padding: '0 0 16px 12px ' },
 });
 
 interface AggregatedAttributionsPanelProps {

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -27,6 +27,7 @@ interface ListProps {
   addPaddingBottom?: boolean;
   allowHorizontalScrolling?: boolean;
   leftScrollBar?: boolean;
+  className?: string;
 }
 
 function maxHeightWasGiven(
@@ -47,7 +48,7 @@ export function List(props: ListProps): ReactElement {
     : Math.min(currentHeight, maxHeight);
 
   return (
-    <div style={{ maxHeight: currentHeight }}>
+    <div className={props.className} style={{ maxHeight: currentHeight }}>
       <VirtualizedList
         height={listHeight}
         width={'vertical'}

--- a/src/Frontend/Components/PackageList/PackageList.tsx
+++ b/src/Frontend/Components/PackageList/PackageList.tsx
@@ -13,6 +13,13 @@ import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
 import { List } from '../List/List';
 import { PackagePanelCard } from '../PackagePanelCard/PackagePanelCard';
 import { ListCardConfig } from '../../types/types';
+import { makeStyles } from '@mui/styles';
+import clsx from 'clsx';
+import useScrollbarSize from 'react-scrollbar-size';
+
+const NUMBER_OF_DISPLAYED_ITEMS = 15;
+const CARD_VERTICAL_DISTANCE = 41;
+const MAX_HEIGHT = NUMBER_OF_DISPLAYED_ITEMS * CARD_VERTICAL_DISTANCE;
 
 interface PackageListProps {
   attributionIdsWithCount?: Array<AttributionIdWithCount>;
@@ -30,6 +37,15 @@ interface PackageListProps {
 
 export function PackageList(props: PackageListProps): ReactElement {
   const attributionIdsWithCount = props.attributionIdsWithCount || [];
+  const { width } = useScrollbarSize();
+
+  const useStyles = makeStyles({
+    paddingRight: {
+      paddingRight: width,
+    },
+  });
+
+  const classes = useStyles();
 
   function getSortedAttributionIds(): Array<string> {
     if (!attributionIdsWithCount.length) {
@@ -96,12 +112,15 @@ export function PackageList(props: PackageListProps): ReactElement {
     );
   }
 
+  const currentHeight = attributionIdsWithCount.length * CARD_VERTICAL_DISTANCE;
+
   return (
     <List
       getListItem={getPackagePanelCard}
-      max={{ numberOfDisplayedItems: 15 }}
+      max={{ numberOfDisplayedItems: NUMBER_OF_DISPLAYED_ITEMS }}
       length={attributionIdsWithCount.length}
-      cardVerticalDistance={41}
+      cardVerticalDistance={CARD_VERTICAL_DISTANCE}
+      className={clsx(currentHeight < MAX_HEIGHT && classes.paddingRight)}
     />
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8881,6 +8881,11 @@ react-scripts@5.0.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+react-scrollbar-size@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-scrollbar-size/-/react-scrollbar-size-4.0.0.tgz#47c130b9c46331c1bdade030b890d80388da9c6b"
+  integrity sha512-6ocQusPakZGPQQc5mxMRd9Cqy1ALKHyR6eGFbNWM94NPRBnhqAo0DSWXBodhgm9vg8y21o3ZudYJD8gyoW/NRw==
+
 react-transition-group@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Adjust style so icons are aligned in package list
![image](https://user-images.githubusercontent.com/45177671/146354506-00bedced-6b94-43cd-88cd-dc7b2f39dd25.png)
vs.
![image](https://user-images.githubusercontent.com/45177671/146354091-55128904-d670-47fd-aa37-1e24c60125d9.png)

### Context and reason for change
- Better styling

### How can the changes be tested
- The changes can be tested in the UI.
