### PR TITLE
Add a popup for Report view for editing

### DIFF
--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -260,7 +260,8 @@ export function usePurl(
 
 export function useRows(
   view: View,
-  resetViewIfThisIdChanges = ''
+  resetViewIfThisIdChanges = '',
+  smallerLicenseTextOrCommentField?: boolean
 ): {
   isLicenseTextShown: boolean;
   setIsLicenseTextShown: Dispatch<SetStateAction<boolean>>;
@@ -269,14 +270,18 @@ export function useRows(
   commentRows: number;
 } {
   const [isLicenseTextShown, setIsLicenseTextShown] = useState<boolean>(false);
-  const licenseTextRows = getLicenseTextMaxRows(useWindowHeight(), view);
+  const reduceRowsCount = smallerLicenseTextOrCommentField ? 5 : 0;
+  const licenseTextRows =
+    getLicenseTextMaxRows(useWindowHeight(), view) - reduceRowsCount;
 
   useEffect(() => {
     setIsLicenseTextShown(false);
   }, [resetViewIfThisIdChanges]);
 
   const copyrightRows = isLicenseTextShown ? 1 : 6;
-  const commentRows = isLicenseTextShown ? 1 : Math.max(licenseTextRows - 2, 1);
+  const commentRows = isLicenseTextShown
+    ? 1
+    : Math.max(licenseTextRows - 2, 1) - reduceRowsCount;
 
   return {
     isLicenseTextShown,

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -11,7 +11,6 @@ import { PackageInfo } from '../../../shared/shared-types';
 import { getTemporaryPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 import { ResourcesList } from '../ResourcesList/ResourcesList';
-import { setUpdateTemporaryPackageInfoForCreator } from '../ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers';
 import { isEqual } from 'lodash';
 import {
   deleteAttributionGloballyAndSave,
@@ -25,8 +24,9 @@ import {
 } from '../../state/selectors/attribution-view-resource-selectors';
 import { OpossumColors } from '../../shared-styles';
 import { useWindowHeight } from '../../util/use-window-height';
-import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { PopupType } from '../../enums/enums';
+import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 
 const useStyles = makeStyles({
   root: {
@@ -88,10 +88,7 @@ export function AttributionDetailsViewer(): ReactElement | null {
       dispatch(deleteAttributionGloballyAndSave(selectedAttributionId));
     } else {
       dispatch(
-        openPopupWithTargetAttributionId(
-          PopupType.ConfirmDeletionPopup,
-          selectedAttributionId
-        )
+        openPopup(PopupType.ConfirmDeletionPopup, selectedAttributionId)
       );
     }
   }
@@ -116,9 +113,7 @@ export function AttributionDetailsViewer(): ReactElement | null {
         displayPackageInfo={temporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoFor}
         onSaveButtonClick={dispatchSavePackageInfo}
-        onSaveGloballyButtonClick={(): void => {}}
         onDeleteButtonClick={deleteAttribution}
-        onDeleteGloballyButtonClick={(): void => {}}
         setTemporaryPackageInfo={(packageInfo: PackageInfo): void => {
           dispatch(setTemporaryPackageInfo(packageInfo));
         }}

--- a/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
@@ -7,15 +7,16 @@ import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
-import { getTargetAttributionId } from '../../state/selectors/view-selector';
+import { getPopupAttributionId } from '../../state/selectors/view-selector';
 
 export function ConfirmDeletionGloballyPopup(): ReactElement {
-  const targetAttributionId: string = useAppSelector(getTargetAttributionId);
+  const targetAttributionId = useAppSelector(getPopupAttributionId);
 
   const dispatch = useAppDispatch();
 
   function deleteAttributionGlobally(): void {
-    dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
+    targetAttributionId &&
+      dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
   }
 
   return (

--- a/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
@@ -7,7 +7,7 @@ import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getSelectedView,
-  getTargetAttributionId,
+  getPopupAttributionId,
 } from '../../state/selectors/view-selector';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
@@ -20,17 +20,19 @@ import { View } from '../../enums/enums';
 export function ConfirmDeletionPopup(): ReactElement {
   const view = useAppSelector(getSelectedView);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
-  const targetAttributionId = useAppSelector(getTargetAttributionId);
+  const targetAttributionId = useAppSelector(getPopupAttributionId);
 
   const dispatch = useAppDispatch();
 
   function deleteAttributionForResource(): void {
     if (view === View.Audit) {
-      dispatch(
-        deleteAttributionAndSave(selectedResourceId, targetAttributionId)
-      );
+      targetAttributionId &&
+        dispatch(
+          deleteAttributionAndSave(selectedResourceId, targetAttributionId)
+        );
     } else {
-      dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
+      targetAttributionId &&
+        dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
     }
   }
 

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement, useCallback } from 'react';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { ButtonText } from '../../enums/enums';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
+import {
+  getIsSavingDisabled,
+  getTemporaryPackageInfo,
+} from '../../state/selectors/all-views-resource-selectors';
+import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
+import { PackageInfo } from '../../../shared/shared-types';
+import {
+  savePackageInfo,
+  savePackageInfoIfSavingIsNotDisabled,
+} from '../../state/actions/resource-actions/save-actions';
+import { getPopupAttributionId } from '../../state/selectors/view-selector';
+import { closeEditAttributionPopupOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
+import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
+
+export function EditAttributionPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+  const popupAttributionId = useAppSelector(getPopupAttributionId);
+  const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
+  const setUpdateTemporaryPackageInfoFor =
+    setUpdateTemporaryPackageInfoForCreator(dispatch, temporaryPackageInfo);
+
+  const saveFileRequestListener = useCallback(() => {
+    dispatch(
+      savePackageInfoIfSavingIsNotDisabled(
+        null,
+        popupAttributionId,
+        temporaryPackageInfo
+      )
+    );
+  }, [dispatch, popupAttributionId, temporaryPackageInfo]);
+
+  const dispatchSavePackageInfo = useCallback(() => {
+    dispatch(savePackageInfo(null, popupAttributionId, temporaryPackageInfo));
+  }, [dispatch, popupAttributionId, temporaryPackageInfo]);
+
+  function checkForModifiedPackageInfoBeforeClosing(): void {
+    popupAttributionId &&
+      dispatch(closeEditAttributionPopupOrOpenUnsavedPopup(popupAttributionId));
+  }
+  function savePackageInfoBeforeClosing(): void {
+    dispatchSavePackageInfo();
+    dispatch(closePopup());
+  }
+  const isSavingDisabled = useAppSelector(getIsSavingDisabled);
+
+  return (
+    <NotificationPopup
+      content={
+        <AttributionColumn
+          isEditable
+          areButtonsHidden
+          showManualAttributionData
+          displayPackageInfo={temporaryPackageInfo}
+          setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoFor}
+          setTemporaryPackageInfo={(packageInfo: PackageInfo): void => {
+            dispatch(setTemporaryPackageInfo(packageInfo));
+          }}
+          saveFileRequestListener={saveFileRequestListener}
+          smallerLicenseTextOrCommentField
+        />
+      }
+      header={'Edit Attribution'}
+      isOpen={true}
+      fullWidth={true}
+      leftButtonText={ButtonText.Cancel}
+      rightButtonText={ButtonText.Save}
+      onBackdropClick={checkForModifiedPackageInfoBeforeClosing}
+      onEscapeKeyDown={checkForModifiedPackageInfoBeforeClosing}
+      onLeftButtonClick={checkForModifiedPackageInfoBeforeClosing}
+      onRightButtonClick={savePackageInfoBeforeClosing}
+      isRightButtonDisabled={isSavingDisabled}
+    />
+  );
+}

--- a/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { EditAttributionPopup } from '../EditAttributionPopup';
+import {
+  Attributions,
+  PackageInfo,
+  Resources,
+} from '../../../../shared/shared-types';
+import {
+  navigateToView,
+  openPopup,
+} from '../../../state/actions/view-actions/view-actions';
+import { ButtonText, PopupType, View } from '../../../enums/enums';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import { IpcRenderer } from 'electron';
+import { setTemporaryPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
+import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
+import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
+
+let originalIpcRenderer: IpcRenderer;
+
+describe('The EditAttributionPopup', () => {
+  beforeAll(() => {
+    originalIpcRenderer = global.window.ipcRenderer;
+    global.window.ipcRenderer = {
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      invoke: jest.fn(),
+    } as unknown as IpcRenderer;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  afterAll(() => {
+    // Important to restore the original value.
+    global.window.ipcRenderer = originalIpcRenderer;
+  });
+
+  const testResources: Resources = {
+    thirdParty: {
+      'package_1.tr.gz': 1,
+      'package_2.tr.gz': 1,
+    },
+  };
+  const testTemporaryPackageInfo: PackageInfo = {
+    attributionConfidence: 20,
+    packageName: 'jQuery',
+    packageVersion: '16.5.0',
+    packagePURLAppendix: '?appendix',
+    packageNamespace: 'namespace',
+    packageType: 'type',
+    comment: 'some comment',
+    copyright: 'Copyright Doe Inc. 2019',
+    licenseText: 'Permission is hereby granted',
+    licenseName: 'Made up license name',
+    url: 'www.1999.com',
+  };
+  const testAttributions: Attributions = {
+    test_selected_id: testTemporaryPackageInfo,
+    test_marked_id: { packageName: 'Vue' },
+  };
+  const testResourcesToManualAttributions = {
+    'package_1.tr.gz': ['test_selected_id'],
+    'package_2.tr.gz': ['test_marked_id'],
+  };
+
+  test('renders and clicks cancel closes the popup', () => {
+    const expectedHeader = 'Edit Attribution';
+    const { store } = renderComponentWithStore(<EditAttributionPopup />);
+    store.dispatch(navigateToView(View.Report));
+    store.dispatch(
+      openPopup(PopupType.EditAttributionPopup, 'test_selected_id')
+    );
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    store.dispatch(setSelectedAttributionId('test_selected_id'));
+    store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+
+    expect(screen.getByText(expectedHeader)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jQuery')).toBeInTheDocument();
+
+    fireEvent.click(screen.queryByText(ButtonText.Cancel) as Element);
+    expect(getOpenPopup(store.getState())).toBe(null);
+  });
+
+  test('renders and clicks cancel opens NotSavedPopup if package info has been changed', () => {
+    const expectedHeader = 'Edit Attribution';
+    const { store } = renderComponentWithStore(<EditAttributionPopup />);
+    store.dispatch(navigateToView(View.Report));
+    store.dispatch(
+      openPopup(PopupType.EditAttributionPopup, 'test_selected_id')
+    );
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    const changedTestTemporaryPackageInfo = {
+      ...testTemporaryPackageInfo,
+      comment: 'changed comment',
+    };
+
+    store.dispatch(setSelectedAttributionId('test_selected_id'));
+    store.dispatch(setTemporaryPackageInfo(changedTestTemporaryPackageInfo));
+
+    expect(screen.getByText(expectedHeader)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jQuery')).toBeInTheDocument();
+
+    fireEvent.click(screen.queryByText(ButtonText.Cancel) as Element);
+    expect(getOpenPopup(store.getState())).toBe(PopupType.NotSavedPopup);
+  });
+
+  test('renders and clicks save saves changed  package info', () => {
+    const expectedHeader = 'Edit Attribution';
+    const { store } = renderComponentWithStore(<EditAttributionPopup />);
+    store.dispatch(navigateToView(View.Report));
+    store.dispatch(
+      openPopup(PopupType.EditAttributionPopup, 'test_selected_id')
+    );
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    const changedTestTemporaryPackageInfo = {
+      ...testTemporaryPackageInfo,
+      comment: 'changed comment',
+    };
+
+    store.dispatch(setSelectedAttributionId('test_selected_id'));
+    store.dispatch(setTemporaryPackageInfo(changedTestTemporaryPackageInfo));
+
+    expect(screen.getByText(expectedHeader)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('jQuery')).toBeInTheDocument();
+
+    fireEvent.click(screen.queryByText(ButtonText.Save) as Element);
+    expect(getOpenPopup(store.getState())).toBe(null);
+    expect(getTemporaryPackageInfo(store.getState()).comment).toBe(
+      changedTestTemporaryPackageInfo.comment
+    );
+  });
+});

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -15,6 +15,7 @@ import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/Co
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
 import { useAppSelector } from '../../state/hooks';
 import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup';
+import { EditAttributionPopup } from '../EditAttributionPopup/EditAttributionPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -36,6 +37,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <ConfirmDeletionPopup />;
     case PopupType.ConfirmMultiSelectDeletionPopup:
       return <ConfirmMultiSelectDeletionPopup />;
+    case PopupType.EditAttributionPopup:
+      return <EditAttributionPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.tests.tsx
@@ -4,10 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import {
-  openPopup,
-  openPopupWithTargetAttributionId,
-} from '../../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../../state/actions/view-actions/view-actions';
 import {
   createTestAppStore,
   renderComponentWithStore,
@@ -73,12 +70,7 @@ describe('The GlobalPopUp', () => {
     renderComponentWithStore(<GlobalPopup />, {
       store: testStore,
     });
-    testStore.dispatch(
-      openPopupWithTargetAttributionId(
-        PopupType.ReplaceAttributionPopup,
-        'uuid1'
-      )
-    );
+    testStore.dispatch(openPopup(PopupType.ReplaceAttributionPopup, 'uuid1'));
 
     expect(
       screen.getByText('This removes the following attribution')
@@ -87,9 +79,7 @@ describe('The GlobalPopUp', () => {
 
   test('opens the ConfirmDeletionPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
-    store.dispatch(
-      openPopupWithTargetAttributionId(PopupType.ConfirmDeletionPopup, 'test')
-    );
+    store.dispatch(openPopup(PopupType.ConfirmDeletionPopup, 'test'));
 
     expect(
       screen.getByText(
@@ -100,12 +90,7 @@ describe('The GlobalPopUp', () => {
 
   test('opens the ConfirmDeletionGloballyPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
-    store.dispatch(
-      openPopupWithTargetAttributionId(
-        PopupType.ConfirmDeletionGloballyPopup,
-        'test'
-      )
-    );
+    store.dispatch(openPopup(PopupType.ConfirmDeletionGloballyPopup, 'test'));
 
     expect(
       screen.getByText(

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -5,10 +5,11 @@
 
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { ButtonText, View } from '../../enums/enums';
+import { ButtonText, PopupType, View } from '../../enums/enums';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import {
   closePopup,
+  openPopup,
   setTargetView,
 } from '../../state/actions/view-actions/view-actions';
 import {
@@ -53,11 +54,18 @@ export function NotSavedPopup(): ReactElement {
     dispatch(navigateToTargetResourceOrAttribution());
   }
 
+  function reopenEditAttributionPopupIfItWasPreviouslyOpen(): void {
+    if (view === View.Report && currentAttributionId) {
+      dispatch(openPopup(PopupType.EditAttributionPopup, currentAttributionId));
+    }
+  }
+
   function handleCancelClick(): void {
     dispatch(setTargetView(null));
     dispatch(setTargetSelectedResourceId(''));
     dispatch(setTargetSelectedAttributionId(''));
     dispatch(closePopup());
+    reopenEditAttributionPopupIfItWasPreviouslyOpen();
   }
 
   const content = `There are unsaved changes. ${

--- a/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
+++ b/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
@@ -8,6 +8,7 @@ import { IpcRenderer } from 'electron';
 import React from 'react';
 import { ButtonText, PopupType, View } from '../../../enums/enums';
 import {
+  navigateToView,
   openPopup,
   setTargetView,
 } from '../../../state/actions/view-actions/view-actions';
@@ -31,8 +32,12 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { setTemporaryPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { getSelectedResourceId } from '../../../state/selectors/audit-view-resource-selectors';
 
-function setupTestState(store: EnhancedTestStore, targetView?: View): void {
-  store.dispatch(openPopup(PopupType.NotSavedPopup));
+function setupTestState(
+  store: EnhancedTestStore,
+  targetView?: View,
+  popupAttributionId?: string
+): void {
+  store.dispatch(openPopup(PopupType.NotSavedPopup, popupAttributionId));
   store.dispatch(setTargetSelectedResourceId('test_id'));
   store.dispatch(setSelectedResourceId(''));
   store.dispatch(loadFromFile(EMPTY_PARSED_FILE_CONTENT));
@@ -94,6 +99,19 @@ describe('NotSavedPopup and do not change view', () => {
     expect(getSelectedResourceId(store.getState())).toBe('test_id');
     expect(getTemporaryPackageInfo(store.getState())).toEqual({});
     expect(isAuditViewSelected(store.getState())).toBe(true);
+  });
+
+  test('renders a NotSavedPopup and click cancel in Report view reopens EditAttribuionPopup', () => {
+    const { store } = renderComponentWithStore(<NotSavedPopup />);
+    store.dispatch(navigateToView(View.Report));
+    store.dispatch(
+      openPopup(PopupType.EditAttributionPopup, 'test_selected_id')
+    );
+    setupTestState(store, undefined, 'test_selected_id');
+
+    expect(screen.getByText('There are unsaved changes.')).toBeInTheDocument();
+    fireEvent.click(screen.queryByText(ButtonText.Cancel) as Element);
+    expect(getOpenPopup(store.getState())).toBe(PopupType.EditAttributionPopup);
   });
 });
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -29,10 +29,7 @@ import {
   savePackageInfo,
   unlinkAttributionAndSavePackageInfo,
 } from '../../state/actions/resource-actions/save-actions';
-import {
-  openPopup,
-  openPopupWithTargetAttributionId,
-} from '../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionIdOfDisplayedPackageInManualPanel,
@@ -151,12 +148,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       if (isPreselected) {
         dispatch(deleteAttributionAndSave(selectedResourceId, attributionId));
       } else {
-        dispatch(
-          openPopupWithTargetAttributionId(
-            PopupType.ConfirmDeletionPopup,
-            attributionId
-          )
-        );
+        dispatch(openPopup(PopupType.ConfirmDeletionPopup, attributionId));
       }
     }
 
@@ -165,10 +157,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
         dispatch(deleteAttributionGloballyAndSave(attributionId));
       } else {
         dispatch(
-          openPopupWithTargetAttributionId(
-            PopupType.ConfirmDeletionGloballyPopup,
-            attributionId
-          )
+          openPopup(PopupType.ConfirmDeletionGloballyPopup, attributionId)
         );
       }
     }
@@ -314,10 +303,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             disabled: mergeButtonDisplayState.deactivateReplaceMarkedByButton,
             onClick: (): void => {
               dispatch(
-                openPopupWithTargetAttributionId(
-                  PopupType.ReplaceAttributionPopup,
-                  attributionId
-                )
+                openPopup(PopupType.ReplaceAttributionPopup, attributionId)
               );
             },
             hidden: mergeButtonDisplayState.hideReplaceMarkedByButton,

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -18,7 +18,7 @@ import { PackageCard } from '../PackageCard/PackageCard';
 import makeStyles from '@mui/styles/makeStyles';
 import { savePackageInfo } from '../../state/actions/resource-actions/save-actions';
 import { setAttributionIdMarkedForReplacement } from '../../state/actions/resource-actions/attribution-view-simple-actions';
-import { getTargetAttributionId } from '../../state/selectors/view-selector';
+import { getPopupAttributionId } from '../../state/selectors/view-selector';
 
 const useStyles = makeStyles({
   typography: {
@@ -37,20 +37,21 @@ export function ReplaceAttributionPopup(): ReactElement {
   const markedAttributionId = useAppSelector(
     getAttributionIdMarkedForReplacement
   );
-  const targetAttributionId = useAppSelector(getTargetAttributionId);
+  const targetAttributionId = useAppSelector(getPopupAttributionId);
 
   function handleCancelClick(): void {
     dispatch(closePopup());
   }
 
   function handleOkClick(): void {
-    dispatch(
-      savePackageInfo(
-        null,
-        markedAttributionId,
-        attributions[targetAttributionId]
-      )
-    );
+    targetAttributionId &&
+      dispatch(
+        savePackageInfo(
+          null,
+          markedAttributionId,
+          attributions[targetAttributionId]
+        )
+      );
     dispatch(setAttributionIdMarkedForReplacement(''));
     dispatch(closePopup());
   }
@@ -87,7 +88,7 @@ export function ReplaceAttributionPopup(): ReactElement {
       <MuiTypography className={classes.typography}>
         and links its resources to the attribution
       </MuiTypography>
-      {getAttributionCard(targetAttributionId)}
+      {targetAttributionId && getAttributionCard(targetAttributionId)}
     </div>
   );
 

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup';
-import { openPopupWithTargetAttributionId } from '../../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../../state/actions/view-actions/view-actions';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import {
@@ -45,10 +45,7 @@ function setupTestState(store: EnhancedTestStore): void {
   store.dispatch(setSelectedAttributionId('test_selected_id'));
   store.dispatch(setAttributionIdMarkedForReplacement('test_marked_id'));
   store.dispatch(
-    openPopupWithTargetAttributionId(
-      PopupType.ReplaceAttributionPopup,
-      'test_selected_id'
-    )
+    openPopup(PopupType.ReplaceAttributionPopup, 'test_selected_id')
   );
   store.dispatch(
     loadFromFile(

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -11,9 +11,9 @@ import {
   AttributionsToResources,
   AttributionsWithResources,
 } from '../../../shared/shared-types';
-import { View } from '../../enums/enums';
+import { PopupType } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import { navigateToView } from '../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
 import {
   getFilesWithChildren,
   getFrequentLicensesTexts,
@@ -83,7 +83,7 @@ export function ReportView(): ReactElement {
 
   function getOnIconClick(): (attributionId: string) => void {
     return (attributionId): void => {
-      dispatch(navigateToView(View.Attribution));
+      dispatch(openPopup(PopupType.EditAttributionPopup, attributionId));
       dispatch(changeSelectedAttributionIdOrOpenUnsavedPopup(attributionId));
     };
   }

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -16,10 +16,7 @@ import {
 import { PanelPackage } from '../../types/types';
 import { hasAttributionMultipleResources } from '../../util/has-attribution-multiple-resources';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
-import {
-  getDisplayPackageInfo,
-  setUpdateTemporaryPackageInfoForCreator,
-} from './resource-details-attribution-column-helpers';
+import { getDisplayPackageInfo } from './resource-details-attribution-column-helpers';
 import {
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
@@ -33,8 +30,9 @@ import {
   getDisplayedPackage,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
-import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
+import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 
 interface ResourceDetailsAttributionColumnProps {
   showParentAttributions: boolean;
@@ -90,7 +88,7 @@ export function ResourceDetailsAttributionColumn(
       );
     } else {
       dispatch(
-        openPopupWithTargetAttributionId(
+        openPopup(
           PopupType.ConfirmDeletionPopup,
           attributionIdOfSelectedPackageInManualPanel
         )
@@ -109,7 +107,7 @@ export function ResourceDetailsAttributionColumn(
       );
     } else {
       dispatch(
-        openPopupWithTargetAttributionId(
+        openPopup(
           PopupType.ConfirmDeletionGloballyPopup,
           attributionIdOfSelectedPackageInManualPanel
         )

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
@@ -3,11 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChangeEvent } from 'react';
 import { Attributions, PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
-import { AppThunkDispatch } from '../../state/types';
-import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { PanelPackage } from '../../types/types';
 
 export function getDisplayPackageInfo(
@@ -37,26 +34,4 @@ export function getDisplayPackageInfo(
   }
 
   return displayPackageInfo;
-}
-
-export function setUpdateTemporaryPackageInfoForCreator(
-  dispatch: AppThunkDispatch,
-  temporaryPackageInfo: PackageInfo
-) {
-  return (propertyToUpdate: string) => {
-    return (
-      event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ): void => {
-      const newValue =
-        event.target.type === 'number'
-          ? parseInt(event.target.value)
-          : event.target.value;
-      dispatch(
-        setTemporaryPackageInfo({
-          ...temporaryPackageInfo,
-          [propertyToUpdate]: newValue,
-        })
-      );
-    };
-  };
 }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -19,6 +19,7 @@ export enum PopupType {
   ConfirmDeletionPopup = 'ConfirmDeletionPopup',
   ConfirmDeletionGloballyPopup = 'ConfirmDeletionGloballyPopup',
   ConfirmMultiSelectDeletionPopup = 'ConfirmMultiSelectDeletionPopup',
+  EditAttributionPopup = 'EditAttributionPopup',
 }
 
 export enum SavePackageInfoOperation {

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -58,7 +58,7 @@ describe('The report view', () => {
     global.window.ipcRenderer = originalIpcRenderer;
   });
 
-  test('navigates to attribution view', () => {
+  test('opens a EditAttributionPopup by clicking on edit and saves changes', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -96,13 +96,17 @@ describe('The report view', () => {
     screen.getByText(`${DiscreteConfidence.High}`);
 
     clickOnEditIconForElement(screen, 'jQuery');
-
+    expect(screen.getByText('Edit Attribution'));
     expectValueInTextBox(screen, 'Name', 'jQuery');
     expectValueInTextBox(
       screen,
       'License Text (to appear in attribution document)',
       'MIT'
     );
+    insertValueIntoTextBox(screen, 'Comment', 'Test comment');
+    clickOnButton(screen, ButtonText.Save);
+    expect(screen.queryByText('Edit Attribution')).not.toBeInTheDocument();
+    expect(screen.getByText('Test comment'));
   });
 
   test('recognizes frequent licenses and shows full license text in report view', () => {

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -173,3 +173,15 @@ export function navigateToTargetResourceOrAttribution(): AppThunkAction {
     dispatch(closePopup());
   };
 }
+
+export function closeEditAttributionPopupOrOpenUnsavedPopup(
+  popupAttributionId: string
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    if (wereTemporaryPackageInfoModified(getState())) {
+      dispatch(openPopup(PopupType.NotSavedPopup, popupAttributionId));
+    } else {
+      dispatch(closePopup());
+    }
+  };
+}

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -9,7 +9,7 @@ import {
   getActiveFilters,
   getOpenPopup,
   getSelectedView,
-  getTargetAttributionId,
+  getPopupAttributionId,
   getTargetView,
   isAttributionViewSelected,
   isAuditViewSelected,
@@ -19,7 +19,6 @@ import {
   closePopup,
   navigateToView,
   openPopup,
-  openPopupWithTargetAttributionId,
   resetViewState,
   updateActiveFilters,
   setTargetView,
@@ -170,15 +169,12 @@ describe('popup actions', () => {
   });
   test('sets targetAttributionId and popupType', () => {
     const testStore = createTestAppStore();
-    expect(getTargetAttributionId(testStore.getState())).toEqual('');
+    expect(getPopupAttributionId(testStore.getState())).toEqual(null);
     const testAttributionId = 'test';
     testStore.dispatch(
-      openPopupWithTargetAttributionId(
-        PopupType.ConfirmDeletionPopup,
-        testAttributionId
-      )
+      openPopup(PopupType.ConfirmDeletionPopup, testAttributionId)
     );
-    expect(getTargetAttributionId(testStore.getState())).toEqual(
+    expect(getPopupAttributionId(testStore.getState())).toEqual(
       testAttributionId
     );
     expect(getOpenPopup(testStore.getState())).toBe(

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -3,15 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View, FilterType } from '../../../enums/enums';
+import { View, FilterType } from '../../../enums/enums';
+import { PopupInfo } from '../../../types/types';
 
 export const ACTION_SET_TARGET_VIEW = 'ACTION_SET_TARGET_VIEW';
 export const ACTION_SET_VIEW = 'ACTION_SET_VIEW';
 export const ACTION_OPEN_POPUP = 'ACTION_OPEN_POPUP';
 export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
-export const ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID =
-  'ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID';
 export const ACTION_UPDATE_ACTIVE_FILTERS = 'ACTION_UPDATE_ACTIVE_FILTERS';
 
 export type ViewAction =
@@ -20,7 +19,6 @@ export type ViewAction =
   | ClosePopupAction
   | ResetViewStateAction
   | OpenPopupAction
-  | OpenPopupWithTargetAttributionIdAction
   | UpdateActiveFilters;
 
 export interface ResetViewStateAction {
@@ -41,29 +39,12 @@ export interface ClosePopupAction {
   type: typeof ACTION_CLOSE_POPUP;
 }
 
-export type OpenPopupActionPopupType = Exclude<
-  PopupType,
-  | PopupType.ConfirmDeletionPopup
-  | PopupType.ConfirmDeletionGloballyPopup
-  | PopupType.ReplaceAttributionPopup
->;
-
 export interface OpenPopupAction {
   type: typeof ACTION_OPEN_POPUP;
-  payload: OpenPopupActionPopupType;
+  payload: PopupInfo;
 }
 
 export interface UpdateActiveFilters {
   type: typeof ACTION_UPDATE_ACTIVE_FILTERS;
   payload: FilterType;
-}
-
-interface OpenPopupWithTargetAttributionIdActionPayload {
-  popupType: PopupType;
-  attributionId: string;
-}
-
-export interface OpenPopupWithTargetAttributionIdAction {
-  type: typeof ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID;
-  payload: OpenPopupWithTargetAttributionIdActionPayload;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -13,19 +13,16 @@ import { setTemporaryPackageInfo } from '../resource-actions/all-views-simple-ac
 import { getAttributionOfDisplayedPackageInManualPanel } from '../../selectors/audit-view-resource-selectors';
 import {
   ACTION_CLOSE_POPUP,
-  ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
   ClosePopupAction,
-  OpenPopupWithTargetAttributionIdAction,
   OpenPopupAction,
   ResetViewStateAction,
   SetTargetView,
   SetView,
-  OpenPopupActionPopupType,
   UpdateActiveFilters,
 } from './types';
 import { setMultiSelectSelectedAttributionIds } from '../resource-actions/attribution-view-simple-actions';
@@ -67,9 +64,16 @@ export function setTargetView(targetView: View | null): SetTargetView {
 }
 
 export function openPopup(
-  popupType: OpenPopupActionPopupType
+  popup: PopupType,
+  attributionId?: string
 ): OpenPopupAction {
-  return { type: ACTION_OPEN_POPUP, payload: popupType };
+  return {
+    type: ACTION_OPEN_POPUP,
+    payload: {
+      popup,
+      attributionId,
+    },
+  };
 }
 
 export function closePopup(): ClosePopupAction {
@@ -82,18 +86,5 @@ export function updateActiveFilters(
   return {
     type: ACTION_UPDATE_ACTIVE_FILTERS,
     payload: filterType,
-  };
-}
-
-export function openPopupWithTargetAttributionId(
-  popupType: PopupType,
-  attributionId: string
-): OpenPopupWithTargetAttributionIdAction {
-  return {
-    type: ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID,
-    payload: {
-      popupType,
-      attributionId,
-    },
   };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -3,7 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PopupType, View, FilterType } from '../../enums/enums';
+import { View, FilterType } from '../../enums/enums';
+import { PopupInfo } from '../../types/types';
 import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
@@ -12,23 +13,20 @@ import {
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
   ViewAction,
-  ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID,
 } from '../actions/view-actions/types';
 import { getUpdatedFilters } from '../helpers/set-filters';
 
 export interface ViewState {
   view: View;
   targetView: View | null;
-  openPopup: PopupType | null;
-  targetAttributionId: string;
+  popupInfo: PopupInfo | null;
   activeFilters: Set<FilterType>;
 }
 
 export const initialViewState: ViewState = {
   view: View.Audit,
   targetView: null,
-  openPopup: null,
-  targetAttributionId: '',
+  popupInfo: null,
   activeFilters: new Set<FilterType>(),
 };
 
@@ -52,23 +50,17 @@ export function viewState(
     case ACTION_CLOSE_POPUP:
       return {
         ...state,
-        openPopup: null,
+        popupInfo: null,
       };
     case ACTION_OPEN_POPUP:
       return {
         ...state,
-        openPopup: action.payload,
+        popupInfo: action.payload,
       };
     case ACTION_UPDATE_ACTIVE_FILTERS:
       return {
         ...state,
         activeFilters: getUpdatedFilters(state.activeFilters, action.payload),
-      };
-    case ACTION_OPEN_POPUP_WITH_TARGET_ATTRIBUTION_ID:
-      return {
-        ...state,
-        targetAttributionId: action.payload.attributionId,
-        openPopup: action.payload.popupType,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -26,6 +26,7 @@ import {
   getAttributionOfDisplayedPackageInManualPanel,
 } from './audit-view-resource-selectors';
 import { getSelectedAttributionId } from './attribution-view-resource-selectors';
+import { getPopupAttributionId } from '../../state/selectors/view-selector';
 
 export function getResources(state: State): Resources | null {
   return state.resourceState.allViews.resources;
@@ -114,10 +115,14 @@ export function getProjectMetadata(state: State): ProjectMetadata {
 }
 
 export function getAttributionIdToSaveTo(state: State): string | null {
-  if (getSelectedView(state) === View.Attribution)
-    return getSelectedAttributionId(state);
-
-  return getAttributionIdOfDisplayedPackageInManualPanel(state);
+  switch (getSelectedView(state)) {
+    case View.Attribution:
+      return getSelectedAttributionId(state);
+    case View.Report:
+      return getPopupAttributionId(state);
+    case View.Audit:
+      return getAttributionIdOfDisplayedPackageInManualPanel(state);
+  }
 }
 
 export function getPackageInfoOfSelectedAttribution(state: State): PackageInfo {

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -27,13 +27,13 @@ export function getTargetView(state: State): View | null {
 }
 
 export function getOpenPopup(state: State): null | PopupType {
-  return state.viewState.openPopup;
+  return state.viewState.popupInfo?.popup || null;
 }
 
 export function getActiveFilters(state: State): Set<FilterType> {
   return state.viewState.activeFilters;
 }
 
-export function getTargetAttributionId(state: State): string {
-  return state.viewState.targetAttributionId;
+export function getPopupAttributionId(state: State): string | null {
+  return state.viewState.popupInfo?.attributionId || null;
 }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IpcRenderer } from 'electron';
-import { PackagePanelTitle } from '../enums/enums';
+import { PackagePanelTitle, PopupType } from '../enums/enums';
 import { ResourceState } from '../state/reducers/resource-reducer';
 import { ViewState } from '../state/reducers/view-reducer';
 import { PackageInfo } from '../../shared/shared-types';
@@ -76,4 +76,9 @@ export interface PathPredicate {
 export interface ResourcesListBatch {
   resourceIds: Array<string>;
   header?: string;
+}
+
+export interface PopupInfo {
+  popup: PopupType;
+  attributionId?: string;
 }

--- a/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
+++ b/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ChangeEvent } from 'react';
+import { PackageInfo } from '../../shared/shared-types';
+import { AppThunkDispatch } from '../state/types';
+import { setTemporaryPackageInfo } from '../state/actions/resource-actions/all-views-simple-actions';
+
+export function setUpdateTemporaryPackageInfoForCreator(
+  dispatch: AppThunkDispatch,
+  temporaryPackageInfo: PackageInfo
+) {
+  return (propertyToUpdate: string) => {
+    return (
+      event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    ): void => {
+      const newValue =
+        event.target.type === 'number'
+          ? parseInt(event.target.value)
+          : event.target.value;
+      dispatch(
+        setTemporaryPackageInfo({
+          ...temporaryPackageInfo,
+          [propertyToUpdate]: newValue,
+        })
+      );
+    };
+  };
+}


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Add new component EditAttributionPopup and open it when clicking on the edit button in report view
- The Popup contains the attribution column and allows user to edit the selected attribution and save changes
- If changes are not saved, open the NotSavedPopup
- Cancel NotSavedPopup leads to the EditAttributionPopup again

### Context and reason for change
- User wants to edit the attribution in report view directly without being redirected to attribution view

### How can the changes be tested
The changes can be test with `yarn test:unit` and in the UI

