### PR TITLE
Add multiselect deletion to attribution view

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -255,9 +255,13 @@ the `Audit View` and has two main components:
 All existing attributions are listed and can be selected. **Pre-selected**
 attributions are signaled by an `P` icon. They can be confirmed, which converts them into attributions
 in all views and in the progress bar. However, that is not a requirement. **Pre-selected** and manual
-attributions are both written in the output file. On top there is an icon for openning the filter section. By clicking
+attributions are both written in the output file. On top there is an icon for opening the filter section. By clicking
 on it, a dropdown will be shown with filters that allows for filtering for attributions marked for follow-up, first
-party and not first party. The last two are mutually exclusive.
+party and not first party. The last two are mutually exclusive. Additionally, the attribution view has a multi-select
+mode, which can be activated by checking the _Multi-select_ checkbox at the top. In multi-select mode, a checkbox is
+visible next to every attribution. If at least one attribution has a checked checkbox, the context menu displays the
+_Delete selected globally_ option. This option deletes every selected attribution in all files, after confirming the
+deletions in a pop-up.
 
 #### Selected Attribution Panel
 

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -8,7 +8,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
-import { DiscreteConfidence } from '../../enums/enums';
+import { CheckboxLabel, DiscreteConfidence } from '../../enums/enums';
 import { doNothing } from '../../util/do-nothing';
 import { prettifySource } from '../../util/prettify-source';
 import { Checkbox } from '../Checkbox/Checkbox';
@@ -58,21 +58,21 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
       <div className={classes.displayRow}>
         <Checkbox
           className={classes.checkBox}
-          label={'1st Party'}
+          label={CheckboxLabel.FirstParty}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.firstParty)}
           onChange={props.firstPartyChangeHandler}
         />
         <Checkbox
           className={classes.checkBox}
-          label={'Follow-up'}
+          label={CheckboxLabel.FollowUp}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.followUp)}
           onChange={props.followUpChangeHandler}
         />
         <Checkbox
           className={classes.checkBox}
-          label={'Exclude From Notice'}
+          label={CheckboxLabel.ExcludeFromNotice}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.excludeFromNotice)}
           onChange={props.excludeFromNoticeChangeHandler}

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -18,6 +18,7 @@ import { TextBox } from '../InputElements/TextBox';
 import { useAttributionColumnStyles } from './shared-attribution-column-styles';
 import { getExternalAttributionSources } from '../../state/selectors/all-views-resource-selectors';
 import { useAppSelector } from '../../state/hooks';
