### PR TITLE
Improvements on backend logging

### DIFF
--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -151,6 +151,7 @@ export function getSendErrorInformationListener(
   webContents: WebContents
 ): (_: unknown, args: SendErrorInformationArgs) => Promise<void> {
   return async (_, args: SendErrorInformationArgs): Promise<void> => {
+    log.error(args.error.message + args.errorInfo.componentStack);
     await getMessageBoxForErrors(
       args.error.message,
       args.errorInfo.componentStack,
@@ -243,14 +244,19 @@ export function _exportFileAndOpenFolder(mainWindow: BrowserWindow) {
 
     try {
       if (exportedFilePath) {
+        log.info(
+          `Starting to create ${exportArgs.type} export to ${exportedFilePath}`
+        );
         await fileExporter(exportedFilePath, exportArgs);
       } else {
+        log.error(`Failed to create ${exportArgs.type} export.`);
         throw new Error(`Failed to create ${exportArgs.type} export.`);
       }
     } finally {
       loadingWindow.close();
 
       if (exportedFilePath) {
+        log.info(`... Successfully created ${exportArgs.type} export`);
         shell.showItemInFolder(exportedFilePath);
       }
     }

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -169,5 +169,16 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         },
       ],
     },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Open log files folder',
+          click: async (): Promise<void> => {
+            await shell.openPath(app.getPath('logs'));
+          },
+        },
+      ],
+    },
   ]);
 }


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Log errors in frontend in log file
- Change create output file log
- Add logs for export files
- Add 'help' tab with option to open folder for log files

### Context and reason for change
- Errors in frontend should be also save in log files
- Enable users to find location of log files
- Fix: #428

### How can the changes be tested
In the app, click on 'Help' and 'Open log files folder' and check logs in the file


