### PR TITLE
Experiment for replacing makeStyles in MUI 5

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -64,21 +64,18 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
     <MuiPaper className={classes.panel} elevation={0} square={true}>
       <div className={classes.displayRow}>
         <Checkbox
-          className={classes.checkBox}
           label={CheckboxLabel.FirstParty}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.firstParty)}
           onChange={props.firstPartyChangeHandler}
         />
         <Checkbox
-          className={classes.checkBox}
           label={CheckboxLabel.FollowUp}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.followUp)}
           onChange={props.followUpChangeHandler}
         />
         <Checkbox
-          className={classes.checkBox}
           label={CheckboxLabel.ExcludeFromNotice}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.excludeFromNotice)}

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -43,9 +43,6 @@ const useStyles = makeStyles({
   },
   disabledIcon,
   clickableIcon,
-  hiddenFilter: {
-    display: 'none',
-  },
 });
 
 export function AttributionView(): ReactElement {
@@ -105,9 +102,7 @@ export function AttributionView(): ReactElement {
           />
         }
         filterElement={
-          <FilterMultiSelect
-            className={showMultiSelect ? undefined : classes.hiddenFilter}
-          />
+          <FilterMultiSelect sx={showMultiSelect ? {} : { display: 'none' }} />
         }
       />
       <AttributionDetailsViewer />

--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -8,13 +8,15 @@ import React, { ReactElement } from 'react';
 import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
 import { styled } from '@mui/material/styles';
+
 interface CheckboxProps {
   label?: string;
   disabled?: boolean;
   checked: boolean;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
   white?: boolean;
-  isMultiSelect?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component?: any;
 }
 
 const CheckboxComponent = styled('div')({
@@ -25,16 +27,9 @@ const CheckboxComponent = styled('div')({
   marginLeft: -2,
 });
 
-const MultiSelectCheckboxComponent = styled('div')({
-  height: 40,
-  marginTop: 1,
-});
-
 export function Checkbox(props: CheckboxProps): ReactElement {
   const whiteMode = props.white ? { color: OpossumColors.white } : {};
-  const Component = props.isMultiSelect
-    ? MultiSelectCheckboxComponent
-    : CheckboxComponent;
+  const Component = props.component ?? CheckboxComponent;
 
   return (
     <Component>

--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -5,34 +5,39 @@
 
 import MuiCheckbox from '@mui/material/Checkbox';
 import React, { ReactElement } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from 'clsx';
 import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
-
-const useStyles = makeStyles({
-  white: {
-    color: OpossumColors.white,
-  },
-  disabledLabel: {
-    color: OpossumColors.disabledGrey,
-  },
-});
-
+import { styled } from '@mui/material/styles';
 interface CheckboxProps {
   label?: string;
   disabled?: boolean;
   checked: boolean;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
-  className?: string;
   white?: boolean;
+  isMultiSelect?: boolean;
 }
 
+const CheckboxComponent = styled('div')({
+  height: 40,
+  display: 'flex',
+  alignItems: 'center',
+  marginRight: 12,
+  marginLeft: -2,
+});
+
+const MultiSelectCheckboxComponent = styled('div')({
+  height: 40,
+  marginTop: 1,
+});
+
 export function Checkbox(props: CheckboxProps): ReactElement {
-  const classes = useStyles();
-  const whiteMode = clsx(props.white && classes.white);
+  const whiteMode = props.white ? { color: OpossumColors.white } : {};
+  const Component = props.isMultiSelect
+    ? MultiSelectCheckboxComponent
+    : CheckboxComponent;
+
   return (
-    <div className={props.className}>
+    <Component>
       <MuiCheckbox
         disabled={props.disabled}
         checked={props.checked}
@@ -41,19 +46,16 @@ export function Checkbox(props: CheckboxProps): ReactElement {
           'aria-label': `checkbox ${props.label}`,
         }}
         color={'default'}
-        classes={{
-          root: whiteMode,
-          checked: whiteMode,
-        }}
+        sx={{ '&:root': whiteMode, '&:checked': whiteMode }}
       />
       <MuiTypography
-        className={clsx(
-          whiteMode,
-          props.disabled ? classes.disabledLabel : null
-        )}
+        sx={{
+          ...whiteMode,
+          color: props.disabled ? OpossumColors.disabledGrey : '',
+        }}
       >
         {props.label || ''}
       </MuiTypography>
-    </div>
+    </Component>
   );
 }

--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ import React, { ReactElement } from 'react';
 import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
 import { styled } from '@mui/material/styles';
+import { StyledComponent } from '@mui/styles';
 
 interface CheckboxProps {
   label?: string;
@@ -15,8 +16,8 @@ interface CheckboxProps {
   checked: boolean;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
   white?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  component?: any;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  component?: StyledComponent<{}>;
 }
 
 const CheckboxComponent = styled('div')({

--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -19,23 +19,11 @@ import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import MergeTypeIcon from '@mui/icons-material/MergeType';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { ButtonText } from '../../enums/enums';
-import makeStyles from '@mui/styles/makeStyles';
 import { PopoverPosition, PopoverReference } from '@mui/material';
 import { OpossumColors } from '../../shared-styles';
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-
-const useStyles = makeStyles({
-  icon: {
-    marginRight: -20,
-  },
-  menuItem: {
-    '&:hover': {
-      backgroundColor: OpossumColors.lightBlueOnHover,
-    },
-  },
-});
 
 const BUTTON_TITLE_TO_ICON_MAP: {
   [buttonText in ButtonText]?: JSX.Element;
@@ -81,8 +69,6 @@ interface anchorAttributes {
 }
 
 export function ContextMenu(props: ContextMenuProps): ReactElement | null {
-  const iconClasses = useStyles();
-
   const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
   const [anchorPosition, setAnchorPosition] = useState<
     undefined | PopoverPosition
@@ -164,9 +150,13 @@ export function ContextMenu(props: ContextMenuProps): ReactElement | null {
             }}
             disabled={menuItem.disabled}
             role={'button'}
-            className={iconClasses.menuItem}
+            sx={{
+              '&:hover': {
+                backgroundColor: OpossumColors.lightBlueOnHover,
+              },
+            }}
           >
-            <MuiListItemIcon className={iconClasses.icon}>
+            <MuiListItemIcon sx={{ marginRight: '-20px' }}>
               {BUTTON_TITLE_TO_ICON_MAP[menuItem.buttonText]}
             </MuiListItemIcon>
             <MuiListItemText sx={{ pl: 2 }} primary={menuItem.buttonText} />

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -15,9 +15,8 @@ import { FilterType } from '../../enums/enums';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { updateActiveFilters } from '../../state/actions/view-actions/view-actions';
 import { getActiveFilters } from '../../state/selectors/view-selector';
-import { makeStyles } from '@mui/styles';
 import { OpossumColors } from '../../shared-styles';
-import clsx from 'clsx';
+import { SxProps } from '@mui/material';
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -27,7 +26,7 @@ const FILTERS = [
   FilterType.HideFirstParty,
 ];
 
-const useStyles = makeStyles({
+const classes = {
   dropDownForm: {
     margin: '12px 0px 8px 0px',
     backgroundColor: OpossumColors.white,
@@ -36,13 +35,13 @@ const useStyles = makeStyles({
     },
     '& label': {
       backgroundColor: OpossumColors.white,
-      padding: 1,
+      padding: '1px',
     },
   },
   dropDownSelect: {
     minHeight: 36,
     '& svg': {
-      paddingRight: 6,
+      paddingRight: '6px',
     },
   },
   dropDownBox: {
@@ -55,17 +54,18 @@ const useStyles = makeStyles({
     fontSize: 12,
   },
   dropdownStyle: {
-    maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-    left: '7px !important',
+    '& paper': {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      left: '7px !important',
+    },
   },
-});
+};
 
 interface FilterMultiSelectProps {
-  className?: string;
+  sx?: SxProps;
 }
 
 export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
-  const classes = useStyles();
   const dispatch = useAppDispatch();
   const activeFilters = Array.from(useAppSelector(getActiveFilters));
 
@@ -91,25 +91,32 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
 
   return (
     <MuiFormControl
-      className={clsx(classes.dropDownForm, props.className)}
+      sx={[
+        classes.dropDownForm,
+        ...(props.sx
+          ? Array.isArray(props.sx)
+            ? props.sx
+            : [props.sx]
+          : [{}]),
+      ]}
       size="small"
       fullWidth
     >
       <MuiInputLabel>Filter</MuiInputLabel>
       <MuiSelect
-        className={classes.dropDownSelect}
+        sx={classes.dropDownSelect}
         data-testid="test-id-filter-multi-select"
         multiple
         value={activeFilters}
         input={<MuiOutlinedInput />}
         renderValue={(selectedFilters): ReactElement => (
-          <MuiBox className={classes.dropDownBox}>
+          <MuiBox sx={classes.dropDownBox}>
             {selectedFilters.map((filter) => (
               <MuiChip
                 key={filter}
                 label={filter}
                 size="small"
-                className={classes.chip}
+                sx={classes.chip}
                 onMouseDown={(event): void => {
                   event.preventDefault();
                   event.stopPropagation();
@@ -121,7 +128,7 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
             ))}
           </MuiBox>
         )}
-        MenuProps={{ classes: { paper: classes.dropdownStyle } }}
+        MenuProps={{ sx: classes.dropdownStyle }}
       >
         {getMenuItems()}
       </MuiSelect>

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -17,6 +17,7 @@ import { updateActiveFilters } from '../../state/actions/view-actions/view-actio
 import { getActiveFilters } from '../../state/selectors/view-selector';
 import { OpossumColors } from '../../shared-styles';
 import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -91,14 +92,10 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
 
   return (
     <MuiFormControl
-      sx={[
-        classes.dropDownForm,
-        ...(props.sx
-          ? Array.isArray(props.sx)
-            ? props.sx
-            : [props.sx]
-          : [{}]),
-      ]}
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.dropDownForm,
+        sxProps: props.sx,
+      })}
       size="small"
       fullWidth
     >

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -361,7 +361,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       <Checkbox
         checked={multiSelectSelectedAttributionIds.includes(attributionId)}
         onChange={handleMultiSelectAttributionSelected}
-        className={classes.multiSelectCheckbox}
+        isMultiSelect
       />
     ) : undefined;
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -58,6 +58,7 @@ import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { PackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { getPackageInfoKeys } from '../../../shared/shared-util';
+import { styled } from '@mui/material/styles';
 
 const useStyles = makeStyles({
   hiddenIcon: {
@@ -78,6 +79,11 @@ const useStyles = makeStyles({
     flexGrow: 1,
     minWidth: 0,
   },
+});
+
+const MultiSelectCheckboxComponent = styled('div')({
+  height: 40,
+  marginTop: 1,
 });
 
 interface PackageCardProps {
@@ -361,7 +367,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       <Checkbox
         checked={multiSelectSelectedAttributionIds.includes(attributionId)}
         onChange={handleMultiSelectAttributionSelected}
-        isMultiSelect
+        component={MultiSelectCheckboxComponent}
       />
     ) : undefined;
 

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -31,9 +31,6 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: OpossumColors.lightestBlue,
   },
-  multiselect: {
-    maxWidth: '300px',
-  },
 });
 
 export function ReportView(): ReactElement {
@@ -64,7 +61,7 @@ export function ReportView(): ReactElement {
         attributionsWithResources={useFilters(attributionsWithResources)}
         isFileWithChildren={isFileWithChildren}
         onIconClick={getOnIconClick()}
-        topElement={<FilterMultiSelect className={classes.multiselect} />}
+        topElement={<FilterMultiSelect sx={{ maxWidth: '300px' }} />}
       />
     </div>
   );

--- a/src/Frontend/util/get-sx-from-props-and-classes.ts
+++ b/src/Frontend/util/get-sx-from-props-and-classes.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SxProps } from '@mui/material';
+import { SystemStyleObject } from '@mui/system/styleFunctionSx';
+
+export type MuiSx = (
+  | boolean
+  | SystemStyleObject
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | ((theme: {}) => SystemStyleObject)
+)[];
+
+export function getSxFromPropsAndClasses({
+  sxProps,
+  styleClass,
+}: {
+  sxProps?: SxProps;
+  styleClass?: SystemStyleObject;
+}): MuiSx {
+  return [
+    styleClass ?? {},
+    ...(sxProps ? (Array.isArray(sxProps) ? sxProps : [sxProps]) : [{}]),
+  ];
+}


### PR DESCRIPTION
Signed-off-by: Ruiyun Xie <ruiyun.xie@tum.de>

### Summary of changes
- Experiment for replacing makeStyles with styled() and sx prop
- For Checkbox, ContextMenu and FilterMultiSelect

### Context and reason for change
- makeStyles etc. are deprecated in MUI v5

### How can the changes be tested
- In the UI
