### PR TITLE
Update react-query to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "packageurl-js": "^0.0.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-query": "^3.34.19",
+    "react-query": "^4.0.0-beta.3",
     "react-redux": "^7.2.8",
     "react-window": "^1.8.5",
     "redux": "^4.1.2",

--- a/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
@@ -109,7 +109,7 @@ export function PackageSearchPopup(): ReactElement {
         search={currentSearchTerm}
         autoFocus={false}
       />
-      {isLoading ? (
+      {isLoading && Boolean(currentSearchTerm) ? (
         <Spinner />
       ) : isError ? (
         <Alert

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,6 +2395,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/uuid@^8.3.4":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
@@ -8990,14 +8995,16 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-query@^3.34.19:
-  version "3.34.19"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.19.tgz#0ff049b6e0d2ed148e9abfdd346625d0e88dc229"
-  integrity sha512-JO0Ymi58WKmvnhgg6bGIrYIeKb64KsKaPWo8JcGnmK2jJxAs2XmMBzlP75ZepSU7CHzcsWtIIyhMrLbX3pb/3w==
+react-query@^4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-4.0.0-beta.3.tgz#7f63d55f165988ff37bc58297aabec962ccda962"
+  integrity sha512-WZkiBD+B3rVfPwR9e7W1TvshLYCfsCKx2t/jqpF/ZP3KwQnLAQ8aO67qtrP616QAK1qk3AfJMSsFtDwgYcq0AA==
   dependencies:
     "@babel/runtime" "^7.5.5"
+    "@types/use-sync-external-store" "^0.0.3"
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
+    use-sync-external-store "^1.0.0"
 
 react-redux@^7.2.8:
   version "7.2.8"
@@ -10585,6 +10592,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz#d98f4a9c2e73d0f958e7e2d2c2bfb5f618cbd8fd"
+  integrity sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
### Summary of changes
Update `react-query` to version 4. 

### Context and reason for change
We recently updated to `react` version 18. When updating the `react` types we saw some errors associated with `react-query` and it turns out that version 3 does not support `react` 18. 

### How can the changes be tested
Existing unit tests should cover the basics, I tried the "package search" feature manually.