### PR TITLE
Improve buttons in edit popup

### DIFF
--- a/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -31,10 +31,14 @@ export function ConfirmationPopup(props: ConfirmationPopupProps): ReactElement {
     <NotificationPopup
       content={props.content}
       header={props.header}
-      leftButtonText={ButtonText.Confirm}
-      onLeftButtonClick={handleDeletionClick}
-      rightButtonText={ButtonText.Cancel}
-      onRightButtonClick={handleCancelClick}
+      leftButtonConfig={{
+        onClick: handleDeletionClick,
+        buttonText: ButtonText.Confirm,
+      }}
+      rightButtonConfig={{
+        onClick: handleCancelClick,
+        buttonText: ButtonText.Cancel,
+      }}
       isOpen={true}
     />
   );

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -73,13 +73,13 @@ export function EditAttributionPopup(): ReactElement {
       header={'Edit Attribution'}
       isOpen={true}
       fullWidth={false}
-      leftButtonText={ButtonText.Cancel}
-      rightButtonText={ButtonText.Save}
+      leftButtonText={ButtonText.Save}
+      rightButtonText={ButtonText.Cancel}
       onBackdropClick={checkForModifiedPackageInfoBeforeClosing}
       onEscapeKeyDown={checkForModifiedPackageInfoBeforeClosing}
-      onLeftButtonClick={checkForModifiedPackageInfoBeforeClosing}
-      onRightButtonClick={savePackageInfoBeforeClosing}
-      isRightButtonDisabled={isSavingDisabled}
+      onLeftButtonClick={savePackageInfoBeforeClosing}
+      onRightButtonClick={checkForModifiedPackageInfoBeforeClosing}
+      isLeftButtonDisabled={isSavingDisabled}
     />
   );
 }

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -73,13 +73,17 @@ export function EditAttributionPopup(): ReactElement {
       header={'Edit Attribution'}
       isOpen={true}
       fullWidth={false}
-      leftButtonText={ButtonText.Save}
-      rightButtonText={ButtonText.Cancel}
+      leftButtonConfig={{
+        onClick: savePackageInfoBeforeClosing,
+        buttonText: ButtonText.Save,
+        isDisabled: isSavingDisabled,
+      }}
+      rightButtonConfig={{
+        onClick: checkForModifiedPackageInfoBeforeClosing,
+        buttonText: ButtonText.Cancel,
+      }}
       onBackdropClick={checkForModifiedPackageInfoBeforeClosing}
       onEscapeKeyDown={checkForModifiedPackageInfoBeforeClosing}
-      onLeftButtonClick={savePackageInfoBeforeClosing}
-      onRightButtonClick={checkForModifiedPackageInfoBeforeClosing}
-      isLeftButtonDisabled={isSavingDisabled}
     />
   );
 }

