### PR TITLE
Suppress console.error in tests

### DIFF
--- a/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
@@ -80,6 +80,8 @@ describe('ClearlyDefinedPackageCard', () => {
     expect(getOpenPopup(store.getState())).toBeNull();
   });
   it('shows error message when fetch fails', async () => {
+    // suppress output to console
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     axiosMock.onGet(definitionEndpoint).replyOnce(404);
 
     renderComponentWithStore(

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
@@ -111,6 +111,8 @@ describe('PackageSearchPopup', () => {
   });
 
   it('shows an error message', async () => {
+    // suppress output to console
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     axiosMock.onGet(requestURLSearchEndpoint).replyOnce(200, []);
     axiosMock.onGet(requestURLSearchEndpoint).replyOnce(404);
 


### PR DESCRIPTION

### Summary of changes

Suppress console.error in tests

### Context and reason for change

So far the console was spammed during tests. In relevant tests the
output of console.error is now suppressed.

After:
![Screenshot 2022-03-16 at 13 42 13](https://user-images.githubusercontent.com/46576389/158592866-47381f0b-ed6e-42c4-9200-c7cbff48844a.png)


Before:
![Screenshot 2022-03-16 at 13 42 31](https://user-images.githubusercontent.com/46576389/158592860-63f54815-cd71-4896-953d-7c38347416cb.png)

