### PR TITLE
ProgressBar: make every file with signal reachable through clicking

### DIFF
--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -45,7 +45,7 @@ export function ProgressBar(): ReactElement {
     useAppSelector(getProgressBarData);
 
   const onProgressBarClick = useOnProgressBarClick(
-    progressBarData?.filesWithNonInheritedSignalOnly || []
+    progressBarData?.resourcesWithNonInheritedSignalOnly || []
   );
 
   return (

--- a/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
@@ -87,7 +87,7 @@ describe('ProgressBar helpers', () => {
       filesWithManualAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 3,
       filesWithOnlyExternalAttributionCount: 3,
-      filesWithNonInheritedSignalOnly: ['file1', 'file2', 'file3'],
+      resourcesWithNonInheritedSignalOnly: ['file1', 'file2', 'file3'],
     };
     const expectedProgressBarBackground: string =
       'linear-gradient(to right,' +
@@ -123,7 +123,7 @@ describe('ProgressBar helpers', () => {
       [33, 33, 1, 33],
     ],
   ]).test(
-    'roundToAtLeastOnePercentAndNormalize rounds and subtracts difference from the maxium',
+    'roundToAtLeastOnePercentAndNormalize rounds and subtracts difference from the maximum',
     (input: Array<number>, expectedOutput: Array<number>) => {
       expect(roundToAtLeastOnePercentAndNormalize(input)).toEqual(
         expectedOutput

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -253,7 +253,7 @@ describe('The load and navigation simple actions', () => {
       filesWithManualAttributionCount: 4,
       filesWithOnlyExternalAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: ['/folder2/file2'],
+      resourcesWithNonInheritedSignalOnly: ['/folder2/file2', '/folder3/'],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -209,7 +209,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 0,
       filesWithOnlyExternalAttributionCount: 2,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [
+      resourcesWithNonInheritedSignalOnly: [
         '/root/src/something.js',
         '/root/readme.md',
       ],
@@ -219,7 +219,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: ['/root/readme.md'],
+      resourcesWithNonInheritedSignalOnly: ['/root/readme.md'],
     };
 
     const testStore = createTestAppStore();
@@ -276,7 +276,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
 
     testStore.dispatch(
@@ -367,14 +367,14 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: ['/root/src/something.js'],
+      resourcesWithNonInheritedSignalOnly: ['/root/src/something.js'],
     };
     const emptyTestTemporaryPackageInfo: PackageInfo = {};
 
@@ -605,7 +605,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
 
     const testStore = createTestAppStore();
@@ -681,14 +681,14 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: ['/folder/somethingElse.js'],
+      resourcesWithNonInheritedSignalOnly: ['/folder/somethingElse.js'],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -74,7 +74,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(2);
-    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
+    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
       '/thirdParty/package_1.tr.gz',
       '/thirdParty/package_2.tr.gz',
     ]);
@@ -140,7 +140,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(1);
-    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
+    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
       '/thirdParty/package_1.tr.gz',
     ]);
   });
@@ -231,10 +231,12 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(5);
-    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([
+    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
       '/folder1/breakpoint1/file1',
+      '/folder2/',
       '/folder2/breakpoint2/file3',
       '/folder3/breakpoint3/file5',
+      '/folder5/',
       '/folder5/file9',
     ]);
   });
@@ -285,7 +287,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(0);
-    expect(progressBarData.filesWithNonInheritedSignalOnly).toEqual([]);
+    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([]);
   });
 
   test('resourceHasOnlyPreSelectedAttributions with only pre-selected attributions', () => {
@@ -318,7 +320,7 @@ describe('The getUpdatedProgressBarData function', () => {
       filesWithManualAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
       filesWithOnlyExternalAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
     const resources: Resources = {
       dir1: { subdir1: { file1: 1 } },
@@ -341,7 +343,7 @@ describe('The getUpdatedProgressBarData function', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
-      filesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedSignalOnly: [],
     };
 
     updateProgressBarDataForResources(

--- a/src/Frontend/state/helpers/progress-bar-data-helpers.ts
+++ b/src/Frontend/state/helpers/progress-bar-data-helpers.ts
@@ -25,7 +25,7 @@ export function getUpdatedProgressBarData(
     filesWithManualAttributionCount: 0,
     filesWithOnlyPreSelectedAttributionCount: 0,
     filesWithOnlyExternalAttributionCount: 0,
-    filesWithNonInheritedSignalOnly: [],
+    resourcesWithNonInheritedSignalOnly: [],
   };
 
   updateProgressBarDataForResources(
@@ -111,13 +111,21 @@ export function updateProgressBarDataForResources(
         progressBarData.filesWithManualAttributionCount++;
       } else if (hasNonInheritedExternalAttributions) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
-        progressBarData.filesWithNonInheritedSignalOnly.push(path);
+        progressBarData.resourcesWithNonInheritedSignalOnly.push(path);
       } else if (hasParentExternalAttribution) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
       }
     }
 
     if (resourceCanHaveChildren) {
+      if (
+        !isFileWithChildren(path) &&
+        !hasManualAttribution &&
+        hasNonInheritedExternalAttributions
+      ) {
+        progressBarData.resourcesWithNonInheritedSignalOnly.push(path);
+      }
+
       const isBreakpoint = isAttributionBreakpoint(path);
       updateProgressBarDataForResources(
         progressBarData,

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -25,7 +25,7 @@ export interface ProgressBarData {
   filesWithManualAttributionCount: number;
   filesWithOnlyPreSelectedAttributionCount: number;
   filesWithOnlyExternalAttributionCount: number;
-  filesWithNonInheritedSignalOnly: Array<string>;
+  resourcesWithNonInheritedSignalOnly: Array<string>;
 }
 
 export interface PanelPackage {


### PR DESCRIPTION
Signed-off-by: Leslie Lazzarino <leslie.lazzarino@tngtech.com>

### Summary of changes

Folders with signals only can also be reached by means of clicking on the progress bar.

### Context and reason for change

When a folder has signal and no attribution his files are shown in the progress bar as having only signal. Anyway, those files and their parent folders with signals where unreachable by means of clicking on the progress bar.
 
### How can the changes be tested

By changing an input file to recreate such configuration.
