### PR TITLE
Remove hint if resource or its parent has signal

### DIFF
--- a/src/ElectronBackend/input/__tests__/cleanInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/cleanInputData.test.ts
@@ -17,6 +17,7 @@ import {
   cleanNonExistentResolvedExternalSignals,
   getAllResourcePaths,
   parseFrequentLicenses,
+  removeHintIfSignalsExist,
   sanitizeRawAttributions,
   sanitizeRawBaseUrlsForSources,
   sanitizeResourcesToAttributions,
@@ -341,6 +342,48 @@ describe('sanitizeResourcesToAttributions', () => {
       '/file1': ['uuid1'],
       '/folder1/': ['uuid2', 'uuid3'],
       '/folder1/file2': ['uuid1'],
+    });
+  });
+});
+
+describe('removeHintIfSignalsExist', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('removes hint as a external signal if the resource has other signals', () => {
+    const resourcesToAttributions: ResourcesToAttributions = {
+      '/file1': ['attr2', 'attr4'],
+    };
+    const attributions: Attributions = {
+      attr2: { source: { name: 'HINT', documentConfidence: 1 } },
+      attr4: {},
+    };
+    removeHintIfSignalsExist(resourcesToAttributions, attributions);
+    expect(resourcesToAttributions).toEqual({
+      '/file1': ['attr4'],
+    });
+    expect(attributions).toEqual({
+      attr4: {},
+    });
+  });
+
+  test('removes hint (globally) as a external signal if parent of the resource has other signals', () => {
+    const resourcesToAttributions: ResourcesToAttributions = {
+      '/file1/': ['attr4'],
+      '/file1/file2': ['attr2'],
+      '/file3': ['attr2'],
+    };
+    const attributions: Attributions = {
+      attr2: { source: { name: 'HINT', documentConfidence: 1 } },
+      attr4: {},
+    };
+    removeHintIfSignalsExist(resourcesToAttributions, attributions);
+    expect(resourcesToAttributions).toEqual({
+      '/file1/': ['attr4'],
+    });
+    expect(attributions).toEqual({
+      attr4: {},
     });
   });
 });

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -17,6 +17,7 @@ import {
   cleanNonExistentAttributions,
   cleanNonExistentResolvedExternalSignals,
   parseFrequentLicenses,
+  removeHintIfSignalsExist,
   sanitizeRawAttributions,
   sanitizeRawBaseUrlsForSources,
   sanitizeResourcesToAttributions,
@@ -101,6 +102,12 @@ export async function loadJsonFromFilePath(
   );
 
   log.info('Converting and cleaning data');
+  // Hints are now a special kind of external attribution,
+  // and will be supported in a less hacky way in the near future.
+  removeHintIfSignalsExist(
+    resourcesToExternalAttributions,
+    externalAttributions
+  );
   const parsedFileContent: ParsedFileContent = {
     metadata: parsingResult.metadata,
     resources: parsingResult.resources,

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -8,6 +8,7 @@ import { IpcRenderer } from 'electron';
 import React from 'react';
 import {
   Attributions,
+  ExternalAttributionSources,
   PackageInfo,
   Resources,
   ResourcesToAttributions,
@@ -211,6 +212,127 @@ describe('The ResourceDetailsViewer', () => {
 
     expect(screen.getByText('Signals in Folder Content'));
     expect(screen.getByText('JQuery, 1.0'));
+  });
+
+  test('shows Hint as External Packages', () => {
+    const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
+    const externalAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'Another Package',
+        source: {
+          name: 'HINT',
+          documentConfidence: 1,
+        },
+      },
+    };
+    const resourcesToExternalAttributions: ResourcesToAttributions = {
+      '/test_id': ['uuid_1'],
+    };
+    const externalAttributionSources: ExternalAttributionSources = {
+      HINT: {
+        name: 'Hint',
+        priority: 1,
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions,
+          resourcesToExternalAttributions,
+          externalAttributionSources,
+        })
+      )
+    );
+
+    store.dispatch(setSelectedResourceId('/test_id'));
+    store.dispatch(setTemporaryPackageInfo({}));
+
+    expect(screen.getByText('Signals'));
+    expect(screen.getByText('Hint'));
+  });
+
+  test('hides Hint as External Packages if has another signal', () => {
+    const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
+    const externalAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'Another Package',
+        source: {
+          name: 'HINT',
+          documentConfidence: 1,
+        },
+      },
+      uuid_2: {
+        packageName: 'JQuery',
+        packageVersion: '1.0',
+      },
+    };
+    const resourcesToExternalAttributions: ResourcesToAttributions = {
+      '/test_id': ['uuid_1', 'uuid_2'],
+    };
+    const externalAttributionSources: ExternalAttributionSources = {
+      HINT: {
+        name: 'Hint',
+        priority: 1,
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions,
+          resourcesToExternalAttributions,
+          externalAttributionSources,
+        })
+      )
+    );
+
+    store.dispatch(setSelectedResourceId('/test_id'));
+    store.dispatch(setTemporaryPackageInfo({}));
+
+    expect(screen.getByText('Signals'));
+    expect(screen.getByText('JQuery, 1.0'));
+    expect(screen.queryByText('Hint')).toBeFalsy;
+  });
+
+  test('hides Hint as External Packages if parent has another signal', () => {
+    const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
+    const externalAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'Another Package',
+        source: {
+          name: 'HINT',
+          documentConfidence: 1,
+        },
+      },
+      uuid_2: {
+        packageName: 'JQuery',
+        packageVersion: '1.0',
+      },
+    };
+    const resourcesToExternalAttributions: ResourcesToAttributions = {
+      '/test_id': ['uuid_2'],
+      '/test_id/subdirectory': ['uuid_1'],
+    };
+    const externalAttributionSources: ExternalAttributionSources = {
+      HINT: {
+        name: 'Hint',
+        priority: 1,
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions,
+          resourcesToExternalAttributions,
+          externalAttributionSources,
+        })
+      )
+    );
+
+    store.dispatch(setSelectedResourceId('/test_id/subdirectory'));
+    store.dispatch(setTemporaryPackageInfo({}));
+
+    expect(screen.getByText('Signals'));
+    expect(screen.queryByText('Hint')).toBeFalsy;
   });
 
   test('selects an external package and a manual package, showing the right info', () => {

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -12,6 +12,7 @@ import {
 } from '@testing-library/react';
 import {
   Attributions,
+  ExternalAttributionSources,
   ParsedFileContent,
   Resources,
   ResourcesToAttributions,
@@ -66,6 +67,7 @@ export function getParsedInputFileEnrichedWithTestData(testData: {
   resourcesToExternalAttributions?: ResourcesToAttributions;
   attributionBreakpoints?: Set<string>;
   filesWithChildren?: Set<string>;
+  externalAttributionSources?: ExternalAttributionSources;
 }): ParsedFileContent {
   const defaultTestResources: Resources = {
     thirdParty: {
@@ -101,6 +103,7 @@ export function getParsedInputFileEnrichedWithTestData(testData: {
     },
     attributionBreakpoints: testData.attributionBreakpoints || new Set(),
     filesWithChildren: testData.filesWithChildren || new Set(),
+    externalAttributionSources: testData.externalAttributionSources || {},
   };
 }
 


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- While inputting data, concatenate attributions with children's attributions, and check whether hint and other signals exists
- If it is the case, remove the hint signal 

### Context and reason for change
User does not want to see the hint signal if the resource has other signals or its parent have other signals.

### How can the changes be tested
The changes can be tested by running `yarn test:unit` or add a  signal (external attribution) in the `oppsum_input.json` file for either `/package.json` or its parent (`/`) and test in the UI.

