### PR TITLE
Remove empty comment and change logic of checking same attributions between parent and child

### DIFF
--- a/src/ElectronBackend/input/__tests__/cleanInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/cleanInputData.test.ts
@@ -114,6 +114,38 @@ describe('sanitizeRawAttributions', () => {
       expectedAttributions
     );
   });
+
+  test('leaves non-empty comment unchanged', () => {
+    const rawAttributions: RawAttributions = {
+      id: {
+        comment: 'Test comment',
+      },
+    };
+    const expectedAttributions: Attributions = {
+      id: {
+        comment: 'Test comment',
+      },
+    };
+
+    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
+      expectedAttributions
+    );
+  });
+
+  test('removes empty comment', () => {
+    const rawAttributions: RawAttributions = {
+      id: {
+        comment: '',
+      },
+    };
+    const expectedAttributions: Attributions = {
+      id: {},
+    };
+
+    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
+      expectedAttributions
+    );
+  });
 });
 
 describe('sanitizeRawBaseUrlsForSources', () => {

--- a/src/ElectronBackend/input/cleanInputData.ts
+++ b/src/ElectronBackend/input/cleanInputData.ts
@@ -131,6 +131,9 @@ export function sanitizeRawAttributions(
     if (rawAttributions[attributionId]?.followUp !== FollowUp) {
       delete rawAttributions[attributionId].followUp;
     }
+    if (rawAttributions[attributionId]?.comment === '') {
+      delete rawAttributions[attributionId].comment;
+    }
   }
 
   return rawAttributions as Attributions;

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -392,9 +392,10 @@ function removeManualAttributionFromChildIfInferable(
   }
 
   if (
-    isEqual(
-      manualData.resourcesToAttributions[closestParentWithAttribution]?.sort(),
-      manualData.resourcesToAttributions[childId]?.sort()
+    resourcesHaveTheSameAttributions(
+      closestParentWithAttribution,
+      childId,
+      manualData
     )
   ) {
     const childAttributions: Array<string> =
@@ -419,6 +420,41 @@ function removeManualAttributionFromChildIfInferable(
       )
     );
   }
+}
+
+function allAttributionsAreEqual(
+  attributions: PackageInfo[],
+  otherAttributions: PackageInfo[]
+): boolean {
+  const hasSameLength = attributions.length === otherAttributions.length;
+  const allAttributionsAreInOtherAttributions = attributions.every(
+    (attribution) =>
+      otherAttributions.some((otherAttribution) =>
+        attributionsAreEqual(attribution, otherAttribution)
+      )
+  );
+  return hasSameLength && allAttributionsAreInOtherAttributions;
+}
+
+function resourcesHaveTheSameAttributions(
+  firstResource: string,
+  secondResource: string,
+  manualData: AttributionData
+): boolean {
+  const attributionIdsOfFirstResource =
+    manualData.resourcesToAttributions[firstResource]?.sort() || [];
+  const attributionIdsOfSecondResource =
+    manualData.resourcesToAttributions[secondResource]?.sort() || [];
+  const attributionsOfFirstResource = attributionIdsOfFirstResource.map(
+    (id) => manualData.attributions[id]
+  );
+  const attributionsOfSecondResource = attributionIdsOfSecondResource.map(
+    (id) => manualData.attributions[id]
+  );
+  return allAttributionsAreEqual(
+    attributionsOfFirstResource,
+    attributionsOfSecondResource
+  );
 }
 
 function removeManualAttributionFromChildrenOfParentsIfInferable(


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Remove empty comment by import.
- Change logic for checking same attributions between parent and child to check all attributions and not only the ids.

### Context and reason for change
- Empty string are imported as a comment

### How can the changes be tested
- Changes can be test via `yarn test:unit`, `yarn test:integration-ci` and `yarn test:e2e`