### PR TITLE
Make icons configurable

### DIFF
--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -5,8 +5,6 @@
 
 import makeStyles from '@mui/styles/makeStyles';
 import MuiTooltip from '@mui/material/Tooltip';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Filter1Icon from '@mui/icons-material/Filter1';
 import InsertCommentIcon from '@mui/icons-material/InsertComment';
 import AnnouncementIcon from '@mui/icons-material/Announcement';
@@ -19,10 +17,10 @@ import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import clsx from 'clsx';
 import React, { ReactElement } from 'react';
 import {
-  OpossumColors,
-  tooltipStyle,
   baseIcon,
   clickableIcon,
+  OpossumColors,
+  tooltipStyle,
 } from '../../shared-styles';
 
 const useStyles = makeStyles({
@@ -56,49 +54,6 @@ interface IconProps {
 interface LabelDetailIconProps extends IconProps {
   labelDetail?: string;
   disabled?: boolean;
-}
-
-interface ClickableIconProps extends IconProps {
-  label: string;
-  onClick: () => void;
-}
-
-export function ClosedFolderIcon(props: ClickableIconProps): ReactElement {
-  const classes = useStyles();
-
-  return (
-    <ChevronRightIcon
-      className={clsx(
-        classes.clickableIcon,
-        classes.openCloseFolderIcons,
-        props.className
-      )}
-      onClick={(event): void => {
-        event.stopPropagation();
-        props.onClick();
-      }}
-      aria-label={`closed folder ${props.label}`}
-    />
-  );
-}
-
-export function OpenFolderIcon(props: ClickableIconProps): ReactElement {
-  const classes = useStyles();
-
-  return (
-    <ExpandMoreIcon
-      className={clsx(
-        classes.clickableIcon,
-        classes.openCloseFolderIcons,
-        props.className
-      )}
-      onClick={(event): void => {
-        event.stopPropagation();
-        props.onClick();
-      }}
-      aria-label={`open folder ${props.label}`}
-    />
-  );
 }
 
 export function FirstPartyIcon(props: IconProps): ReactElement {

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -5,31 +5,16 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { doNothing } from '../../../util/do-nothing';
 import {
-  ClosedFolderIcon,
   CommentIcon,
   DirectoryIcon,
   ExcludeFromNoticeIcon,
   FileIcon,
   FirstPartyIcon,
   FollowUpIcon,
-  OpenFolderIcon,
 } from '../Icons';
 
 describe('The Icons', () => {
-  test('renders ClosedFolderIcon', () => {
-    render(<ClosedFolderIcon onClick={doNothing} label={'test_label'} />);
-
-    expect(screen.getByLabelText('closed folder test_label'));
-  });
-
-  test('renders OpenFolderIcon', () => {
-    render(<OpenFolderIcon onClick={doNothing} label={'test_label'} />);
-
-    expect(screen.getByLabelText('open folder test_label'));
-  });
-
   test('renders CommentIcon', () => {
     render(<CommentIcon />);
 

--- a/src/Frontend/Components/VirtualisedTree/Icons.tsx
+++ b/src/Frontend/Components/VirtualisedTree/Icons.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import clsx from 'clsx';
+
+interface NodeIconProps {
+  className?: string;
+  ariaLabel: string;
+  onClick: () => void;
+  icon: ReactElement;
+}
+
+export function NodeIcon(props: NodeIconProps): ReactElement {
+  return (
+    <div
+      className={clsx(props.className)}
+      onClick={(event): void => {
+        event.stopPropagation();
+        props.onClick();
+      }}
+      aria-label={props.ariaLabel}
+    >
+      {props.icon}
+    </div>
+  );
+}

--- a/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/Components/VirtualisedTree/VirtualizedTree.tsx
@@ -52,6 +52,8 @@ interface VirtualizedTreeProps {
   ariaLabel?: string;
   cardHeight: number;
   maxHeight?: number;
+  expandedNodeIcon?: ReactElement;
+  nonExpandedNodeIcon?: ReactElement;
 }
 
 export function VirtualizedTree(
@@ -88,7 +90,13 @@ export function VirtualizedTree(
           max={maxListLength}
           cardVerticalDistance={props.cardHeight}
           getListItem={(index: number): ReactElement => (
-            <VirtualizedTreeItem {...treeItemProps[index]} />
+            <VirtualizedTreeItem
+              {...{
+                ...treeItemProps[index],
+                expandedNodeIcon: props.expandedNodeIcon,
+                nonExpandedNodeIcon: props.nonExpandedNodeIcon,
+              }}
+            />
           )}
           alwaysShowHorizontalScrollBar={true}
         />

--- a/src/Frontend/Components/VirtualisedTree/VirtualizedTreeItem.tsx
+++ b/src/Frontend/Components/VirtualisedTree/VirtualizedTreeItem.tsx
@@ -6,9 +6,12 @@
 import clsx from 'clsx';
 import React, { ReactElement } from 'react';
 import { Resources } from '../../../shared/shared-types';
-import { ClosedFolderIcon, OpenFolderIcon } from '../Icons/Icons';
 import makeStyles from '@mui/styles/makeStyles';
 import { OpossumColors } from '../../shared-styles';
+import { NodeIcon } from './Icons';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { ClassNameMap } from '@mui/styles';
 
 const INDENT_PER_DEPTH_LEVEL = 12;
 const SIMPLE_NODE_EXTRA_INDENT = 28;
@@ -39,6 +42,16 @@ const useStyles = makeStyles({
   listItem: {
     display: 'flex',
   },
+  clickableIcon: {
+    width: 16,
+    height: 20,
+    padding: 0,
+    margin: 0,
+    color: OpossumColors.darkBlue,
+    '&:hover': {
+      background: OpossumColors.middleBlue,
+    },
+  },
 });
 
 export interface VirtualizedTreeItemData {
@@ -56,6 +69,8 @@ export interface VirtualizedTreeItemData {
     resource: Resources | 1,
     nodeId: string
   ) => ReactElement;
+  expandedNodeIcon?: ReactElement;
+  nonExpandedNodeIcon?: ReactElement;
 }
 
 export function VirtualizedTreeItem(
@@ -71,11 +86,14 @@ export function VirtualizedTreeItem(
     <div className={classes.listItem}>
       <div className={classes.treeItemSpacer} style={{ width: marginRight }} />
       {props.isExpandable
-        ? getFolderIcon(
+        ? getExpandableNodeIcon(
             props.isExpandedNode,
             props.nodeId,
             props.nodeIdsToExpand,
-            props.onToggle
+            props.onToggle,
+            classes,
+            props.expandedNodeIcon,
+            props.nonExpandedNodeIcon
           )
         : null}
       <div
@@ -99,23 +117,28 @@ export function VirtualizedTreeItem(
   );
 }
 
-function getFolderIcon(
+function getExpandableNodeIcon(
   isExpandedNode: boolean,
   nodeId: string,
   nodeIdsToExpand: Array<string>,
-  onToggle: (nodeIdsToExpand: Array<string>) => void
+  onToggle: (nodeIdsToExpand: Array<string>) => void,
+  classes: ClassNameMap<'clickableIcon'>,
+  expandedNodeIcon: ReactElement = (
+    <ChevronRightIcon className={clsx(classes.clickableIcon)} />
+  ),
+  nonExpandedNodeIcon: ReactElement = (
+    <ExpandMoreIcon className={clsx(classes.clickableIcon)} />
+  )
 ): ReactElement {
-  return isExpandedNode ? (
-    <OpenFolderIcon
+  const ariaLabel = isExpandedNode ? `expand ${nodeId}` : `collapse ${nodeId}`;
+  const icon = isExpandedNode ? expandedNodeIcon : nonExpandedNodeIcon;
+  return (
+    <NodeIcon
       onClick={(): void => {
         onToggle(nodeIdsToExpand);
       }}
-      label={nodeId}
-    />
-  ) : (
-    <ClosedFolderIcon
-      onClick={(): void => onToggle(nodeIdsToExpand)}
-      label={nodeId}
+      ariaLabel={ariaLabel}
+      icon={icon}
     />
   );
 }

--- a/src/Frontend/test-helpers/resource-browser-test-helpers.ts
+++ b/src/Frontend/test-helpers/resource-browser-test-helpers.ts
@@ -9,9 +9,7 @@ export function collapseFolderByClickingOnIcon(
   screen: Screen,
   resourceId: string
 ): void {
-  fireEvent.click(
-    screen.getByLabelText(`open folder ${resourceId}`) as Element
-  );
+  fireEvent.click(screen.getByLabelText(`expand ${resourceId}`) as Element);
 }
 
 export function getElementInResourceBrowser(


### PR DESCRIPTION

### Summary of changes

Allow configuring icons for virtualized tree by
passing them as properties.

### Context and reason for change

Improve configurability of virtualized tree to extract it to own package.
