### PR TITLE
Rename tabs

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -160,10 +160,10 @@ In the opossumUI, a distinction between **signals** and **attributions** is made
 In the `Attribution Selection Column` the following sub-panels may be present:
 
 - `Attribution Sub-Panel` (always shown),
-- `Signals Sub-Panel` (accessible via the `SIGNALS & CONTENT` tab),
-- `Attributions in Folder Content Sub-Panel` (accessible via the `SIGNALS & CONTENT` tab),
-- `Signals in Folder Content Sub-Panel` (accessible via the `SIGNALS & CONTENT` tab),
-- `Add to Attribution Sub-Panel` (accessible via the `ALL ATTRIBUTIONS` tab).
+- `Signals Sub-Panel` (accessible via the `LOCAL` tab),
+- `Attributions in Folder Content Sub-Panel` (accessible via the `LOCAL` tab),
+- `Signals in Folder Content Sub-Panel` (accessible via the `LOCAL` tab),
+- `Add to Attribution Sub-Panel` (accessible via the `GLOBAL` tab).
 
 The `Attributions Sub-Panel` shows a list of all attributions that are assigned to the selected resource.
 **Pre-selected** attributions are signaled by an `P` icon. They can be confirmed, therefore being considered

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles({
 });
 
 interface ResourceDetailsTabsProps {
-  isAllAttributionsTabEnabled: boolean;
+  isGlobalTabEnabled: boolean;
   isAddToPackageEnabled: boolean;
 }
 
@@ -61,13 +61,13 @@ export function ResourceDetailsTabs(
   );
 
   enum Tabs {
-    SignalsAndContent = 0,
-    AllAttributions = 1,
+    Local = 0,
+    Global = 1,
   }
