### PR TITLE
Add web workers without ejecting & extra packages

### DIFF
--- a/src/Frontend/Components/AppContainer/__tests__/AppContainer.test.tsx
+++ b/src/Frontend/Components/AppContainer/__tests__/AppContainer.test.tsx
@@ -10,6 +10,8 @@ import { IpcRenderer } from 'electron';
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../ResourceDetailsTabs/get-new-accordion-worker');
+
 describe('The AppContainer', () => {
   beforeAll(() => {
     originalIpcRenderer = global.window.ipcRenderer;

--- a/src/Frontend/Components/AuditView/__tests__/AuditView.test.tsx
+++ b/src/Frontend/Components/AuditView/__tests__/AuditView.test.tsx
@@ -7,6 +7,8 @@ import { AuditView } from '../AuditView';
 import React from 'react';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
+jest.mock('../../ResourceDetailsTabs/get-new-accordion-worker');
+
 describe('The AuditView', () => {
   test('renders AuditView', () => {
     renderComponentWithStore(<AuditView />);

--- a/src/Frontend/Components/ResourceDetailsTabs/__mocks__/get-new-accordion-worker.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/__mocks__/get-new-accordion-worker.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function getNewAccordionWorker(): Worker {
+  throw new Error('JEST-MOCK-GET-NEW-ACCORDION-WORKER');
+}

--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -17,6 +17,8 @@ import { setSelectedResourceId } from '../../../state/actions/resource-actions/a
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { clickOnTab } from '../../../test-helpers/package-panel-helpers';
 
+jest.mock('../get-new-accordion-worker');
+
 describe('The ResourceDetailsTabs', () => {
   test('switches between tabs', () => {
     const testResources: Resources = {

--- a/src/Frontend/Components/ResourceDetailsTabs/accordion-worker.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/accordion-worker.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getPanelData } from './resource-details-tabs-helpers';
+
+self.onmessage = ({
+  data: {
+    selectedResourceId,
+    manualData,
+    externalData,
+    resolvedExternalAttributions,
+  },
+}): void => {
+  const output = getPanelData(
+    selectedResourceId,
+    manualData,
+    externalData,
+    resolvedExternalAttributions
+  );
+
+  self.postMessage({
+    output,
+  });
+};

--- a/src/Frontend/Components/ResourceDetailsTabs/get-new-accordion-worker.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/get-new-accordion-worker.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function getNewAccordionWorker(): Worker {
+  return new Worker(new URL('./accordion-worker', import.meta.url));
+}

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -31,6 +31,8 @@ import {
 } from '../../../test-helpers/attribution-column-test-helpers';
 import { clickOnTab } from '../../../test-helpers/package-panel-helpers';
 
+jest.mock('../../ResourceDetailsTabs/get-new-accordion-worker');
+
 const testExternalLicense = 'Computed attribution license.';
 const testExternalLicense2 = 'Other computed attribution license.';
 const testManualLicense = 'Manual attribution license.';

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -56,6 +56,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
@@ -47,6 +47,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open_file_in_external_link.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open_file_in_external_link.test.tsx
@@ -24,6 +24,8 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -50,6 +50,8 @@ import { ATTRIBUTION_SOURCES } from '../../../../shared/shared-constants';
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
@@ -30,6 +30,8 @@ import { clickOnCardInAttributionList } from '../../../test-helpers/package-pane
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -52,6 +52,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -44,6 +44,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -40,6 +40,8 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -53,6 +53,8 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
@@ -38,6 +38,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -43,6 +43,8 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -65,6 +65,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -31,6 +31,8 @@ import {
 
 let originalIpcRenderer: IpcRenderer;
 
+jest.mock('../../../Components/ResourceDetailsTabs/get-new-accordion-worker');
+
 jest.setTimeout(TEST_TIMEOUT);
 
 function mockElectronBackend(mockChannelReturn: ParsedFileContent): void {


### PR DESCRIPTION
### Summary of changes

Introduce web workers and compute accordion data in a worker (async, not in the main process). Since Webpack 5 web workers are supported by default, not requiring any external package or change in the Webpack configuration. Further changes:
- Web worker can run out of memory with big files, such error is caught and the computation is then performed as fallback on main,
- jest does not support web workers yet, therefore they need to be mocked in the test. The mock just throws an error in the worker and triggers the fallback computation on main.

### Context and reason for change

The app gets stuck for a while when clicking on a folder with a lot of signals inside. Web workers allow to calculate the accordion faster, meanwhile leaving the main process free to process user input.

### How can the changes be tested

Open keycloak input and navigate away from the root folder (somewhere where there is an attribution). Then click on the root folder. On the right and above the accordion the UI will change instantly, meanwhile the old accordion will be shown until the new one is ready.
The fallback path can be tested using the ORT input file.
