### PR TITLE
Fix CORS issues when fetching from pypi

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -10,8 +10,13 @@ import upath from 'upath';
 import { createMenu } from './menu';
 import { getIconPath } from './iconHelpers';
 
+const filter = {
+  urls: ['https://registry.npmjs.org/*'],
+};
+
 function allowCORS(mainWindow: Electron.BrowserWindow): void {
   mainWindow.webContents.session.webRequest.onHeadersReceived(
+    filter,
     (details, callback) => {
       callback({
         responseHeaders: {


### PR DESCRIPTION
### Summary of changes

This PR conditionally adds a Access-Control-Allow-Origin header to requests going to npmjs urls. 

### Context and reason for change

Adding the Access-Control-Allow-Origin header is only necessary for npmjs urls. Using a filter allows to conditionally attach this header to requests going to certain urls. For pypi urls (and github, WIP) this is not necessary and actually will complain.

### How can the changes be tested

Test license fetching with
`https://pypi.org/project/numpy`
`https://npmjs.com/package/react`


