### PR TITLE
Update docs and fix checkbox

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -255,9 +255,13 @@ the `Audit View` and has two main components:
 All existing attributions are listed and can be selected. **Pre-selected**
 attributions are signaled by an `P` icon. They can be confirmed, which converts them into attributions
 in all views and in the progress bar. However, that is not a requirement. **Pre-selected** and manual
-attributions are both written in the output file. On top there is an icon for openning the filter section. By clicking
+attributions are both written in the output file. On top there is an icon for opening the filter section. By clicking
 on it, a dropdown will be shown with filters that allows for filtering for attributions marked for follow-up, first
-party and not first party. The last two are mutually exclusive.
+party and not first party. The last two are mutually exclusive. Additionally, the attribution view has a multi-select
+mode, which can be activated by checking the _Multi-select_ checkbox at the top. In multi-select mode, a checkbox is
+visible next to every attribution. If at least one attribution has a checked checkbox, the context menu displays the
+_Delete selected globally_ option. This option deletes every selected attribution in all files, after confirming the
+deletions in a pop-up.
 
 #### Selected Attribution Panel
 

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -138,9 +138,6 @@ const useStyles = makeStyles({
       background: OpossumColors.white,
     },
   },
-  multiSelected: {
-    background: OpossumColors.lightestBlue,
-  },
 });
 
 interface ListCardProps {
@@ -190,60 +187,64 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             : classes.selected
           : null,
         props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
-        props.cardConfig.isResolved && classes.resolved,
-        props.cardConfig.isMultiSelected && !props.cardConfig.isSelected
-          ? classes.multiSelected
-          : ''
+        props.cardConfig.isResolved && classes.resolved
       )}
-      onClick={props.onClick}
     >
       {props.leftElement ? props.leftElement : null}
-      <div className={classes.iconColumn}>
-        {props.leftIcon ? props.leftIcon : null}
-        {getDisplayedCount() ? (
-          <MuiTypography variant={'body2'} className={classes.count}>
-            {getDisplayedCount()}
-          </MuiTypography>
-        ) : null}
-      </div>
       <div
         className={clsx(
-          classes.textLines,
+          classes.root,
           props.cardConfig.isResource ? null : classes.longTextInFlexbox
         )}
+        onClick={props.onClick}
       >
-        <MuiTypography
-          variant={'body2'}
+        <div className={classes.iconColumn}>
+          {props.leftIcon ? props.leftIcon : null}
+          {getDisplayedCount() ? (
+            <MuiTypography variant={'body2'} className={classes.count}>
+              {getDisplayedCount()}
+            </MuiTypography>
+          ) : null}
+        </div>
+        <div
           className={clsx(
-            props.cardConfig.isHeader ? classes.header : classes.textLine,
-            props.cardConfig.isResource
-              ? classes.textShortenedFromLeftSide
-              : classes.textShortened
+            classes.textLines,
+            props.cardConfig.isResource ? null : classes.longTextInFlexbox
           )}
         >
