### PR TITLE
hard code types requiring namespace

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -114,6 +114,13 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
         text={props.temporaryPurl}
         handleChange={props.handlePurlChange}
         isEditable={props.isEditable}
+        isHighlighted={
+          props.showHighlight &&
+          isImportantAttributionInformationMissing(
+            'packageNamespace',
+            props.displayPackageInfo
+          )
+        }
       />
       <TextBox
         isEditable={props.isEditable}

--- a/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
@@ -120,49 +120,52 @@ describe('The table helpers', () => {
     ${'packageName'}
     ${'url'}
     ${'packageVersion'}
-  `('isMarkedTableCell handles $property correctly', ({ property }) => {
-    const testTableConfig: TableConfig = {
-      attributionProperty: property,
-      displayName: 'Follow-up',
-    };
+  `(
+    'isImportantAttributionInformationMissing handles $property correctly',
+    ({ property }) => {
+      const testTableConfig: TableConfig = {
+        attributionProperty: property,
+        displayName: 'Follow-up',
+      };
 
-    let testAttributionInfo: AttributionInfo = {
-      [property]: '',
-      resources: ['1'],
-    };
+      let testAttributionInfo: AttributionInfo = {
+        [property]: '',
+        resources: ['1'],
+      };
 
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(true);
+      expect(
+        isImportantAttributionInformationMissing(
+          testTableConfig.attributionProperty,
+          testAttributionInfo
+        )
+      ).toEqual(true);
 
-    testAttributionInfo = {
-      resources: ['1'],
-    };
+      testAttributionInfo = {
+        resources: ['1'],
+      };
 
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(true);
+      expect(
+        isImportantAttributionInformationMissing(
+          testTableConfig.attributionProperty,
+          testAttributionInfo
+        )
+      ).toEqual(true);
 
-    testAttributionInfo = {
-      [property]: 'test',
-      resources: ['1'],
-    };
+      testAttributionInfo = {
+        [property]: 'test',
+        resources: ['1'],
+      };
 
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(false);
-  });
+      expect(
+        isImportantAttributionInformationMissing(
+          testTableConfig.attributionProperty,
+          testAttributionInfo
+        )
+      ).toEqual(false);
+    }
+  );
 
-  test('isMarkedTableCell handles attributionConfidence correctly', () => {
+  test('isImportantAttributionInformationMissing handles attributionConfidence correctly', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'attributionConfidence',
       displayName: 'Follow-up',
@@ -204,7 +207,7 @@ describe('The table helpers', () => {
     ).toEqual(false);
   });
 
-  test('isMarkedTableCell does not mark first party or excluded attributions', () => {
+  test('isImportantAttributionInformationMissing does not mark first party or excluded attributions', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'licenseName',
       displayName: 'Unimportant',

--- a/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
+++ b/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AttributionInfo } from '../../../shared/shared-types';
+import { isImportantAttributionInformationMissing } from '../is-important-attribution-information-missing';
+
+describe('isImportantAttributionInformationMissing', () => {
+  test('returns true for a github purl without namespace', () => {
+    const testAttributionInfo: AttributionInfo = {
+      packageType: 'github',
+      resources: ['1'],
+    };
+    expect(
+      isImportantAttributionInformationMissing(
+        'packageNamespace',
+        testAttributionInfo
+      )
+    ).toEqual(true);
+  });
+
+  test('returns false if exclude from notice', () => {
+    const testAttributionInfo: AttributionInfo = {
+      excludeFromNotice: true,
+      resources: ['1'],
+    };
+    expect(
+      isImportantAttributionInformationMissing(
+        'excludeFromNotice',
+        testAttributionInfo
+      )
+    ).toEqual(false);
+  });
+
+  test('returns true if package name is missing', () => {
+    const testAttributionInfo: AttributionInfo = {
+      resources: ['1'],
+    };
+    expect(
+      isImportantAttributionInformationMissing(
+        'packageName',
+        testAttributionInfo
+      )
+    ).toEqual(true);
+  });
+
+  test('returns false if copyright is not missing', () => {
+    const testAttributionInfo: AttributionInfo = {
+      copyright: 'test',
+      resources: ['1'],
+    };
+    expect(
+      isImportantAttributionInformationMissing('copyright', testAttributionInfo)
+    ).toEqual(false);
+  });
+
+  test('returns true if confidence is smaller then 50 ', () => {
+    const testAttributionInfo: AttributionInfo = {
+      attributionConfidence: 20,
+      resources: ['1'],
+    };
+    expect(
+      isImportantAttributionInformationMissing(
+        'attributionConfidence',
+        testAttributionInfo
+      )
+    ).toEqual(true);
+  });
+});

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -5,6 +5,14 @@
 
 import { AttributionInfo } from '../../shared/shared-types';
 
+const TYPES_REQUIRING_NAMESPACE = [
+  'bitbucket',
+  'composer',
+  'deb',
+  'golang',
+  'github',
+  'maven',
+];
 interface ExtendedAttributionInfo extends AttributionInfo {
   icons: unknown;
 }
@@ -30,7 +38,26 @@ export function isImportantAttributionInformationMissing(
         !extendedAttributionInfo['attributionConfidence'] ||
         extendedAttributionInfo['attributionConfidence'] < 50
       );
+    case 'packageNamespace':
+      return isNamespaceRequiredButMissing(
+        extendedAttributionInfo['packageType'],
+        extendedAttributionInfo[attributionProperty]
+      );
     default:
       return false;
   }
+}
+
+function isNamespaceRequiredButMissing(
+  packageType?: string,
+  packageNamespace?: string
+): boolean {
+  if (
+    packageType &&
+    TYPES_REQUIRING_NAMESPACE.includes(packageType) &&
+    !packageNamespace
+  ) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Hard code types for purl, which requires a namespace (github and maven)
- Mark a purl for such types as invalid if namespace is missing

### Context and reason for change
- These purls are useless without namespace
- Fix: #502 

### How can the changes be tested
- In the UI


