### PR TITLE
Allow confirm selected attributions globally

### DIFF
--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -14,6 +14,7 @@ import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import UndoIcon from '@mui/icons-material/Undo';
 import DoneIcon from '@mui/icons-material/Done';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
+import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import MergeTypeIcon from '@mui/icons-material/MergeType';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
@@ -40,7 +41,8 @@ const BUTTON_TITLE_TO_ICON_MAP: {
   [buttonText in ButtonText]?: JSX.Element;
 } = {
   [ButtonText.Confirm]: <DoneIcon fontSize="small" />,
-  [ButtonText.ConfirmGlobally]: <DoneAllIcon fontSize="small" />,
+  [ButtonText.ConfirmGlobally]: <DoneOutlineIcon fontSize="small" />,
+  [ButtonText.ConfirmSelectedGlobally]: <DoneAllIcon fontSize="small" />,
   [ButtonText.Delete]: <DeleteOutlineIcon fontSize="small" />,
   [ButtonText.DeleteGlobally]: <DeleteIcon fontSize="small" />,
   [ButtonText.DeleteSelectedGlobally]: <DeleteSweepIcon fontSize="small" />,

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -47,6 +47,7 @@ export enum ButtonText {
   Cancel = 'Cancel',
   Confirm = 'Confirm',
   ConfirmGlobally = 'Confirm globally',
+  ConfirmSelectedGlobally = 'Confirm selected globally',
   Delete = 'Delete',
   DeleteGlobally = 'Delete globally',
   DeleteSelectedGlobally = 'Delete selected globally',


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Add confirm selected globally in context menu and adjust icons
- Show the button if at least one attribution is preselected
- Allow feature to confirm selected attributions globally

### Context and reason for change
- Having the feature to mutli-select attributions, we are able to allow more operations than deletion.

### How can the changes be tested
The changes can be tested in the UI and by run `yarn test:unit`