-          {props.cardConfig.isResource ? <bdi>{props.text}</bdi> : props.text}
-        </MuiTypography>
-        {props.secondLineText ? (
           <MuiTypography
             variant={'body2'}
             className={clsx(
-              classes.textLine,
+              props.cardConfig.isHeader ? classes.header : classes.textLine,
               props.cardConfig.isResource
                 ? classes.textShortenedFromLeftSide
                 : classes.textShortened
             )}
           >
-            {props.cardConfig.isResource ? (
-              <bdi>{props.secondLineText}</bdi>
-            ) : (
-              props.secondLineText
-            )}
+            {props.cardConfig.isResource ? <bdi>{props.text}</bdi> : props.text}
           </MuiTypography>
+          {props.secondLineText ? (
+            <MuiTypography
+              variant={'body2'}
+              className={clsx(
+                classes.textLine,
+                props.cardConfig.isResource
+                  ? classes.textShortenedFromLeftSide
+                  : classes.textShortened
+              )}
+            >
+              {props.cardConfig.isResource ? (
+                <bdi>{props.secondLineText}</bdi>
+              ) : (
+                props.secondLineText
+              )}
+            </MuiTypography>
+          ) : null}
+        </div>
+        {props.rightIcons ? (
+          <div className={classes.iconColumn}>{props.rightIcons}</div>
         ) : null}
       </div>
-      {props.rightIcons ? (
-        <div className={classes.iconColumn}>{props.rightIcons}</div>
-      ) : null}
     </div>
   );
 }

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { App } from '../../../Components/App/App';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { IpcRenderer } from 'electron';
 import React from 'react';
 import {
@@ -40,14 +40,12 @@ import {
   clickOnElementInResourceBrowser,
   expectResourceBrowserIsNotShown,
 } from '../../../test-helpers/resource-browser-test-helpers';
-import {
-  clickOnCardInAttributionList,
-  getCardInAttributionList,
-} from '../../../test-helpers/package-panel-helpers';
+import { clickOnCardInAttributionList } from '../../../test-helpers/package-panel-helpers';
 import {
   clickOnButton,
   clickOnCheckbox,
   clickOnMultiSelectCheckboxInPackageCard,
+  expectSelectCheckboxInPackageCardIsChecked,
   getCheckbox,
   getParsedInputFileEnrichedWithTestData,
   goToView,
@@ -290,12 +288,7 @@ describe('In Attribution View the ContextMenu', () => {
     clickOnMultiSelectCheckboxInPackageCard(screen, 'React, 16.5.0');
     clickOnMultiSelectCheckboxInPackageCard(screen, 'Vue, 1.2.0');
 
-    expect(
-      within(getCardInAttributionList(screen, 'React, 16.5.0')).getByRole(
-        'checkbox'
-      ) as HTMLInputElement
-    ).toBeChecked();
-
+    expectSelectCheckboxInPackageCardIsChecked(screen, 'React, 16.5.0');
     expectButtonInPackageContextMenu(
       screen,
       'React, 16.5.0',

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -19,7 +19,6 @@ import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
 import { canHaveChildren } from '../util/can-have-children';
-import { getCardInAttributionList } from './package-panel-helpers';
 
 export const TEST_TIMEOUT = 15000;
 
@@ -189,16 +188,32 @@ export function getCheckbox(screen: Screen, label: string): HTMLInputElement {
   }) as HTMLInputElement;
 }
 
+function getMultiSelectCheckboxInPackageCard(
+  screen: Screen,
+  cardLabel: string
+): Element {
+  const packageCard = (
+    (screen.getByText(cardLabel).parentElement as HTMLElement)
+      .parentElement as HTMLElement
+  ).parentElement as HTMLElement;
+  const checkbox = within(packageCard).getByRole('checkbox') as Element;
+  expect(checkbox).not.toBeFalsy();
+
+  return checkbox;
+}
+
 export function clickOnMultiSelectCheckboxInPackageCard(
   screen: Screen,
   cardLabel: string
 ): void {
-  const packageCard = getCardInAttributionList(screen, cardLabel);
-  fireEvent.click(within(packageCard).getByRole('checkbox') as Element);
+  fireEvent.click(getMultiSelectCheckboxInPackageCard(screen, cardLabel));
 }
 
-export function clickOnDeleteIcon(screen: Screen): void {
-  fireEvent.click(screen.getByTestId('CancelIcon') as Element);
+export function expectSelectCheckboxInPackageCardIsChecked(
+  screen: Screen,
+  cardLabel: string
+): void {
+  expect(getMultiSelectCheckboxInPackageCard(screen, cardLabel)).toBeChecked();
 }
 
 export function openDropDown(screen: Screen): void {


### PR DESCRIPTION
### Summary of changes

This commit updates the documentation with a description of the multi-select feature and changes the checkbox clicking behavior. Clicking the checkbox next to an attribution to multi-select it no longer changes the selected attribution.

### Context and reason for change

A user does not always want to change the selected attribution, when adding an attribution to the multi-select.

### How can the changes be tested

Test multi-select with example file in attribution view.

