### PR TITLE
Fix signals in folder content when loading ORT input file

### DIFF
--- a/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
+++ b/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
@@ -25,6 +25,10 @@ export const AccordionWorkersContextProvider: FC = ({ children }) => {
   const externalData = useAppSelector(getExternalData);
   useMemo(() => {
     try {
+      // remove data from previous file or empty data from app just opened
+      resourceDetailsTabsWorkers.containedExternalAttributionsAccordionWorker.postMessage(
+        { externalData: null }
+      );
       resourceDetailsTabsWorkers.containedExternalAttributionsAccordionWorker.postMessage(
         { externalData }
       );

--- a/src/Frontend/web-workers/contained-external-attributions-accordion-worker.ts
+++ b/src/Frontend/web-workers/contained-external-attributions-accordion-worker.ts
@@ -11,7 +11,8 @@ let cachedExternalData: AttributionData | null = null;
 self.onmessage = ({
   data: { selectedResourceId, externalData, resolvedExternalAttributions },
 }): void => {
-  if (externalData) {
+  // externalData = null is used to empty the cached data
+  if (externalData !== undefined) {
     cachedExternalData = externalData;
   }
 


### PR DESCRIPTION
### Context and reason for change

When ExternalData is too big posting it to the contained-external-attributions-accordion-worker at file loading fails. If the cachedExternalData in the worker was null, a null output will be returned posting to the worker for a resourceId. That will trigger the fallback synchronous calculation of the accordion content. But this process can fail if old data was cached in the worker when the data loading fails (including empty externalData when the app is started). 

### Summary of changes

Now whenever the externalData in the store change (i.e. when a file is opened) first the cached data in the worker are set to null, then the loading of the actual data is attempted.

### How can the changes be tested

Open the ORT test file, click in the root folder. The Signals in Folder Content accordion should be populated.