### PR TITLE
Add feature flag

### DIFF
--- a/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
+++ b/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
@@ -135,7 +135,7 @@ describe('error handling', () => {
       );
       expect(mockCallback.mock.calls.length).toBe(1);
       expect(mockCallback.mock.calls[0][0]).toContain(
-        IpcChannel['RestoreFrontend']
+        IpcChannel.RestoreFrontend
       );
       expect(loadJsonFromFilePath).toBeCalled();
     });
@@ -176,7 +176,7 @@ describe('error handling', () => {
       );
       expect(mockCallback.mock.calls.length).toBe(1);
       expect(mockCallback.mock.calls[0][0]).toContain(
-        IpcChannel['RestoreFrontend']
+        IpcChannel.RestoreFrontend
       );
       expect(loadJsonFromFilePath).toBeCalled();
     });

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -228,7 +228,7 @@ describe('Test of loading function', () => {
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(2);
       expect(mainWindow.webContents.send).toHaveBeenLastCalledWith(
-        IpcChannel['FileLoaded'],
+        IpcChannel.FileLoaded,
         expectedFileContent
       );
 
@@ -252,7 +252,7 @@ describe('Test of loading function', () => {
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(2);
       expect(mainWindow.webContents.send).toHaveBeenLastCalledWith(
-        IpcChannel['FileLoaded'],
+        IpcChannel.FileLoaded,
         expectedFileContent
       );
       expect(dialog.showMessageBox).not.toBeCalled();
@@ -460,7 +460,7 @@ describe('Test of loading function', () => {
     };
 
     expect(mainWindow.webContents.send).toBeCalledWith(
-      IpcChannel['FileLoaded'],
+      IpcChannel.FileLoaded,
       expectedLoadedFile
     );
     expect(dialog.showMessageBox).not.toBeCalled();
@@ -506,7 +506,7 @@ describe('Test of loading function', () => {
     };
 
     expect(mainWindow.webContents.send).toBeCalledWith(
-      IpcChannel['FileLoaded'],
+      IpcChannel.FileLoaded,
       expectedLoadedFile
     );
     expect(dialog.showMessageBox).not.toBeCalled();
@@ -533,7 +533,7 @@ function assertFileLoadedCorrectly(testUuid: string): void {
   };
 
   expect(mainWindow.webContents.send).toBeCalledWith(
-    IpcChannel['FileLoaded'],
+    IpcChannel.FileLoaded,
     expectedLoadedFile
   );
   expect(dialog.showMessageBox).not.toBeCalled();

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -142,6 +142,15 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         { label: 'Full Screen', role: 'togglefullscreen' },
         { label: 'Zoom In', role: 'zoomIn' },
         { label: 'Zoom Out', role: 'zoomOut' },
+        {
+          label: 'Highlight critical signals',
+          type: 'checkbox',
+          click(): void {
+            webContents.send(IpcChannel.ToggleHighlightForCriticalSignals, {
+              toggleHighlightForCriticalSignals: true,
+            });
+          },
+        },
       ],
     },
     {

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -594,7 +594,7 @@ describe('The AttributionColumn', () => {
       clickOnButton(screen, 'resolve attribution');
       expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
       expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-        IpcChannel['SaveFile'],
+        IpcChannel.SaveFile,
         expectedSaveFileArgs
       );
     });

--- a/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -45,12 +45,12 @@ describe('ErrorBoundary', () => {
 
     expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(2);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['SendErrorInformation'],
+      IpcChannel.SendErrorInformation,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledTimes(1);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['RestoreFrontend'],
+      IpcChannel.RestoreFrontend,
       expect.anything()
     );
 

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -42,7 +42,7 @@ describe('The GoToLinkButton', () => {
 
       expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
       expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-        IpcChannel['OpenLink'],
+        IpcChannel.OpenLink,
         { link: expected_link }
       );
     }

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -10,6 +10,8 @@ import React, { ReactElement } from 'react';
 import { OpossumColors } from '../../shared-styles';
 import { ListCardConfig } from '../../types/types';
 import { Criticality } from '../../../shared/shared-types';
+import { useAppSelector } from '../../state/hooks';
+import { getHighlightForCriticalSignals } from '../../state/selectors/view-selector';
 
 const defaultCardHeight = 40;
 const hoveredSelectedBackgroundColor = OpossumColors.middleBlueOnHover;
@@ -203,6 +205,9 @@ interface ListCardProps {
 
 export function ListCard(props: ListCardProps): ReactElement | null {
   const classes = useStyles();
+  const showHighlightForCriticalSignals = useAppSelector(
+    getHighlightForCriticalSignals
+  );
 
   function getDisplayedCount(): string {
     const count = props.count ? props.count.toString() : '';
@@ -299,15 +304,17 @@ export function ListCard(props: ListCardProps): ReactElement | null {
           <div className={classes.iconColumn}>{props.rightIcons}</div>
         ) : null}
       </div>
-      <div
-        className={
-          props.cardConfig.criticality === Criticality.High
-            ? classes.highCriticality
-            : props.cardConfig.criticality === Criticality.Medium
-            ? classes.mediumCriticality
-            : undefined
-        }
-      />
+      {showHighlightForCriticalSignals ? (
+        <div
+          className={
+            props.cardConfig.criticality === Criticality.High
+              ? classes.highCriticality
+              : props.cardConfig.criticality === Criticality.Medium
+              ? classes.mediumCriticality
+              : undefined
+          }
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
+++ b/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
@@ -4,14 +4,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 import { ListCard } from '../ListCard';
 import { Checkbox } from '../../Checkbox/Checkbox';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
 describe('The ListCard', () => {
   test('renders text with no count', () => {
-    render(
+    renderComponentWithStore(
       <ListCard
         text={'card text'}
         secondLineText={'card text of second line'}
@@ -25,7 +26,7 @@ describe('The ListCard', () => {
   });
 
   test('renders text with small count', () => {
-    render(
+    renderComponentWithStore(
       <ListCard
         text={'card text'}
         secondLineText={'card text of second line'}
@@ -41,7 +42,7 @@ describe('The ListCard', () => {
   });
 
   test('renders text with medium count', () => {
-    render(
+    renderComponentWithStore(
       <ListCard
         text={'card text'}
         secondLineText={'card text of second line'}
@@ -57,7 +58,7 @@ describe('The ListCard', () => {
   });
 
   test('renders text with large count', () => {
-    render(
+    renderComponentWithStore(
       <ListCard
         text={'card text'}
         secondLineText={'card text of second line'}
@@ -74,7 +75,7 @@ describe('The ListCard', () => {
 
   test('renders leftElement if provided as input', () => {
     const leftElement = <Checkbox checked={false} onChange={jest.fn()} />;
-    render(
+    renderComponentWithStore(
       <ListCard
         text={'card text'}
         secondLineText={'card text of second line'}

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -141,7 +141,7 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     expect(getOpenPopup(store.getState())).toBe(null);
 
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['SaveFile'],
+      IpcChannel.SaveFile,
       {
         manualAttributions: {
           test_selected_id: {

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -18,6 +18,7 @@ import {
   ExportSpdxDocumentYamlArgs,
   ExportType,
   ParsedFileContent,
+  ToggleHighlightForCriticalSignalsArgs,
 } from '../../../shared/shared-types';
 import { PopupType, View } from '../../enums/enums';
 import { setViewOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -34,7 +35,10 @@ import {
   getManualData,
   getResources,
 } from '../../state/selectors/all-views-resource-selectors';
-import { getSelectedView } from '../../state/selectors/view-selector';
+import {
+  getHighlightForCriticalSignals,
+  getSelectedView,
+} from '../../state/selectors/view-selector';
 import {
   getAttributionsWithAllChildResourcesWithoutFolders,
   getAttributionsWithResources,
@@ -47,7 +51,10 @@ import { OpossumColors } from '../../shared-styles';
 
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
-import { openPopup } from '../../state/actions/view-actions/view-actions';
+import {
+  openPopup,
+  setHighlightForCriticalSignals,
+} from '../../state/actions/view-actions/view-actions';
 import { IconButton } from '../IconButton/IconButton';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 
@@ -100,6 +107,9 @@ export function TopBar(): ReactElement {
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
   const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
+  const showHighlightForCriticalSignals = useAppSelector(
+    getHighlightForCriticalSignals
+  );
   const dispatch = useAppDispatch();
 
   function fileLoadedListener(
@@ -273,6 +283,19 @@ export function TopBar(): ReactElement {
     }
   }
 
+  function setToggleHighlightForCriticalSignalsListener(
+    event: IpcRendererEvent,
+    toggleHighlightForCriticalSignalsArgs: ToggleHighlightForCriticalSignalsArgs
+  ): void {
+    if (
+      toggleHighlightForCriticalSignalsArgs?.toggleHighlightForCriticalSignals
+    ) {
+      dispatch(
+        setHighlightForCriticalSignals(!showHighlightForCriticalSignals)
+      );
+    }
+  }
+
   useIpcRenderer(IpcChannel.FileLoaded, fileLoadedListener, [dispatch]);
   useIpcRenderer(IpcChannel.ResetLoadedFile, resetLoadedFileListener, [
     dispatch,
@@ -296,6 +319,11 @@ export function TopBar(): ReactElement {
     frequentLicenseTexts,
     filesWithChildren,
   ]);
+  useIpcRenderer(
+    IpcChannel.ToggleHighlightForCriticalSignals,
+    setToggleHighlightForCriticalSignalsListener,
+    [dispatch, showHighlightForCriticalSignals]
+  );
 
   function handleClick(
     event: React.MouseEvent<HTMLElement>,

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -18,42 +18,44 @@ import { IpcChannel } from '../../../../shared/ipc-channels';
 describe('TopBar', () => {
   test('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(7);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(8);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['FileLoaded'],
+      IpcChannel.FileLoaded,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['Logging'],
+      IpcChannel.Logging,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['ResetLoadedFile'],
+      IpcChannel.ResetLoadedFile,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['ExportFileRequest'],
+      IpcChannel.ExportFileRequest,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['ShowSearchPopup'],
+      IpcChannel.ShowSearchPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['ShowProjectMetadataPopup'],
+      IpcChannel.ShowProjectMetadataPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel['SetBaseURLForRoot'],
+      IpcChannel.SetBaseURLForRoot,
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel.ToggleHighlightForCriticalSignals,
       expect.anything()
     );
 
     fireEvent.click(screen.queryByLabelText('open file') as Element);
     expect(store.getState().resourceState).toMatchObject(initialResourceState);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['OpenFile']
-    );
+    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(IpcChannel.OpenFile);
   });
 
   test('switches between views', () => {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
@@ -51,7 +51,7 @@ describe('The go to link button', () => {
     clickGoToLinkIcon(screen, 'link to open');
     expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['OpenLink'],
+      IpcChannel.OpenLink,
       { link: expectedLinkForParent }
     );
 
@@ -60,7 +60,7 @@ describe('The go to link button', () => {
     clickGoToLinkIcon(screen, 'link to open');
     expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(2);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['OpenLink'],
+      IpcChannel.OpenLink,
       { link: expectedLinkForFile }
     );
   });

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -166,7 +166,7 @@ describe('Other popups of the app', () => {
 
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
     expectUnsavedChangesPopupIsNotShown(screen);
     expectValueNotInTextBox(screen, 'Name', testPackageName);
@@ -227,7 +227,7 @@ describe('Other popups of the app', () => {
     };
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
     expectUnsavedChangesPopupIsNotShown(screen);
     expectButton(screen, ButtonText.Save, true);
@@ -360,7 +360,7 @@ describe('Other popups of the app', () => {
 
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 });

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -224,7 +224,7 @@ describe('In Attribution View the ContextMenu', () => {
     // make sure resources are now linked to React attribution
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -244,9 +244,9 @@ describe('The App in attribution view', () => {
     };
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['OpenFile']],
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
-      [IpcChannel['SaveFile'], expect.anything()],
+      [IpcChannel.OpenFile],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expect.anything()],
     ]);
   });
 
@@ -334,8 +334,8 @@ describe('The App in attribution view', () => {
 
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['OpenFile']],
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.OpenFile],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 
@@ -397,8 +397,8 @@ describe('The App in attribution view', () => {
     expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['OpenFile']],
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.OpenFile],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 
@@ -480,8 +480,8 @@ describe('The App in attribution view', () => {
     // make sure resources are now linked to React attribution
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['OpenFile']],
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.OpenFile],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -364,7 +364,7 @@ describe('In Audit View the ContextMenu', () => {
       // make sure resources are now linked to React attribution
       // @ts-ignore
       expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-        [IpcChannel['SaveFile'], expectedSaveFileArgs],
+        [IpcChannel.SaveFile, expectedSaveFileArgs],
       ]);
     });
 
@@ -409,7 +409,7 @@ describe('In Audit View the ContextMenu', () => {
       // make sure resources are now linked to React attribution
       // @ts-ignore
       expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-        [IpcChannel['SaveFile'], expectedSaveFileArgs],
+        [IpcChannel.SaveFile, expectedSaveFileArgs],
       ]);
     });
   });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -122,7 +122,7 @@ describe('The App in Audit View', () => {
 
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
 
     expectButton(screen, ButtonText.Save, true);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -493,7 +493,7 @@ describe('The App in Audit View', () => {
     // make sure resources are now linked to React attribution
     // @ts-ignore
     expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel['SaveFile'], expectedSaveFileArgs],
+      [IpcChannel.SaveFile, expectedSaveFileArgs],
     ]);
   });
 });

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -1057,7 +1057,7 @@ describe('The addToSelectedResource action', () => {
     testStore.dispatch(saveManualAndResolvedAttributionsToFile());
     expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
     expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel['SaveFile'],
+      IpcChannel.SaveFile,
       expectedSaveFileArgs
     );
   });

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -8,6 +8,7 @@ import { FilterType, PopupType, View } from '../../../../enums/enums';
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
   getActiveFilters,
+  getHighlightForCriticalSignals,
   getOpenPopup,
   getPopupAttributionId,
   getSelectedView,
@@ -21,6 +22,7 @@ import {
   navigateToView,
   openPopup,
   resetViewState,
+  setHighlightForCriticalSignals,
   setTargetView,
   updateActiveFilters,
 } from '../view-actions';
@@ -147,6 +149,14 @@ describe('view actions', () => {
     expect(
       getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
     ).toBe(true);
+  });
+
+  test('sets showHighlightForCriticalSignals', () => {
+    const testStore = createTestAppStore();
+
+    expect(getHighlightForCriticalSignals(testStore.getState())).toBe(false);
+    testStore.dispatch(setHighlightForCriticalSignals(true));
+    expect(getHighlightForCriticalSignals(testStore.getState())).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -12,6 +12,8 @@ export const ACTION_OPEN_POPUP = 'ACTION_OPEN_POPUP';
 export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
 export const ACTION_UPDATE_ACTIVE_FILTERS = 'ACTION_UPDATE_ACTIVE_FILTERS';
+export const ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS =
+  'ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS';
 
 export type ViewAction =
   | SetView
@@ -19,7 +21,8 @@ export type ViewAction =
   | ClosePopupAction
   | ResetViewStateAction
   | OpenPopupAction
-  | UpdateActiveFilters;
+  | UpdateActiveFilters
+  | SetHighlightForCriticalSignalsAction;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -47,4 +50,9 @@ export interface OpenPopupAction {
 export interface UpdateActiveFilters {
   type: typeof ACTION_UPDATE_ACTIVE_FILTERS;
   payload: FilterType;
+}
+
+export interface SetHighlightForCriticalSignalsAction {
+  type: typeof ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS;
+  payload: boolean;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -15,12 +15,14 @@ import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
+  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
   ClosePopupAction,
   OpenPopupAction,
   ResetViewStateAction,
+  SetHighlightForCriticalSignalsAction,
   SetTargetView,
   SetView,
   UpdateActiveFilters,
@@ -86,5 +88,14 @@ export function updateActiveFilters(
   return {
     type: ACTION_UPDATE_ACTIVE_FILTERS,
     payload: filterType,
+  };
+}
+
+export function setHighlightForCriticalSignals(
+  showHighlightForCriticalSignals: boolean
+): SetHighlightForCriticalSignalsAction {
+  return {
+    type: ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
+    payload: showHighlightForCriticalSignals,
   };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -10,6 +10,7 @@ import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
+  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
@@ -22,6 +23,7 @@ export interface ViewState {
   targetView: View | null;
   popupInfo: Array<PopupInfo>;
   activeFilters: Set<FilterType>;
+  showHighlightForCriticalSignals: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -29,6 +31,7 @@ export const initialViewState: ViewState = {
   targetView: null,
   popupInfo: [],
   activeFilters: new Set<FilterType>(),
+  showHighlightForCriticalSignals: false,
 };
 
 export function viewState(
@@ -62,6 +65,11 @@ export function viewState(
       return {
         ...state,
         activeFilters: getUpdatedFilters(state.activeFilters, action.payload),
+      };
+    case ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS:
+      return {
+        ...state,
+        showHighlightForCriticalSignals: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -40,3 +40,7 @@ export function getPopupAttributionId(state: State): string | null {
   const popup = state.viewState.popupInfo.slice(-1);
   return popup.length === 1 ? popup[0].attributionId ?? null : null;
 }
+
+export function getHighlightForCriticalSignals(state: State): boolean {
+  return state.viewState.showHighlightForCriticalSignals;
+}

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -9,6 +9,7 @@ import {
   BaseURLForRootArgs,
   ExportType,
   ParsedFileContent,
+  ToggleHighlightForCriticalSignalsArgs,
 } from '../../shared/shared-types';
 
 type ResetStateListener = (
@@ -33,12 +34,18 @@ type SetBaseURLForRootListener = (
   baseURLForRootArgs: BaseURLForRootArgs
 ) => void;
 
+type ToggleHighlightForCriticalSignalsListener = (
+  event: IpcRendererEvent,
+  showHighlightForCriticalSignalsArgs: ToggleHighlightForCriticalSignalsArgs
+) => void;
+
 type Listener =
   | ResetStateListener
   | SetStateListener
   | LoggingListener
   | ExportFileRequestListener
-  | SetBaseURLForRootListener;
+  | SetBaseURLForRootListener
+  | ToggleHighlightForCriticalSignalsListener;
 
 export function useIpcRenderer(
   channel: string,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -15,6 +15,7 @@ export enum IpcChannel {
   SaveFile = 'save-file',
   SaveFileRequest = 'save-file-request',
   SendErrorInformation = 'send-error-information',
+  ToggleHighlightForCriticalSignals = 'toggle-highlight-for-critical-signals',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
   SetBaseURLForRoot = 'set-base-url-for-root',

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -177,6 +177,10 @@ export interface BaseURLForRootArgs {
   baseURLForRoot: string;
 }
 
+export interface ToggleHighlightForCriticalSignalsArgs {
+  toggleHighlightForCriticalSignals: boolean;
+}
+
 export interface ExternalAttributionSources {
   [source: string]: {
     name: string;


### PR DESCRIPTION
### Summary of changes

Add feature flag to show highlighting for critical signals. The feature flag can be set via the menu. Furthermore, the use of the ipcChannel enum is refactored.

### Context and reason for change

There should be a feature flag for the highlighting signals featrure. It first has to proove to be valuable.

### How can the changes be tested


![Screenshot 2022-03-28 at 11 03 34](https://user-images.githubusercontent.com/46576389/160366978-0d5b0081-88fb-47b3-b38f-935b06ba9de3.png)
![Screenshot 2022-03-28 at 11 03 48](https://user-images.githubusercontent.com/46576389/160366987-5a610230-f9ac-4d22-ab70-038a738786f4.png)

