### PR TITLE
Add multi-select delete popup

### DIFF
--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
+import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
+import { getMultiSelectSelectedAttributionIds } from '../../state/selectors/attribution-view-resource-selectors';
+
+export function ConfirmMultiSelectDeletionPopup(): ReactElement {
+  const multiSelectSelectedAttributionIds = useAppSelector(
+    getMultiSelectSelectedAttributionIds
+  );
+
+  const dispatch = useAppDispatch();
+
+  function deleteMultiSelectSelectedAttributionIds(): void {
+    multiSelectSelectedAttributionIds.forEach((attributionId) => {
+      dispatch(deleteAttributionGloballyAndSave(attributionId));
+    });
+  }
+
+  return (
+    <ConfirmationPopup
+      onConfirmation={deleteMultiSelectSelectedAttributionIds}
+      content={
+        'Do you really want to delete the selected attributions for all files? ' +
+        `This action will delete ${multiSelectSelectedAttributionIds.length} attributions.`
+      }
+      header={'Confirm Deletion'}
+    />
+  );
+}

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -3,7 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup';
@@ -11,8 +14,39 @@ import {
   setMultiSelectMode,
   setMultiSelectSelectedAttributionIds,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import {
+  Attributions,
+  Resources,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import {
+  clickOnButton,
+  getParsedInputFileEnrichedWithTestData,
+} from '../../../test-helpers/general-test-helpers';
+import { ButtonText } from '../../../enums/enums';
+import { getManualAttributions } from '../../../state/selectors/all-views-resource-selectors';
+import { IpcRenderer } from 'electron';
+
+let originalIpcRenderer: IpcRenderer;
 
 describe('The ConfirmMultiSelectDeletionPopup', () => {
+  beforeAll(() => {
+    originalIpcRenderer = global.window.ipcRenderer;
+    global.window.ipcRenderer = {
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      invoke: jest.fn(),
+    } as unknown as IpcRenderer;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  afterAll(() => {
+    // Important to restore the original value.
+    global.window.ipcRenderer = originalIpcRenderer;
+  });
+
   test('renders', () => {
     const expectedContent =
       'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
@@ -26,5 +60,55 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
 
     expect(screen.getByText(expectedContent)).toBeTruthy();
     expect(screen.getByText(expectedHeader)).toBeTruthy();
+  });
+
+  test('deletes attributions', () => {
+    const expectedContent =
+      'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
+    const expectedHeader = 'Confirm Deletion';
+
+    const testResources: Resources = {
+      'something.js': 1,
+      'somethingElse.js': 1,
+    };
+    const testManualAttributions: Attributions = {
+      uuid1: {
+        packageName: 'React',
+      },
+      uuid2: {
+        packageName: 'Vue',
+      },
+    };
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      '/something.js': ['uuid1'],
+      '/somethingElse.js': ['uuid2'],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testManualAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(
+      setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2'])
+    );
+
+    const { store } = renderComponentWithStore(
+      <ConfirmMultiSelectDeletionPopup />,
+      { store: testStore }
+    );
+
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2']));
+    expect(screen.getByText(expectedContent)).toBeTruthy();
+    expect(screen.getByText(expectedHeader)).toBeTruthy();
+    clickOnButton(screen, ButtonText.Confirm);
+    expect(getManualAttributions(store.getState())).toEqual({});
   });
 });

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+
+describe('The ConfirmMultiSelectDeletionPopup', () => {
+  test('renders', () => {
+    const expectedContent =
+      'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
+    const expectedHeader = 'Confirm Deletion';
+
+    const { store } = renderComponentWithStore(
+      <ConfirmMultiSelectDeletionPopup />
+    );
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
+
+    expect(screen.getByText(expectedContent)).toBeTruthy();
+    expect(screen.getByText(expectedHeader)).toBeTruthy();
+  });
+});

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -14,6 +14,7 @@ import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttri
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
 import { useAppSelector } from '../../state/hooks';
+import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -33,6 +34,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <ConfirmDeletionGloballyPopup />;
     case PopupType.ConfirmDeletionPopup:
       return <ConfirmDeletionPopup />;
+    case PopupType.ConfirmMultiSelectDeletionPopup:
+      return <ConfirmMultiSelectDeletionPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -18,6 +18,10 @@ import { screen } from '@testing-library/react';
 import { Attributions } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 
 describe('The GlobalPopUp', () => {
   test('does not open by default', () => {
@@ -107,6 +111,19 @@ describe('The GlobalPopUp', () => {
     expect(
       screen.getByText(
         'Do you really want to delete this attribution for all files?'
+      )
+    ).toBeTruthy();
+  });
+
+  test('opens the ConfirmMultiSelectDeletionPopup', () => {
+    const { store } = renderComponentWithStore(<GlobalPopup />);
+    store.dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
+
+    expect(
+      screen.getByText(
+        'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.'
       )
     ).toBeTruthy();
   });

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -35,7 +35,10 @@ import {
   savePackageInfo,
   unlinkAttributionAndSavePackageInfo,
 } from '../../state/actions/resource-actions/save-actions';
-import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
+import {
+  openPopup,
+  openPopupWithTargetAttributionId,
+} from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionIdOfDisplayedPackageInManualPanel,
@@ -278,6 +281,13 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             buttonText: ButtonText.DeleteGlobally,
             onClick: openConfirmDeletionGloballyPopup,
             hidden: isExternalAttribution || !showGlobalButtons,
+          },
+          {
+            buttonText: ButtonText.DeleteSelectedGlobally,
+            onClick: (): void => {
+              dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));
+            },
+            hidden: multiSelectSelectedAttributionIds.length === 0,
           },
           {
             buttonText: ButtonText.Confirm,

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -18,6 +18,7 @@ export enum PopupType {
   ReplaceAttributionPopup = 'ReplaceAttributionPopup',
   ConfirmDeletionPopup = 'ConfirmDeletionPopup',
   ConfirmDeletionGloballyPopup = 'ConfirmDeletionGloballyPopup',
+  ConfirmMultiSelectDeletionPopup = 'ConfirmMultiSelectDeletionPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -48,6 +49,7 @@ export enum ButtonText {
   ConfirmGlobally = 'Confirm globally',
   Delete = 'Delete',
   DeleteGlobally = 'Delete globally',
+  DeleteSelectedGlobally = 'Delete selected globally',
   Hide = 'Hide',
   MarkForReplacement = 'Mark for replacement',
   Save = 'Save',

--- a/src/Frontend/test-helpers/context-menu-test-helpers.ts
+++ b/src/Frontend/test-helpers/context-menu-test-helpers.ts
@@ -33,6 +33,7 @@ export function expectGlobalOnlyContextMenuForNotPreselectedAttribution(
     ButtonText.Confirm,
     ButtonText.ConfirmGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -69,6 +70,7 @@ export function expectGlobalOnlyContextMenuForPreselectedAttribution(
       ButtonText.Confirm,
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -90,6 +92,7 @@ export function expectContextMenuForNotPreSelectedAttributionMultipleResources(
     ButtonText.Confirm,
     ButtonText.ConfirmGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -126,6 +129,7 @@ export function expectContextMenuForPreSelectedAttributionMultipleResources(
       ButtonText.Unhide,
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -147,6 +151,7 @@ export function expectContextMenuForNotPreSelectedAttributionSingleResource(
     ButtonText.ConfirmGlobally,
     ButtonText.DeleteGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -182,6 +187,7 @@ export function expectContextMenuForExternalAttributionInPackagePanel(
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
       ButtonText.MarkForReplacement,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -205,6 +211,7 @@ export function expectContextMenuForHiddenExternalAttributionInPackagePanel(
       ButtonText.MarkForReplacement,
       ButtonText.ReplaceMarked,
       ButtonText.UnmarkForReplacement,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -224,7 +231,7 @@ export function testCorrectMarkAndUnmarkForReplacementInContextMenu(
     packageName,
     ButtonText.UnmarkForReplacement
   );
-  expectButtonNotInPackageContextMenu(
+  expectButtonInPackageContextMenu(
     screen,
     packageName,
     ButtonText.MarkForReplacement
@@ -235,7 +242,7 @@ export function expectUnmarkForReplacementInContextMenu(
   screen: Screen,
   packageName: string
 ): void {
-  expectButtonNotInPackageContextMenu(
+  expectButtonInPackageContextMenu(
     screen,
     packageName,
     ButtonText.UnmarkForReplacement
@@ -314,7 +321,7 @@ export function expectCorrectButtonsInContextMenu(
   hiddenButtons: Array<ButtonText>
 ): void {
   shownButtons.forEach((buttonText) => {
-    expectButtonNotInPackageContextMenu(screen, cardLabel, buttonText);
+    expectButtonInPackageContextMenu(screen, cardLabel, buttonText);
   });
 
   hiddenButtons.forEach((buttonText) => {
@@ -328,22 +335,7 @@ export function expectButtonInPackageContextMenu(
   buttonLabel: ButtonText
 ): void {
   openContextMenuOnCardPackageCard(screen, cardLabel);
-  const button = getButton(screen, buttonLabel);
-  const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
-
-  expect(buttonAttribute).not.toBeNull();
-}
-
-export function expectButtonNotInPackageContextMenu(
-  screen: Screen,
-  cardLabel: string,
-  buttonLabel: ButtonText
-): void {
-  openContextMenuOnCardPackageCard(screen, cardLabel);
-  const button = getButton(screen, buttonLabel);
-  const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
-
-  expect(buttonAttribute).toBeNull();
+  getButton(screen, buttonLabel);
   closeContextMenuOnCardPackageCard(screen, cardLabel);
 }
 

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, fireEvent, Screen } from '@testing-library/react';
+import { act, fireEvent, Screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import {
   Attributions,
@@ -19,6 +19,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
 import { canHaveChildren } from '../util/can-have-children';
+import { getCardInAttributionList } from './package-panel-helpers';
 
 export const TEST_TIMEOUT = 15000;
 
@@ -180,6 +181,20 @@ export function clickOnCheckbox(screen: Screen, label: string): void {
   fireEvent.click(
     screen.getByRole('checkbox', { name: `checkbox ${label}` }) as Element
   );
+}
+
+export function getCheckbox(screen: Screen, label: string): HTMLInputElement {
+  return screen.getByRole('checkbox', {
+    name: `checkbox ${label}`,
+  }) as HTMLInputElement;
+}
+
+export function clickOnMultiSelectCheckboxInPackageCard(
+  screen: Screen,
+  cardLabel: string
+): void {
+  const packageCard = getCardInAttributionList(screen, cardLabel);
+  fireEvent.click(within(packageCard).getByRole('checkbox') as Element);
 }
 
 export function clickOnDeleteIcon(screen: Screen): void {

--- a/src/Frontend/test-helpers/popup-test-helpers.ts
+++ b/src/Frontend/test-helpers/popup-test-helpers.ts
@@ -57,3 +57,20 @@ export function expectConfirmDeletionPopupVisible(screen: Screen): void {
 export function expectConfirmDeletionPopupNotVisible(screen: Screen): void {
   expect(screen.queryByText('Confirm Deletion')).toBeFalsy();
 }
+
+export function expectConfirmMultiSelectDeletionPopupVisible(
+  screen: Screen,
+  numberOfSelectedAttributions: number
+): void {
+  expect(
+    screen.getByText(
+      `Do you really want to delete the selected attributions for all files? This action will delete ${numberOfSelectedAttributions} attributions.`
+    )
+  ).toBeTruthy();
+}
+
+export function expectConfirmMultiSelectDeletionPopupNotVisible(
+  screen: Screen
+): void {
+  expect(screen.queryByText('Confirm Deletion')).toBeFalsy();
+}


### PR DESCRIPTION
### Summary of changes

This commit adds the multi-select delete functionality by adding a multi-select delete option to the context menu in attribution view, which opens a new popup for deleting selected attributions.

### Context and reason for change

The multi-select feature had no functionality before this pull request. This adds the option to delete multi-selected attributions.

### How can the changes be tested

Run the tests (unit tests + integration test in src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx) or test with example file


