### PR TITLE
Always show multiselect checkboxes

### DIFF
--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -11,14 +11,6 @@ import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
 import { FilteredList } from '../FilteredList/FilteredList';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { ListCardConfig } from '../../types/types';
-import { Checkbox } from '../Checkbox/Checkbox';
-import { getMultiSelectMode } from '../../state/selectors/attribution-view-resource-selectors';
-import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../../state/actions/resource-actions/attribution-view-simple-actions';
-import { CheckboxLabel } from '../../enums/enums';
 import { useCheckboxStyles } from '../../shared-styles';
 
 const useStyles = makeStyles({
@@ -51,8 +43,6 @@ export function AttributionList(props: AttributionListProps): ReactElement {
   const attributionIds: Array<string> = Object.keys({
     ...props.attributions,
   }).sort(getAlphabeticalComparer(attributions));
-  const multiSelectMode = useAppSelector(getMultiSelectMode);
-  const dispatch = useAppDispatch();
 
   function getAttributionCard(attributionId: string): ReactElement {
     const attribution = attributions[attributionId];
@@ -95,29 +85,15 @@ export function AttributionList(props: AttributionListProps): ReactElement {
           licenseName: attribution.licenseName,
         }}
         hideResourceSpecificButtons={true}
+        showCheckBox={true}
       />
     );
-  }
-
-  function handleMultiSelectModeChange(
-    event: React.ChangeEvent<HTMLInputElement>
-  ): void {
-    if (!event.target.checked) {
-      dispatch(setMultiSelectSelectedAttributionIds([]));
-    }
-    dispatch(setMultiSelectMode(event.target.checked));
   }
 
   return (
     <div className={props.className}>
       <div className={classes.topElements}>
         <MuiTypography className={classes.title}>{props.title}</MuiTypography>
-        <Checkbox
-          label={CheckboxLabel.MultiSelectMode}
-          checked={multiSelectMode}
-          onChange={handleMultiSelectModeChange}
-          className={classes.checkBox}
-        />
         {props.topRightElement}
       </div>
       {props.filterElement}

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -18,18 +18,14 @@ import {
   renderComponentWithStore,
 } from '../../../test-helpers/render-component-with-store';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
-import {
-  clickOnCheckbox,
-  getParsedInputFileEnrichedWithTestData,
-} from '../../../test-helpers/general-test-helpers';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
   clickOnButtonInPackageContextMenu,
   expectButtonInPackageContextMenu,
   expectGlobalOnlyContextMenuForNotPreselectedAttribution,
   testCorrectMarkAndUnmarkForReplacementInContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
-import { ButtonText, CheckboxLabel } from '../../../enums/enums';
-import { getMultiSelectMode } from '../../../state/selectors/attribution-view-resource-selectors';
+import { ButtonText } from '../../../enums/enums';
 
 function getTestStore(manualAttributions: Attributions): EnhancedTestStore {
   const store = createTestAppStore();
@@ -226,22 +222,5 @@ describe('The AttributionList', () => {
       'React, 16.0.0',
       true
     );
-  });
-
-  test('sets multiSelectMode on click', () => {
-    const { store } = renderComponentWithStore(
-      <AttributionList
-        attributions={packages}
-        selectedAttributionId={''}
-        attributionIdMarkedForReplacement={''}
-        onCardClick={mockCallback}
-        maxHeight={1000}
-        title={'title'}
-      />,
-      { store: getTestStore(packages) }
-    );
-    expect(getMultiSelectMode(store.getState())).toBeFalsy();
-    clickOnCheckbox(screen, CheckboxLabel.MultiSelectMode);
-    expect(getMultiSelectMode(store.getState())).toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -10,10 +10,7 @@ import {
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import {
   Attributions,
   Resources,
@@ -55,7 +52,6 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
     const { store } = renderComponentWithStore(
       <ConfirmMultiSelectDeletionPopup />
     );
-    store.dispatch(setMultiSelectMode(true));
     store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
 
     expect(screen.getByText(expectedContent)).toBeInTheDocument();
@@ -94,7 +90,6 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
         })
       )
     );
-    testStore.dispatch(setMultiSelectMode(true));
     testStore.dispatch(
       setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2'])
     );
@@ -104,7 +99,6 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
       { store: testStore }
     );
 
-    store.dispatch(setMultiSelectMode(true));
     store.dispatch(setMultiSelectSelectedAttributionIds(['uuid1', 'uuid2']));
     expect(screen.getByText(expectedContent)).toBeInTheDocument();
     expect(screen.getByText(expectedHeader)).toBeInTheDocument();

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -18,10 +18,7 @@ import { screen } from '@testing-library/react';
 import { Attributions } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 
 describe('The GlobalPopUp', () => {
   test('does not open by default', () => {
@@ -120,7 +117,6 @@ describe('The GlobalPopUp', () => {
   test('opens the ConfirmMultiSelectDeletionPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     store.dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));
-    store.dispatch(setMultiSelectMode(true));
     store.dispatch(setMultiSelectSelectedAttributionIds(['uuid_1', 'uuid_2']));
 
     expect(

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -42,7 +42,6 @@ import {
 import { ResourcePathPopup } from '../ResourcePathPopup/ResourcePathPopup';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import {
-  getMultiSelectMode,
   getMultiSelectSelectedAttributionIds,
   getSelectedAttributionId,
 } from '../../state/selectors/attribution-view-resource-selectors';
@@ -89,6 +88,7 @@ interface PackageCardProps {
   onIconClick?(): void;
   hideContextMenuAndMultiSelect?: boolean;
   hideResourceSpecificButtons?: boolean;
+  showCheckBox?: boolean;
 }
 
 export function PackageCard(props: PackageCardProps): ReactElement | null {
@@ -114,7 +114,6 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   const attributionIdMarkedForReplacement = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const multiSelectMode = useAppSelector(getMultiSelectMode);
   const multiSelectSelectedAttributionIds = useAppSelector(
     getMultiSelectSelectedAttributionIds
   );
@@ -320,7 +319,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   }
 
   const leftElement =
-    multiSelectMode && !props.hideContextMenuAndMultiSelect ? (
+    props.showCheckBox && !props.hideContextMenuAndMultiSelect ? (
       <Checkbox
         checked={multiSelectSelectedAttributionIds.includes(attributionId)}
         onChange={handleMultiSelectAttributionSelected}
@@ -347,7 +346,9 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   ) : undefined;
 
   return (
-    <div className={clsx(multiSelectMode && classes.multiSelectPackageCard)}>
+    <div
+      className={clsx(!props.showCheckBox && classes.multiSelectPackageCard)}
+    >
       {!Boolean(props.hideContextMenuAndMultiSelect) && (
         <ResourcePathPopup
           isOpen={showAssociatedResourcesPopup}

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -21,10 +21,7 @@ import {
 import { ButtonText } from '../../../enums/enums';
 import { clickOnButtonInPackageContextMenu } from '../../../test-helpers/context-menu-test-helpers';
 import { IpcRenderer } from 'electron';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { getMultiSelectSelectedAttributionIds } from '../../../state/selectors/attribution-view-resource-selectors';
 
 const testResources: Resources = {
@@ -187,6 +184,7 @@ describe('The PackageCard', () => {
           name: 'packageName',
         }}
         onClick={doNothing}
+        showCheckBox={true}
       />,
       { store: testStore }
     );
@@ -194,7 +192,6 @@ describe('The PackageCard', () => {
     expect(screen.getByText('packageName'));
     expect(screen.queryByText('checkbox')).not.toBeInTheDocument();
 
-    store.dispatch(setMultiSelectMode(true));
     store.dispatch(setMultiSelectSelectedAttributionIds(['another_id']));
     fireEvent.click(screen.getByRole('checkbox') as Element);
     expect(

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -19,7 +19,6 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
   setAttributionIdMarkedForReplacement,
-  setMultiSelectMode,
   setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
@@ -127,7 +126,6 @@ describe('ReplaceAttributionPopup and do not change view', () => {
   test('does not show multi-select checkbox for attributions', () => {
     const testStore = createTestAppStore();
     setupTestState(testStore);
-    testStore.dispatch(setMultiSelectMode(true));
     testStore.dispatch(
       setMultiSelectSelectedAttributionIds(['test_marked_id'])
     );

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -69,7 +69,6 @@ export enum FilterType {
 }
 
 export enum CheckboxLabel {
-  MultiSelectMode = 'Multi-select',
   FirstParty = '1st Party',
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -25,12 +25,7 @@ import {
 } from '../../../test-helpers/context-menu-test-helpers';
 import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import {
-  ButtonText,
-  CheckboxLabel,
-  DiscreteConfidence,
-  View,
-} from '../../../enums/enums';
+import { ButtonText, DiscreteConfidence, View } from '../../../enums/enums';
 import {
   expectValueInConfidenceField,
   expectValueInTextBox,
@@ -43,10 +38,8 @@ import {
 import { clickOnCardInAttributionList } from '../../../test-helpers/package-panel-helpers';
 import {
   clickOnButton,
-  clickOnCheckbox,
   clickOnMultiSelectCheckboxInPackageCard,
   expectSelectCheckboxInPackageCardIsChecked,
-  getCheckbox,
   getParsedInputFileEnrichedWithTestData,
   goToView,
   mockElectronIpcRendererOn,
@@ -276,13 +269,6 @@ describe('In Attribution View the ContextMenu', () => {
     expectGlobalOnlyContextMenuForPreselectedAttribution(
       screen,
       'React, 16.5.0'
-    );
-    expect(getCheckbox(screen, CheckboxLabel.MultiSelectMode).checked).toEqual(
-      false
-    );
-    clickOnCheckbox(screen, CheckboxLabel.MultiSelectMode);
-    expect(getCheckbox(screen, CheckboxLabel.MultiSelectMode).checked).toEqual(
-      true
     );
 
     clickOnMultiSelectCheckboxInPackageCard(screen, 'React, 16.5.0');

--- a/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
@@ -6,13 +6,11 @@
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
   setAttributionIdMarkedForReplacement,
-  setMultiSelectMode,
   setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
   setTargetSelectedAttributionId,
 } from '../attribution-view-simple-actions';
 import {
-  getMultiSelectMode,
   getMultiSelectSelectedAttributionIds,
   getSelectedAttributionId,
   getTargetSelectedAttributionId,
@@ -45,13 +43,7 @@ describe('The load and navigation simple actions', () => {
       'test'
     );
   });
-  test('sets and gets multiSelectMode', () => {
-    const testStore = createTestAppStore();
-    expect(getMultiSelectMode(testStore.getState())).toBeFalsy();
 
-    testStore.dispatch(setMultiSelectMode(true));
-    expect(getMultiSelectMode(testStore.getState())).toBeTruthy();
-  });
   test('sets and gets multiSelectSelectedAttributionIds', () => {
     const testStore = createTestAppStore();
     expect(

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -44,7 +44,6 @@ import {
 } from '../all-views-simple-actions';
 import {
   setAttributionIdMarkedForReplacement,
-  setMultiSelectMode,
   setMultiSelectSelectedAttributionIds,
   setSelectedAttributionId,
 } from '../attribution-view-simple-actions';
@@ -486,7 +485,6 @@ describe('The savePackageInfo action', () => {
         })
       )
     );
-    testStore.dispatch(setMultiSelectMode(true));
     testStore.dispatch(
       setMultiSelectSelectedAttributionIds([testManualAttributionUuid_1])
     );
@@ -627,7 +625,6 @@ describe('The savePackageInfo action', () => {
       expectedProgressBarData
     );
 
-    testStore.dispatch(setMultiSelectMode(true));
     testStore.dispatch(
       setMultiSelectSelectedAttributionIds(['toReplaceUuid', 'uuid1'])
     );

--- a/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-view-simple-actions.ts
@@ -6,12 +6,10 @@
 import {
   ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
   ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS,
-  ACTION_SET_MULTI_SELECT_MODE,
   ACTION_SET_SELECTED_ATTRIBUTION_ID,
   ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
   SetAttributionIdMarkedForReplacement,
   SetMultiSelectSelectedAttributionIds,
-  SetMultiSelectMode,
   SetSelectedAttributionId,
   SetTargetSelectedAttributionIdAction,
 } from './types';
@@ -40,15 +38,6 @@ export function setAttributionIdMarkedForReplacement(
   return {
     type: ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT,
     payload: attributionIdMarkedForReplacement,
-  };
-}
-
-export function setMultiSelectMode(
-  multiSelectMode: boolean
-): SetMultiSelectMode {
-  return {
-    type: ACTION_SET_MULTI_SELECT_MODE,
-    payload: multiSelectMode,
   };
 }
 

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -66,7 +66,6 @@ export const ACTION_SET_BASE_URLS_FOR_SOURCES =
   'ACTION_SET_BASE_URLS_FOR_SOURCES';
 export const ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES =
   'ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES';
-export const ACTION_SET_MULTI_SELECT_MODE = 'ACTION_SET_MULTISELECT_MODE';
 export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
   'ACTION_SET_ATTRIBUTION_IDS_MARKED_FOR_MULTISELECT';
 
@@ -101,7 +100,6 @@ export type ResourceAction =
   | SetBaseUrlsForSources
   | SetAttributionIdMarkedForReplacement
   | SetExternalAttributionSources
-  | SetMultiSelectMode
   | SetMultiSelectSelectedAttributionIds;
 
 export interface ResetResourceStateAction {
@@ -268,11 +266,6 @@ export interface SetExternalAttributionSources {
 export interface SetAttributionIdMarkedForReplacement {
   type: typeof ACTION_SET_ATTRIBUTION_ID_MARKED_FOR_REPLACEMENT;
   payload: string;
-}
-
-export interface SetMultiSelectMode {
-  type: typeof ACTION_SET_MULTI_SELECT_MODE;
-  payload: boolean;
 }
 
 export interface SetMultiSelectSelectedAttributionIds {

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -24,14 +24,6 @@ import {
   updateActiveFilters,
   setTargetView,
 } from '../view-actions';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../../resource-actions/attribution-view-simple-actions';
-import {
-  getMultiSelectMode,
-  getMultiSelectSelectedAttributionIds,
-} from '../../../selectors/attribution-view-resource-selectors';
 
 describe('view actions', () => {
   test('sets view to AuditView as initial value', () => {
@@ -155,23 +147,6 @@ describe('view actions', () => {
     expect(
       getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
     ).toBe(true);
-  });
-
-  test('resets multi-select on view change', () => {
-    const testStore = createTestAppStore();
-    testStore.dispatch(setMultiSelectMode(true));
-    testStore.dispatch(setMultiSelectSelectedAttributionIds(['some_id']));
-
-    testStore.dispatch(navigateToView(View.Report));
-
-    expect(getMultiSelectMode(testStore.getState())).toBeFalsy();
-    expect(
-      getMultiSelectSelectedAttributionIds(testStore.getState())
-    ).toStrictEqual([]);
-
-    expect(isAuditViewSelected(testStore.getState())).toBe(false);
-    expect(isAttributionViewSelected(testStore.getState())).toBe(false);
-    expect(isReportViewSelected(testStore.getState())).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -28,10 +28,7 @@ import {
   OpenPopupActionPopupType,
   UpdateActiveFilters,
 } from './types';
-import {
-  setMultiSelectMode,
-  setMultiSelectSelectedAttributionIds,
-} from '../resource-actions/attribution-view-simple-actions';
+import { setMultiSelectSelectedAttributionIds } from '../resource-actions/attribution-view-simple-actions';
 
 export function resetViewState(): ResetViewStateAction {
   return { type: ACTION_RESET_VIEW_STATE };
@@ -45,7 +42,6 @@ export function navigateToView(view: View): AppThunkAction {
 
     dispatch(setTargetView(null));
     dispatch(setView(view));
-    dispatch(setMultiSelectMode(false));
     dispatch(setMultiSelectSelectedAttributionIds([]));
 
     const updatedTemporaryPackageInfo: PackageInfo =

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -40,7 +40,6 @@ import {
   ACTION_SET_FREQUENT_LICENSES,
   ACTION_SET_IS_SAVING_DISABLED,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
-  ACTION_SET_MULTI_SELECT_MODE,
   ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS,
   ACTION_SET_PROGRESS_BAR_DATA,
   ACTION_SET_PROJECT_METADATA,
@@ -99,7 +98,6 @@ export const initialResourceState: ResourceState = {
   attributionView: {
     selectedAttributionId: '',
     targetSelectedAttributionId: '',
-    multiSelectMode: false,
     multiSelectSelectedAttributionIds: [],
   },
   fileSearchPopup: {
@@ -133,7 +131,6 @@ export type ResourceState = {
   attributionView: {
     selectedAttributionId: string;
     targetSelectedAttributionId: string;
-    multiSelectMode: boolean;
     multiSelectSelectedAttributionIds: Array<string>;
   };
   fileSearchPopup: {
@@ -285,14 +282,6 @@ export const resourceState = (
         attributionView: {
           ...state.attributionView,
           targetSelectedAttributionId: action.payload,
-        },
-      };
-    case ACTION_SET_MULTI_SELECT_MODE:
-      return {
-        ...state,
-        attributionView: {
-          ...state.attributionView,
-          multiSelectMode: action.payload,
         },
       };
     case ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS:

--- a/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
@@ -26,10 +26,6 @@ export function getResourceIdsOfSelectedAttribution(
   return [];
 }
 
-export function getMultiSelectMode(state: State): boolean {
-  return state.resourceState.attributionView.multiSelectMode;
-}
-
 export function getMultiSelectSelectedAttributionIds(
   state: State
 ): Array<string> {


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Remove checkbox on the top
- Remove state
- Add new property to PackageCard

### Context and reason for change
- Checkbox in attribution view should always be shown

### How can the changes be tested
Changes can be test via yarn test:unit, yarn test:integration-ci and yarn test:e2e and in the UI
