### PR TITLE
Add support for fetching license info from github

### DIFF
--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/github-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/github-fetching-helpers.test.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  convertGithubPayload,
+  getGithubAPIUrl,
+} from '../github-fetching-helpers';
+
+describe('getGithubAPIUrl', () => {
+  it('handles a normal github url', () => {
+    expect(getGithubAPIUrl('https://github.com/opossum-tool/OpossumUI')).toBe(
+      'https://api.github.com/repos/opossum-tool/OpossumUI/license'
+    );
+  });
+
+  it('handles a trailing slash', () => {
+    expect(getGithubAPIUrl('https://github.com/opossum-tool/OpossumUI/')).toBe(
+      'https://api.github.com/repos/opossum-tool/OpossumUI/license'
+    );
+  });
+
+  it('handles additional parts at the end of the url', () => {
+    expect(
+      getGithubAPIUrl(
+        'https://github.com/opossum-tool/OpossumUI/some/more/suffixes'
+      )
+    ).toBe('https://api.github.com/repos/opossum-tool/OpossumUI/license');
+  });
+});
+
+describe('convertGithubPayload', () => {
+  it('raises for invalid payload', async () => {
+    const payload = { license: {} };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    await expect(
+      convertGithubPayload(mockResponse as unknown as Response)
+    ).rejects.toBeTruthy();
+  });
+
+  it('parses payload correctly', async () => {
+    const payload = {
+      license: { spdx_id: 'Apache-2.0' },
+      content: 'TGljZW5zZSBUZXh0', // "License Text" in base64
+      html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
+    };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    const packageInfo = await convertGithubPayload(
+      mockResponse as unknown as Response
+    );
+    expect(packageInfo).toStrictEqual({
+      licenseName: 'Apache-2.0',
+      licenseText: 'License Text',
+      packageType: 'github',
+      packageNamespace: 'opossum-tool',
+      packageName: 'OpossumUI',
+      packagePURLAppendix: undefined,
+    });
+  });
+
+  it('handles non existing license text correctly', async () => {
+    const payload = {
+      license: { spdx_id: 'Apache-2.0' },
+      html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
+    };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    const packageInfo = await convertGithubPayload(
+      mockResponse as unknown as Response
+    );
+    expect(packageInfo).toStrictEqual({
+      licenseName: 'Apache-2.0',
+      packageType: 'github',
+      licenseText: undefined,
+      packageNamespace: 'opossum-tool',
+      packageName: 'OpossumUI',
+      packagePURLAppendix: undefined,
+    });
+  });
+
+  it('handles empty license text correctly', async () => {
+    const payload = {
+      license: { spdx_id: 'Apache-2.0' },
+      content: '',
+      html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
+    };
+    const mockResponse = {
+      json: (): typeof payload => payload,
+    };
+
+    const packageInfo = await convertGithubPayload(
+      mockResponse as unknown as Response
+    );
+    expect(packageInfo).toStrictEqual({
+      licenseName: 'Apache-2.0',
+      packageType: 'github',
+      licenseText: undefined,
+      packageNamespace: 'opossum-tool',
+      packageName: 'OpossumUI',
+      packagePURLAppendix: undefined,
+    });
+  });
+});

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
@@ -6,6 +6,7 @@
 import { getLicenseFetchingInformation } from '../license-fetching-helpers';
 import { convertPypiPayload } from '../pypi-fetching-helpers';
 import { convertNpmPayload } from '../npm-fetching-helpers';
+import { convertGithubPayload } from '../github-fetching-helpers';
 
 describe('getLicenseFetchingInformation', () => {
   it('returns null for undefined as input', () => {
@@ -51,5 +52,14 @@ describe('getLicenseFetchingInformation', () => {
         'https://npmjs.com/package/@angular/animations/1.0'
       )
     ).toBeNull();
+  });
+
+  it('recognizes github urls', () => {
+    expect(
+      getLicenseFetchingInformation('https://github.com/opossum-tool/OpossumUI')
+    ).toMatchObject({
+      url: 'https://api.github.com/repos/opossum-tool/OpossumUI/license',
+      convertPayload: convertGithubPayload,
+    });
   });
 });

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
@@ -62,4 +62,10 @@ describe('getLicenseFetchingInformation', () => {
       convertPayload: convertGithubPayload,
     });
   });
