### PR TITLE
Fix usage of useAppSelector

### DIFF
--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -10,9 +10,10 @@ import MuiTooltip from '@mui/material/Tooltip';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
-import { getIsFileWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { GoToLinkButton } from '../GoToLinkButton/GoToLinkButton';
 import { useAppSelector } from '../../state/hooks';
+import { getFilesWithChildren } from '../../state/selectors/all-views-resource-selectors';
+import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 
 const useStyles = makeStyles({
   root: {
@@ -35,7 +36,8 @@ const useStyles = makeStyles({
 export function PathBar(): ReactElement | null {
   const classes = useStyles();
   const path = useAppSelector(getSelectedResourceId);
-  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+  const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
 
   return path ? (
     <div className={classes.root}>

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -15,8 +15,8 @@ import { View } from '../../enums/enums';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { navigateToView } from '../../state/actions/view-actions/view-actions';
 import {
+  getFilesWithChildren,
   getFrequentLicensesTexts,
-  getIsFileWithChildren,
   getManualAttributions,
   getManualAttributionsToResources,
 } from '../../state/selectors/all-views-resource-selectors';
@@ -25,6 +25,7 @@ import { useFilters } from '../../util/use-filters';
 import { Table } from '../Table/Table';
 import { OpossumColors } from '../../shared-styles';
 import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
+import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 
 const useStyles = makeStyles({
   root: {
@@ -44,7 +45,8 @@ export function ReportView(): ReactElement {
     getManualAttributionsToResources
   );
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
-  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+  const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
   const dispatch = useAppDispatch();
 
   const attributionsWithResources = getAttributionsWithResources(

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -8,10 +8,10 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
 import {
+  getAttributionBreakpoints,
   getExternalData,
   getManualData,
   getTemporaryPackageInfo,
-  isAttributionBreakpoint,
 } from '../../state/selectors/all-views-resource-selectors';
 import { PanelPackage } from '../../types/types';
 import { hasAttributionMultipleResources } from '../../util/has-attribution-multiple-resources';
@@ -34,6 +34,7 @@ import {
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { openPopupWithTargetAttributionId } from '../../state/actions/view-actions/view-actions';
+import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 
 interface ResourceDetailsAttributionColumnProps {
   showParentAttributions: boolean;
@@ -50,10 +51,10 @@ export function ResourceDetailsAttributionColumn(
   const attributionIdOfSelectedPackageInManualPanel: string | null =
     useAppSelector(getAttributionIdOfDisplayedPackageInManualPanel);
   const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
-  const selectedResourceIsAttributionBreakpoint = useAppSelector(
-    isAttributionBreakpoint(selectedResourceId)
-  );
-
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
+  const selectedResourceIsAttributionBreakpoint = getAttributionBreakpointCheck(
+    attributionBreakpoints
+  )(selectedResourceId);
   const dispatch = useAppDispatch();
 
   function dispatchUnlinkAttributionAndSavePackageInfo(): void {

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -24,8 +24,9 @@ import {
   OpossumColors,
   resourceBrowserWidthInPixels,
 } from '../../shared-styles';
-import { isAttributionBreakpoint } from '../../state/selectors/all-views-resource-selectors';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
+import { getAttributionBreakpoints } from '../../state/selectors/all-views-resource-selectors';
 
 const useStyles = makeStyles({
   root: {
@@ -69,10 +70,10 @@ export function ResourceDetailsViewer(): ReactElement | null {
     getAttributionIdsOfSelectedResource,
     isEqual
   );
-  const resourceIsAttributionBreakpoint: boolean = useAppSelector(
-    isAttributionBreakpoint(selectedResourceId)
-  );
-
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
+  const resourceIsAttributionBreakpoint = getAttributionBreakpointCheck(
+    attributionBreakpoints
+  )(selectedResourceId);
   const dispatch = useAppDispatch();
 
   useEffect(() => {

--- a/src/Frontend/Components/ResourcesList/ResourcesList.tsx
+++ b/src/Frontend/Components/ResourcesList/ResourcesList.tsx
@@ -11,10 +11,11 @@ import { List } from '../List/List';
 import { ListCard } from '../ListCard/ListCard';
 import { doNothing } from '../../util/do-nothing';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
-import { getIsFileWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { OpossumColors } from '../../shared-styles';
 import { convertResourcesListBatchesToResourcesListItems } from './resource-list-helpers';
 import { ResourcesListBatch } from '../../types/types';
+import { getFilesWithChildren } from '../../state/selectors/all-views-resource-selectors';
+import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 
 const useStyles = makeStyles({
   root: {
@@ -36,8 +37,8 @@ export interface ResourcesListItem {
 
 export function ResourcesList(props: ResourcesListProps): ReactElement {
   const classes = useStyles();
-
-  const isFileWithChildren = useAppSelector(getIsFileWithChildren);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+  const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
   const dispatch = useAppDispatch();
   const onClickCallback = props.onClickCallback ?? doNothing;
 

--- a/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
@@ -13,10 +13,8 @@ import { createTestAppStore } from '../../../test-helpers/render-component-with-
 import {
   getAttributionBreakpoints,
   getFilesWithChildren,
-  getIsFileWithChildren,
   getPackageInfoOfSelectedAttribution,
   getProjectMetadata,
-  isAttributionBreakpoint,
 } from '../all-views-resource-selectors';
 import {
   setAttributionBreakpoints,
@@ -71,7 +69,7 @@ describe('Attribution breakpoints', () => {
     '/node_modules/',
   ]);
 
-  test('can be created, listed, and checked.', () => {
+  test('can be created and listed.', () => {
     const testStore = createTestAppStore();
     expect(getAttributionBreakpoints(testStore.getState())).toEqual(new Set());
 
@@ -80,12 +78,6 @@ describe('Attribution breakpoints', () => {
     expect(getAttributionBreakpoints(testStore.getState())).toEqual(
       testAttributionBreakpoints
     );
-    expect(
-      isAttributionBreakpoint('/path/breakpoint/')(testStore.getState())
-    ).toEqual(true);
-    expect(
-      isAttributionBreakpoint('/path/no-breakpoint/')(testStore.getState())
-    ).toEqual(false);
   });
 });
 
@@ -105,16 +97,6 @@ describe('Files with children', () => {
     expect(getFilesWithChildren(testStore.getState())).toEqual(
       testFilesWithChildren
     );
-  });
-
-  test('can get fileWithChildrenCheck', () => {
-    const testStore = createTestAppStore();
-
-    testStore.dispatch(setFilesWithChildren(testFilesWithChildren));
-
-    const isFileWithChildren = getIsFileWithChildren(testStore.getState());
-    expect(isFileWithChildren(testFileWithChildren)).toBe(true);
-    expect(isFileWithChildren('/some_other_path')).toBe(false);
   });
 });
 

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -18,7 +18,7 @@ import {
   ExternalAttributionSources,
 } from '../../../shared/shared-types';
 import { View } from '../../enums/enums';
-import { PathPredicate, ProgressBarData, State } from '../../types/types';
+import { ProgressBarData, State } from '../../types/types';
 import { getSelectedView } from './view-selector';
 import { getStrippedPackageInfo } from '../../util/get-stripped-package-info';
 import {
@@ -26,8 +26,6 @@ import {
   getAttributionOfDisplayedPackageInManualPanel,
 } from './audit-view-resource-selectors';
 import { getSelectedAttributionId } from './attribution-view-resource-selectors';
-import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
-import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 
 export function getResources(state: State): Resources | null {
   return state.resourceState.allViews.resources;
@@ -113,22 +111,6 @@ export function getFilesWithChildren(state: State): Set<string> {
 
 export function getProjectMetadata(state: State): ProjectMetadata {
   return state.resourceState.allViews.metadata;
-}
-
-export function isAttributionBreakpoint(
-  path: string
-): (state: State) => boolean {
-  return (state: State): boolean =>
-    getAttributionBreakpointCheck(
-      state.resourceState.allViews.attributionBreakpoints
-    )(path);
-}
-
-export function getIsFileWithChildren(state: State): PathPredicate {
-  return (path: string): boolean =>
-    getFileWithChildrenCheck(state.resourceState.allViews.filesWithChildren)(
-      path
-    );
 }
 
 export function getAttributionIdToSaveTo(state: State): string | null {


### PR DESCRIPTION
### Summary of changes
- Remove functions getIsFileWithChildren and isAttributionBreakpoint and adjust code accordingly

### Context and reason for change
- New functions are created everytime when calling getIsFileWithChildren and isAttributionBreakpoint with useAppSelector, causing the references changing and components rerendering unnecessarily

### How can the changes be tested
- Run `yarn test:unit`

