### PR TITLE
Bring back show resources icon

### DIFF
--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -76,6 +76,7 @@ export function ManualAttributionList(
           url: attribution.url,
           licenseName: attribution.licenseName,
         }}
+        showOpenResourcesIcon={!isButton}
       />
     );
   }

--- a/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
+++ b/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
@@ -73,7 +73,7 @@ describe('The ManualAttributionList', () => {
     expect(mockCallback.mock.calls.length).toBe(0);
   });
 
-  test('renders first party icon', () => {
+  test('renders first party icon and show resources icon', () => {
     renderComponentWithStore(
       <ManualAttributionList
         selectedResourceId="/folder/"
@@ -85,6 +85,7 @@ describe('The ManualAttributionList', () => {
     );
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByLabelText('First party icon'));
+    expect(screen.getAllByLabelText('show resources'));
   });
 
   test('renders button', () => {

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { getKey, getRightIcons } from './package-card-helpers';
+import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 
 const useStyles = makeStyles({
   hiddenIcon: {
@@ -87,7 +88,7 @@ interface PackageCardProps {
   cardConfig: ListCardConfig;
   onClick(): void;
   onIconClick?(): void;
-  openResourcesIcon?: JSX.Element;
+  showOpenResourcesIcon?: boolean;
   hideContextMenuAndMultiSelect?: boolean;
   hideResourceSpecificButtons?: boolean;
 }
@@ -347,6 +348,23 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     />
   ) : undefined;
 
+  const openResourcesIcon = props.showOpenResourcesIcon ? (
+    <IconButton
+      tooltipTitle="show resources"
+      placement="right"
+      onClick={(): void => {
+        setShowAssociatedResourcesPopup(true);
+      }}
+      key={`open-resources-icon-${props.cardContent.name}-${props.cardContent.packageVersion}`}
+      icon={
+        <OpenInBrowserIcon
+          className={classes.clickableIcon}
+          aria-label={'show resources'}
+        />
+      }
+    />
+  ) : undefined;
+
   return (
     <div className={clsx(multiSelectMode && classes.multiSelectPackageCard)}>
       {!Boolean(props.hideContextMenuAndMultiSelect) && (
@@ -377,7 +395,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             props.cardContent,
             props.cardConfig,
             classes,
-            props.openResourcesIcon
+            openResourcesIcon
           )}
           leftElement={leftElement}
         />

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -87,6 +87,7 @@ interface PackageCardProps {
   cardConfig: ListCardConfig;
   onClick(): void;
   onIconClick?(): void;
+  openResourcesIcon?: JSX.Element;
   hideContextMenuAndMultiSelect?: boolean;
   hideResourceSpecificButtons?: boolean;
 }
@@ -375,7 +376,8 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           rightIcons={getRightIcons(
             props.cardContent,
             props.cardConfig,
-            classes
+            classes,
+            props.openResourcesIcon
           )}
           leftElement={leftElement}
         />

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -20,9 +20,14 @@ export function getKey(prefix: string, cardContent: ListCardContent): string {
 export function getRightIcons(
   cardContent: ListCardContent,
   cardConfig: ListCardConfig,
-  classes: ClassNameMap<'followUpIcon' | 'excludeFromNoticeIcon'>
+  classes: ClassNameMap<'followUpIcon' | 'excludeFromNoticeIcon'>,
+  openResourcesIcon?: JSX.Element
 ): Array<ReactElement> {
   const rightIcons: Array<JSX.Element> = [];
+
+  if (openResourcesIcon) {
+    rightIcons.push(openResourcesIcon);
+  }
 
   if (cardConfig.firstParty) {
     rightIcons.push(

--- a/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
+++ b/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
@@ -61,6 +61,7 @@ describe('The PackagePanel', () => {
 
     expect(screen.getByText('React, 16.5.0'));
     expect(screen.getByText('JQuery'));
+    expect(screen.getAllByLabelText('show resources'));
   });
 
   test('groups by source and prettifies known sources', () => {

--- a/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
+++ b/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
@@ -8,6 +8,14 @@ import { getCardLabels } from '../../util/get-card-labels';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { ListCardConfig, ListCardContent } from '../../types/types';
+import { IconButton } from '../IconButton/IconButton';
+import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
+import { makeStyles } from '@mui/styles';
+import { clickableIcon } from '../../shared-styles';
+
+const useStyles = makeStyles({
+  clickableIcon,
+});
 
 interface PackagePanelCardProps {
   cardContent: ListCardContent;
@@ -20,6 +28,7 @@ interface PackagePanelCardProps {
 }
 
 export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
+  const classes = useStyles();
   const [showAssociatedResourcesPopup, setShowAssociatedResourcesPopup] =
     useState<boolean>(false);
 
@@ -40,6 +49,22 @@ export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
         cardConfig={props.cardConfig}
         packageCount={props.packageCount}
         hideResourceSpecificButtons={props.hideResourceSpecificButtons}
+        openResourcesIcon={
+          <IconButton
+            tooltipTitle="show resources"
+            placement="right"
+            onClick={(): void => {
+              setShowAssociatedResourcesPopup(true);
+            }}
+            key={`open-resources-icon-${props.cardContent.name}-${props.cardContent.packageVersion}`}
+            icon={
+              <OpenInBrowserIcon
+                className={classes.clickableIcon}
+                aria-label={'show resources'}
+              />
+            }
+          />
+        }
       />
     </div>
   );

--- a/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
+++ b/src/Frontend/Components/PackagePanelCard/PackagePanelCard.tsx
@@ -3,19 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement, useState } from 'react';
-import { getCardLabels } from '../../util/get-card-labels';
+import React, { ReactElement } from 'react';
 import { PackageCard } from '../PackageCard/PackageCard';
-import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { ListCardConfig, ListCardContent } from '../../types/types';
-import { IconButton } from '../IconButton/IconButton';
-import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
-import { makeStyles } from '@mui/styles';
-import { clickableIcon } from '../../shared-styles';
-
-const useStyles = makeStyles({
-  clickableIcon,
-});
 
 interface PackagePanelCardProps {
   cardContent: ListCardContent;
@@ -28,19 +18,8 @@ interface PackagePanelCardProps {
 }
 
 export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
-  const classes = useStyles();
-  const [showAssociatedResourcesPopup, setShowAssociatedResourcesPopup] =
-    useState<boolean>(false);
-
   return (
     <div>
-      <ResourcePathPopup
-        isOpen={showAssociatedResourcesPopup}
-        closePopup={(): void => setShowAssociatedResourcesPopup(false)}
-        attributionId={props.attributionId}
-        isExternalAttribution={Boolean(props.cardConfig.isExternalAttribution)}
-        displayedAttributionName={getCardLabels(props.cardContent)[0] || ''}
-      />
       <PackageCard
         attributionId={props.attributionId}
         cardContent={props.cardContent}
@@ -49,22 +28,7 @@ export function PackagePanelCard(props: PackagePanelCardProps): ReactElement {
         cardConfig={props.cardConfig}
         packageCount={props.packageCount}
         hideResourceSpecificButtons={props.hideResourceSpecificButtons}
-        openResourcesIcon={
-          <IconButton
-            tooltipTitle="show resources"
-            placement="right"
-            onClick={(): void => {
-              setShowAssociatedResourcesPopup(true);
-            }}
-            key={`open-resources-icon-${props.cardContent.name}-${props.cardContent.packageVersion}`}
-            icon={
-              <OpenInBrowserIcon
-                className={classes.clickableIcon}
-                aria-label={'show resources'}
-              />
-            }
-          />
-        }
+        showOpenResourcesIcon={true}
       />
     </div>
   );

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -3,7 +3,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, fireEvent, Screen, within } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  getByRole,
+  Screen,
+  within,
+} from '@testing-library/react';
 import {
   Attributions,
   ParsedFileContent,
@@ -292,4 +298,14 @@ export function getPackagePanel(
     (screen.getByText(packagePanelName).parentElement as HTMLElement)
       .parentElement as HTMLElement
   ).parentElement as HTMLElement;
+}
+
+export function getOpenResourcesButtonForPackagePanel(
+  screen: Screen,
+  packageName: string
+): HTMLElement {
+  // eslint-disable-next-line testing-library/prefer-screen-queries
+  return getByRole(getPackagePanel(screen, packageName), 'button', {
+    name: 'show resources',
+  });
 }


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Bring back show resources icon for attributions and signals

### Context and reason for change
- show resources icon was moved to the context menu, but still wanted in the package cards

### How can the changes be tested
The changes can be tested in the UI.

