### PR TITLE
Support fetching information from npm url

### DIFF
--- a/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
@@ -19,6 +19,11 @@ jest.mock('electron', () => ({
         loadURL: jest.fn(),
         webContents: {
           openDevTools: jest.fn(),
+          session: {
+            webRequest: {
+              onHeadersReceived: jest.fn(),
+            },
+          },
         },
       };
     }

--- a/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
@@ -19,6 +19,11 @@ jest.mock('electron', () => ({
         loadURL: jest.fn(),
         webContents: {
           openDevTools: jest.fn(),
+          session: {
+            webRequest: {
+              onHeadersReceived: jest.fn(),
+            },
+          },
         },
       };
     }

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -55,6 +55,11 @@ jest.mock('electron', () => ({
           openDevTools: jest.fn(),
           send: jest.fn(),
           close: jest.fn(),
+          session: {
+            webRequest: {
+              onHeadersReceived: jest.fn(),
+            },
+          },
         },
         close: jest.fn(() => {
           return Promise.resolve(null);

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -10,6 +10,19 @@ import upath from 'upath';
 import { createMenu } from './menu';
 import { getIconPath } from './iconHelpers';
 
+function allowCORS(mainWindow: Electron.BrowserWindow): void {
+  mainWindow.webContents.session.webRequest.onHeadersReceived(
+    (details, callback) => {
+      callback({
+        responseHeaders: {
+          'Access-Control-Allow-Origin': ['http://localhost:3000'],
+          ...details.responseHeaders,
+        },
+      });
+    }
+  );
+}
+
 export async function createWindow(): Promise<BrowserWindow> {
   const mainWindow: BrowserWindow = new BrowserWindow({
     width: 1920,
@@ -24,6 +37,9 @@ export async function createWindow(): Promise<BrowserWindow> {
 
   Menu.setApplicationMenu(createMenu(mainWindow));
   await loadApplication(mainWindow, '', '../../index.html', true);
+
+  // Electron is running on localhost, CORS needs to allow requests from there
+  allowCORS(mainWindow);
 
   return mainWindow;
 }

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -89,6 +89,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           <>
             <FetchLicenseInformationButton
               url={props.displayPackageInfo.url}
+              version={props.displayPackageInfo.packageVersion}
               isDisabled={!props.isEditable}
             />
             <IconButton

--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -188,9 +188,13 @@ function EnabledFetchLicenseInformationButton(
 
 export function FetchLicenseInformationButton(props: {
   url?: string;
+  version?: string;
   isDisabled: boolean;
 }): ReactElement {
-  const licenseFetchingInformation = getLicenseFetchingInformation(props.url);
+  const licenseFetchingInformation = getLicenseFetchingInformation(
+    props.url,
+    props.version
+  );
   return !props.isDisabled && licenseFetchingInformation ? (
     <EnabledFetchLicenseInformationButton
       url={licenseFetchingInformation.url}

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
@@ -5,6 +5,7 @@
 
 import { getLicenseFetchingInformation } from '../license-fetching-helpers';
 import { convertPypiPayload } from '../pypi-fetching-helpers';
+import { convertNpmPayload } from '../npm-fetching-helpers';
 
 describe('getLicenseFetchingInformation', () => {
   it('returns null for undefined as input', () => {
@@ -22,5 +23,33 @@ describe('getLicenseFetchingInformation', () => {
       url: 'https://pypi.org/pypi/numpy/json',
       convertPayload: convertPypiPayload,
     });
+  });
+
+  it('recognizes npm urls', () => {
+    expect(
+      getLicenseFetchingInformation('https://npmjs.com/package/react')
+    ).toMatchObject({
+      url: 'https://registry.npmjs.org/react',
+      convertPayload: convertNpmPayload,
+    });
+  });
+
+  it('recognizes npm urls with complicated package names', () => {
+    expect(
+      getLicenseFetchingInformation(
+        'https://npmjs.com/package/@angular/animations/'
+      )
+    ).toMatchObject({
+      url: 'https://registry.npmjs.org/@angular/animations',
+      convertPayload: convertNpmPayload,
+    });
+  });
+
+  it('rejects npm urls with version in url', () => {
+    expect(
+      getLicenseFetchingInformation(
+        'https://npmjs.com/package/@angular/animations/1.0'
+      )
+    ).toBeNull();
   });
 });

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/npm-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/npm-fetching-helpers.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { convertNpmPayload, getNpmAPIUrl } from '../npm-fetching-helpers';
+
+describe('getNpmAPIUrl', () => {
+  it('handles a simple package name', () => {
+    expect(getNpmAPIUrl('https://npmjs.com/package/react')).toBe(
+      'https://registry.npmjs.org/react'
+    );
+  });
+
+  it('handles a simple package name without package in the url', () => {
+    expect(getNpmAPIUrl('https://npmjs.com/react')).toBe(
+      'https://registry.npmjs.org/react'
+    );
+  });
+
+  it('handles a simple package name with version', () => {
+    expect(getNpmAPIUrl('https://npmjs.com/package/react', '1.0')).toBe(
+      'https://registry.npmjs.org/react/1.0'
+    );
+  });
+
+  it('handles a simple package name with trailing slash', () => {
+    expect(getNpmAPIUrl('https://npmjs.com/package/react/', '1.0')).toBe(
+      'https://registry.npmjs.org/react/1.0'
+    );
+  });
+
+  it('handles a complicated package name', () => {
+    expect(getNpmAPIUrl('https://npmjs.com/package/@angular/animation')).toBe(
+      'https://registry.npmjs.org/@angular/animation'
+    );
+  });
+
+  it('handles a complicated package name with version', () => {
+    expect(
+      getNpmAPIUrl('https://npmjs.com/package/@angular/animation', '1.0')
+    ).toBe('https://registry.npmjs.org/@angular/animation/1.0');
+  });
+});
+
+describe('convertNpmPayload', () => {
+  it('raises error for invalid payload', async () => {
+    const payload = { name: 'test' };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    await expect(
+      convertNpmPayload(mockResponse as unknown as Response)
+    ).rejects.toBeTruthy();
+  });
+
+  it('parses payload correctly', async () => {
+    const payload = { name: 'test', license: 'MIT' };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    const packageInfo = await convertNpmPayload(
+      mockResponse as unknown as Response
+    );
+    expect(packageInfo).toStrictEqual({
+      licenseName: 'MIT',
+      packageName: 'test',
+      packageType: 'npm',
+      packageNamespace: undefined,
+      packagePURLAppendix: undefined,
+    });
+  });
+});

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -5,8 +5,10 @@
 
 import { PackageInfo } from '../../../shared/shared-types';
 import { convertPypiPayload, getPypiAPIUrl } from './pypi-fetching-helpers';
+import { convertNpmPayload, getNpmAPIUrl } from './npm-fetching-helpers';
 
 const PYPI_REGEX = new RegExp('^https://pypi.org/(pypi|project)/[\\w-+,_]+/?$');
+const NPM_REGEX = new RegExp('^https://npmjs.com/(package/)?[\\w-+,_@/]+/?$');
 
 export interface LicenseFetchingInformation {
   url: string;
@@ -14,7 +16,8 @@ export interface LicenseFetchingInformation {
 }
 
 export function getLicenseFetchingInformation(
-  url?: string
+  url?: string,
+  version?: string
 ): LicenseFetchingInformation | null {
   if (!url) {
     return null;
@@ -24,6 +27,11 @@ export function getLicenseFetchingInformation(
     return {
       url: getPypiAPIUrl(url),
       convertPayload: convertPypiPayload,
+    };
+  } else if (NPM_REGEX.test(url)) {
+    return {
+      url: getNpmAPIUrl(url, version),
+      convertPayload: convertNpmPayload,
     };
   }
   return null;

--- a/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo } from '../../../shared/shared-types';
+import { Validator, Schema } from 'jsonschema';
+
+export function getNpmAPIUrl(url: string, version?: string): string {
+  const packageName = url
+    .replace(new RegExp('^https://npmjs.com/(package/)?'), '')
+    .replace(new RegExp('/$'), '');
+  return `https://registry.npmjs.org/${packageName}${
+    version ? `/${version}` : ''
+  }`;
+}
+
+const jsonSchemaValidator = new Validator();
+
+const NPM_SCHEMA: Schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    license: { type: 'string' },
+  },
+  required: ['name', 'license'],
+};
+
+export async function convertNpmPayload(
+  payload: Response
+): Promise<PackageInfo> {
+  const convertedPayload = await payload.json();
+  jsonSchemaValidator.validate(convertedPayload, NPM_SCHEMA, {
+    throwError: true,
+  });
+  return {
+    licenseName: convertedPayload.license as string,
+    packageName: convertedPayload.name as string,
+    packageType: 'npm',
+    packageNamespace: undefined,
+    packagePURLAppendix: undefined,
+  };
+}


### PR DESCRIPTION
### Summary of changes

- add support for fetching from npm urls
- avoid that request gets rejected because of CORS policy

### Context and reason for change

We previously added support to fetch information from Pypi. Another very popular package manager is npm.

Related to #216 

### How can the changes be tested

Besides the unit tests you can try various urls or your favorite npm package
`https://npmjs.com/package/@angular/animations/`
`https://npmjs.com/package/react/`