--- a/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
+++ b/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
@@ -41,10 +41,12 @@ export function FileSearchPopup(): ReactElement {
       header={'Search for Files and Directories'}
       isOpen={true}
       fullWidth={true}
-      rightButtonText={ButtonText.Cancel}
+      rightButtonConfig={{
+        onClick: close,
+        buttonText: ButtonText.Cancel,
+      }}
       onBackdropClick={close}
       onEscapeKeyDown={close}
-      onRightButtonClick={close}
     />
   );
 }

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -76,22 +76,30 @@ export function NotSavedPopup(): ReactElement {
     <NotificationPopup
       content={content}
       header={'Warning'}
-      leftButtonText={ButtonText.Save}
-      isLeftButtonDisabled={isSavingDisabled}
-      onLeftButtonClick={
-        showSaveGloballyButton ? handleSaveClick : handleSaveGloballyClick
+      leftButtonConfig={{
+        onClick: showSaveGloballyButton
+          ? handleSaveClick
+          : handleSaveGloballyClick,
+        buttonText: ButtonText.Save,
+        isDisabled: isSavingDisabled,
+      }}
+      centerLeftButtonConfig={
+        showSaveGloballyButton
+          ? {
+              onClick: handleSaveGloballyClick,
+              buttonText: ButtonText.SaveGlobally,
+              isDisabled: isSavingDisabled,
+            }
+          : undefined
       }
-      centerLeftButtonText={
-        showSaveGloballyButton ? ButtonText.SaveGlobally : undefined
-      }
-      isCenterLeftButtonDisabled={isSavingDisabled}
-      onCenterLeftButtonClick={
-        showSaveGloballyButton ? handleSaveGloballyClick : undefined
-      }
-      centerRightButtonText={ButtonText.Undo}
-      onCenterRightButtonClick={handleUndoClick}
-      rightButtonText={ButtonText.Cancel}
-      onRightButtonClick={handleCancelClick}
+      centerRightButtonConfig={{
+        onClick: handleUndoClick,
+        buttonText: ButtonText.Undo,
+      }}
+      rightButtonConfig={{
+        onClick: handleCancelClick,
+        buttonText: ButtonText.Cancel,
+      }}
       isOpen={true}
     />
   );

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -11,22 +11,15 @@ import MuiDialogTitle from '@mui/material/DialogTitle';
 import React, { ReactElement, useEffect } from 'react';
 import { Button } from '../Button/Button';
 import { doNothing } from '../../util/do-nothing';
+import { ButtonConfig } from '../../types/types';
 
 interface NotificationPopupProps {
   header: string;
   content: ReactElement | string;
-  leftButtonText?: string;
-  centerLeftButtonText?: string;
-  centerRightButtonText?: string;
-  rightButtonText?: string;
-  isLeftButtonDisabled?: boolean;
-  isCenterLeftButtonDisabled?: boolean;
-  isCenterRightButtonDisabled?: boolean;
-  isRightButtonDisabled?: boolean;
-  onLeftButtonClick?(): void;
-  onCenterLeftButtonClick?(): void;
-  onCenterRightButtonClick?(): void;
-  onRightButtonClick?(): void;
+  leftButtonConfig?: ButtonConfig;
+  rightButtonConfig?: ButtonConfig;
+  centerLeftButtonConfig?: ButtonConfig;
+  centerRightButtonConfig?: ButtonConfig;
   onBackdropClick?(): void;
   onEscapeKeyDown?(): void;
   isOpen: boolean;
@@ -78,36 +71,36 @@ export function NotificationPopup(props: NotificationPopupProps): ReactElement {
         )}
       </MuiDialogContent>
       <MuiDialogActions>
-        {props.leftButtonText && props.onLeftButtonClick ? (
+        {props.leftButtonConfig ? (
           <Button
-            buttonText={props.leftButtonText}
-            onClick={props.onLeftButtonClick}
+            buttonText={props.leftButtonConfig.buttonText}
+            onClick={props.leftButtonConfig.onClick}
             isDark={true}
-            disabled={props.isLeftButtonDisabled}
+            disabled={props.leftButtonConfig.isDisabled}
           />
         ) : null}
-        {props.centerLeftButtonText && props.onCenterLeftButtonClick ? (
+        {props.centerLeftButtonConfig ? (
           <Button
-            buttonText={props.centerLeftButtonText}
-            onClick={props.onCenterLeftButtonClick}
+            buttonText={props.centerLeftButtonConfig.buttonText}
+            onClick={props.centerLeftButtonConfig.onClick}
             isDark={false}
-            disabled={props.isCenterLeftButtonDisabled}
+            disabled={props.centerLeftButtonConfig.isDisabled}
           />
         ) : null}
-        {props.centerRightButtonText && props.onCenterRightButtonClick ? (
+        {props.centerRightButtonConfig ? (
           <Button
-            buttonText={props.centerRightButtonText}
-            onClick={props.onCenterRightButtonClick}
+            buttonText={props.centerRightButtonConfig.buttonText}
+            onClick={props.centerRightButtonConfig.onClick}
             isDark={false}
-            disabled={props.isCenterRightButtonDisabled}
+            disabled={props.centerRightButtonConfig.isDisabled}
           />
         ) : null}
-        {props.rightButtonText && props.onRightButtonClick ? (
+        {props.rightButtonConfig ? (
           <Button
-            buttonText={props.rightButtonText}
-            onClick={props.onRightButtonClick}
+            buttonText={props.rightButtonConfig.buttonText}
+            onClick={props.rightButtonConfig.onClick}
             isDark={false}
-            disabled={props.isRightButtonDisabled}
+            disabled={props.rightButtonConfig.isDisabled}
           />
         ) : null}
       </MuiDialogActions>

--- a/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
+++ b/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
@@ -6,6 +6,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { NotificationPopup } from '../NotificationPopup';
+import { ButtonConfig } from '../../../types/types';
 
 describe('NotificationPopup', () => {
   test('renders open popup with text', () => {
@@ -14,18 +15,30 @@ describe('NotificationPopup', () => {
     const onCenterLeftButtonClick = jest.fn();
     const onCenterRightButtonClick = jest.fn();
 
+    const leftButtonConfig: ButtonConfig = {
+      onClick: onLeftButtonClick,
+      buttonText: 'leftButtonText',
+    };
+    const rightButtonConfig: ButtonConfig = {
+      onClick: onRightButtonClick,
+      buttonText: 'rightButtonText',
+    };
+    const centerLeftButtonConfig: ButtonConfig = {
+      onClick: onCenterLeftButtonClick,
+      buttonText: 'centerLeftButtonText',
+    };
+    const centerRightButtonConfig: ButtonConfig = {
+      onClick: onCenterRightButtonClick,
+      buttonText: 'centerRightButtonText',
+    };
     render(
       <NotificationPopup
         content={'content text'}
         header={'header text'}
-        leftButtonText={'leftButtonText'}
-        onLeftButtonClick={onLeftButtonClick}
-        rightButtonText={'rightButtonText'}
-        onRightButtonClick={onRightButtonClick}
-        centerLeftButtonText={'centerLeftButtonText'}
-        onCenterLeftButtonClick={onCenterLeftButtonClick}
-        centerRightButtonText={'centerRightButtonText'}
-        onCenterRightButtonClick={onCenterRightButtonClick}
+        leftButtonConfig={leftButtonConfig}
+        rightButtonConfig={rightButtonConfig}
+        centerLeftButtonConfig={centerLeftButtonConfig}
+        centerRightButtonConfig={centerRightButtonConfig}
         isOpen={true}
       />
     );

--- a/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
+++ b/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
@@ -81,10 +81,12 @@ export function ProjectMetadataPopup(): ReactElement {
       header={'Project Metadata'}
       isOpen={true}
       fullWidth={true}
-      rightButtonText={ButtonText.Close}
+      rightButtonConfig={{
+        onClick: close,
+        buttonText: ButtonText.Close,
+      }}
       onBackdropClick={close}
       onEscapeKeyDown={close}
-      onRightButtonClick={close}
     />
   );
 }

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -43,7 +43,7 @@ export function ReplaceAttributionPopup(): ReactElement {
     dispatch(closePopup());
   }
 
-  function handleOkClick(): void {
+  function handleReplaceClick(): void {
     targetAttributionId &&
       dispatch(
         savePackageInfo(
@@ -96,10 +96,14 @@ export function ReplaceAttributionPopup(): ReactElement {
     <NotificationPopup
       content={content}
       header={'Replacing an attribution'}
-      leftButtonText={ButtonText.Replace}
-      onLeftButtonClick={handleOkClick}
-      rightButtonText={ButtonText.Cancel}
-      onRightButtonClick={handleCancelClick}
+      leftButtonConfig={{
+        onClick: handleReplaceClick,
+        buttonText: ButtonText.Replace,
+      }}
+      rightButtonConfig={{
+        onClick: handleCancelClick,
+        buttonText: ButtonText.Cancel,
+      }}
       isOpen={true}
     />
   );

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -77,8 +77,10 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
     <NotificationPopup
       header={header}
       headerClassname={classes.header}
-      rightButtonText={ButtonText.Close}
-      onRightButtonClick={props.closePopup}
+      rightButtonConfig={{
+        onClick: props.closePopup,
+        buttonText: ButtonText.Close,
+      }}
       onBackdropClick={props.closePopup}
       onEscapeKeyDown={props.closePopup}
       content={

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -82,3 +82,9 @@ export interface PopupInfo {
   popup: PopupType;
   attributionId?: string;
 }
+
+export interface ButtonConfig {
+  onClick(): void;
+  buttonText: string;
+  isDisabled?: boolean;
+}


### PR DESCRIPTION
### Summary of changes

Exchange left and right button in edit popup. Refacator NotificationPopup interface.

### Context and reason for change

The left button should be the "save" button, and it should have the more prominent color (blue). This was not the case.
Further, instead of providing button configuration for all buttons as a flat object, a new type - ButtonConfig - is introduced to improve the interface.


Before:
![Screenshot 2022-02-10 at 10 38 48](https://user-images.githubusercontent.com/46576389/153389783-6abdb1e0-5177-4d44-afd6-66a78209a32d.png)


After:
![Screenshot 2022-02-10 at 10 39 47](https://user-images.githubusercontent.com/46576389/153389759-01a52b8d-50f5-4bf9-bdd1-c130cbfa46ed.png)