-  const [selectedTab, setSelectedTab] = useState<Tabs>(Tabs.SignalsAndContent);
+  const [selectedTab, setSelectedTab] = useState<Tabs>(Tabs.Local);
   useEffect(() => {
-    setSelectedTab(Tabs.SignalsAndContent);
-  }, [selectedResourceId, Tabs.SignalsAndContent]);
+    setSelectedTab(Tabs.Local);
+  }, [selectedResourceId, Tabs.Local]);
 
   const assignableAttributionIds: Array<string> = remove(
     Object.keys(manualData.attributions),
@@ -76,7 +76,7 @@ export function ResourceDetailsTabs(
   );
 
   const isAddToPackageEnabled: boolean =
-    props.isAllAttributionsTabEnabled && props.isAddToPackageEnabled;
+    props.isGlobalTabEnabled && props.isAddToPackageEnabled;
   const aggregatedAttributionsPanel = useMemo(
     () => (
       <AggregatedAttributionsPanel
@@ -85,6 +85,11 @@ export function ResourceDetailsTabs(
     ),
     [isAddToPackageEnabled]
   );
+
+  const tabLabels = {
+    [Tabs.Local]: 'Local',
+    [Tabs.Global]: 'Global',
+  };
 
   return (
     <React.Fragment>
@@ -98,23 +103,22 @@ export function ResourceDetailsTabs(
         classes={{ indicator: classes.indicator }}
       >
         <MuiTab
-          label={'Signals & Content'}
-          aria-label={'Signals & Content Tab'}
-          id={`tab-${Tabs.SignalsAndContent}`}
+          label={tabLabels[Tabs.Local]}
+          aria-label={'Local Tab'}
+          id={`tab-${Tabs.Local}`}
           className={classes.tab}
         />
         <MuiTab
-          label={'All Attributions'}
-          aria-label={'All Attributions Tab'}
-          id={`tab-${Tabs.AllAttributions}`}
+          label={tabLabels[Tabs.Global]}
+          aria-label={'Global Tab'}
+          id={`tab-${Tabs.Global}`}
           disabled={
-            !props.isAllAttributionsTabEnabled ||
-            assignableAttributionIds.length < 1
+            !props.isGlobalTabEnabled || assignableAttributionIds.length < 1
           }
           className={classes.tab}
         />
       </MuiTabs>
-      {selectedTab === Tabs.SignalsAndContent ? (
+      {selectedTab === Tabs.Local ? (
         aggregatedAttributionsPanel
       ) : (
         <AllAttributionsPanel
@@ -124,7 +128,7 @@ export function ResourceDetailsTabs(
           }
           attributionIds={assignableAttributionIds}
           isAddToPackageEnabled={
-            props.isAllAttributionsTabEnabled && props.isAddToPackageEnabled
+            props.isGlobalTabEnabled && props.isAddToPackageEnabled
           }
         />
       )}

--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -30,7 +30,7 @@ describe('The ResourceDetailsTabs', () => {
 
     const { store } = renderComponentWithStore(
       <ResourceDetailsTabs
-        isAllAttributionsTabEnabled={true}
+        isGlobalTabEnabled={true}
         isAddToPackageEnabled={true}
       />
     );
@@ -48,10 +48,10 @@ describe('The ResourceDetailsTabs', () => {
     });
     expect(screen.getByText('Signals'));
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expect(screen.queryByText('Signals')).not.toBeInTheDocument();
 
-    clickOnTab(screen, 'Signals & Content Tab');
+    clickOnTab(screen, 'Local Tab');
     expect(screen.getByText('Signals'));
   });
 
@@ -68,7 +68,7 @@ describe('The ResourceDetailsTabs', () => {
 
     const { store } = renderComponentWithStore(
       <ResourceDetailsTabs
-        isAllAttributionsTabEnabled={true}
+        isGlobalTabEnabled={true}
         isAddToPackageEnabled={true}
       />
     );
@@ -87,7 +87,7 @@ describe('The ResourceDetailsTabs', () => {
     });
     expect(screen.getByText('Signals'));
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expect(screen.getByText('Signals'));
   });
 });

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -118,7 +118,7 @@ export function ResourceDetailsViewer(): ReactElement | null {
           )}
           <div className={classes.tabsDiv}>
             <ResourceDetailsTabs
-              isAllAttributionsTabEnabled={!showParentAttributions}
+              isGlobalTabEnabled={!showParentAttributions}
               isAddToPackageEnabled={!resourceIsAttributionBreakpoint}
             />
           </div>

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -482,11 +482,11 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByText('Signals'));
     expect(screen.queryByText(manualPackagePanelLabel)).not.toBeInTheDocument();
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expect(screen.queryByText('Signals')).not.toBeInTheDocument();
     expect(screen.getByText(manualPackagePanelLabel));
 
-    clickOnTab(screen, 'Signals & Content Tab');
+    clickOnTab(screen, 'Local Tab');
     expect(screen.getByText('Signals'));
     expect(screen.queryByText(manualPackagePanelLabel)).not.toBeInTheDocument();
   });
@@ -515,7 +515,7 @@ describe('The ResourceDetailsViewer', () => {
     store.dispatch(setSelectedResourceId('/fileWithAttribution'));
     expect(screen.getByText('Signals'));
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expect(screen.getByText('Signals'));
   });
 
