### PR TITLE
Add button to fetch license information from pypi

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
+    "react-scrollbar-size": "4.0.0",
     "react-window": "^1.8.5",
     "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
@@ -32,13 +33,13 @@
     "stream-json": "^1.7.2",
     "upath": "^2.0.1",
     "uuid": "^8.3.0",
-    "write-file-atomic": "^3.0.3",
-    "react-scrollbar-size": "4.0.0"
+    "write-file-atomic": "^3.0.3"
   },
   "devDependencies": {
     "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/electron-devtools-installer": "^2.2.0",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.178",

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -14,6 +14,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IconButton } from '../IconButton/IconButton';
 import { makeStyles } from '@mui/styles';
 import { clickableIcon, disabledIcon } from '../../shared-styles';
+import { FetchLicenseInformationButton } from '../FetchLicenseInformationButton/FetchLicenseInformationButton';
 
 const useStyles = makeStyles({ clickableIcon, disabledIcon });
 
@@ -85,22 +86,28 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
         text={props.displayPackageInfo.url}
         handleChange={props.setUpdateTemporaryPackageInfoFor('url')}
         endIcon={
-          <IconButton
-            tooltipTitle="open link in browser"
-            placement="right"
-            onClick={openUrl}
-            disabled={!props.displayPackageInfo.url}
-            icon={
-              <OpenInNewIcon
-                aria-label={'Url icon'}
-                className={
-                  props.displayPackageInfo.url
-                    ? iconClasses.clickableIcon
-                    : iconClasses.disabledIcon
-                }
-              />
-            }
-          />
+          <>
+            <FetchLicenseInformationButton
+              url={props.displayPackageInfo.url}
+              isDisabled={!props.isEditable}
+            />
+            <IconButton
+              tooltipTitle="open link in browser"
+              placement="right"
+              onClick={openUrl}
+              disabled={!props.displayPackageInfo.url}
+              icon={
+                <OpenInNewIcon
+                  aria-label={'Url icon'}
+                  className={
+                    props.displayPackageInfo.url
+                      ? iconClasses.clickableIcon
+                      : iconClasses.disabledIcon
+                  }
+                />
+              }
+            />
+          </>
         }
       />
     </MuiPaper>

