### PR TITLE
Fix expand icons in tree

### DIFF
--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTreeNode.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTreeNode.tsx
@@ -96,11 +96,9 @@ function getExpandableNodeIcon(
   nodeIdsToExpand: Array<string>,
   onToggle: (nodeIdsToExpand: Array<string>) => void,
   iconClassName: string,
-  expandedNodeIcon: ReactElement = (
-    <ChevronRightIcon className={iconClassName} />
-  ),
+  expandedNodeIcon: ReactElement = <ExpandMoreIcon className={iconClassName} />,
   nonExpandedNodeIcon: ReactElement = (
-    <ExpandMoreIcon className={iconClassName} />
+    <ChevronRightIcon className={iconClassName} />
   )
 ): ReactElement {
   const ariaLabel = isExpandedNode ? `expand ${nodeId}` : `collapse ${nodeId}`;


### PR DESCRIPTION

### Summary of changes

Fix expand icons in tree

### Context and reason for change

Before:
![Screenshot 2022-02-09 at 16 34 51](https://user-images.githubusercontent.com/46576389/153234425-c4f84524-1683-45a8-8d69-ef12665c528a.png)


After:
![Screenshot 2022-02-09 at 16 34 35](https://user-images.githubusercontent.com/46576389/153234412-2b2dbf0a-ad3f-4cc1-817d-fb0faa7db457.png)

