### PR TITLE
Fix styling

### DIFF
--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -270,7 +270,7 @@ export function useRows(
   commentRows: number;
 } {
   const [isLicenseTextShown, setIsLicenseTextShown] = useState<boolean>(false);
-  const reduceRowsCount = smallerLicenseTextOrCommentField ? 5 : 0;
+  const reduceRowsCount = smallerLicenseTextOrCommentField ? 5 : 1;
   const licenseTextRows =
     getLicenseTextMaxRows(useWindowHeight(), view) - reduceRowsCount;
 

--- a/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
+++ b/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
@@ -18,7 +18,7 @@ export const useAttributionColumnStyles = makeStyles({
     display: 'flex',
   },
   textBox: {
-    marginBottom: 0,
+    marginBottom: 6,
     flex: 1,
   },
   rightTextBox: {


### PR DESCRIPTION

### Summary of changes

Fix styling

After:
![Screenshot 2022-02-07 at 12 45 17](https://user-images.githubusercontent.com/46576389/152782295-38db1ddb-386b-4b07-ad74-b2270bf008fc.png)


### Context and reason for change

In the attribution column there was no vertical spacing between individual
text boxes. Furthermore, sometimes the buttons did overlap the comment
text box.

Before:
![Screenshot 2022-02-07 at 12 44 21](https://user-images.githubusercontent.com/46576389/152782177-54d9eec3-92dd-4e38-a21e-d7d0fc8513c9.png)



### How can the changes be tested

Check appearance with several zoom levels.

