### PR TITLE
Removed code for create range in tests

### DIFF
--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -403,16 +403,6 @@ describe('The AttributionColumn', () => {
   });
 
   describe('there are different license text labels', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).document.createRange = (): unknown => ({
-      setStart: (): void => {},
-      setEnd: (): void => {},
-      commonAncestorContainer: {
-        nodeName: 'BODY',
-        ownerDocument: document,
-      },
-    });
-
     test('shows standard text if editable and non frequent license', () => {
       const testTemporaryPackageInfo: PackageInfo = { packageName: 'jQuery' };
       renderComponentWithStore(

--- a/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
@@ -9,16 +9,6 @@ import { doNothing } from '../../../util/do-nothing';
 import { AutoComplete } from '../AutoComplete';
 import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(global as any).document.createRange = (): unknown => ({
-  setStart: (): void => {},
-  setEnd: (): void => {},
-  commonAncestorContainer: {
-    nodeName: 'BODY',
-    ownerDocument: document,
-  },
-});
-
 describe('The AutoComplete', () => {
   test('renders text and label', () => {
     const testLicenseNames = ['MIT', 'GPL'];

--- a/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
@@ -19,16 +19,6 @@ import { DiscreteConfidence } from '../../../enums/enums';
 describe('ProgressBar', () => {
   jest.useFakeTimers();
   test('ProgressBar renders', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).document.createRange = (): unknown => ({
-      setStart: (): void => {},
-      setEnd: (): void => {},
-      commonAncestorContainer: {
-        nodeName: 'BODY',
-        ownerDocument: document,
-      },
-    });
-
     const testResources: Resources = {
       folder1: { file1: 1, file2: 1 },
       folder2: { file1: 1, file2: 1 },

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -41,16 +41,6 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 
 describe('The App in Audit View', () => {
   test('saves new attributions to file in AuditView', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).document.createRange = (): unknown => ({
-      setStart: (): void => {},
-      setEnd: (): void => {},
-      commonAncestorContainer: {
-        nodeName: 'BODY',
-        ownerDocument: document,
-      },
-    });
-
     const testPackageName = 'React';
     const testLicenseNames = ['MIT', 'MIT License'];
     const mockChannelReturn: ParsedFileContent = {

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -266,15 +266,6 @@ export function expectValuesInProgressbarTooltip(
   filesWithOnlyPreSelectedAttributions: number,
   filesWithOnlySignals: number
 ): void {
-  global.document.createRange = (): Range =>
-    ({
-      setStart: (): void => {},
-      setEnd: (): void => {},
-      commonAncestorContainer: {
-        nodeName: 'BODY',
-        ownerDocument: document,
-      },
-    } as unknown as Range);
   jest.useFakeTimers();
   const progressBar = screen.getByLabelText('ProgressBar');
   fireEvent.mouseOver(progressBar);


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
Removed code for create range in tests

### Context and reason for change
This fix is not needed anymore since jest v26

### How can the changes be tested
By running `yarn test:unit` and `yarn test:integration-ci`

