### PR TITLE
Fix bug for inference

### DIFF
--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -77,7 +77,7 @@ export function ResourceDetailsViewer(): ReactElement | null {
 
   useEffect(() => {
     setOverrideParentMode(false);
-  }, [selectedResourceId]);
+  }, [selectedResourceId, attributionIdsOfSelectedResource]);
 
   const parentOfSelectedResourceHasAttributions = Boolean(
     attributionIdsOfSelectedResourceClosestParent.length


### PR DESCRIPTION
### Summary of changes

- when deleting one attribution for a resource with several attributions one has to check if the remaining attributions are might be covered by a parent

### Context and reason for change
There was a bug:

- add two attributions to some resource
- then add the same two attributions to some other resource
 - then add one of these to the parent of one of these
 - then remove the other one from its child using "Delete" in context menu
 - observe that attribution is not removed from child

### How can the changes be tested

The described bug should be fixed
