### PR TITLE
Extract hard-coded root folder.

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -29,6 +29,8 @@ import { VirtualizedTree } from '../VirtualisedTree/VirtualizedTree';
 import { Resources } from '../../../shared/shared-types';
 import { getTreeItemLabel } from './get-tree-item-label';
 
+const ROOT_FOLDER_LABEL = '';
+
 export function ResourceBrowser(): ReactElement | null {
   const resources = useAppSelector(getResources);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
@@ -97,16 +99,16 @@ export function ResourceBrowser(): ReactElement | null {
       );
   }
 
-  return (
+  return resources ? (
     <VirtualizedTree
       expandedIds={expandedIds}
       isFileWithChildren={getFileWithChildrenCheck(filesWithChildren)}
       onSelect={handleSelect}
       onToggle={handleToggle}
-      resources={resources}
+      resources={{ [ROOT_FOLDER_LABEL]: resources }}
       selectedResourceId={selectedResourceId}
       ariaLabel={'resource browser'}
       getTreeItemLabel={getTreeItemLabelGetter()}
     />
-  );
+  ) : null;
 }

--- a/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
@@ -54,7 +54,7 @@ const useStyles = makeStyles({
 });
 
 interface VirtualizedTreeProps {
-  resources: Resources | null;
+  resources: Resources;
   getTreeItemLabel: (
     resourceName: string,
     resource: Resources | 1,
@@ -74,19 +74,18 @@ export function VirtualizedTree(
   const classes = useStyles();
   const treeHeight: number = useWindowHeight() - topBarHeight - 4;
 
-  const treeItems: Array<ReactElement> = props.resources
-    ? renderTree(
-        { '': props.resources },
-        '',
-        classes,
-        props.expandedIds,
-        props.selectedResourceId,
-        props.isFileWithChildren,
-        props.onSelect,
-        props.onToggle,
-        props.getTreeItemLabel
-      )
-    : [];
+  // eslint-disable-next-line testing-library/render-result-naming-convention
+  const treeItems: Array<ReactElement> = renderTree(
+    props.resources,
+    '',
+    classes,
+    props.expandedIds,
+    props.selectedResourceId,
+    props.isFileWithChildren,
+    props.onSelect,
+    props.onToggle,
+    props.getTreeItemLabel
+  );
 
   return props.resources ? (
     <div aria-label={props.ariaLabel} className={classes.root}>

--- a/src/Frontend/Components/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
+++ b/src/Frontend/Components/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
@@ -11,34 +11,52 @@ import { doNothing } from '../../../util/do-nothing';
 
 describe('The VirtualizedTree', () => {
   const testResources: Resources = {
-    thirdParty: {
-      'package_1.tr.gz': 1,
-      'package_2.tr.gz': 1,
-    },
-    root: {
-      src: {
-        'something.js': 1,
+    '': {
+      thirdParty: {
+        'package_1.tr.gz': 1,
+        'package_2.tr.gz': 1,
       },
-      'readme.md': 1,
+      root: {
+        src: {
+          'something.js': 1,
+        },
+        'package.json': 1,
+      },
     },
+    docs: { 'readme.md': 1 },
   };
 
   test('renders VirtualizedTree', () => {
     render(
       <VirtualizedTree
-        expandedIds={['/']}
+        expandedIds={['/', '/thirdParty/', '/root/', '/root/src/', 'docs/']}
         isFileWithChildren={(path: string): boolean => Boolean(path)}
         onSelect={doNothing}
         onToggle={doNothing}
         resources={testResources}
         selectedResourceId={'/thirdParty/'}
-        getTreeItemLabel={(resourceName, resource, nodeId): ReactElement => (
-          <div>{nodeId}</div>
-        )}
+        getTreeItemLabel={
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          (resourceName, resource, nodeId): ReactElement => (
+            <div>{resourceName || '/'}</div>
+          )
+        }
       />
     );
-    expect(screen.getByText('/'));
-    expect(screen.getByText('/thirdParty/'));
-    expect(screen.getByText('/root/'));
+
+    for (const label of [
+      '/',
+      'thirdParty',
+      'package_1.tr.gz',
+      'package_2.tr.gz',
+      'root',
+      'src',
+      'something.js',
+      'package.json',
+      'docs',
+      'readme.md',
+    ]) {
+      expect(screen.getByText(label));
+    }
   });
 });


### PR DESCRIPTION
Signed-off-by: Leslie Lazzarino <leslie.lazzarino@tngtech.com>

### Summary of changes

The resource root folder, added in the UI to the resources provided in the input file, was hardcoded inside the VirtualizedTree. Now it added to the resources before giving them to the tree. 

### Context and reason for change

Step in the direction of making the VirtualizedTree more generic and extract it to a separate package

### How can the changes be tested

Basically just a refactoring. The file tree in the app should still look and work as before.

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