+
+  it('recognizes github urls', () => {
+    expect(
+      getLicenseFetchingInformation('https://github.com/opossum-tool/')
+    ).toBeNull();
+  });
 });

--- a/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Facebook, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo } from '../../../shared/shared-types';
+import { Validator, Schema } from 'jsonschema';
+
+const jsonSchemaValidator = new Validator();
+
+export function getGithubAPIUrl(url: string): string {
+  const { namespace, packageName } =
+    getPackageNamespaceAndPackageNameFromGithubURL(url);
+
+  return `https://api.github.com/repos/${namespace}/${packageName}/license`;
+}
+
+function getPackageNamespaceAndPackageNameFromGithubURL(url: string): {
+  namespace: string;
+  packageName: string;
+} {
+  const urlSuffix = url
+    .replace(new RegExp('^https://github.com/'), '')
+    .split('/');
+  return {
+    namespace: urlSuffix[0],
+    packageName: urlSuffix[1],
+  };
+}
+
+const GITHUB_SCHEMA: Schema = {
+  type: 'object',
+  properties: {
+    html_url: { type: 'string' },
+    content: { type: 'string' },
+    license: {
+      type: 'object',
+      properties: { spdx_id: { type: 'string' } },
+      required: ['spdx_id'],
+    },
+  },
+  required: ['license', 'html_url'],
+};
+
+export async function convertGithubPayload(
+  payload: Response
+): Promise<PackageInfo> {
+  const convertedPayload = await payload.json();
+  jsonSchemaValidator.validate(convertedPayload, GITHUB_SCHEMA, {
+    throwError: true,
+  });
+
+  const { namespace, packageName } =
+    getPackageNamespaceAndPackageNameFromGithubURL(
+      convertedPayload.html_url as string
+    );
+  const licenseText = convertedPayload.content
+    ? Buffer.from(convertedPayload.content, 'base64').toString()
+    : null;
+  return {
+    licenseName: convertedPayload.license.spdx_id as string,
+    licenseText: licenseText ?? undefined,
+    packageType: 'github',
+    packageNamespace: namespace,
+    packageName,
+    packagePURLAppendix: undefined,
+  };
+}

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -6,9 +6,14 @@
 import { PackageInfo } from '../../../shared/shared-types';
 import { convertPypiPayload, getPypiAPIUrl } from './pypi-fetching-helpers';
 import { convertNpmPayload, getNpmAPIUrl } from './npm-fetching-helpers';
+import {
+  convertGithubPayload,
+  getGithubAPIUrl,
+} from './github-fetching-helpers';
 
 const PYPI_REGEX = new RegExp('^https://pypi.org/(pypi|project)/[\\w-+,_]+/?$');
 const NPM_REGEX = new RegExp('^https://npmjs.com/(package/)?[\\w-+,_@/]+/?$');
+const GITHUB_REGEX = new RegExp('^https://github.com/');
 
 export interface LicenseFetchingInformation {
   url: string;
@@ -32,6 +37,11 @@ export function getLicenseFetchingInformation(
     return {
       url: getNpmAPIUrl(url, version),
       convertPayload: convertNpmPayload,
+    };
+  } else if (GITHUB_REGEX.test(url)) {
+    return {
+      url: getGithubAPIUrl(url),
+      convertPayload: convertGithubPayload,
     };
   }
   return null;

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -13,7 +13,7 @@ import {
 
 const PYPI_REGEX = new RegExp('^https://pypi.org/(pypi|project)/[\\w-+,_]+/?$');
 const NPM_REGEX = new RegExp('^https://npmjs.com/(package/)?[\\w-+,_@/]+/?$');
-const GITHUB_REGEX = new RegExp('^https://github.com/');
+const GITHUB_REGEX = new RegExp('^https://github.com/[^/]+/[^/]+');
 
 export interface LicenseFetchingInformation {
   url: string;


### PR DESCRIPTION
### Summary of changes
Adds support to fetch license information based on a github URL from the github API.

### How can the changes be tested
- Execute unit tests
- open the app and fill e.g. `https://github.com/opossum-tool/OpossumUI` in the URL
![Screenshot_20220207_191609](https://user-images.githubusercontent.com/26271333/152847636-bf454a76-2edc-49bd-b88c-c21b68ce70a2.png)

