### PR TITLE
Improve regex for urls for license fetching

### DIFF
--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/license-fetching-helpers.test.ts
@@ -35,6 +35,15 @@ describe('getLicenseFetchingInformation', () => {
     });
   });
 
+  it('recognizes npm urls starting with www', () => {
+    expect(
+      getLicenseFetchingInformation('https://www.npmjs.com/package/react')
+    ).toMatchObject({
+      url: 'https://registry.npmjs.org/react',
+      convertPayload: convertNpmPayload,
+    });
+  });
+
   it('recognizes npm urls with complicated package names', () => {
     expect(
       getLicenseFetchingInformation(

--- a/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
@@ -20,7 +20,7 @@ function getPackageNamespaceAndPackageNameFromGithubURL(url: string): {
   packageName: string;
 } {
   const urlSuffix = url
-    .replace(new RegExp('^https://github.com/'), '')
+    .replace(new RegExp('^https://(www.)?github.com/'), '')
     .split('/');
   return {
     namespace: urlSuffix[0],

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -11,9 +11,13 @@ import {
   getGithubAPIUrl,
 } from './github-fetching-helpers';
 
-const PYPI_REGEX = new RegExp('^https://pypi.org/(pypi|project)/[\\w-+,_]+/?$');
-const NPM_REGEX = new RegExp('^https://npmjs.com/(package/)?[\\w-+,_@/]+/?$');
-const GITHUB_REGEX = new RegExp('^https://github.com/[^/]+/[^/]+');
+const PYPI_REGEX = new RegExp(
+  '^https://(www.)?pypi.org/(pypi|project)/[\\w-+,_]+/?$'
+);
+const NPM_REGEX = new RegExp(
+  '^https://(www.)?npmjs.com/(package/)?[\\w-+,_@/]+/?$'
+);
+const GITHUB_REGEX = new RegExp('^https://(www.)?github.com/[^/]+/[^/]+');
 
 export interface LicenseFetchingInformation {
   url: string;

--- a/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
@@ -8,7 +8,7 @@ import { Schema, Validator } from 'jsonschema';
 
 export function getNpmAPIUrl(url: string, version?: string): string {
   const packageName = url
-    .replace(new RegExp('^https://npmjs.com/(package/)?'), '')
+    .replace(new RegExp('^https://(www.)?npmjs.com/(package/)?'), '')
     .replace(new RegExp('/$'), '');
   return `https://registry.npmjs.org/${packageName}${
     version ? `/${version}` : ''


### PR DESCRIPTION
### Summary of changes
Improve the regex which detects URLs which are eligible to fetch information from package managers.

### Context and reason for change
`https://npmjs.com/package/react` leads to a clickable button, whereas `https://www.npmjs.com/package/react` shows a deactivated button.

### How can the changes be tested

Run tests and use an example like `https://www.npmjs.com/package/react`

