### PR TITLE
Fix highlighting confidence

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -104,13 +104,6 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
                 name: `Low (${DiscreteConfidence.Low})`,
               },
             ]}
-            isHighlighted={
-              props.showHighlight &&
-              isImportantAttributionInformationMissing(
-                'attributionConfidence',
-                props.displayPackageInfo
-              )
-            }
           />
         ) : (
           <NumberBox

--- a/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
@@ -165,48 +165,6 @@ describe('The table helpers', () => {
     }
   );
 
-  test('isImportantAttributionInformationMissing handles attributionConfidence correctly', () => {
-    const testTableConfig: TableConfig = {
-      attributionProperty: 'attributionConfidence',
-      displayName: 'Follow-up',
-    };
-
-    let testAttributionInfo: AttributionInfo = {
-      attributionConfidence: 49,
-      resources: ['1'],
-    };
-
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(true);
-
-    testAttributionInfo = {
-      resources: ['1'],
-    };
-
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(true);
-
-    testAttributionInfo = {
-      attributionConfidence: 50,
-      resources: ['1'],
-    };
-
-    expect(
-      isImportantAttributionInformationMissing(
-        testTableConfig.attributionProperty,
-        testAttributionInfo
-      )
-    ).toEqual(false);
-  });
-
   test('isImportantAttributionInformationMissing does not mark first party or excluded attributions', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'licenseName',

--- a/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
+++ b/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
@@ -54,17 +54,4 @@ describe('isImportantAttributionInformationMissing', () => {
       isImportantAttributionInformationMissing('copyright', testAttributionInfo)
     ).toEqual(false);
   });
-
-  test('returns true if confidence is smaller then 50 ', () => {
-    const testAttributionInfo: AttributionInfo = {
-      attributionConfidence: 20,
-      resources: ['1'],
-    };
-    expect(
-      isImportantAttributionInformationMissing(
-        'attributionConfidence',
-        testAttributionInfo
-      )
-    ).toEqual(true);
-  });
 });

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -33,11 +33,6 @@ export function isImportantAttributionInformationMissing(
     case 'packageVersion':
     case 'url':
       return !extendedAttributionInfo[attributionProperty];
-    case 'attributionConfidence':
-      return (
-        !extendedAttributionInfo['attributionConfidence'] ||
-        extendedAttributionInfo['attributionConfidence'] < 50
-      );
     case 'packageNamespace':
       return isNamespaceRequiredButMissing(
         extendedAttributionInfo['packageType'],


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Never highlight confidence as incomplete after discussion with @JakobSchubert

### Context and reason for change
- In attribution view confidence is always displayed as high if missing but still highlighted as incomplete
- Therefore, check for confidence is removed in attribution view
- And for consistency, check for confidence is also removed in report view

### How can the changes be tested
- The changes can be tested in the UI