--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement, useEffect, useState } from 'react';
+import CachedIcon from '@mui/icons-material/Cached';
+import { IconButton } from '../IconButton/IconButton';
+import { makeStyles } from '@mui/styles';
+import {
+  clickableIcon,
+  disabledIcon,
+  baseIcon,
+  OpossumColors,
+} from '../../shared-styles';
+import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
+import { getTemporaryPackageInfo } from '../../state/selectors/all-views-resource-selectors';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import clsx from 'clsx';
+import { PackageInfo } from '../../../shared/shared-types';
+import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
+import { doNothing } from '../../util/do-nothing';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import {
+  getLicenseFetchingInformation,
+  LicenseFetchingInformation,
+} from './license-fetching-helpers';
+
+const useStyles = makeStyles({
+  clickableIcon,
+  disabledIcon,
+  baseIcon,
+  errorIcon: {
+    color: OpossumColors.red,
+  },
+  successfulIcon: {
+    color: OpossumColors.green,
+  },
+  spinningIcon: {
+    color: OpossumColors.darkBlue,
+    animationName: '$spin',
+    animationDuration: '1000ms',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
+  },
+  '@keyframes spin': {
+    from: {
+      transform: 'rotate(0deg)',
+    },
+    to: {
+      transform: 'rotate(-360deg)',
+    },
+  },
+});
+
+const FETCH_DATA_TOOLTIP = 'Fetch data';
+
+export enum FetchStatus {
+  Idle = 'Idle',
+  Success = 'Success',
+  Error = 'Error',
+  InFlight = 'InFlight',
+}
+
+export function useFetchPackageInfo(props: LicenseFetchingInformation): {
+  fetchStatus: FetchStatus;
+  errorMessage: string;
+  fetchData: () => void;
+} {
+  const dispatch = useAppDispatch();
+  const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const [fetchStatus, setFetchStatus] = useState<FetchStatus>(FetchStatus.Idle);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [fetchedPackageInfo, setFetchedPackageInfo] =
+    useState<{ selectedResourceId: string; packageInfo: PackageInfo }>();
+
+  function fetchData(): void {
+    setFetchStatus(FetchStatus.InFlight);
+    fetch(props.url)
+      .then(async (res) => {
+        setFetchedPackageInfo({
+          selectedResourceId,
+          packageInfo: await props.convertPayload(res),
+        });
+        setFetchStatus(FetchStatus.Success);
+      })
+      .catch((error: Error) => {
+        setErrorMessage(error.message);
+        setFetchStatus(FetchStatus.Error);
+      });
+  }
+
+  useEffect(() => {
+    if (
+      fetchStatus === FetchStatus.Success &&
+      fetchedPackageInfo?.packageInfo &&
+      selectedResourceId === fetchedPackageInfo?.selectedResourceId
+    ) {
+      dispatch(
+        setTemporaryPackageInfo({
+          ...temporaryPackageInfo,
+          ...fetchedPackageInfo.packageInfo,
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchStatus, fetchedPackageInfo, dispatch, selectedResourceId]);
+
+  useEffect(() => {
+    setErrorMessage('');
+    setFetchedPackageInfo(undefined);
+    setFetchStatus(FetchStatus.Idle);
+  }, [props.url]);
+
+  return {
+    fetchStatus,
+    errorMessage,
+    fetchData,
+  };
+}
+
+function DisabledFetchLicenseInformationButton(): ReactElement {
+  const classes = useStyles();
+
+  return (
+    <IconButton
+      tooltipTitle={FETCH_DATA_TOOLTIP}
+      placement="right"
+      disabled={false}
+      onClick={doNothing}
+      icon={<CachedIcon className={classes.disabledIcon} />}
+    />
+  );
+}
+
+function EnabledFetchLicenseInformationButton(
+  props: LicenseFetchingInformation
+): ReactElement {
+  const classes = useStyles();
+  const { fetchStatus, errorMessage, fetchData } = useFetchPackageInfo(props);
+
+  function getIcon(): ReactElement {
+    switch (fetchStatus) {
+      case FetchStatus.InFlight:
+        return (
+          <CachedIcon
+            className={clsx(classes.baseIcon, classes.spinningIcon)}
+          />
+        );
+      case FetchStatus.Error:
+        return (
+          <ErrorOutlineIcon
+            className={clsx(classes.baseIcon, classes.errorIcon)}
+          />
+        );
+      case FetchStatus.Success:
+        return (
+          <CachedIcon
+            className={clsx(classes.baseIcon, classes.successfulIcon)}
+          />
+        );
+      default:
+        return <CachedIcon className={classes.clickableIcon} />;
+    }
+  }
+
+  function getTooltip(): string {
+    switch (fetchStatus) {
+      case FetchStatus.InFlight:
+        return 'Fetching data';
+      case FetchStatus.Error:
+        return errorMessage;
+      default:
+        return FETCH_DATA_TOOLTIP;
+    }
+  }
+
+  return (
+    <IconButton
+      tooltipTitle={getTooltip()}
+      placement="right"
+      onClick={fetchData}
+      icon={getIcon()}
+    />
+  );
+}
+
+export function FetchLicenseInformationButton(props: {
+  url?: string;
+  isDisabled: boolean;
+}): ReactElement {
+  const licenseFetchingInformation = getLicenseFetchingInformation(props.url);
+  return !props.isDisabled && licenseFetchingInformation ? (
+    <EnabledFetchLicenseInformationButton
+      url={licenseFetchingInformation.url}
+      convertPayload={licenseFetchingInformation.convertPayload}
+    />
+  ) : (
+    <DisabledFetchLicenseInformationButton />
+  );
+}

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import React, { ReactElement, ReactNode } from 'react';
+import {
+  FetchLicenseInformationButton,
+  FetchStatus,
+  useFetchPackageInfo,
+} from '../FetchLicenseInformationButton';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { PackageInfo } from '../../../../shared/shared-types';
+import { Store } from 'redux';
+import { Provider } from 'react-redux';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
+
+describe('FetchLicenseInformationButton', () => {
+  it('renders disabled button', () => {
+    render(<FetchLicenseInformationButton isDisabled={true} url={''} />);
+    expect(screen.getByLabelText('Fetch data')).toBeTruthy();
+  });
+
+  it('renders enabled button', () => {
+    renderComponentWithStore(
+      <FetchLicenseInformationButton
+        url={'https://pypi.org/pypi/test'}
+        isDisabled={false}
+      />
+    );
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function mockConvertPayload(_: Response): Promise<PackageInfo> {
+  return Promise.resolve({ licenseName: 'testLicense' });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function mockConvertPayloadRaises(_: Response): Promise<PackageInfo> {
+  throw new Error('unexpected error');
+}
+
+const MOCK_URL = 'mock_url';
+
+function getWrapper(store: Store, children: ReactNode): ReactElement {
+  return <Provider store={store}>{children}</Provider>;
+}
+
+describe('useFetchPackageInfo', () => {
+  // @ts-ignore
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => {
+        Promise.resolve({});
+      },
+    })
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns idle', () => {
+    const store = createTestAppStore();
+    const { result } = renderHook(
+      () =>
+        useFetchPackageInfo({
+          url: MOCK_URL,
+          convertPayload: mockConvertPayload,
+        }),
+      {
+        wrapper: ({ children }) => getWrapper(store, children),
+      }
+    );
+    expect(result.current.fetchStatus).toBe(FetchStatus.Idle);
+  });
+
+  it('fetches data', async () => {
+    const store = createTestAppStore();
+    const { result } = renderHook(
+      () =>
+        useFetchPackageInfo({
+          url: MOCK_URL,
+          convertPayload: mockConvertPayload,
+        }),
+      {
+        wrapper: ({ children }) => getWrapper(store, children),
+      }
+    );
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.fetchData();
+    });
+    expect(result.current.fetchStatus).toBe(FetchStatus.Success);
+    expect(getTemporaryPackageInfo(store.getState())).toMatchObject({
+      licenseName: 'testLicense',
+    });
+  });
+
+  it('handles errors', async () => {
+    const store = createTestAppStore();
+    const { result } = renderHook(
+      () =>
+        useFetchPackageInfo({
+          url: MOCK_URL,
+          convertPayload: mockConvertPayloadRaises,
+        }),
+      {
+        wrapper: ({ children }) => getWrapper(store, children),
+      }
+    );
+    // eslint-disable-next-line @typescript-eslint/require-await
+    await act(async () => {
+      result.current.fetchData();
+    });
+    expect(result.current.fetchStatus).toBe(FetchStatus.Error);
+    expect(getTemporaryPackageInfo(store.getState())).toMatchObject({});
+  });
+});

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getLicenseFetchingInformation } from '../license-fetching-helpers';
+import { convertPypiPayload } from '../pypi-fetching-helpers';
+
+describe('getLicenseFetchingInformation', () => {
+  it('returns null for undefined as input', () => {
+    expect(getLicenseFetchingInformation()).toBeNull();
+  });
+
+  it('returns null for no match', () => {
+    expect(getLicenseFetchingInformation('https://unknown-url.com')).toBeNull();
+  });
+
+  it('recognizes pypi urls', () => {
+    expect(
+      getLicenseFetchingInformation('https://pypi.org/project/numpy')
+    ).toMatchObject({
+      url: 'https://pypi.org/pypi/numpy/json',
+      convertPayload: convertPypiPayload,
+    });
+  });
+});

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/pypi-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/pypi-fetching-helpers.test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { convertPypiPayload, getPypiAPIUrl } from '../pypi-fetching-helpers';
+
+describe('getPypiAPIUrl', () => {
+  const EXPECTED_URL = 'https://pypi.org/pypi/numpy/json';
+
+  it('appends /json', () => {
+    expect(getPypiAPIUrl('https://pypi.org/pypi/numpy')).toBe(EXPECTED_URL);
+  });
+
+  it('appends json', () => {
+    expect(getPypiAPIUrl('https://pypi.org/pypi/numpy/')).toBe(EXPECTED_URL);
+  });
+
+  it('replaces project by pypi', () => {
+    expect(getPypiAPIUrl('https://pypi.org/project/numpy')).toBe(EXPECTED_URL);
+  });
+});
+
+describe('convertPypiPayload', () => {
+  it('raises for invalid payload', async () => {
+    const payload = {
+      info: { packageName: 'test' },
+    };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    await expect(
+      convertPypiPayload(mockResponse as unknown as Response)
+    ).rejects.toBeTruthy();
+  });
+
+  it('returns correct packageInfo', async () => {
+    const payload = {
+      info: { license: 'test', name: 'test package' },
+    };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    const packageInfo = await convertPypiPayload(
+      mockResponse as unknown as Response
+    );
+    expect(packageInfo).toStrictEqual({
+      licenseName: 'test',
+      packageName: 'test package',
+      packageType: 'pypi',
+      packageNamespace: undefined,
+      packagePURLAppendix: undefined,
+    });
+  });
+});

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo } from '../../../shared/shared-types';
+import { convertPypiPayload, getPypiAPIUrl } from './pypi-fetching-helpers';
+
+const PYPI_REGEX = new RegExp('^https://pypi.org/(pypi|project)/[\\w-+,_]+/?$');
+
+export interface LicenseFetchingInformation {
+  url: string;
+  convertPayload: (payload: Response) => Promise<PackageInfo>;
+}
+
+export function getLicenseFetchingInformation(
+  url?: string
+): LicenseFetchingInformation | null {
+  if (!url) {
+    return null;
+  }
+
+  if (PYPI_REGEX.test(url)) {
+    return {
+      url: getPypiAPIUrl(url),
+      convertPayload: convertPypiPayload,
+    };
+  }
+  return null;
+}

--- a/src/Frontend/Components/FetchLicenseInformationButton/pypi-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/pypi-fetching-helpers.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Validator, Schema } from 'jsonschema';
+import { PackageInfo } from '../../../shared/shared-types';
+
+export function getPypiAPIUrl(url: string): string {
+  const packageName = url
+    .split('/')
+    .filter((x) => x)
+    .slice(-1)[0];
+
+  return `https://pypi.org/pypi/${packageName}/json`;
+}
+
+const jsonSchemaValidator = new Validator();
+
+const PYPI_SCHEMA: Schema = {
+  type: 'object',
+  properties: {
+    info: {
+      type: 'object',
+      properties: {
+        license: {
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+        },
+      },
+      required: ['license', 'name'],
+    },
+  },
+  required: ['info'],
+};
+
+export async function convertPypiPayload(
+  payload: Response
+): Promise<PackageInfo> {
+  const convertedPayload = await payload.json();
+  jsonSchemaValidator.validate(convertedPayload, PYPI_SCHEMA, {
+    throwError: true,
+  });
+  return {
+    licenseName: convertedPayload.info.license as string,
+    packageName: convertedPayload.info.name as string,
+    packageType: 'pypi',
+    packageNamespace: undefined,
+    packagePURLAppendix: undefined,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,6 +1902,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.1.2":
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
@@ -2153,7 +2164,7 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/react-dom@^17.0.11":
+"@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
@@ -2177,6 +2188,13 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.4":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -2191,7 +2209,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.37":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.37":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
@@ -8689,6 +8707,13 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.10:
   version "6.0.10"


### PR DESCRIPTION
### Summary of changes

This is a first POC for #216. A button is added which loads information from the pypi api if the entered url is a valid pypi url.

- add new button
- add interface which can be extended for other providers (github, npm, ...)

### Context and reason for change

- external APIs can be useful for fetching data

### How can the changes be tested

- create an attribution with url: `https://pypi.org/pypi/Faker` for success case, `https://pypi.org/pypi/qwadsadadsad` for error case.

![Peek 2021-12-18 20-55](https://user-images.githubusercontent.com/26271333/146654084-8e7ffe0e-d7bd-4a50-8869-c0bb725d9b74.gif)

