### PR TITLE
Propagate green if all children have attributions

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
@@ -62,6 +62,15 @@ export function getTreeItemLabel(
       )}
       isAttributionBreakpoint={isAttributionBreakpoint(nodeId)}
       showFolderIcon={canHaveChildren && !isFileWithChildren(nodeId)}
+      containsResourcesWithOnlyExternalAttribution={
+        canHaveChildren &&
+        containsResourcesWithOnlyExternalAttribution(
+          nodeId,
+          resourcesToManualAttributions,
+          resourcesToExternalAttributions,
+          resource
+        )
+      }
     />
   );
 }
@@ -150,5 +159,25 @@ function hasParentWithManualAttributionAndNoOwnAttribution(
       resourcesToManualAttributions,
       isAttributionBreakpoint
     ) && !hasManualAttribution(nodeId, resourcesToManualAttributions)
+  );
+}
+
+function containsResourcesWithOnlyExternalAttribution(
+  nodeId: string,
+  resourcesToManualAttributions: ResourcesToAttributions,
+  resourcesToExternalAttributions: ResourcesToAttributions,
+  resource: Resources | 1
+): boolean {
+  if (hasManualAttribution(nodeId, resourcesToManualAttributions)) return false;
+  if (hasExternalAttribution(nodeId, resourcesToExternalAttributions))
+    return true;
+  if (resource === 1) return false;
+  return Object.keys(resource).some((node) =>
+    containsResourcesWithOnlyExternalAttribution(
+      resource[node] === 1 ? nodeId + node : nodeId + node + '/',
+      resourcesToManualAttributions,
+      resourcesToExternalAttributions,
+      resource[node]
+    )
   );
 }

--- a/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
@@ -65,6 +65,9 @@ const useStyles = makeStyles({
   resourceWithoutInformation: {
     color: OpossumColors.disabledGrey,
   },
+  notContainsResourcesWithOnlyExternalAttribution: {
+    color: OpossumColors.pastelMiddleGreen,
+  },
   tooltip: tooltipStyle,
 });
 
@@ -79,6 +82,7 @@ interface StyledTreeItemProps {
   canHaveChildren: boolean;
   isAttributionBreakpoint: boolean;
   showFolderIcon: boolean;
+  containsResourcesWithOnlyExternalAttribution: boolean;
 }
 
 export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
@@ -95,6 +99,13 @@ export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
   } else if (props.hasUnresolvedExternalAttribution) {
     iconClassName = classes.hasSignal;
     labelDetail = 'with signal';
+  } else if (
+    props.containsExternalAttribution &&
+    !props.containsResourcesWithOnlyExternalAttribution
+  ) {
+    iconClassName = classes.notContainsResourcesWithOnlyExternalAttribution;
+    labelDetail =
+      'with all children containing signal also containing attributions';
   } else if (
     props.containsExternalAttribution &&
     props.containsManualAttribution

--- a/src/Frontend/Components/StyledTreeItemLabel/__tests__/StyledTreeItemLabel.test.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/__tests__/StyledTreeItemLabel.test.tsx
@@ -22,6 +22,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={false}
         isAttributionBreakpoint={false}
         showFolderIcon={false}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -45,6 +46,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -67,6 +69,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -90,6 +93,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -113,6 +117,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={false}
         isAttributionBreakpoint={false}
         showFolderIcon={false}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -136,6 +141,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -158,6 +164,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -180,6 +187,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
@@ -202,12 +210,38 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={false}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 
     expect(screen.getByText('Test label')).toBeInTheDocument();
     expect(
       screen.getByLabelText('Directory icon without information')
+    ).toBeInTheDocument();
+  });
+
+  test('renders a folder with all children containing signal also containing attributions', () => {
+    render(
+      <StyledTreeItemLabel
+        labelText={'Test label'}
+        hasManualAttribution={false}
+        hasExternalAttribution={false}
+        hasUnresolvedExternalAttribution={false}
+        hasParentWithManualAttribution={false}
+        containsExternalAttribution={true}
+        containsManualAttribution={true}
+        canHaveChildren={true}
+        isAttributionBreakpoint={false}
+        showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={false}
+      />
+    );
+
+    expect(screen.getByText('Test label')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(
+        'Directory icon with all children containing signal also containing attributions'
+      )
     ).toBeInTheDocument();
   });
 
@@ -224,6 +258,7 @@ describe('StyledTreeItemLabel', () => {
         canHaveChildren={true}
         isAttributionBreakpoint={true}
         showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
       />
     );
 


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
A folder should be light green if:
- some contained resources have signals
- all contained resources with signals have attribution or inferred attribution
- the folder itself has no attribution inferred attribution

### Context and reason for change
- "resolved" signals should not have impact on coloring
- Fix: #424

### How can the changes be tested
- In the UI and with `yarn test:unit`
