### PR TITLE
Fix purl handling

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -113,13 +113,15 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     props.resetViewIfThisIdChanges,
     props.smallerLicenseTextOrCommentField
   );
-  const { temporaryPurl, isDisplayedPurlValid, handlePurlChange } = usePurl(
-    dispatch,
-    packageInfoWereModified,
-    temporaryPackageInfo,
-    props.displayPackageInfo,
-    selectedPackage
-  );
+  const { temporaryPurl, isDisplayedPurlValid, handlePurlChange, updatePurl } =
+    usePurl(
+      dispatch,
+      packageInfoWereModified,
+      temporaryPackageInfo,
+      props.displayPackageInfo,
+      selectedPackage,
+      selectedAttributionId
+    );
   const nameAndVersionAreEditable = props.isEditable && temporaryPurl === '';
   const currentViewSelectedAttributionId =
     view === View.Attribution
@@ -145,7 +147,10 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         ? ButtonText.Confirm
         : ButtonText.Save,
       disabled: isSavingDisabled,
-      onClick: props.onSaveButtonClick,
+      onClick: () => {
+        updatePurl(temporaryPackageInfo);
+        props.onSaveButtonClick && props.onSaveButtonClick();
+      },
       hidden: false,
     });
   }
@@ -156,7 +161,10 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         ? ButtonText.ConfirmGlobally
         : ButtonText.SaveGlobally,
       disabled: isSavingDisabled,
-      onClick: props.onSaveGloballyButtonClick,
+      onClick: () => {
+        updatePurl(temporaryPackageInfo);
+        props.onSaveGloballyButtonClick && props.onSaveGloballyButtonClick();
+      },
       hidden: !Boolean(props.showSaveGloballyButton),
     });
   }
@@ -166,6 +174,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       buttonText: ButtonText.Undo,
       disabled: !packageInfoWereModified,
       onClick: (): void => {
+        updatePurl(initialPackageInfo);
         dispatch(setTemporaryPackageInfo(initialPackageInfo));
       },
     },

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -14,6 +14,7 @@ import {
   Source,
 } from '../../../../shared/shared-types';
 import {
+  ButtonText,
   CheckboxLabel,
   DiscreteConfidence,
   PackagePanelTitle,
@@ -41,6 +42,8 @@ import { setSelectedAttributionId } from '../../../state/actions/resource-action
 import {
   clickGoToLinkIcon,
   expectGoToLinkButtonIsDisabled,
+  expectValueInTextBox,
+  insertValueIntoTextBox,
 } from '../../../test-helpers/attribution-column-test-helpers';
 
 let originalIpcRenderer: IpcRenderer;
@@ -140,6 +143,127 @@ describe('The AttributionColumn', () => {
     expect(
       screen.getByDisplayValue('pkg:type/namespace/jQuery@16.5.0?appendix')
     );
+  });
+
+  test('renders qualifier in the purl correctly', () => {
+    const testTemporaryPackageInfo: PackageInfo = {
+      attributionConfidence: DiscreteConfidence.Low,
+      packageName: 'jQuery',
+      packageVersion: '16.5.0',
+      packagePURLAppendix: '?appendix',
+      packageNamespace: 'namespace',
+      packageType: 'type',
+      comment: 'some comment',
+      copyright: 'Copyright Doe Inc. 2019',
+      licenseText: 'Permission is hereby granted',
+      licenseName: 'Made up license name',
+      url: 'www.1999.com',
+    };
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        displayPackageInfo={testTemporaryPackageInfo}
+        setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
+        onSaveButtonClick={doNothing}
+        setTemporaryPackageInfo={(): (() => void) => doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />
+    );
+    store.dispatch(setSelectedResourceId('test_id'));
+    store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    insertValueIntoTextBox(
+      screen,
+      'PURL',
+      'pkg:type/namespace/jQuery@16.5.0?appendix&#test'
+    );
+    clickOnButton(screen, ButtonText.Save);
+    expectValueInTextBox(
+      screen,
+      'PURL',
+      'pkg:type/namespace/jQuery@16.5.0?appendix=#test'
+    );
+  });
+
+  test('sorts qualifier in the purl alphabetically', () => {
+    const testTemporaryPackageInfo: PackageInfo = {
+      attributionConfidence: DiscreteConfidence.Low,
+      packageName: 'jQuery',
+      packageVersion: '16.5.0',
+      packagePURLAppendix: '?appendix',
+      packageNamespace: 'namespace',
+      packageType: 'type',
+      comment: 'some comment',
+      copyright: 'Copyright Doe Inc. 2019',
+      licenseText: 'Permission is hereby granted',
+      licenseName: 'Made up license name',
+      url: 'www.1999.com',
+    };
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        displayPackageInfo={testTemporaryPackageInfo}
+        setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
+        onSaveButtonClick={doNothing}
+        setTemporaryPackageInfo={(): (() => void) => doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />
+    );
+    store.dispatch(setSelectedResourceId('test_id'));
+    store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    insertValueIntoTextBox(
+      screen,
+      'PURL',
+      'pkg:type/namespace/jQuery@16.5.0?test=appendix&appendix=test#test'
+    );
+    clickOnButton(screen, ButtonText.Save);
+    expectValueInTextBox(
+      screen,
+      'PURL',
+      'pkg:type/namespace/jQuery@16.5.0?appendix=test&test=appendix#test'
+    );
+  });
+
+  test('removes special symbol from the end of the purl if nothing follows', () => {
+    const testTemporaryPackageInfo: PackageInfo = {
+      attributionConfidence: DiscreteConfidence.Low,
+      packageName: 'jQuery',
+      packageVersion: '16.5.0',
+      packagePURLAppendix: '?appendix',
+      packageNamespace: 'namespace',
+      packageType: 'type',
+      comment: 'some comment',
+      copyright: 'Copyright Doe Inc. 2019',
+      licenseText: 'Permission is hereby granted',
+      licenseName: 'Made up license name',
+      url: 'www.1999.com',
+    };
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        displayPackageInfo={testTemporaryPackageInfo}
+        setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
+        onSaveButtonClick={doNothing}
+        setTemporaryPackageInfo={(): (() => void) => doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />
+    );
+    store.dispatch(setSelectedResourceId('test_id'));
+    store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    insertValueIntoTextBox(screen, 'PURL', 'pkg:type/namespace/jQuery@16.5.0?');
+    clickOnButton(screen, ButtonText.Save);
+    expectValueInTextBox(screen, 'PURL', 'pkg:type/namespace/jQuery@16.5.0');
   });
 
   test('renders a TextBox for the source, if it is defined', () => {


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- display what user enters in the purl box and do not regenerate the purl after each input
- check and regenerate purl on save or undo

### Context and reason for change
The purl handling does not work for some cases as it regenerates the purl after each input

### How can the changes be tested
The changes can be tested by runnning `yarn test:integration-ci`  and  `yarn test:unit` and in the UI

