### PR TITLE
Add max tree height and card height to VirtualizedTree props.

### DIFF
--- a/src/ElectronBackend/input/cleanInputData.ts
+++ b/src/ElectronBackend/input/cleanInputData.ts
@@ -18,7 +18,7 @@ import {
   RawBaseUrlsForSources,
   RawFrequentLicense,
 } from '../types/types';
-import { canHaveChildren } from '../../Frontend/util/can-have-children';
+import { canResourceHaveChildren } from '../../Frontend/util/can-resource-have-children';
 
 function addTrailingSlashIfAbsent(resourcePath: string): string {
   return resourcePath.endsWith('/') ? resourcePath : resourcePath.concat('/');
@@ -30,7 +30,7 @@ function getListOfResourcePaths(
   resources: Resources
 ): Array<string> {
   const fullResourcePath =
-    basePath + resourceName + (canHaveChildren(resources) ? '/' : '');
+    basePath + resourceName + (canResourceHaveChildren(resources) ? '/' : '');
 
   return [fullResourcePath].concat(
     Object.keys(resources)

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -28,6 +28,10 @@ import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import { VirtualizedTree } from '../VirtualisedTree/VirtualizedTree';
 import { Resources } from '../../../shared/shared-types';
 import { getTreeItemLabel } from './get-tree-item-label';
+import { useWindowHeight } from '../../util/use-window-height';
+import { topBarHeight } from '../TopBar/TopBar';
+
+const TREE_ROW_HEIGHT = 20;
 
 const ROOT_FOLDER_LABEL = '';
 
@@ -99,6 +103,8 @@ export function ResourceBrowser(): ReactElement | null {
       );
   }
 
+  const maxTreeHeight: number = useWindowHeight() - topBarHeight - 4;
+
   return resources ? (
     <VirtualizedTree
       expandedIds={expandedIds}
@@ -109,6 +115,8 @@ export function ResourceBrowser(): ReactElement | null {
       selectedResourceId={selectedResourceId}
       ariaLabel={'resource browser'}
       getTreeItemLabel={getTreeItemLabelGetter()}
+      cardHeight={TREE_ROW_HEIGHT}
+      maxHeight={maxTreeHeight}
     />
   ) : null;
 }

--- a/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsTabs/resource-details-tabs-helpers.ts
@@ -12,7 +12,7 @@ import {
   ResourcesToAttributions,
 } from '../../../shared/shared-types';
 import { getAttributedChildren } from '../../util/get-attributed-children';
-import { isIdOfResourceWithChildren } from '../../util/can-have-children';
+import { isIdOfResourceWithChildren } from '../../util/can-resource-have-children';
 
 export interface PanelData {
   title: PackagePanelTitle;

--- a/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
@@ -7,14 +7,17 @@ import makeStyles from '@mui/styles/makeStyles';
 import React, { ReactElement } from 'react';
 import { renderTree } from './render-tree';
 import { List } from '../List/List';
-import { useWindowHeight } from '../../util/use-window-height';
 import {
   OpossumColors,
   resourceBrowserWidthInPixels,
 } from '../../shared-styles';
-import { topBarHeight } from '../TopBar/TopBar';
 import { Resources } from '../../../shared/shared-types';
-import { PathPredicate } from '../../types/types';
+import {
+  Height,
+  NumberOfDisplayedItems,
+  PathPredicate,
+} from '../../types/types';
+import { min } from 'lodash';
 
 const useStyles = makeStyles({
   root: {
@@ -53,6 +56,8 @@ const useStyles = makeStyles({
   },
 });
 
+const DEFAULT_MAX_TREE_DISPLAYED_ITEMS = 5;
+
 interface VirtualizedTreeProps {
   resources: Resources;
   getTreeItemLabel: (
@@ -66,13 +71,14 @@ interface VirtualizedTreeProps {
   onSelect: (event: React.ChangeEvent<unknown>, nodeId: string) => void;
   onToggle: (nodeIdsToExpand: Array<string>) => void;
   ariaLabel?: string;
+  cardHeight: number;
+  maxHeight?: number;
 }
 
 export function VirtualizedTree(
   props: VirtualizedTreeProps
 ): ReactElement | null {
   const classes = useStyles();
-  const treeHeight: number = useWindowHeight() - topBarHeight - 4;
 
   // eslint-disable-next-line testing-library/render-result-naming-convention
   const treeItems: Array<ReactElement> = renderTree(
@@ -87,13 +93,22 @@ export function VirtualizedTree(
     props.getTreeItemLabel
   );
 
+  const maxListLength: NumberOfDisplayedItems | Height = props.maxHeight
+    ? { height: props.maxHeight }
+    : {
+        numberOfDisplayedItems: min([
+          treeItems.length,
+          DEFAULT_MAX_TREE_DISPLAYED_ITEMS,
+        ]) as number,
+      };
+
   return props.resources ? (
     <div aria-label={props.ariaLabel} className={classes.root}>
       <div className={classes.content}>
         <List
           length={treeItems.length}
-          max={{ height: treeHeight }}
-          cardVerticalDistance={20}
+          max={maxListLength}
+          cardVerticalDistance={props.cardHeight}
           getListItem={(index: number): ReactElement => treeItems[index]}
           alwaysShowHorizontalScrollBar={true}
         />

--- a/src/Frontend/Components/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
+++ b/src/Frontend/Components/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
@@ -41,6 +41,8 @@ describe('The VirtualizedTree', () => {
             <div>{resourceName || '/'}</div>
           )
         }
+        cardHeight={20}
+        maxHeight={5000}
       />
     );
 

--- a/src/Frontend/state/helpers/file-search-helpers.ts
+++ b/src/Frontend/state/helpers/file-search-helpers.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Resources } from '../../../shared/shared-types';
-import { canHaveChildren } from '../../util/can-have-children';
+import { canResourceHaveChildren } from '../../util/can-resource-have-children';
 
 export function getPathsFromResources(resources: Resources): Array<string> {
   const paths = getPathsFromResourcesHelper(resources);
@@ -20,10 +20,10 @@ function getPathsFromResourcesHelper(
   Object.keys(resources).forEach((resourceName) => {
     const resource: Resources | 1 = resources[resourceName];
     const path = `${parentPath}${resourceName}${
-      canHaveChildren(resource) ? '/' : ''
+      canResourceHaveChildren(resource) ? '/' : ''
     }`;
     paths.push(path);
-    if (canHaveChildren(resource)) {
+    if (canResourceHaveChildren(resource)) {
       const newPaths: Array<string> = getPathsFromResourcesHelper(
         resource,
         path

--- a/src/Frontend/state/helpers/progress-bar-data-helpers.ts
+++ b/src/Frontend/state/helpers/progress-bar-data-helpers.ts
@@ -9,7 +9,7 @@ import {
   ResourcesToAttributions,
 } from '../../../shared/shared-types';
 import { PathPredicate, ProgressBarData } from '../../types/types';
-import { canHaveChildren } from '../../util/can-have-children';
+import { canResourceHaveChildren } from '../../util/can-resource-have-children';
 
 export function getUpdatedProgressBarData(
   resources: Resources,
@@ -78,7 +78,7 @@ export function updateProgressBarDataForResources(
   for (const resourceName of Object.keys(resources)) {
     const resource: Resources | 1 = resources[resourceName];
     const path = `${parentPath}${resourceName}${
-      canHaveChildren(resource) ? '/' : ''
+      canResourceHaveChildren(resource) ? '/' : ''
     }`;
 
     const hasOnlyPreselectedAttributionFromParent = Boolean(
@@ -101,7 +101,7 @@ export function updateProgressBarDataForResources(
     const hasNonInheritedExternalAttributions = Boolean(
       resourcesToExternalAttributions[path]
     );
-    const resourceCanHaveChildren = canHaveChildren(resource);
+    const resourceCanHaveChildren = canResourceHaveChildren(resource);
 
     if (!resourceCanHaveChildren || isFileWithChildren(path)) {
       progressBarData.fileCount++;

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -21,7 +21,7 @@ import { PathPredicate, State } from '../../types/types';
 import { getManualAttributions } from '../selectors/all-views-resource-selectors';
 import { v4 as uuid4 } from 'uuid';
 import { remove } from 'lodash';
-import { isIdOfResourceWithChildren } from '../../util/can-have-children';
+import { isIdOfResourceWithChildren } from '../../util/can-resource-have-children';
 
 export function createManualAttribution(
   manualData: AttributionData,

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -23,7 +23,7 @@ import {
 import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
-import { canHaveChildren } from '../util/can-have-children';
+import { canResourceHaveChildren } from '../util/can-resource-have-children';
 
 export const TEST_TIMEOUT = 15000;
 
@@ -108,7 +108,7 @@ function getResourceIdOfRoot(resources: Resources): string {
   return (
     '/' +
     Object.keys(resources)[0] +
-    (canHaveChildren(resources[Object.keys(resources)[0]]) ? '' : '/')
+    (canResourceHaveChildren(resources[Object.keys(resources)[0]]) ? '' : '/')
   );
 }
 

--- a/src/Frontend/util/__tests__/can-have-children.test..ts
+++ b/src/Frontend/util/__tests__/can-have-children.test..ts
@@ -5,21 +5,21 @@
 
 import { Resources } from '../../../shared/shared-types';
 import {
-  canHaveChildren,
+  canResourceHaveChildren,
   isIdOfResourceWithChildren,
-} from '../can-have-children';
+} from '../can-resource-have-children';
 
 describe('canHaveChildren', () => {
   test('returns true for a folder', () => {
     const testResources: Resources = {};
 
-    expect(canHaveChildren(testResources)).toBe(true);
+    expect(canResourceHaveChildren(testResources)).toBe(true);
   });
 
   test('returns false for a file', () => {
     const testFileFromResources = 1;
 
-    expect(canHaveChildren(testFileFromResources)).toBe(false);
+    expect(canResourceHaveChildren(testFileFromResources)).toBe(false);
   });
 });
 

--- a/src/Frontend/util/can-resource-have-children.ts
+++ b/src/Frontend/util/can-resource-have-children.ts
@@ -5,7 +5,7 @@
 
 import { Resources } from '../../shared/shared-types';
 
-export function canHaveChildren(
+export function canResourceHaveChildren(
   resource: Resources | 1
 ): resource is Resources {
   return resource !== 1;

--- a/src/Frontend/util/get-attributions-with-resources.ts
+++ b/src/Frontend/util/get-attributions-with-resources.ts
@@ -14,9 +14,9 @@ import {
 } from '../../shared/shared-types';
 import { PathPredicate } from '../types/types';
 import {
-  canHaveChildren,
+  canResourceHaveChildren,
   isIdOfResourceWithChildren,
-} from './can-have-children';
+} from './can-resource-have-children';
 import { removeTrailingSlashIfFileWithChildren } from './remove-trailing-slash-if-file-with-children';
 
 export function getAttributionsWithResources(
@@ -134,7 +134,7 @@ function getAllChildPathsOfFolder(
 
   for (const directChild of Object.keys(childTree)) {
     const childSubtree = childTree[directChild];
-    if (canHaveChildren(childSubtree)) {
+    if (canResourceHaveChildren(childSubtree)) {
       const directChildPath = folderPath + directChild + '/';
       if (isAttributionBreakpoint(directChildPath)) {
         continue;

--- a/src/Frontend/util/lodash-extension-utils.ts
+++ b/src/Frontend/util/lodash-extension-utils.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { remove } from 'lodash';
-import { isIdOfResourceWithChildren } from './can-have-children';
+import { isIdOfResourceWithChildren } from './can-resource-have-children';
 
 export function replaceInArray<T>(
   array: Array<T>,


### PR DESCRIPTION
Signed-off-by: Leslie Lazzarino <leslie.lazzarino@tngtech.com>

### Summary of changes

maxTreeHeight and cardHeight are now properties of the VirtualizedTree, instead of being hard coded somewhere inside. Also the naming scheme in RenderTree has been made more consistent, avoiding the use of terms like "folder" and "file" where expandable/simple nodes are meant.
 
### Context and reason for change

Making VirtualizedTree more generic for package extraction.

### How can the changes be tested

Basically a refactoring, the file tree in the app should work like before.

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

