### PR TITLE
Allow missing base urls

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -238,7 +238,8 @@
   ],
   "baseUrlsForSources": {
     "/": "https://github.com/opossum-tool/OpossumUI/blob/main/src/{path}?test=bla",
-    "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4"
+    "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4",
+    "/Frontend/test-helpers/": null
   },
   "externalAttributionSources": {
     "SC": {

--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -203,7 +203,7 @@
     },
     "baseUrlsForSources": {
       "type": "object",
-      "description": "Map from paths to the respective base url. The base url should contain a {path} placeholder. E.g. https://github.com/opossum-tool/opossumUI/blob/main/{path}",
+      "description": "Map from paths to the respective base url. The base url should contain a {path} placeholder. E.g. https://github.com/opossum-tool/opossumUI/blob/main/{path}. The base url might be null to indicate a missing link.",
       "additionalProperties": true
     },
     "externalAttributionSources": {

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -73,7 +73,7 @@ export interface ParsedOpossumInputFile {
 }
 
 export interface RawBaseUrlsForSources {
-  [path: string]: string;
+  [path: string]: string | null;
 }
 
 export interface ParsedOpossumOutputFile {

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -51,9 +51,15 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
     let link = '';
     for (let index = 0; index < sortedParents.length; index++) {
       const parent = sortedParents[index];
-      if (isAttributionBreakpoint(parent) || isAttributionBreakpoint(path)) {
+      const baseUrlOfParent = baseUrlsForSources[parent];
+      if (
+        isAttributionBreakpoint(parent) ||
+        isAttributionBreakpoint(path) ||
+        baseUrlOfParent === null
+      ) {
         break;
       }
+
       if (parent in baseUrlsForSources) {
         const pathWithoutParentWithUrl = path.replace(
           new RegExp(`^${parent}`),
@@ -62,7 +68,7 @@ export function GoToLinkButton(props: GoToLinkProps): ReactElement {
         const pathWithoutLeadingAndTrailingSlashes = pathWithoutParentWithUrl
           .replace(/^\//, '')
           .replace(/\/$/, '');
-        link = baseUrlsForSources[parent].replace(
+        link = baseUrlOfParent.replace(
           '{path}',
           pathWithoutLeadingAndTrailingSlashes
         );

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -68,4 +68,18 @@ describe('The GoToLinkButton', () => {
       );
     }
   );
+
+  it('does not show link if base url of parent is null ', () => {
+    const parentPath = '/parent_directory/';
+    const testBaseUrlsForSources: BaseUrlsForSources = {
+      [parentPath]: null,
+    };
+    const { store } = renderComponentWithStore(<GoToLinkButton />);
+    store.dispatch(setSelectedResourceId(parentPath));
+    store.dispatch(setBaseUrlsForSources(testBaseUrlsForSources));
+
+    expect(screen.getByLabelText('link to open')).toHaveStyle(
+      'visibility: hidden'
+    );
+  });
 });

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -106,7 +106,7 @@ export interface ParsedFileContent {
 }
 
 export interface BaseUrlsForSources {
-  [path: string]: string;
+  [path: string]: string | null;
 }
 
 export interface SendErrorInformationArgs {


### PR DESCRIPTION

### Summary of changes

Allow missing base urls

### Context and reason for change

In the case that a file or folder has no valid URL tht could be opened, it is possible to set its base url to "null" in the opossum input file. Then the open file link is not displayed in the UI.

### How can the changes be tested

Open example file and observe that "/Frontend/test-helpers/" and its children have no link displayed.