+import { useCheckboxStyles } from '../../shared-styles';
 
 const useStyles = makeStyles({
   confidenceDropDown: {
@@ -50,7 +51,11 @@ interface AuditingSubPanelProps {
 }
 
 export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
-  const classes = { ...useAttributionColumnStyles(), ...useStyles() };
+  const classes = {
+    ...useAttributionColumnStyles(),
+    ...useCheckboxStyles(),
+    ...useStyles(),
+  };
   const attributionSources = useAppSelector(getExternalAttributionSources);
 
   return (

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -13,7 +13,7 @@ import {
   SaveFileArgs,
   Source,
 } from '../../../../shared/shared-types';
-import { PackagePanelTitle } from '../../../enums/enums';
+import { CheckboxLabel, PackagePanelTitle } from '../../../enums/enums';
 import {
   setFrequentLicences,
   setResources,
@@ -181,7 +181,7 @@ describe('The AttributionColumn', () => {
     store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
     expect(getTemporaryPackageInfo(store.getState()).followUp).toBeUndefined();
 
-    clickOnCheckbox(screen, 'Follow-up');
+    clickOnCheckbox(screen, CheckboxLabel.FollowUp);
     expect(getTemporaryPackageInfo(store.getState()).followUp).toBe(FollowUp);
   });
 
@@ -206,7 +206,7 @@ describe('The AttributionColumn', () => {
       getTemporaryPackageInfo(store.getState()).excludeFromNotice
     ).toBeUndefined();
 
-    clickOnCheckbox(screen, 'Exclude From Notice');
+    clickOnCheckbox(screen, CheckboxLabel.ExcludeFromNotice);
     expect(getTemporaryPackageInfo(store.getState()).excludeFromNotice).toBe(
       true
     );
@@ -407,7 +407,7 @@ describe('The AttributionColumn', () => {
         getTemporaryPackageInfo(store.getState()).copyright
       ).toBeUndefined();
 
-      clickOnCheckbox(screen, '1st Party');
+      clickOnCheckbox(screen, CheckboxLabel.FirstParty);
       expect(getTemporaryPackageInfo(store.getState()).firstParty).toBe(true);
     });
 
@@ -437,7 +437,7 @@ describe('The AttributionColumn', () => {
         testCopyright
       );
 
-      clickOnCheckbox(screen, '1st Party');
+      clickOnCheckbox(screen, CheckboxLabel.FirstParty);
       expect(getTemporaryPackageInfo(store.getState()).copyright).toBe(
         testCopyright
       );

--- a/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
+++ b/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
@@ -29,11 +29,4 @@ export const useAttributionColumnStyles = makeStyles({
       color: OpossumColors.orange,
     },
   },
-  checkBox: {
-    height: 40,
-    display: 'flex',
-    alignItems: 'center',
-    marginRight: 12,
-    marginLeft: -2,
-  },
 });

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -12,7 +12,6 @@ import { FilteredList } from '../FilteredList/FilteredList';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ListCardConfig } from '../../types/types';
 import { Checkbox } from '../Checkbox/Checkbox';
-import { useAttributionColumnStyles } from '../AttributionColumn/shared-attribution-column-styles';
 import { getMultiSelectMode } from '../../state/selectors/attribution-view-resource-selectors';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
@@ -20,6 +19,7 @@ import {
   setMultiSelectSelectedAttributionIds,
 } from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { CheckboxLabel } from '../../enums/enums';
+import { useCheckboxStyles } from '../../shared-styles';
 
 const useStyles = makeStyles({
   topElements: {
@@ -46,7 +46,7 @@ interface AttributionListProps {
 }
 
 export function AttributionList(props: AttributionListProps): ReactElement {
-  const classes = { ...useAttributionColumnStyles(), ...useStyles() };
+  const classes = { ...useCheckboxStyles(), ...useStyles() };
   const attributions = { ...props.attributions };
   const attributionIds: Array<string> = Object.keys({
     ...props.attributions,

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -11,6 +11,12 @@ import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
 import { FilteredList } from '../FilteredList/FilteredList';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ListCardConfig } from '../../types/types';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { useAttributionColumnStyles } from '../AttributionColumn/shared-attribution-column-styles';
+import { getMultiSelectMode } from '../../state/selectors/attribution-view-resource-selectors';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { setMultiSelectMode } from '../../state/actions/resource-actions/attribution-view-simple-actions';
+import { CheckboxLabel } from '../../enums/enums';
 
 const useStyles = makeStyles({
   topElements: {
@@ -37,11 +43,13 @@ interface AttributionListProps {
 }
 
 export function AttributionList(props: AttributionListProps): ReactElement {
-  const classes = useStyles();
+  const classes = { ...useAttributionColumnStyles(), ...useStyles() };
   const attributions = { ...props.attributions };
   const attributionIds: Array<string> = Object.keys({
     ...props.attributions,
   }).sort(getAlphabeticalComparer(attributions));
+  const multiSelectMode = useAppSelector(getMultiSelectMode);
+  const dispatch = useAppDispatch();
 
   function getAttributionCard(attributionId: string): ReactElement {
     const attribution = attributions[attributionId];
@@ -88,10 +96,22 @@ export function AttributionList(props: AttributionListProps): ReactElement {
     );
   }
 
+  function handleMultiSelectModeChange(
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void {
+    dispatch(setMultiSelectMode(event.target.checked));
+  }
+
   return (
     <div className={props.className}>
       <div className={classes.topElements}>
         <MuiTypography className={classes.title}>{props.title}</MuiTypography>
+        <Checkbox
+          label={CheckboxLabel.MultiSelectMode}
+          checked={multiSelectMode}
+          onChange={handleMultiSelectModeChange}
+          className={classes.checkBox}
+        />
         {props.topRightElement}
       </div>
       {props.filterElement}

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -15,7 +15,10 @@ import { Checkbox } from '../Checkbox/Checkbox';
 import { useAttributionColumnStyles } from '../AttributionColumn/shared-attribution-column-styles';
 import { getMultiSelectMode } from '../../state/selectors/attribution-view-resource-selectors';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { setMultiSelectMode } from '../../state/actions/resource-actions/attribution-view-simple-actions';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { CheckboxLabel } from '../../enums/enums';
 
 const useStyles = makeStyles({
@@ -99,6 +102,9 @@ export function AttributionList(props: AttributionListProps): ReactElement {
   function handleMultiSelectModeChange(
     event: React.ChangeEvent<HTMLInputElement>
   ): void {
+    if (!event.target.checked) {
+      dispatch(setMultiSelectSelectedAttributionIds([]));
+    }
     dispatch(setMultiSelectMode(event.target.checked));
   }
 

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -18,14 +18,18 @@ import {
   renderComponentWithStore,
 } from '../../../test-helpers/render-component-with-store';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
-import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import {
+  clickOnCheckbox,
+  getParsedInputFileEnrichedWithTestData,
+} from '../../../test-helpers/general-test-helpers';
 import {
   clickOnButtonInPackageContextMenu,
   expectButtonInPackageContextMenu,
   expectGlobalOnlyContextMenuForNotPreselectedAttribution,
   testCorrectMarkAndUnmarkForReplacementInContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
-import { ButtonText } from '../../../enums/enums';
+import { ButtonText, CheckboxLabel } from '../../../enums/enums';
+import { getMultiSelectMode } from '../../../state/selectors/attribution-view-resource-selectors';
 
 function getTestStore(manualAttributions: Attributions): EnhancedTestStore {
   const store = createTestAppStore();
@@ -224,5 +228,22 @@ describe('The AttributionList', () => {
       'React, 16.0.0',
       true
     );
+  });
+
+  test('sets multiSelectMode on click', () => {
+    const { store } = renderComponentWithStore(
+      <AttributionList
+        attributions={packages}
+        selectedAttributionId={''}
+        attributionIdMarkedForReplacement={''}
+        onCardClick={mockCallback}
+        maxHeight={1000}
+        title={'title'}
+      />,
+      { store: getTestStore(packages) }
+    );
+    expect(getMultiSelectMode(store.getState())).toBeFalsy();
+    clickOnCheckbox(screen, CheckboxLabel.MultiSelectMode);
+    expect(getMultiSelectMode(store.getState())).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
+import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
+import { getMultiSelectSelectedAttributionIds } from '../../state/selectors/attribution-view-resource-selectors';
+
+export function ConfirmMultiSelectDeletionPopup(): ReactElement {
+  const multiSelectSelectedAttributionIds = useAppSelector(
+    getMultiSelectSelectedAttributionIds
+  );
+
+  const dispatch = useAppDispatch();
+
+  function deleteMultiSelectSelectedAttributionIds(): void {
+    multiSelectSelectedAttributionIds.forEach((attributionId) => {
+      dispatch(deleteAttributionGloballyAndSave(attributionId));
+    });
+  }
+
+  return (
+    <ConfirmationPopup
+      onConfirmation={deleteMultiSelectSelectedAttributionIds}
+      content={
+        'Do you really want to delete the selected attributions for all files? ' +
+        `This action will delete ${multiSelectSelectedAttributionIds.length} attributions.`
+      }
+      header={'Confirm Deletion'}
+    />
+  );
+}

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -3,7 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup';
@@ -11,8 +14,39 @@ import {
   setMultiSelectMode,
   setMultiSelectSelectedAttributionIds,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import {
+  Attributions,
+  Resources,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import {
+  clickOnButton,
+  getParsedInputFileEnrichedWithTestData,
+} from '../../../test-helpers/general-test-helpers';
+import { ButtonText } from '../../../enums/enums';
+import { getManualAttributions } from '../../../state/selectors/all-views-resource-selectors';
+import { IpcRenderer } from 'electron';
+
+let originalIpcRenderer: IpcRenderer;
 
 describe('The ConfirmMultiSelectDeletionPopup', () => {
+  beforeAll(() => {
+    originalIpcRenderer = global.window.ipcRenderer;
+    global.window.ipcRenderer = {
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      invoke: jest.fn(),
+    } as unknown as IpcRenderer;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  afterAll(() => {
+    // Important to restore the original value.
+    global.window.ipcRenderer = originalIpcRenderer;
+  });
+
   test('renders', () => {
     const expectedContent =
       'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
@@ -26,5 +60,55 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
 
     expect(screen.getByText(expectedContent)).toBeTruthy();
     expect(screen.getByText(expectedHeader)).toBeTruthy();
+  });
+
+  test('deletes attributions', () => {
+    const expectedContent =
+      'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
+    const expectedHeader = 'Confirm Deletion';
+
+    const testResources: Resources = {
+      'something.js': 1,
+      'somethingElse.js': 1,
+    };
+    const testManualAttributions: Attributions = {
+      uuid1: {
+        packageName: 'React',
+      },
+      uuid2: {
+        packageName: 'Vue',
+      },
+    };
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      '/something.js': ['uuid1'],
+      '/somethingElse.js': ['uuid2'],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testManualAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(
+      setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2'])
+    );
+
+    const { store } = renderComponentWithStore(
+      <ConfirmMultiSelectDeletionPopup />,
+      { store: testStore }
+    );
+
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2']));
+    expect(screen.getByText(expectedContent)).toBeTruthy();
+    expect(screen.getByText(expectedHeader)).toBeTruthy();
+    clickOnButton(screen, ButtonText.Confirm);
+    expect(getManualAttributions(store.getState())).toEqual({});
   });
 });

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+
+describe('The ConfirmMultiSelectDeletionPopup', () => {
+  test('renders', () => {
+    const expectedContent =
+      'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
+    const expectedHeader = 'Confirm Deletion';
+
+    const { store } = renderComponentWithStore(
+      <ConfirmMultiSelectDeletionPopup />
+    );
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
+
+    expect(screen.getByText(expectedContent)).toBeTruthy();
+    expect(screen.getByText(expectedHeader)).toBeTruthy();
+  });
+});

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -14,6 +14,7 @@ import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttri
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
 import { useAppSelector } from '../../state/hooks';
+import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -33,6 +34,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <ConfirmDeletionGloballyPopup />;
     case PopupType.ConfirmDeletionPopup:
       return <ConfirmDeletionPopup />;
+    case PopupType.ConfirmMultiSelectDeletionPopup:
+      return <ConfirmMultiSelectDeletionPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -18,6 +18,10 @@ import { screen } from '@testing-library/react';
 import { Attributions } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 
 describe('The GlobalPopUp', () => {
   test('does not open by default', () => {
@@ -107,6 +111,19 @@ describe('The GlobalPopUp', () => {
     expect(
       screen.getByText(
         'Do you really want to delete this attribution for all files?'
+      )
+    ).toBeTruthy();
+  });
+
+  test('opens the ConfirmMultiSelectDeletionPopup', () => {
+    const { store } = renderComponentWithStore(<GlobalPopup />);
+    store.dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));
+    store.dispatch(setMultiSelectMode(true));
+    store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
+
+    expect(
+      screen.getByText(
+        'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.'
       )
     ).toBeTruthy();
   });

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -138,9 +138,6 @@ const useStyles = makeStyles({
       background: OpossumColors.white,
     },
   },
-  multiSelected: {
-    background: OpossumColors.lightestBlue,
-  },
 });
 
 interface ListCardProps {
@@ -190,60 +187,64 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             : classes.selected
           : null,
         props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
-        props.cardConfig.isResolved && classes.resolved,
-        props.cardConfig.isMultiSelected && !props.cardConfig.isSelected
-          ? classes.multiSelected
-          : ''
+        props.cardConfig.isResolved && classes.resolved
       )}
-      onClick={props.onClick}
     >
       {props.leftElement ? props.leftElement : null}
-      <div className={classes.iconColumn}>
-        {props.leftIcon ? props.leftIcon : null}
-        {getDisplayedCount() ? (
-          <MuiTypography variant={'body2'} className={classes.count}>
-            {getDisplayedCount()}
-          </MuiTypography>
-        ) : null}
-      </div>
       <div
         className={clsx(
-          classes.textLines,
+          classes.root,
           props.cardConfig.isResource ? null : classes.longTextInFlexbox
         )}
+        onClick={props.onClick}
       >
-        <MuiTypography
-          variant={'body2'}
+        <div className={classes.iconColumn}>
+          {props.leftIcon ? props.leftIcon : null}
+          {getDisplayedCount() ? (
+            <MuiTypography variant={'body2'} className={classes.count}>
+              {getDisplayedCount()}
+            </MuiTypography>
+          ) : null}
+        </div>
+        <div
           className={clsx(
-            props.cardConfig.isHeader ? classes.header : classes.textLine,
-            props.cardConfig.isResource
-              ? classes.textShortenedFromLeftSide
-              : classes.textShortened
+            classes.textLines,
+            props.cardConfig.isResource ? null : classes.longTextInFlexbox
           )}
         >
-          {props.cardConfig.isResource ? <bdi>{props.text}</bdi> : props.text}
-        </MuiTypography>
-        {props.secondLineText ? (
           <MuiTypography
             variant={'body2'}
             className={clsx(
-              classes.textLine,
+              props.cardConfig.isHeader ? classes.header : classes.textLine,
               props.cardConfig.isResource
                 ? classes.textShortenedFromLeftSide
                 : classes.textShortened
             )}
           >
-            {props.cardConfig.isResource ? (
-              <bdi>{props.secondLineText}</bdi>
-            ) : (
-              props.secondLineText
-            )}
+            {props.cardConfig.isResource ? <bdi>{props.text}</bdi> : props.text}
           </MuiTypography>
+          {props.secondLineText ? (
+            <MuiTypography
+              variant={'body2'}
+              className={clsx(
+                classes.textLine,
+                props.cardConfig.isResource
+                  ? classes.textShortenedFromLeftSide
+                  : classes.textShortened
+              )}
+            >
+              {props.cardConfig.isResource ? (
+                <bdi>{props.secondLineText}</bdi>
+              ) : (
+                props.secondLineText
+              )}
+            </MuiTypography>
+          ) : null}
+        </div>
+        {props.rightIcons ? (
+          <div className={classes.iconColumn}>{props.rightIcons}</div>
         ) : null}
       </div>
-      {props.rightIcons ? (
-        <div className={classes.iconColumn}>{props.rightIcons}</div>
-      ) : null}
     </div>
   );
 }

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -138,6 +138,9 @@ const useStyles = makeStyles({
       background: OpossumColors.white,
     },
   },
+  multiSelected: {
+    background: OpossumColors.lightestBlue,
+  },
 });
 
 interface ListCardProps {
@@ -148,6 +151,7 @@ interface ListCardProps {
   onClick(): void;
   leftIcon?: JSX.Element;
   rightIcons?: Array<JSX.Element>;
+  leftElement?: JSX.Element;
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
@@ -186,10 +190,14 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             : classes.selected
           : null,
         props.cardConfig.isMarkedForReplacement && classes.markedForReplacement,
-        props.cardConfig.isResolved && classes.resolved
+        props.cardConfig.isResolved && classes.resolved,
+        props.cardConfig.isMultiSelected && !props.cardConfig.isSelected
+          ? classes.multiSelected
+          : ''
       )}
       onClick={props.onClick}
     >
+      {props.leftElement ? props.leftElement : null}
       <div className={classes.iconColumn}>
         {props.leftIcon ? props.leftIcon : null}
         {getDisplayedCount() ? (

--- a/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
+++ b/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 import { ListCard } from '../ListCard';
+import { Checkbox } from '../../Checkbox/Checkbox';
 
 describe('The ListCard', () => {
   test('renders text with no count', () => {
@@ -69,5 +70,22 @@ describe('The ListCard', () => {
     expect(screen.getByText('card text'));
     expect(screen.getByText('card text of second line'));
     expect(screen.getByText('1M'));
+  });
+
+  test('renders leftElement if provided as input', () => {
+    const leftElement = <Checkbox checked={false} onChange={jest.fn()} />;
+    render(
+      <ListCard
+        text={'card text'}
+        secondLineText={'card text of second line'}
+        onClick={doNothing}
+        cardConfig={{}}
+        leftElement={leftElement}
+      />
+    );
+
+    expect(screen.getByText('card text'));
+    expect(screen.getByText('card text of second line'));
+    expect(screen.getByRole('checkbox')).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -63,7 +63,7 @@ export function ManualAttributionList(
       <PackageCard
         attributionId={isButton ? '' : attributionId}
         onClick={onClick}
-        hideContextMenu={isButton}
+        hideContextMenuAndMultiSelect={isButton}
         cardConfig={cardConfig}
         key={`AttributionCard-${attribution.packageName}-${attributionId}`}
         cardContent={{

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -35,7 +35,10 @@ import {
   savePackageInfo,
   unlinkAttributionAndSavePackageInfo,
 } from '../../state/actions/resource-actions/save-actions';
-import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
+import {
+  openPopup,
+  openPopupWithTargetAttributionId,
+} from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionIdOfDisplayedPackageInManualPanel,
@@ -278,6 +281,13 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             buttonText: ButtonText.DeleteGlobally,
             onClick: openConfirmDeletionGloballyPopup,
             hidden: isExternalAttribution || !showGlobalButtons,
+          },
+          {
+            buttonText: ButtonText.DeleteSelectedGlobally,
+            onClick: (): void => {
+              dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));
+            },
+            hidden: multiSelectSelectedAttributionIds.length === 0,
           },
           {
             buttonText: ButtonText.Confirm,

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -63,7 +63,7 @@ export function ReplaceAttributionPopup(): ReactElement {
         attributionId={attributionId}
         onClick={doNothing}
         cardConfig={{}}
-        hideContextMenu={true}
+        hideContextMenuAndMultiSelect={true}
         cardContent={{
           id: `attribution-list-${attributionId}`,
           name: attribution?.packageName,

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -19,6 +19,8 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
   setAttributionIdMarkedForReplacement,
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { Attributions, Resources } from '../../../../shared/shared-types';
@@ -114,6 +116,24 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     expect(screen.queryByText(ButtonText.Confirm)).toBeFalsy();
     expect(screen.queryByText(ButtonText.ConfirmGlobally)).toBeFalsy();
     expect(screen.queryByText(ButtonText.DeleteGlobally)).toBeFalsy();
+  });
+
+  test('does not show multi-select checkbox for attributions', () => {
+    const testStore = createTestAppStore();
+    setupTestState(testStore);
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(
+      setMultiSelectSelectedAttributionIds(['test_marked_id'])
+    );
+
+    renderComponentWithStore(<ReplaceAttributionPopup />, {
+      store: testStore,
+    });
+
+    expect(screen.getByText('Replacing an attribution')).toBeTruthy();
+    expect(screen.getByText('React')).toBeTruthy();
+    expect(screen.getByText('Vue')).toBeTruthy();
+    expect(screen.queryByText('checkbox')).toBeFalsy();
   });
 
   test('renders a ReplaceAttributionPopup and click replace', () => {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -65,3 +65,10 @@ export enum FilterType {
   HideFirstParty = 'Hide First Party',
   OnlyFollowUp = 'Only Follow Up',
 }
+
+export enum CheckboxLabel {
+  MultiSelectMode = 'Multi-select',
+  FirstParty = '1st Party',
+  FollowUp = 'Follow-up',
+  ExcludeFromNotice = 'Exclude From Notice',
+}

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -18,6 +18,7 @@ export enum PopupType {
   ReplaceAttributionPopup = 'ReplaceAttributionPopup',
   ConfirmDeletionPopup = 'ConfirmDeletionPopup',
   ConfirmDeletionGloballyPopup = 'ConfirmDeletionGloballyPopup',
+  ConfirmMultiSelectDeletionPopup = 'ConfirmMultiSelectDeletionPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -48,6 +49,7 @@ export enum ButtonText {
   ConfirmGlobally = 'Confirm globally',
   Delete = 'Delete',
   DeleteGlobally = 'Delete globally',
+  DeleteSelectedGlobally = 'Delete selected globally',
   Hide = 'Hide',
   MarkForReplacement = 'Mark for replacement',
   Save = 'Save',

--- a/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
@@ -17,7 +17,12 @@ import {
 import { screen } from '@testing-library/react';
 import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import { ButtonText, FilterType, View } from '../../../enums/enums';
+import {
+  ButtonText,
+  CheckboxLabel,
+  FilterType,
+  View,
+} from '../../../enums/enums';
 import { IpcRenderer } from 'electron';
 import { ParsedFileContent } from '../../../../shared/shared-types';
 import React from 'react';
@@ -103,7 +108,7 @@ describe('The App integration', () => {
     screen.getByText('Vue');
 
     clickOnCardInAttributionList(screen, 'Vue');
-    clickOnCheckbox(screen, 'Follow-up');
+    clickOnCheckbox(screen, CheckboxLabel.FollowUp);
     clickOnButton(screen, ButtonText.Save);
 
     openDropDown(screen);

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { App } from '../../../Components/App/App';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { IpcRenderer } from 'electron';
 import React from 'react';
 import {
@@ -40,14 +40,12 @@ import {
   clickOnElementInResourceBrowser,
   expectResourceBrowserIsNotShown,
 } from '../../../test-helpers/resource-browser-test-helpers';
-import {
-  clickOnCardInAttributionList,
-  getCardInAttributionList,
-} from '../../../test-helpers/package-panel-helpers';
+import { clickOnCardInAttributionList } from '../../../test-helpers/package-panel-helpers';
 import {
   clickOnButton,
   clickOnCheckbox,
   clickOnMultiSelectCheckboxInPackageCard,
+  expectSelectCheckboxInPackageCardIsChecked,
   getCheckbox,
   getParsedInputFileEnrichedWithTestData,
   goToView,
@@ -290,12 +288,7 @@ describe('In Attribution View the ContextMenu', () => {
     clickOnMultiSelectCheckboxInPackageCard(screen, 'React, 16.5.0');
     clickOnMultiSelectCheckboxInPackageCard(screen, 'Vue, 1.2.0');
 
-    expect(
-      within(getCardInAttributionList(screen, 'React, 16.5.0')).getByRole(
-        'checkbox'
-      ) as HTMLInputElement
-    ).toBeChecked();
-
+    expectSelectCheckboxInPackageCardIsChecked(screen, 'React, 16.5.0');
     expectButtonInPackageContextMenu(
       screen,
       'React, 16.5.0',

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import makeStyles from '@mui/styles/makeStyles';
+
 export const OpossumColors = {
   almostWhiteBlue: 'hsl(220, 41%, 97%)',
   lightestBlue: 'hsl(220, 41%, 92%)',
@@ -59,3 +61,13 @@ export const disabledIcon = {
   ...baseIcon,
   color: OpossumColors.disabledButtonGrey,
 };
+
+export const useCheckboxStyles = makeStyles({
+  checkBox: {
+    height: 40,
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: 12,
+    marginLeft: -2,
+  },
+});

--- a/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
@@ -6,10 +6,14 @@
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
   setAttributionIdMarkedForReplacement,
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
   setTargetSelectedAttributionId,
 } from '../attribution-view-simple-actions';
 import {
+  getMultiSelectMode,
+  getMultiSelectSelectedAttributionIds,
   getSelectedAttributionId,
   getTargetSelectedAttributionId,
 } from '../../../selectors/attribution-view-resource-selectors';
@@ -40,5 +44,23 @@ describe('The load and navigation simple actions', () => {
     expect(getAttributionIdMarkedForReplacement(testStore.getState())).toBe(
       'test'
     );
+  });
+  test('sets and gets multiSelectMode', () => {
+    const testStore = createTestAppStore();
+    expect(getMultiSelectMode(testStore.getState())).toBeFalsy();
+
+    testStore.dispatch(setMultiSelectMode(true));
+    expect(getMultiSelectMode(testStore.getState())).toBeTruthy();
+  });
+  test('sets and gets multiSelectSelectedAttributionIds', () => {
+    const testStore = createTestAppStore();
+    expect(
+      getMultiSelectSelectedAttributionIds(testStore.getState())
+    ).toStrictEqual([]);
+
+    testStore.dispatch(setMultiSelectSelectedAttributionIds(['id_1']));
+    expect(
+      getMultiSelectSelectedAttributionIds(testStore.getState())
+    ).toStrictEqual(['id_1']);
   });
 });

--- a/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
@@ -5,9 +5,13 @@
 
 import {
   ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
+  ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS,
+  ACTION_SET_MULTI_SELECT_MODE,
   ACTION_SET_SELECTED_ATTRIBUTION_ID,
   ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
   SetAttributionIdMarkedForReplacement,
+  SetMultiSelectSelectedAttributionIds,
+  SetMultiSelectMode,
   SetSelectedAttributionId,
   SetTargetSelectedAttributionIdAction,
 } from './types';
@@ -36,5 +40,23 @@ export function setAttributionIdMarkedForReplacement(
   return {
     type: ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
     payload: attributionIdMarkedForReplacement,
+  };
+}
+
+export function setMultiSelectMode(
+  multiSelectMode: boolean
+): SetMultiSelectMode {
+  return {
+    type: ACTION_SET_MULTI_SELECT_MODE,
+    payload: multiSelectMode,
+  };
+}
+
+export function setMultiSelectSelectedAttributionIds(
+  multiSelectSelectedAttributionIds: Array<string>
+): SetMultiSelectSelectedAttributionIds {
+  return {
+    type: ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS,
+    payload: multiSelectSelectedAttributionIds,
   };
 }

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -54,6 +54,8 @@ import {
 import { isEmpty } from 'lodash';
 import { getAttributionBreakpointCheckForState } from '../../../util/is-attribution-breakpoint';
 import { openPopup } from '../view-actions/view-actions';
+import { getMultiSelectSelectedAttributionIds } from '../../selectors/attribution-view-resource-selectors';
+import { setMultiSelectSelectedAttributionIds } from './attribution-view-simple-actions';
 
 export function setIsSavingDisabled(
   isSavingDisabled: boolean
@@ -209,7 +211,17 @@ export function addToSelectedResource(
 export function deleteAttributionGloballyAndSave(
   attributionId: string
 ): AppThunkAction {
-  return (dispatch: AppThunkDispatch): void => {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
+    }
+
     dispatch(savePackageInfo(null, attributionId, {}));
   };
 }
@@ -221,6 +233,16 @@ export function deleteAttributionAndSave(
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+
+    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
+    }
 
     if (attributionsToResources[attributionId].length > 1) {
       dispatch(unlinkResourceFromAttributionAndSave(resourceId, attributionId));

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  Attributions,
   AttributionsToResources,
   PackageInfo,
   SaveFileArgs,
@@ -133,6 +134,11 @@ export function savePackageInfo(
 
     dispatch(resetSelectedPackagePanelIfContainedAttributionWasRemoved());
     dispatch(resetTemporaryPackageInfo());
+    dispatch(
+      filterMultiSelectSelectedAttributionIdsIfAttributionWasRemoved(
+        attributionId
+      )
+    );
 
     dispatch(saveManualAndResolvedAttributionsToFile());
   };
@@ -211,17 +217,7 @@ export function addToSelectedResource(
 export function deleteAttributionGloballyAndSave(
   attributionId: string
 ): AppThunkAction {
-  return (dispatch: AppThunkDispatch, getState: () => State): void => {
-    const multiSelectSelectedAttributionIds =
-      getMultiSelectSelectedAttributionIds(getState());
-    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
-      dispatch(
-        setMultiSelectSelectedAttributionIds(
-          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
-        )
-      );
-    }
-
+  return (dispatch: AppThunkDispatch): void => {
     dispatch(savePackageInfo(null, attributionId, {}));
   };
 }
@@ -233,21 +229,32 @@ export function deleteAttributionAndSave(
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const attributionsToResources: AttributionsToResources =
       getManualAttributionsToResources(getState());
-    const multiSelectSelectedAttributionIds =
-      getMultiSelectSelectedAttributionIds(getState());
-
-    if (multiSelectSelectedAttributionIds.includes(attributionId)) {
-      dispatch(
-        setMultiSelectSelectedAttributionIds(
-          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
-        )
-      );
-    }
 
     if (attributionsToResources[attributionId].length > 1) {
       dispatch(unlinkResourceFromAttributionAndSave(resourceId, attributionId));
     } else {
       dispatch(deleteAttributionGloballyAndSave(attributionId));
+    }
+  };
+}
+
+function filterMultiSelectSelectedAttributionIdsIfAttributionWasRemoved(
+  attributionId: string | null
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const multiSelectSelectedAttributionIds =
+      getMultiSelectSelectedAttributionIds(getState());
+    const attributions: Attributions = getManualAttributions(getState());
+    if (
+      attributionId &&
+      !attributions[attributionId] &&
+      multiSelectSelectedAttributionIds.includes(attributionId)
+    ) {
+      dispatch(
+        setMultiSelectSelectedAttributionIds(
+          multiSelectSelectedAttributionIds.filter((id) => id !== attributionId)
+        )
+      );
     }
   };
 }

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -66,6 +66,9 @@ export const ACTION_SET_BASE_URLS_FOR_SOURCES =
   'ACTION_SET_BASE_URLS_FOR_SOURCES';
 export const ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES =
   'ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES';
+export const ACTION_SET_MULTI_SELECT_MODE = 'ACTION_SET_MULTISELECT_MODE';
+export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
+  'ACTION_SET_ATTRIBUTION_IDS_MARKED_FOR_MULTISELECT';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -97,7 +100,9 @@ export type ResourceAction =
   | SetFileSearch
   | SetBaseUrlsForSources
   | SetAttributionIdMarkedForReplacement
-  | SetExternalAttributionSources;
+  | SetExternalAttributionSources
+  | SetMultiSelectMode
+  | SetMultiSelectSelectedAttributionIds;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -263,4 +268,14 @@ export interface SetExternalAttributionSources {
 export interface SetAttributionIdMarkedForReplacement {
   type: typeof ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT;
   payload: string;
+}
+
+export interface SetMultiSelectMode {
+  type: typeof ACTION_SET_MULTI_SELECT_MODE;
+  payload: boolean;
+}
+
+export interface SetMultiSelectSelectedAttributionIds {
+  type: typeof ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS;
+  payload: Array<string>;
 }

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -24,6 +24,14 @@ import {
   updateActiveFilters,
   setTargetView,
 } from '../view-actions';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../../resource-actions/attribution-view-simple-actions';
+import {
+  getMultiSelectMode,
+  getMultiSelectSelectedAttributionIds,
+} from '../../../selectors/attribution-view-resource-selectors';
 
 describe('view actions', () => {
   test('sets view to AuditView as initial value', () => {
@@ -147,6 +155,23 @@ describe('view actions', () => {
     expect(
       getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
     ).toBe(true);
+  });
+
+  test('resets multi-select on view change', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setMultiSelectMode(true));
+    testStore.dispatch(setMultiSelectSelectedAttributionIds(['some_id']));
+
+    testStore.dispatch(navigateToView(View.Report));
+
+    expect(getMultiSelectMode(testStore.getState())).toBeFalsy();
+    expect(
+      getMultiSelectSelectedAttributionIds(testStore.getState())
+    ).toStrictEqual([]);
+
+    expect(isAuditViewSelected(testStore.getState())).toBe(false);
+    expect(isAttributionViewSelected(testStore.getState())).toBe(false);
+    expect(isReportViewSelected(testStore.getState())).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -28,6 +28,10 @@ import {
   OpenPopupActionPopupType,
   UpdateActiveFilters,
 } from './types';
+import {
+  setMultiSelectMode,
+  setMultiSelectSelectedAttributionIds,
+} from '../resource-actions/attribution-view-simple-actions';
 
 export function resetViewState(): ResetViewStateAction {
   return { type: ACTION_RESET_VIEW_STATE };
@@ -41,6 +45,8 @@ export function navigateToView(view: View): AppThunkAction {
 
     dispatch(setTargetView(null));
     dispatch(setView(view));
+    dispatch(setMultiSelectMode(false));
+    dispatch(setMultiSelectSelectedAttributionIds([]));
 
     const updatedTemporaryPackageInfo: PackageInfo =
       view === View.Audit

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -40,6 +40,8 @@ import {
   ACTION_SET_FREQUENT_LICENSES,
   ACTION_SET_IS_SAVING_DISABLED,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
+  ACTION_SET_MULTI_SELECT_MODE,
+  ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS,
   ACTION_SET_PROGRESS_BAR_DATA,
   ACTION_SET_PROJECT_METADATA,
   ACTION_SET_RESOLVED_EXTERNAL_ATTRIBUTIONS,
@@ -62,9 +64,9 @@ import {
   updateManualAttribution,
 } from '../helpers/save-action-helpers';
 import {
+  addUnresolvedAttributionsToResourcesWithAttributedChildren,
   getMatchingAttributionId,
   removeResolvedAttributionsFromResourcesWithAttributedChildren,
-  addUnresolvedAttributionsToResourcesWithAttributedChildren,
 } from '../helpers/action-and-reducer-helpers';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
@@ -97,6 +99,8 @@ export const initialResourceState: ResourceState = {
   attributionView: {
     selectedAttributionId: '',
     targetSelectedAttributionId: '',
+    multiSelectMode: false,
+    multiSelectSelectedAttributionIds: [],
   },
   fileSearchPopup: {
     fileSearch: '',
@@ -129,6 +133,8 @@ export type ResourceState = {
   attributionView: {
     selectedAttributionId: string;
     targetSelectedAttributionId: string;
+    multiSelectMode: boolean;
+    multiSelectSelectedAttributionIds: Array<string>;
   };
   fileSearchPopup: {
     fileSearch: string;
@@ -279,6 +285,22 @@ export const resourceState = (
         attributionView: {
           ...state.attributionView,
           targetSelectedAttributionId: action.payload,
+        },
+      };
+    case ACTION_SET_MULTI_SELECT_MODE:
+      return {
+        ...state,
+        attributionView: {
+          ...state.attributionView,
+          multiSelectMode: action.payload,
+        },
+      };
+    case ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS:
+      return {
+        ...state,
+        attributionView: {
+          ...state.attributionView,
+          multiSelectSelectedAttributionIds: action.payload,
         },
       };
     case ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT:

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -300,7 +300,7 @@ export const resourceState = (
         ...state,
         attributionView: {
           ...state.attributionView,
-          multiSelectSelectedAttributionIds: action.payload,
+          multiSelectSelectedAttributionIds: [...action.payload],
         },
       };
     case ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT:

--- a/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
@@ -25,3 +25,13 @@ export function getResourceIdsOfSelectedAttribution(
   }
   return [];
 }
+
+export function getMultiSelectMode(state: State): boolean {
+  return state.resourceState.attributionView.multiSelectMode;
+}
+
+export function getMultiSelectSelectedAttributionIds(
+  state: State
+): Array<string> {
+  return state.resourceState.attributionView.multiSelectSelectedAttributionIds;
+}

--- a/src/Frontend/test-helpers/context-menu-test-helpers.ts
+++ b/src/Frontend/test-helpers/context-menu-test-helpers.ts
@@ -33,6 +33,7 @@ export function expectGlobalOnlyContextMenuForNotPreselectedAttribution(
     ButtonText.Confirm,
     ButtonText.ConfirmGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -69,6 +70,7 @@ export function expectGlobalOnlyContextMenuForPreselectedAttribution(
       ButtonText.Confirm,
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -90,6 +92,7 @@ export function expectContextMenuForNotPreSelectedAttributionMultipleResources(
     ButtonText.Confirm,
     ButtonText.ConfirmGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -126,6 +129,7 @@ export function expectContextMenuForPreSelectedAttributionMultipleResources(
       ButtonText.Unhide,
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -147,6 +151,7 @@ export function expectContextMenuForNotPreSelectedAttributionSingleResource(
     ButtonText.ConfirmGlobally,
     ButtonText.DeleteGlobally,
     ButtonText.UnmarkForReplacement,
+    ButtonText.DeleteSelectedGlobally,
   ];
 
   if (showReplaceMarked) {
@@ -182,6 +187,7 @@ export function expectContextMenuForExternalAttributionInPackagePanel(
       ButtonText.UnmarkForReplacement,
       ButtonText.ReplaceMarked,
       ButtonText.MarkForReplacement,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -205,6 +211,7 @@ export function expectContextMenuForHiddenExternalAttributionInPackagePanel(
       ButtonText.MarkForReplacement,
       ButtonText.ReplaceMarked,
       ButtonText.UnmarkForReplacement,
+      ButtonText.DeleteSelectedGlobally,
     ]
   );
 }
@@ -224,7 +231,7 @@ export function testCorrectMarkAndUnmarkForReplacementInContextMenu(
     packageName,
     ButtonText.UnmarkForReplacement
   );
-  expectButtonNotInPackageContextMenu(
+  expectButtonInPackageContextMenu(
     screen,
     packageName,
     ButtonText.MarkForReplacement
@@ -235,7 +242,7 @@ export function expectUnmarkForReplacementInContextMenu(
   screen: Screen,
   packageName: string
 ): void {
-  expectButtonNotInPackageContextMenu(
+  expectButtonInPackageContextMenu(
     screen,
     packageName,
     ButtonText.UnmarkForReplacement
@@ -314,7 +321,7 @@ export function expectCorrectButtonsInContextMenu(
   hiddenButtons: Array<ButtonText>
 ): void {
   shownButtons.forEach((buttonText) => {
-    expectButtonNotInPackageContextMenu(screen, cardLabel, buttonText);
+    expectButtonInPackageContextMenu(screen, cardLabel, buttonText);
   });
 
   hiddenButtons.forEach((buttonText) => {
@@ -328,22 +335,7 @@ export function expectButtonInPackageContextMenu(
   buttonLabel: ButtonText
 ): void {
   openContextMenuOnCardPackageCard(screen, cardLabel);
-  const button = getButton(screen, buttonLabel);
-  const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
-
-  expect(buttonAttribute).not.toBeNull();
-}
-
-export function expectButtonNotInPackageContextMenu(
-  screen: Screen,
-  cardLabel: string,
-  buttonLabel: ButtonText
-): void {
-  openContextMenuOnCardPackageCard(screen, cardLabel);
-  const button = getButton(screen, buttonLabel);
-  const buttonAttribute = button.attributes.getNamedItem('aria-disabled');
-
-  expect(buttonAttribute).toBeNull();
+  getButton(screen, buttonLabel);
   closeContextMenuOnCardPackageCard(screen, cardLabel);
 }
 

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -19,7 +19,6 @@ import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
 import { canHaveChildren } from '../util/can-have-children';
-import { getCardInAttributionList } from './package-panel-helpers';
 
 export const TEST_TIMEOUT = 15000;
 
@@ -189,16 +188,32 @@ export function getCheckbox(screen: Screen, label: string): HTMLInputElement {
   }) as HTMLInputElement;
 }
 
+function getMultiSelectCheckboxInPackageCard(
+  screen: Screen,
+  cardLabel: string
+): Element {
+  const packageCard = (
+    (screen.getByText(cardLabel).parentElement as HTMLElement)
+      .parentElement as HTMLElement
+  ).parentElement as HTMLElement;
+  const checkbox = within(packageCard).getByRole('checkbox') as Element;
+  expect(checkbox).not.toBeFalsy();
+
+  return checkbox;
+}
+
 export function clickOnMultiSelectCheckboxInPackageCard(
   screen: Screen,
   cardLabel: string
 ): void {
-  const packageCard = getCardInAttributionList(screen, cardLabel);
-  fireEvent.click(within(packageCard).getByRole('checkbox') as Element);
+  fireEvent.click(getMultiSelectCheckboxInPackageCard(screen, cardLabel));
 }
 
-export function clickOnDeleteIcon(screen: Screen): void {
-  fireEvent.click(screen.getByTestId('CancelIcon') as Element);
+export function expectSelectCheckboxInPackageCardIsChecked(
+  screen: Screen,
+  cardLabel: string
+): void {
+  expect(getMultiSelectCheckboxInPackageCard(screen, cardLabel)).toBeChecked();
 }
 
 export function openDropDown(screen: Screen): void {

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, fireEvent, Screen } from '@testing-library/react';
+import { act, fireEvent, Screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import {
   Attributions,
@@ -19,6 +19,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
 import { canHaveChildren } from '../util/can-have-children';
+import { getCardInAttributionList } from './package-panel-helpers';
 
 export const TEST_TIMEOUT = 15000;
 
@@ -180,6 +181,20 @@ export function clickOnCheckbox(screen: Screen, label: string): void {
   fireEvent.click(
     screen.getByRole('checkbox', { name: `checkbox ${label}` }) as Element
   );
+}
+
+export function getCheckbox(screen: Screen, label: string): HTMLInputElement {
+  return screen.getByRole('checkbox', {
+    name: `checkbox ${label}`,
+  }) as HTMLInputElement;
+}
+
+export function clickOnMultiSelectCheckboxInPackageCard(
+  screen: Screen,
+  cardLabel: string
+): void {
+  const packageCard = getCardInAttributionList(screen, cardLabel);
+  fireEvent.click(within(packageCard).getByRole('checkbox') as Element);
 }
 
 export function clickOnDeleteIcon(screen: Screen): void {

--- a/src/Frontend/test-helpers/popup-test-helpers.ts
+++ b/src/Frontend/test-helpers/popup-test-helpers.ts
@@ -57,3 +57,20 @@ export function expectConfirmDeletionPopupVisible(screen: Screen): void {
 export function expectConfirmDeletionPopupNotVisible(screen: Screen): void {
   expect(screen.queryByText('Confirm Deletion')).toBeFalsy();
 }
+
+export function expectConfirmMultiSelectDeletionPopupVisible(
+  screen: Screen,
+  numberOfSelectedAttributions: number
+): void {
+  expect(
+    screen.getByText(
+      `Do you really want to delete the selected attributions for all files? This action will delete ${numberOfSelectedAttributions} attributions.`
+    )
+  ).toBeTruthy();
+}
+
+export function expectConfirmMultiSelectDeletionPopupNotVisible(
+  screen: Screen
+): void {
+  expect(screen.queryByText('Confirm Deletion')).toBeFalsy();
+}

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -66,6 +66,7 @@ export interface ListCardConfig {
   followUp?: boolean;
   isHeader?: boolean;
   isContextMenuOpen?: boolean;
+  isMultiSelected?: boolean;
 }
 
 export interface PathPredicate {


### PR DESCRIPTION
### Summary of changes

A mode to multi-select attributions for deletion is added in attribution view.

### Context and reason for change

So far attributions had to be deleted one by one. This diff adds the possibility for multi-deletion.

### How can the changes be tested


