### PR TITLE
Add checkbox for multi-select to package cards

### DIFF
--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -15,7 +15,10 @@ import { Checkbox } from '../Checkbox/Checkbox';
 import { useAttributionColumnStyles } from '../AttributionColumn/shared-attribution-column-styles';
 import { getMultiSelectMode } from '../../state/selectors/attribution-view-resource-selectors';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { setMultiSelectMode } from '../../state/actions/resource-actions/attribution-view-simple-actions';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { CheckboxLabel } from '../../enums/enums';
 
 const useStyles = makeStyles({
@@ -99,6 +102,9 @@ export function AttributionList(props: AttributionListProps): ReactElement {
   function handleMultiSelectModeChange(
     event: React.ChangeEvent<HTMLInputElement>
   ): void {
+    if (!event.target.checked) {
+      dispatch(setMultiSelectSelectedAttributionIds([]));
+    }
     dispatch(setMultiSelectMode(event.target.checked));
   }
 

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -138,6 +138,9 @@ const useStyles = makeStyles({
       background: OpossumColors.white,
     },
   },
+  multiSelected: {
+    background: OpossumColors.lightestBlue,
+  },
 });
 
 interface ListCardProps {
@@ -148,6 +151,7 @@ interface ListCardProps {
   onClick(): void;
   leftIcon?: JSX.Element;
   rightIcons?: Array<JSX.Element>;
+  leftElement?: JSX.Element;
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
@@ -186,10 +190,14 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             : classes.selected
           : null,
         props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
-        props.cardConfig.isResolved && classes.resolved
+        props.cardConfig.isResolved && classes.resolved,
+        props.cardConfig.isMultiSelected && !props.cardConfig.isSelected
+          ? classes.multiSelected
+          : ''
       )}
       onClick={props.onClick}
     >
+      {props.leftElement ? props.leftElement : null}
       <div className={classes.iconColumn}>
         {props.leftIcon ? props.leftIcon : null}
         {getDisplayedCount() ? (

--- a/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
+++ b/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 import { ListCard } from '../ListCard';
+import { Checkbox } from '../../Checkbox/Checkbox';
 
 describe('The ListCard', () => {
   test('renders text with no count', () => {
@@ -69,5 +70,22 @@ describe('The ListCard', () => {
     expect(screen.getByText('card text'));
     expect(screen.getByText('card text of second line'));
     expect(screen.getByText('1M'));
+  });
+
+  test('renders leftElement if provided as input', () => {
+    const leftElement = <Checkbox checked={false} onChange={jest.fn()} />;
+    render(
+      <ListCard
+        text={'card text'}
+        secondLineText={'card text of second line'}
+        onClick={doNothing}
+        cardConfig={{}}
+        leftElement={leftElement}
+      />
+    );
+
+    expect(screen.getByText('card text'));
+    expect(screen.getByText('card text of second line'));
+    expect(screen.getByRole('checkbox')).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -63,7 +63,7 @@ export function ManualAttributionList(
       <PackageCard
         attributionId={isButton ? '' : attributionId}
         onClick={onClick}
-        hideContextMenu={isButton}
+        hideContextMenuAndMultiSelect={isButton}
         cardConfig={cardConfig}
         key={`AttributionCard-${attribution.packageName}-${attributionId}`}
         cardContent={{

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -63,7 +63,7 @@ export function ReplaceAttributionPopup(): ReactElement {
         attributionId={attributionId}
         onClick={doNothing}
         cardConfig={{}}
-        hideContextMenu={true}
+        hideContextMenuAndMultiSelect={true}
         cardContent={{
           id: `attribution-list-${attributionId}`,
           name: attribution?.packageName,

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -19,6 +19,8 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
   setAttributionIdMarkedForReplacement,
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { Attributions, Resources } from '../../../../shared/shared-types';
@@ -114,6 +116,24 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     expect(screen.queryByText(ButtonText.Confirm)).toBeFalsy();
     expect(screen.queryByText(ButtonText.ConfirmGlobally)).toBeFalsy();
     expect(screen.queryByText(ButtonText.DeleteGlobally)).toBeFalsy();
+  });
+
+  test('does not show multi-select checkbox for attributions', () => {
+    const testStore = createTestAppStore();
+    setupTestState(testStore);
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(
+      setMultiSelectSelectedAttributionIds(['test_marked_id'])
+    );
+
+    renderComponentWithStore(<ReplaceAttributionPopup />, {
+      store: testStore,
+    });
+
+    expect(screen.getByText('Replacing an attribution')).toBeTruthy();
+    expect(screen.getByText('React')).toBeTruthy();
+    expect(screen.getByText('Vue')).toBeTruthy();
+    expect(screen.queryByText('checkbox')).toBeFalsy();
   });
 
   test('renders a ReplaceAttributionPopup and click replace', () => {

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -54,6 +54,8 @@ import {
 import { isEmpty } from 'lodash';
 import { getAttributionBreakpointCheckForState } from '../../../util/is-attribution-breakpoint';
 import { openPopup } from '../view-actions/view-actions';
+import { getMultiSelectSelectedAttributionIds } from '../../selectors/attribution-view-resource-selectors';
+import { setMultiSelectSelectedAttributionIds } from './attribution-view-simple-actions';
 
 export function setIsSavingDisabled(
   isSavingDisabled: boolean
@@ -209,7 +211,17 @@ export function addToSelectedResource(
 export function deleteAttributionGloballyAndSave(
   attributionId: string
 ): AppThunkAction {
-  return (dispatch: AppThunkDispatch): void => {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
+    }
+
     dispatch(savePackageInfo(null, attributionId, {}));
   };
 }
@@ -221,6 +233,16 @@ export function deleteAttributionAndSave(
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+
+    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
+    }
 
     if (attributionsToResources[attributionId].length > 1) {
       dispatch(unlinkResourceFromAttributionAndSave(resourceId, attributionId));

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  Attributions,
   AttributionsToResources,
   PackageInfo,
   SaveFileArgs,
@@ -133,6 +134,11 @@ export function savePackageInfo(
 
     dispatch(resetSelectedPackagePanelIfContainedAttributionWasRemoved());
     dispatch(resetTemporaryPackageInfo());
+    dispatch(
+      filterMultiSelectSelectedAttributionIdsIfAttributionWasRemoved(
+        attributionId
+      )
+    );
 
     dispatch(saveManualAndResolvedAttributionsToFile());
   };
@@ -211,17 +217,7 @@ export function addToSelectedResource(
 export function deleteAttributionGloballyAndSave(
   attributionId: string
 ): AppThunkAction {
-  return (dispatch: AppThunkDispatch, getState: () => State): void => {
-    const multiSelectSelectedAttributionIds =
-      getMultiSelectSelectedAttributionIds(getState());
-    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
-      dispatch(
-        setMultiSelectSelectedAttributionIds(
-          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
-        )
-      );
-    }
-
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(savePackageInfo(null, attributionId, {}));
   };
 }
@@ -233,21 +229,32 @@ export function deleteAttributionAndSave(
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
-    const multiSelectSelectedAttributionIds =
-      getMultiSelectSelectedAttributionIds(getState());
-
-    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
-      dispatch(
-        setMultiSelectSelectedAttributionIds(
-          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
-        )
-      );
-    }
 
     if (attributionsToResources[attributionId].length > 1) {
       dispatch(unlinkResourceFromAttributionAndSave(resourceId, attributionId));
     } else {
       dispatch(deleteAttributionGloballyAndSave(attributionId));
+    }
+  };
+}
+
+function filterMultiSelectSelectedAttributionIdsIfAttributionWasRemoved(
+  attributionId: string | null
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+    const attributions: Attributions = getManualAttributions(getState());
+    if (
+      attributionId &&
+      !attributions[attributionId] &&
+      multiSelectSelectedAttributionIds.includes(attributionId)
+    ) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
     }
   };
 }

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -24,6 +24,14 @@ import {
   updateActiveFilters,
   setTargetView,
 } from '../view-actions';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../resource-actions/attribution-view-simple-actions';
+import {
+  getMultiSelectMode,
+  getMultiSelectSelectedAttributionIds,
+} from '../../../selectors/attribution-view-resource-selectors';
 
 describe('view actions', () => {
   test('sets view to AuditView as initial value', () => {
@@ -147,6 +155,23 @@ describe('view actions', () => {
     expect(
       getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
     ).toBe(true);
+  });
+
+  test('resets multi-select on view change', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(setMultiSelectSelectedAttributionIds(['some_id']));
+
+    testStore.dispatch(navigateToView(View.Report));
+
+    expect(getMultiSelectMode(testStore.getState())).toBeFalsy();
+    expect(
+      getMultiSelectSelectedAttributionIds(testStore.getState())
+    ).toStrictEqual([]);
+
+    expect(isAuditViewSelected(testStore.getState())).toBe(false);
+    expect(isAttributionViewSelected(testStore.getState())).toBe(false);
+    expect(isReportViewSelected(testStore.getState())).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -28,6 +28,10 @@ import {
   OpenPopupActionPopupType,
   UpdateActiveFilters,
 } from './types';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../resource-actions/attribution-view-simple-actions';
 
 export function resetViewState(): ResetViewStateAction {
   return { type: ACTION_RESET_VIEW_STATE };
@@ -41,6 +45,8 @@ export function navigateToView(view: View): AppThunkAction {
 
     dispatch(setTargetView(null));
     dispatch(setView(view));
+    dispatch(setMultiSelectMode(false));
+    dispatch(setMultiSelectSelectedAttributionIds([]));
 
     const updatedTemporaryPackageInfo: PackageInfo =
       view === View.Audit

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -300,7 +300,7 @@ export const resourceState = (
         ...state,
         attributionView: {
           ...state.attributionView,
-          multiSelectSelectedAttributionIds: action.payload,
+          multiSelectSelectedAttributionIds: [...action.payload],
         },
       };
     case ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT:

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -66,6 +66,7 @@ export interface ListCardConfig {
   followUp?: boolean;
   isHeader?: boolean;
   isContextMenuOpen?: boolean;
+  isMultiSelected?: boolean;
 }
 
 export interface PathPredicate {


### PR DESCRIPTION
### Summary of changes

Adds a checkbox to the package card while in multi-select mode for multi-select deletion feature. The checkbox has the same color as the package card. The selection gets reset on view change.

### Context and reason for change

Preparation for adding multi-select deletion.

### How can the changes be tested

Run tests or test checkboxes in attribution view.
