### PR TITLE
Replace makeStyles with sx for FilterMultiSelect

### DIFF
--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -43,9 +43,6 @@ const useStyles = makeStyles({
   },
   disabledIcon,
   clickableIcon,
-  hiddenFilter: {
-    display: 'none',
-  },
 });
 
 export function AttributionView(): ReactElement {
@@ -105,9 +102,7 @@ export function AttributionView(): ReactElement {
           />
         }
         filterElement={
-          <FilterMultiSelect
-            className={showMultiSelect ? undefined : classes.hiddenFilter}
-          />
+          <FilterMultiSelect sx={showMultiSelect ? {} : { display: 'none' }} />
         }
       />
       <AttributionDetailsViewer />

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -15,9 +15,9 @@ import { FilterType } from '../../enums/enums';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { updateActiveFilters } from '../../state/actions/view-actions/view-actions';
 import { getActiveFilters } from '../../state/selectors/view-selector';
-import { makeStyles } from '@mui/styles';
 import { OpossumColors } from '../../shared-styles';
-import clsx from 'clsx';
+import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
@@ -27,7 +27,7 @@ const FILTERS = [
   FilterType.HideFirstParty,
 ];
 
-const useStyles = makeStyles({
+const classes = {
   dropDownForm: {
     margin: '12px 0px 8px 0px',
     backgroundColor: OpossumColors.white,
@@ -36,13 +36,13 @@ const useStyles = makeStyles({
     },
     '& label': {
       backgroundColor: OpossumColors.white,
-      padding: 1,
+      padding: '1px',
     },
   },
   dropDownSelect: {
     minHeight: 36,
     '& svg': {
-      paddingRight: 6,
+      paddingRight: '6px',
     },
   },
   dropDownBox: {
@@ -55,17 +55,18 @@ const useStyles = makeStyles({
     fontSize: 12,
   },
   dropdownStyle: {
-    maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-    left: '7px !important',
+    '& paper': {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      left: '7px !important',
+    },
   },
-});
+};
 
 interface FilterMultiSelectProps {
-  className?: string;
+  sx?: SxProps;
 }
 
 export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
-  const classes = useStyles();
   const dispatch = useAppDispatch();
   const activeFilters = Array.from(useAppSelector(getActiveFilters));
 
@@ -91,25 +92,28 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
 
   return (
     <MuiFormControl
-      className={clsx(classes.dropDownForm, props.className)}
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.dropDownForm,
+        sxProps: props.sx,
+      })}
       size="small"
       fullWidth
     >
       <MuiInputLabel>Filter</MuiInputLabel>
       <MuiSelect
-        className={classes.dropDownSelect}
+        sx={classes.dropDownSelect}
         data-testid="test-id-filter-multi-select"
         multiple
         value={activeFilters}
         input={<MuiOutlinedInput />}
         renderValue={(selectedFilters): ReactElement => (
-          <MuiBox className={classes.dropDownBox}>
+          <MuiBox sx={classes.dropDownBox}>
             {selectedFilters.map((filter) => (
               <MuiChip
                 key={filter}
                 label={filter}
                 size="small"
-                className={classes.chip}
+                sx={classes.chip}
                 onMouseDown={(event): void => {
                   event.preventDefault();
                   event.stopPropagation();
@@ -121,7 +125,7 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
             ))}
           </MuiBox>
         )}
-        MenuProps={{ classes: { paper: classes.dropdownStyle } }}
+        MenuProps={{ sx: classes.dropdownStyle }}
       >
         {getMenuItems()}
       </MuiSelect>

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -31,9 +31,6 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: OpossumColors.lightestBlue,
   },
-  multiselect: {
-    maxWidth: '300px',
-  },
 });
 
 export function ReportView(): ReactElement {
@@ -64,7 +61,7 @@ export function ReportView(): ReactElement {
         attributionsWithResources={useFilters(attributionsWithResources)}
         isFileWithChildren={isFileWithChildren}
         onIconClick={getOnIconClick()}
-        topElement={<FilterMultiSelect className={classes.multiselect} />}
+        topElement={<FilterMultiSelect sx={{ maxWidth: '300px' }} />}
       />
     </div>
   );

--- a/src/Frontend/util/__tests__/get-sx-from-props-and-classes.test.ts
+++ b/src/Frontend/util/__tests__/get-sx-from-props-and-classes.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getSxFromPropsAndClasses,
+  MuiSx,
+} from '../get-sx-from-props-and-classes';
+import { SxProps } from '@mui/material';
+import { SystemStyleObject } from '@mui/system/styleFunctionSx';
+
+describe('getSxFromPropsAndClasses', () => {
+  test('takes styleClass as only input', () => {
+    const testStyleClass: SystemStyleObject = { padding: '6px' };
+    const expectedSx: MuiSx = [testStyleClass, {}];
+
+    expect(getSxFromPropsAndClasses({ styleClass: testStyleClass })).toEqual(
+      expectedSx
+    );
+  });
+
+  test('takes sxProps object as only input', () => {
+    const testSxProps: SxProps = { margin: '12px' };
+    const expectedSx: MuiSx = [{}, testSxProps];
+
+    expect(getSxFromPropsAndClasses({ sxProps: testSxProps })).toEqual(
+      expectedSx
+    );
+  });
+
+  test('takes sxProps array as only input', () => {
+    const testSxProps: SxProps = [{ margin: '12px' }, { border: '1.5px' }];
+    const expectedSx: MuiSx = [{}, ...testSxProps];
+
+    expect(getSxFromPropsAndClasses({ sxProps: testSxProps })).toEqual(
+      expectedSx
+    );
+  });
+
+  test('takes styleClass and sxProps as input', () => {
+    const testStyleClass: SystemStyleObject = { padding: '6px' };
+    const testSxProps: SxProps = { margin: '12px' };
+    const expectedSx: MuiSx = [testStyleClass, testSxProps];
+
+    expect(
+      getSxFromPropsAndClasses({
+        styleClass: testStyleClass,
+        sxProps: testSxProps,
+      })
+    ).toEqual(expectedSx);
+  });
+});

--- a/src/Frontend/util/get-sx-from-props-and-classes.ts
+++ b/src/Frontend/util/get-sx-from-props-and-classes.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SxProps, Theme } from '@mui/material';
+import { SystemStyleObject } from '@mui/system/styleFunctionSx';
+
+export type MuiSx = (
+  | boolean
+  | SystemStyleObject
+  | ((theme: Theme) => SystemStyleObject)
+)[];
+
+export function getSxFromPropsAndClasses({
+  sxProps,
+  styleClass,
+}: {
+  sxProps?: SxProps;
+  styleClass?: SystemStyleObject;
+}): MuiSx {
+  return [
+    styleClass ?? {},
+    ...(sxProps ? (Array.isArray(sxProps) ? sxProps : [sxProps]) : [{}]),
+  ];
+}


### PR DESCRIPTION
Signed-off-by: Leslie Lazzarino <leslie.lazzarino@tngtech.com>

### Summary of changes

Replaced makeStyles with sx for FilterMultiSelect.

### Context and reason for change

Deprecation of makeStyles

### How can the changes be tested

The first party filter in attribution view behaves correctly.

