### PR TITLE
Fix bug that changes disappear after context menu

### DIFF
--- a/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup.tsx
@@ -8,15 +8,23 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
+import { getCurrentAttributionId } from '../../state/selectors/all-views-resource-selectors';
 
 export function ConfirmDeletionGloballyPopup(): ReactElement {
   const targetAttributionId = useAppSelector(getPopupAttributionId);
+  const selectedAttributionId =
+    useAppSelector(getCurrentAttributionId) ?? undefined;
 
   const dispatch = useAppDispatch();
 
   function deleteAttributionGlobally(): void {
     targetAttributionId &&
-      dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
+      dispatch(
+        deleteAttributionGloballyAndSave(
+          targetAttributionId,
+          selectedAttributionId
+        )
+      );
   }
 
   return (

--- a/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletionPopup/ConfirmDeletionPopup.tsx
@@ -10,17 +10,27 @@ import {
   getSelectedView,
 } from '../../state/selectors/view-selector';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
-import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
+import {
+  getAttributionIdOfDisplayedPackageInManualPanel,
+  getSelectedResourceId,
+} from '../../state/selectors/audit-view-resource-selectors';
 import {
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
 } from '../../state/actions/resource-actions/save-actions';
 import { View } from '../../enums/enums';
+import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
 
 export function ConfirmDeletionPopup(): ReactElement {
   const view = useAppSelector(getSelectedView);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const targetAttributionId = useAppSelector(getPopupAttributionId);
+  const selectedAttributionIdAttributionView = useAppSelector(
+    getSelectedAttributionId
+  );
+  const selectedAttributionIdAuditView =
+    useAppSelector(getAttributionIdOfDisplayedPackageInManualPanel) ??
+    undefined;
 
   const dispatch = useAppDispatch();
 
@@ -28,11 +38,20 @@ export function ConfirmDeletionPopup(): ReactElement {
     if (view === View.Audit) {
       targetAttributionId &&
         dispatch(
-          deleteAttributionAndSave(selectedResourceId, targetAttributionId)
+          deleteAttributionAndSave(
+            selectedResourceId,
+            targetAttributionId,
+            selectedAttributionIdAuditView
+          )
         );
     } else {
       targetAttributionId &&
-        dispatch(deleteAttributionGloballyAndSave(targetAttributionId));
+        dispatch(
+          deleteAttributionGloballyAndSave(
+            targetAttributionId,
+            selectedAttributionIdAttributionView
+          )
+        );
     }
   }
 

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ConfirmationPopup } from '../ConfirmationPopup/ConfirmationPopup';
 import { deleteAttributionGloballyAndSave } from '../../state/actions/resource-actions/save-actions';
 import { getMultiSelectSelectedAttributionIds } from '../../state/selectors/attribution-view-resource-selectors';
+import { getCurrentAttributionId } from '../../state/selectors/all-views-resource-selectors';
 
 export function ConfirmMultiSelectDeletionPopup(): ReactElement {
   const multiSelectSelectedAttributionIds = useAppSelector(
@@ -16,9 +17,14 @@ export function ConfirmMultiSelectDeletionPopup(): ReactElement {
 
   const dispatch = useAppDispatch();
 
+  const selectedAttributionId =
+    useAppSelector(getCurrentAttributionId) ?? undefined;
+
   function deleteMultiSelectSelectedAttributionIds(): void {
     multiSelectSelectedAttributionIds.forEach((attributionId) => {
-      dispatch(deleteAttributionGloballyAndSave(attributionId));
+      dispatch(
+        deleteAttributionGloballyAndSave(attributionId, selectedAttributionId)
+      );
     });
   }
 

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -18,7 +18,7 @@ import {
   unlinkAttributionAndSavePackageInfoAndNavigateToTargetView,
 } from '../../state/actions/popup-actions/popup-actions';
 import {
-  getAttributionIdToSaveTo,
+  getCurrentAttributionId,
   getIsSavingDisabled,
   getManualAttributionsToResources,
 } from '../../state/selectors/all-views-resource-selectors';
@@ -29,7 +29,7 @@ import { setTargetSelectedResourceId } from '../../state/actions/resource-action
 
 export function NotSavedPopup(): ReactElement {
   const dispatch = useAppDispatch();
-  const currentAttributionId = useAppSelector(getAttributionIdToSaveTo);
+  const currentAttributionId = useAppSelector(getCurrentAttributionId);
   const attributionsToResources = useAppSelector(
     getManualAttributionsToResources
   );

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -165,7 +165,13 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   function getContextMenuItems(): Array<ContextMenuItem> {
     function openConfirmDeletionPopup(): void {
       if (isPreselected) {
-        dispatch(deleteAttributionAndSave(selectedResourceId, attributionId));
+        dispatch(
+          deleteAttributionAndSave(
+            selectedResourceId,
+            attributionId,
+            selectedAttributionId
+          )
+        );
       } else {
         dispatch(openPopup(PopupType.ConfirmDeletionPopup, attributionId));
       }
@@ -173,7 +179,9 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
 
     function openConfirmDeletionGloballyPopup(): void {
       if (isPreselected) {
-        dispatch(deleteAttributionGloballyAndSave(attributionId));
+        dispatch(
+          deleteAttributionGloballyAndSave(attributionId, selectedAttributionId)
+        );
       } else {
         dispatch(
           openPopup(PopupType.ConfirmDeletionGloballyPopup, attributionId)
@@ -190,7 +198,8 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           unlinkAttributionAndSavePackageInfo(
             selectedResourceId,
             attributionId,
-            packageInfo
+            packageInfo,
+            selectedAttributionId
           )
         );
       }
@@ -198,7 +207,14 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
 
     function confirmAttributionGlobally(currentAttributionId: string): void {
       const packageInfo = getPackageInfo(currentAttributionId);
-      dispatch(savePackageInfo(null, currentAttributionId, packageInfo));
+      dispatch(
+        savePackageInfo(
+          null,
+          currentAttributionId,
+          packageInfo,
+          currentAttributionId !== selectedAttributionId
+        )
+      );
     }
 
     function confirmSelectedAttributionsGlobally(): void {

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -12,6 +12,7 @@ import { doNothing } from '../../util/do-nothing';
 import MuiTypography from '@mui/material/Typography';
 import {
   getAttributionIdMarkedForReplacement,
+  getCurrentAttributionId,
   getManualAttributions,
 } from '../../state/selectors/all-views-resource-selectors';
 import { PackageCard } from '../PackageCard/PackageCard';
@@ -38,6 +39,8 @@ export function ReplaceAttributionPopup(): ReactElement {
     getAttributionIdMarkedForReplacement
   );
   const targetAttributionId = useAppSelector(getPopupAttributionId);
+  const selectedAttributionId =
+    useAppSelector(getCurrentAttributionId) ?? undefined;
 
   function handleCancelClick(): void {
     dispatch(closePopup());
@@ -49,7 +52,8 @@ export function ReplaceAttributionPopup(): ReactElement {
         savePackageInfo(
           null,
           markedAttributionId,
-          attributions[targetAttributionId]
+          attributions[targetAttributionId],
+          markedAttributionId !== selectedAttributionId
         )
       );
     dispatch(setAttributionIdMarkedForReplacement(''));

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -7,7 +7,7 @@
 import { PackagePanelTitle, PopupType, View } from '../../../enums/enums';
 import { State } from '../../../types/types';
 import {
-  getAttributionIdToSaveTo,
+  getCurrentAttributionId,
   getManualAttributions,
   getPackageInfoOfSelected,
   getTemporaryPackageInfo,
@@ -147,7 +147,7 @@ export function selectAttributionInManualPackagePanelOrOpenUnsavedPopup(
 export function unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId = getSelectedResourceId(getState());
-    const attributionId = getAttributionIdToSaveTo(getState()) as string;
+    const attributionId = getCurrentAttributionId(getState()) as string;
     const temporaryPackageInfo = getTemporaryPackageInfo(getState());
 
     dispatch(
@@ -164,7 +164,7 @@ export function unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(): Ap
 export function saveTemporaryPackageInfoAndNavigateToTargetView(): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId = getSelectedResourceId(getState());
-    const attributionId = getAttributionIdToSaveTo(getState());
+    const attributionId = getCurrentAttributionId(getState());
     const temporaryPackageInfo = getTemporaryPackageInfo(getState());
 
     dispatch(

--- a/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
@@ -50,7 +50,7 @@ import {
 import { getSelectedAttributionId } from '../../../selectors/attribution-view-resource-selectors';
 
 describe('resetTemporaryPackageInfo', () => {
-  test('works correctly on audit', () => {
+  test('works correctly on audit view', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
     };

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -198,7 +198,10 @@ export interface SetFilesWithChildren {
 
 export interface CreateAttributionForSelectedResource {
   type: typeof ACTION_CREATE_ATTRIBUTION_FOR_SELECTED_RESOURCE;
-  payload: PackageInfo;
+  payload: {
+    strippedPackageInfo: PackageInfo;
+    jumpToCreatedAttribution: boolean;
+  };
 }
 
 export interface UpdateAttribution {
@@ -206,6 +209,7 @@ export interface UpdateAttribution {
   payload: {
     attributionId: string;
     strippedPackageInfo: PackageInfo;
+    jumpToUpdatedAttribution: boolean;
   };
 }
 
@@ -219,6 +223,7 @@ export interface ReplaceAttributionWithMatchingAttributionAction {
   payload: {
     attributionId: string;
     strippedPackageInfo: PackageInfo;
+    jumpToMatchingAttribution: boolean;
   };
 }
 

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -340,7 +340,7 @@ export const resourceState = (
       const { newManualData, newAttributionId } = createManualAttribution(
         state.allViews.manualData,
         state.auditView.selectedResourceId,
-        action.payload
+        action.payload.strippedPackageInfo
       );
 
       return {
@@ -360,10 +360,12 @@ export const resourceState = (
         },
         auditView: {
           ...state.auditView,
-          displayedPanelPackage: {
-            panel: PackagePanelTitle.ManualPackages,
-            attributionId: newAttributionId,
-          },
+          ...(action.payload.jumpToCreatedAttribution && {
+            displayedPanelPackage: {
+              panel: PackagePanelTitle.ManualPackages,
+              attributionId: newAttributionId,
+            },
+          }),
         },
       };
     case ACTION_UPDATE_ATTRIBUTION:
@@ -386,7 +388,9 @@ export const resourceState = (
             getAttributionBreakpointCheckForResourceState(state),
             getFileWithChildrenCheckForResourceState(state)
           ),
-          temporaryPackageInfo: action.payload.strippedPackageInfo,
+          ...(action.payload.jumpToUpdatedAttribution && {
+            temporaryPackageInfo: action.payload.strippedPackageInfo,
+          }),
         },
       };
     case ACTION_DELETE_ATTRIBUTION:
@@ -473,14 +477,18 @@ export const resourceState = (
         },
         auditView: {
           ...state.auditView,
-          displayedPanelPackage: {
-            panel: PackagePanelTitle.ManualPackages,
-            attributionId: matchingAttributionIdForReplace,
-          },
+          ...(action.payload.jumpToMatchingAttribution && {
+            displayedPanelPackage: {
+              panel: PackagePanelTitle.ManualPackages,
+              attributionId: matchingAttributionIdForReplace,
+            },
+          }),
         },
         attributionView: {
           ...state.attributionView,
-          selectedAttributionId: matchingAttributionIdForReplace,
+          ...(action.payload.jumpToMatchingAttribution && {
+            selectedAttributionId: matchingAttributionIdForReplace,
+          }),
         },
       };
     case ACTION_LINK_TO_ATTRIBUTION:

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -114,7 +114,7 @@ export function getProjectMetadata(state: State): ProjectMetadata {
   return state.resourceState.allViews.metadata;
 }
 
-export function getAttributionIdToSaveTo(state: State): string | null {
+export function getCurrentAttributionId(state: State): string | null {
   switch (getSelectedView(state)) {
     case View.Attribution:
       return getSelectedAttributionId(state);


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
Fixed bug that changes for one attribution disappear after delete or confirm another attribution via context menu in audit and attribution view.

### Context and reason for change
Changes should not be discarded 

### How can the changes be tested
The changes can be tested in the UI