@@ -546,7 +546,7 @@ describe('The ResourceDetailsViewer', () => {
     );
     expect(screen.getByText('Signals'));
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expect(screen.getByText('Signals'));
   });
 

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -142,7 +142,7 @@ describe('The ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'fourthResource.js');
       expectValueInTextBox(screen, 'Name', 'Vue');
-      clickOnTab(screen, 'All Attributions Tab');
+      clickOnTab(screen, 'Global Tab');
 
       expectGlobalOnlyContextMenuForNotPreselectedAttribution(
         screen,
@@ -244,7 +244,7 @@ describe('The ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'fourthResource.js');
       expectValueInTextBox(screen, 'Name', 'Vue');
-      clickOnTab(screen, 'All Attributions Tab');
+      clickOnTab(screen, 'Global Tab');
       expectGlobalOnlyContextMenuForPreselectedAttribution(
         screen,
         'React, 16.5.0'
@@ -369,7 +369,7 @@ describe('The ContextMenu', () => {
     clickOnPathInPopupWithResources(screen, '/thirdResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectGlobalOnlyContextMenuForNotPreselectedAttribution(
       screen,
       'Vue, 1.2.0'

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
@@ -247,7 +247,7 @@ describe('Not saved popup of the app', () => {
       expectUnsavedChangesPopupIsShown(screen);
 
       clickOnButton(screen, ButtonText.Cancel);
-      clickOnTab(screen, 'All Attributions Tab');
+      clickOnTab(screen, 'Global Tab');
       clickAddIconOnCardInAttributionList(screen, 'React, 16.0.0');
       expectUnsavedChangesPopupIsShown(screen);
     }

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -107,7 +107,7 @@ describe('Other popups of the app', () => {
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     expectUnsavedChangesPopupIsNotShown(screen);
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectValueInAddToAttributionList(screen, 'Vue, 1.2.0');
     clickOnCardInAttributionList(screen, 'Vue, 1.2.0');
     expectUnsavedChangesPopupIsShown(screen);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -82,7 +82,7 @@ describe('Add to attribution', () => {
       clickOnElementInResourceBrowser(screen, 'folder1');
       clickOnElementInResourceBrowser(screen, 'firstResource.js');
       clickOnButton(screen, 'Override parent');
-      clickOnTab(screen, 'All Attributions Tab');
+      clickOnTab(screen, 'Global Tab');
       expectValueInAddToAttributionList(screen, 'React, 16.5.0');
       expectValueInAddToAttributionList(screen, 'Vue, 1.2.0');
       expectValueInAddToAttributionList(screen, 'Angular, 10');
@@ -157,7 +157,7 @@ describe('Add to attribution', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectValueInAddToAttributionList(screen, 'Vue, 1.2.0');
     expectValueInAddToAttributionList(screen, 'Angular, 10');
 
@@ -173,7 +173,7 @@ describe('Add to attribution', () => {
     expectValueInAddToAttributionList(screen, 'Angular, 10');
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectValueInAddToAttributionList(screen, 'React, 16.5.0');
     expectValueInAddToAttributionList(screen, 'Angular, 10');
   });
@@ -217,7 +217,7 @@ describe('Add to attribution', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectValueInAddToAttributionList(screen, 'Vue, 1.2.0');
     expectValueInAddToAttributionList(screen, 'Angular, 10');
 
@@ -300,11 +300,11 @@ describe('Add to attribution', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectValueNotInAddToAttributionList(screen, 'Vue, 1.2.0');
     expectValueNotInAddToAttributionList(screen, 'Angular, 10');
 
-    clickOnTab(screen, 'Signals & Content Tab');
+    clickOnTab(screen, 'Local Tab');
     expectValueNotInAddToAttributionList(screen, 'Jquery, 16.5.0');
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -180,7 +180,7 @@ describe('In Audit View the ContextMenu', () => {
       'React, 16.5.0'
     );
 
-    clickOnTab(screen, 'All Attributions Tab');
+    clickOnTab(screen, 'Global Tab');
     expectGlobalOnlyContextMenuForPreselectedAttribution(screen, 'Vue, 1.2.0');
     clickOnButtonInPackageContextMenu(
       screen,


### PR DESCRIPTION
### Summary of changes

Rename tabs

### Context and reason for change

The old naming looked broken.

New:
![Screenshot 2022-03-15 at 10 04 15](https://user-images.githubusercontent.com/46576389/158343289-a6f4e82a-13f5-4c2b-b81e-f1228ae42cfa.png)

Old:
![Screenshot 2022-03-15 at 10 04 40](https://user-images.githubusercontent.com/46576389/158343295-1e628079-0839-4546-9b12-e70b38d662a3.png)


