### PR TITLE
Add field "criticality" to attributions

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -140,6 +140,7 @@
       "comment": "TypeScript is great. \nhttps://www.npmjs.com/package/typescript",
       "packageName": "TypeScript",
       "preSelected": true,
+      "criticality": "high",
       "packageVersion": "3.9.6",
       "url": "www.typescriptlang.org",
       "licenseName": "Apache License Version 2.0",

--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -118,6 +118,10 @@
             "type": "string",
             "description": "Additional human-readable comments about the attribution that don't fit into other fields"
           },
+          "criticality": {
+            "type": "string",
+            "description": "Indication on how critical a signal is. Possible values are \"high\" and \"medium\"."
+          },
           "copyright": {
             "type": "string",
             "description": "Copyright of the package"

--- a/src/ElectronBackend/input/OpossumOutputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumOutputFileSchema.json
@@ -66,6 +66,10 @@
             "type": "string",
             "description": "Additional human-readable comments about the attribution that don't fit into other fields"
           },
+          "criticality": {
+            "type": "string",
+            "description": "Indication on how critical a signal is. Possible values are \"high\" and \"medium\"."
+          },
           "copyright": {
             "type": "string",
             "description": "Copyright of the package"

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -8,6 +8,7 @@ import { BrowserWindow, dialog } from 'electron';
 import path from 'path';
 import upath from 'upath';
 import {
+  Criticality,
   FollowUp,
   PackageInfo,
   ParsedFileContent,
@@ -81,6 +82,7 @@ const inputFileContent: ParsedOpossumInputFile = {
       copyright: '(c) first party',
       firstParty: true,
       excludeFromNotice: true,
+      criticality: Criticality.High,
     },
   },
   frequentLicenses: [
@@ -126,6 +128,7 @@ const expectedFileContent: ParsedFileContent = {
         copyright: '(c) first party',
         excludeFromNotice: true,
         firstParty: true,
+        criticality: Criticality.High,
       },
     },
     resourcesToAttributions: {

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -7,6 +7,7 @@ import { WebContents } from 'electron';
 import {
   Attributions,
   AttributionsToResources,
+  Criticality,
   FollowUp,
   FrequentLicences,
   Resources,
@@ -17,10 +18,10 @@ import {
   cleanNonExistentResolvedExternalSignals,
   getAllResourcePaths,
   parseFrequentLicenses,
-  sanitizeRawAttributions,
+  parseRawAttributions,
   sanitizeRawBaseUrlsForSources,
   sanitizeResourcesToAttributions,
-} from '../cleanInputData';
+} from '../parseInputData';
 import {
   RawAttributions,
   RawBaseUrlsForSources,
@@ -95,9 +96,7 @@ describe('sanitizeRawAttributions', () => {
       },
     };
 
-    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
-      expectedAttributions
-    );
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
   });
 
   test('removes unknown strings from followUp', () => {
@@ -110,9 +109,7 @@ describe('sanitizeRawAttributions', () => {
       id: {},
     };
 
-    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
-      expectedAttributions
-    );
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
   });
 
   test('leaves non-empty comment unchanged', () => {
@@ -127,9 +124,7 @@ describe('sanitizeRawAttributions', () => {
       },
     };
 
-    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
-      expectedAttributions
-    );
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
   });
 
   test('removes empty comment', () => {
@@ -142,9 +137,35 @@ describe('sanitizeRawAttributions', () => {
       id: {},
     };
 
-    expect(sanitizeRawAttributions(rawAttributions)).toEqual(
-      expectedAttributions
-    );
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+  });
+
+  test('leaves criticality unchanged', () => {
+    const rawAttributions: RawAttributions = {
+      id: {
+        criticality: 'high' as Criticality,
+      },
+    };
+    const expectedAttributions: Attributions = {
+      id: {
+        criticality: Criticality.High,
+      },
+    };
+
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+  });
+
+  test('removes empty comment', () => {
+    const rawAttributions: RawAttributions = {
+      id: {
+        criticality: 'invalid value' as Criticality,
+      },
+    };
+    const expectedAttributions: Attributions = {
+      id: {},
+    };
+
+    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
   });
 });
 

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -17,10 +17,10 @@ import {
   cleanNonExistentAttributions,
   cleanNonExistentResolvedExternalSignals,
   parseFrequentLicenses,
-  sanitizeRawAttributions,
+  parseRawAttributions,
   sanitizeRawBaseUrlsForSources,
   sanitizeResourcesToAttributions,
-} from './cleanInputData';
+} from './parseInputData';
 import { parseOpossumInputFile, parseOpossumOutputFile } from './parseFile';
 import {
   GlobalBackendState,
@@ -62,7 +62,7 @@ export async function loadJsonFromFilePath(
   }
 
   log.info('... Successfully parsed input file.');
-  const externalAttributions = sanitizeRawAttributions(
+  const externalAttributions = parseRawAttributions(
     parsingResult.externalAttributions
   );
 
@@ -85,7 +85,7 @@ export async function loadJsonFromFilePath(
 
   log.info(`Starting to parse output file ${manualAttributionFilePath} ...`);
   const opossumOutputData = parseOpossumOutputFile(manualAttributionFilePath);
-  const manualAttributions = sanitizeRawAttributions(
+  const manualAttributions = parseRawAttributions(
     opossumOutputData.manualAttributions
   );
   log.info('... Successfully parsed output file.');

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -8,6 +8,7 @@ import { IpcChannel } from '../../shared/ipc-channels';
 import {
   Attributions,
   BaseUrlsForSources,
+  Criticality,
   FollowUp,
   FrequentLicences,
   Resources,
@@ -124,7 +125,7 @@ export function cleanNonExistentResolvedExternalSignals(
   return resolvedExternalAttributions;
 }
 
-export function sanitizeRawAttributions(
+export function parseRawAttributions(
   rawAttributions: RawAttributions
 ): Attributions {
   for (const attributionId of Object.keys(rawAttributions)) {
@@ -133,6 +134,10 @@ export function sanitizeRawAttributions(
     }
     if (rawAttributions[attributionId]?.comment === '') {
       delete rawAttributions[attributionId].comment;
+    }
+    const criticality = rawAttributions[attributionId]?.criticality;
+    if (criticality && !Object.values(Criticality).includes(criticality)) {
+      delete rawAttributions[attributionId].criticality;
     }
   }
 

--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -19,7 +19,7 @@ import { createTempFolder, deleteFolder } from '../../test-helpers';
 const testCsvHeader =
   '"Index";"Confidence";"Comment";"Package Name";"Package Version";"Package Namespace";' +
   '"Package Type";"PURL Appendix";"URL";"Copyright";"License Name";"License Text (truncated)";"Source";"First Party";' +
-  '"Follow-up";"Origin Attribution ID";"pre-selected";"exclude-from-notice";"Resources"';
+  '"Follow-up";"Origin Attribution ID";"pre-selected";"exclude-from-notice";"criticality";"Resources"';
 
 describe('writeCsvToFile', () => {
   test('writeCsvToFile short', async () => {
@@ -46,13 +46,13 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"'
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"'
     );
     deleteFolder(temporaryPath);
   });
@@ -117,10 +117,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
         '/b"'
     );
     deleteFolder(temporaryPath);
@@ -162,10 +162,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`
+      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`
     );
     deleteFolder(temporaryPath);
   });
@@ -451,25 +451,25 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"/a"`
+      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"";"/a"`
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"'
     );
     deleteFolder(temporaryPath);
   });

--- a/src/ElectronBackend/output/writeCsvToFile.ts
+++ b/src/ElectronBackend/output/writeCsvToFile.ts
@@ -89,6 +89,7 @@ export function getHeadersFromColumns(columns: Array<KeysOfAttributionInfo>): {
     originId: 'Origin Attribution ID',
     preSelected: 'pre-selected',
     excludeFromNotice: 'exclude-from-notice',
+    criticality: 'criticality',
   };
 
   const headers: { [key: string]: string } = {};

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -5,6 +5,7 @@
 
 import {
   Attributions,
+  Criticality,
   ExternalAttributionSources,
   ProjectMetadata,
   Resources,
@@ -48,6 +49,7 @@ interface RawPackageInfo {
   originId?: string;
   preSelected?: boolean;
   excludeFromNotice?: boolean;
+  criticality?: Criticality;
 }
 
 export interface RawAttributions {

--- a/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
+++ b/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfo } from '../../../shared/shared-types';
+import { Criticality, PackageInfo } from '../../../shared/shared-types';
 import { getStrippedPackageInfo } from '../get-stripped-package-info';
 
 describe('The getStrippedPackageInfo function', () => {
@@ -36,6 +36,17 @@ describe('The getStrippedPackageInfo function', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'React',
       preSelected: true,
+    };
+
+    expect(getStrippedPackageInfo(testPackageInfo)).toEqual({
+      packageName: 'React',
+    });
+  });
+
+  test('strips criticality ', () => {
+    const testPackageInfo: PackageInfo = {
+      packageName: 'React',
+      criticality: Criticality.High,
     };
 
     expect(getStrippedPackageInfo(testPackageInfo)).toEqual({

--- a/src/Frontend/util/__tests__/package-info-has-no-significant-fields.test.ts
+++ b/src/Frontend/util/__tests__/package-info-has-no-significant-fields.test.ts
@@ -4,7 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import each from 'jest-each';
-import { FollowUp, PackageInfo } from '../../../shared/shared-types';
+import {
+  Criticality,
+  FollowUp,
+  PackageInfo,
+} from '../../../shared/shared-types';
 import { packageInfoHasNoSignificantFields } from '../package-info-has-no-significant-fields';
 
 describe('The test package', () => {
@@ -15,6 +19,7 @@ describe('The test package', () => {
     { originId: 'another-uuid', attributionConfidence: 100 },
     { followUp: FollowUp },
     { excludeFromNotice: true },
+    { criticality: Criticality.Medium },
     {
       source: {
         name: 'test name',

--- a/src/Frontend/util/get-stripped-package-info.ts
+++ b/src/Frontend/util/get-stripped-package-info.ts
@@ -15,6 +15,7 @@ export function getStrippedPackageInfo(
   );
   delete strippedTemporaryPackageInfo.source;
   delete strippedTemporaryPackageInfo.preSelected;
+  delete strippedTemporaryPackageInfo.criticality;
 
   return removeExcessProperties(strippedTemporaryPackageInfo);
 }

--- a/src/Frontend/util/package-info-has-no-significant-fields.ts
+++ b/src/Frontend/util/package-info-has-no-significant-fields.ts
@@ -15,6 +15,7 @@ export function packageInfoHasNoSignificantFields(
   delete packageInfoWithSignificantFields.originId;
   delete packageInfoWithSignificantFields.preSelected;
   delete packageInfoWithSignificantFields.excludeFromNotice;
+  delete packageInfoWithSignificantFields.criticality;
   delete packageInfoWithSignificantFields.source;
   return isEmpty(packageInfoWithSignificantFields);
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -13,6 +13,11 @@ export interface Resources {
 export type FollowUp = 'FOLLOW_UP';
 export const FollowUp = 'FOLLOW_UP';
 
+export enum Criticality {
+  High = 'high',
+  Medium = 'medium',
+}
+
 export interface PackageInfo {
   attributionConfidence?: number;
   comment?: string;
@@ -31,6 +36,7 @@ export interface PackageInfo {
   originId?: string;
   preSelected?: boolean;
   excludeFromNotice?: boolean;
+  criticality?: Criticality;
 }
 
 export interface Source {

--- a/src/shared/shared-util.ts
+++ b/src/shared/shared-util.ts
@@ -26,6 +26,7 @@ export function getPackageInfoKeys(): Array<KeysOfPackageInfo> {
     originId: true,
     preSelected: true,
     excludeFromNotice: true,
+    criticality: true,
   };
   return Object.keys(packageInfoKeysObject) as Array<KeysOfPackageInfo>;
 }


### PR DESCRIPTION

### Summary of changes

There is a new field introduced in PackageInfo: "criticality". This field has values in an enum and is optional.

### Context and reason for change

The new field will be used to highlight signals that are critical. Criticality is set in the input file used for OpossumUI.



