### PR TITLE
Use sx instead of makestyles

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiPaper from '@mui/material/Paper';
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
 import { CheckboxLabel, DiscreteConfidence } from '../../enums/enums';
@@ -15,23 +13,26 @@ import { Checkbox } from '../Checkbox/Checkbox';
 import { Dropdown } from '../InputElements/Dropdown';
 import { NumberBox } from '../InputElements/NumberBox';
 import { TextBox } from '../InputElements/TextBox';
-import { useAttributionColumnStyles } from './shared-attribution-column-styles';
+import { attributionColumnClasses } from './shared-attribution-column-styles';
 import { getExternalAttributionSources } from '../../state/selectors/all-views-resource-selectors';
 import { useAppSelector } from '../../state/hooks';
-import { useCheckboxStyles } from '../../shared-styles';
+import { checkboxClass } from '../../shared-styles';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
+  ...checkboxClass,
+  ...attributionColumnClasses,
   confidenceDropDown: {
     flex: 0,
     flexBasis: 100,
-    marginBottom: 4,
+    marginBottom: '4px',
   },
   sourceField: {
-    marginBottom: 4,
+    marginBottom: '4px',
     flex: 0.5,
   },
-});
+};
 
 interface AuditingSubPanelProps {
   isEditable: boolean;
@@ -53,32 +54,27 @@ interface AuditingSubPanelProps {
 }
 
 export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
-  const classes = {
-    ...useAttributionColumnStyles(),
-    ...useCheckboxStyles(),
-    ...useStyles(),
-  };
   const attributionSources = useAppSelector(getExternalAttributionSources);
 
   return (
-    <MuiPaper className={classes.panel} elevation={0} square={true}>
-      <div className={classes.displayRow}>
+    <MuiPaper sx={classes.panel} elevation={0} square={true}>
+      <MuiBox sx={classes.displayRow}>
         <Checkbox
-          className={classes.checkBox}
+          sx={classes.checkBox}
           label={CheckboxLabel.FirstParty}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.firstParty)}
           onChange={props.firstPartyChangeHandler}
         />
         <Checkbox
-          className={classes.checkBox}
+          sx={classes.checkBox}
           label={CheckboxLabel.FollowUp}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.followUp)}
           onChange={props.followUpChangeHandler}
         />
         <Checkbox
-          className={classes.checkBox}
+          sx={classes.checkBox}
           label={CheckboxLabel.ExcludeFromNotice}
           disabled={!props.isEditable}
           checked={Boolean(props.displayPackageInfo.excludeFromNotice)}
@@ -86,7 +82,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
         />
         {props.showManualAttributionData ? (
           <Dropdown
-            className={classes.confidenceDropDown}
+            sx={classes.confidenceDropDown}
             isEditable={props.isEditable}
             title={'Confidence'}
             handleChange={props.discreteConfidenceChangeHandler}
@@ -107,7 +103,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
           />
         ) : (
           <NumberBox
-            className={classes.confidenceDropDown}
+            sx={classes.confidenceDropDown}
             title={'Confidence'}
             handleChange={props.setUpdateTemporaryPackageInfoFor(
               'attributionConfidence'
@@ -129,7 +125,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
         {props.displayPackageInfo.source ? (
           <TextBox
             isEditable={false}
-            className={clsx(classes.sourceField, classes.rightTextBox)}
+            sx={{ ...classes.sourceField, ...classes.rightTextBox }}
             title={'Source'}
             text={prettifySource(
               props.displayPackageInfo.source.name,
@@ -138,10 +134,10 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
             handleChange={doNothing}
           />
         ) : null}
-      </div>
+      </MuiBox>
       <TextBox
         isEditable={props.isEditable}
-        className={classes.textBox}
+        sx={classes.textBox}
         title={'Comment'}
         text={props.displayPackageInfo.comment}
         minRows={props.commentRows}

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -4,12 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiPaper from '@mui/material/Paper';
-import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { TextBox } from '../InputElements/TextBox';
-import { useAttributionColumnStyles } from './shared-attribution-column-styles';
+import { attributionColumnClasses } from './shared-attribution-column-styles';
+import MuiBox from '@mui/material/Box';
 
 interface CopyrightSubPanelProps {
   isEditable: boolean;
@@ -22,14 +22,12 @@ interface CopyrightSubPanelProps {
 }
 
 export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
-  const classes = useAttributionColumnStyles();
-
   return (
-    <MuiPaper className={classes.panel} elevation={0} square={true}>
-      <div className={classes.displayRow}>
+    <MuiPaper sx={attributionColumnClasses.panel} elevation={0} square={true}>
+      <MuiBox sx={attributionColumnClasses.displayRow}>
         <TextBox
           isEditable={props.isEditable}
-          className={clsx(classes.textBox)}
+          sx={attributionColumnClasses.textBox}
           title={'Copyright'}
           text={props.displayPackageInfo.copyright}
           minRows={props.copyrightRows}
@@ -44,7 +42,7 @@ export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
             )
           }
         />
-      </div>
+      </MuiBox>
     </MuiPaper>
   );
 }

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiPaper from '@mui/material/Paper';
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
 import { PackageInfo } from '../../../shared/shared-types';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
@@ -18,39 +16,45 @@ import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import MuiAccordionDetails from '@mui/material/AccordionDetails';
-import { useAttributionColumnStyles } from './shared-attribution-column-styles';
+import { attributionColumnClasses } from './shared-attribution-column-styles';
 import { useAppSelector } from '../../state/hooks';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
   expansionPanel: {
     backgroundColor: OpossumColors.lighterBlue,
   },
   expansionPanelExpanded: {
-    margin: '0px 0px 6px 0px !important',
+    '& expanded': {
+      margin: '0px 0px 6px 0px !important',
+    },
   },
   expansionPanelSummary: {
     minHeight: '12px !important',
-    padding: 0,
-    paddingRight: 12,
+    padding: '0px',
+    paddingRight: '12px',
     '& div.MuiAccordionSummary-content': {
-      margin: 0,
+      margin: '0px',
     },
     '& div.MuiAccordionSummary-expandIcon': {
-      padding: 0,
+      padding: '0px',
     },
   },
-  expansionPanelDetails: { height: '100%', padding: 0 },
+  expansionPanelDetails: {
+    height: '100%',
+    padding: '0px',
+  },
   expandMoreIcon: {
-    height: 37,
+    height: '37px',
   },
   licenseTextBox: {
     flex: 1,
   },
   licenseText: {
-    marginTop: 11,
+    marginTop: '11px',
   },
-});
+};
 
 interface LicenseSubPanelProps {
   isEditable: boolean;
@@ -65,7 +69,7 @@ interface LicenseSubPanelProps {
 }
 
 export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
-  const classes = { ...useAttributionColumnStyles(), ...useStyles() };
+  const licenseSubPanelClasses = { ...attributionColumnClasses, ...classes };
 
   const frequentLicensesNameOrder = useAppSelector(
     getFrequentLicensesNameOrder
@@ -76,30 +80,33 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
   }
 
   return (
-    <MuiPaper className={clsx(classes.panel)} elevation={0} square={true}>
+    <MuiPaper sx={licenseSubPanelClasses.panel} elevation={0} square={true}>
       <MuiAccordion
-        className={clsx(classes.textBox, classes.expansionPanel)}
-        classes={{ expanded: classes.expansionPanelExpanded }}
+        sx={{
+          ...licenseSubPanelClasses.expansionPanelExpanded,
+          ...licenseSubPanelClasses.textBox,
+          ...licenseSubPanelClasses.expansionPanel,
+        }}
         elevation={0}
         key={'License'}
         expanded={props.isLicenseTextShown}
         onChange={doNothing}
       >
         <MuiAccordionSummary
-          classes={{ root: classes.expansionPanelSummary }}
+          sx={licenseSubPanelClasses.expansionPanelSummary}
           expandIcon={
             // This div is needed to fix the Firefox warning.
-            <div className={classes.expandMoreIcon}>
+            <MuiBox sx={licenseSubPanelClasses.expandMoreIcon}>
               <ExpandMoreIcon
-                className={classes.expandMoreIcon}
+                sx={licenseSubPanelClasses.expandMoreIcon}
                 onClick={toggleIsLicenseTextShown}
               />
-            </div>
+            </MuiBox>
           }
         >
           <AutoComplete
             isEditable={props.isEditable}
-            className={clsx(classes.licenseTextBox)}
+            sx={licenseSubPanelClasses.licenseTextBox}
             title={'License Name'}
             text={props.displayPackageInfo.licenseName}
             options={frequentLicensesNameOrder}
@@ -118,10 +125,13 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
             }
           />
         </MuiAccordionSummary>
-        <MuiAccordionDetails classes={{ root: classes.expansionPanelDetails }}>
+        <MuiAccordionDetails sx={licenseSubPanelClasses.expansionPanelDetails}>
           <TextBox
             isEditable={props.isEditable}
-            className={clsx(classes.licenseTextBox, classes.licenseText)}
+            sx={{
+              ...licenseSubPanelClasses.licenseTextBox,
+              ...licenseSubPanelClasses.licenseText,
+            }}
             minRows={props.licenseTextRows}
             maxRows={props.licenseTextRows}
             multiline={true}

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -5,21 +5,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiPaper from '@mui/material/Paper';
-import clsx from 'clsx';
 import React, { ChangeEvent, ReactElement } from 'react';
 import { IpcChannel } from '../../../shared/ipc-channels';
 import { PackageInfo } from '../../../shared/shared-types';
 import { TextBox } from '../InputElements/TextBox';
-import { useAttributionColumnStyles } from './shared-attribution-column-styles';
+import { attributionColumnClasses } from './shared-attribution-column-styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IconButton } from '../IconButton/IconButton';
-import { makeStyles } from '@mui/styles';
 import { clickableIcon, disabledIcon } from '../../shared-styles';
 import { FetchLicenseInformationButton } from '../FetchLicenseInformationButton/FetchLicenseInformationButton';
 import { SearchPackagesIcon } from '../Icons/Icons';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({ clickableIcon, disabledIcon });
+const iconClasses = { clickableIcon, disabledIcon };
 
 interface PackageSubPanelProps {
   displayPackageInfo: PackageInfo;
@@ -36,9 +35,6 @@ interface PackageSubPanelProps {
 }
 
 export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
-  const classes = useAttributionColumnStyles();
-  const iconClasses = useStyles();
-
   function openUrl(): void {
     let urlString = props.displayPackageInfo.url;
     if (urlString) {
@@ -55,10 +51,10 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
   }
 
   return (
-    <MuiPaper className={classes.panel} elevation={0} square={true}>
-      <div className={classes.displayRow}>
+    <MuiPaper sx={attributionColumnClasses.panel} elevation={0} square={true}>
+      <MuiBox sx={attributionColumnClasses.displayRow}>
         <TextBox
-          className={clsx(classes.textBox)}
+          sx={attributionColumnClasses.textBox}
           title={'Name'}
           text={props.displayPackageInfo.packageName}
           handleChange={props.setUpdateTemporaryPackageInfoFor('packageName')}
@@ -71,7 +67,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
               disabled={!props.isEditable}
               icon={
                 <SearchPackagesIcon
-                  className={
+                  sx={
                     props.isEditable
                       ? iconClasses.clickableIcon
                       : iconClasses.disabledIcon
@@ -89,7 +85,10 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
           }
         />
         <TextBox
-          className={clsx(classes.textBox, classes.rightTextBox)}
+          sx={{
+            ...attributionColumnClasses.textBox,
+            ...attributionColumnClasses.rightTextBox,
+          }}
           title={'Version'}
           text={props.displayPackageInfo.packageVersion}
           handleChange={props.setUpdateTemporaryPackageInfoFor(
@@ -104,12 +103,14 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
             )
           }
         />
-      </div>
+      </MuiBox>
       <TextBox
-        className={classes.textBox}
-        textFieldClassname={clsx(
-          props.isDisplayedPurlValid ? null : classes.textBoxInvalidInput
-        )}
+        sx={attributionColumnClasses.textBox}
+        textFieldSx={
+          props.isDisplayedPurlValid
+            ? {}
+            : attributionColumnClasses.textBoxInvalidInput
+        }
         title={'PURL'}
         text={props.temporaryPurl}
         handleChange={props.handlePurlChange}
@@ -124,7 +125,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
       />
       <TextBox
         isEditable={props.isEditable}
-        className={clsx(classes.textBox)}
+        sx={attributionColumnClasses.textBox}
         title={'URL'}
         text={props.displayPackageInfo.url}
         handleChange={props.setUpdateTemporaryPackageInfoFor('url')}
@@ -143,7 +144,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
               icon={
                 <OpenInNewIcon
                   aria-label={'Url icon'}
-                  className={
+                  sx={
                     props.displayPackageInfo.url
                       ? iconClasses.clickableIcon
                       : iconClasses.disabledIcon

--- a/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
+++ b/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
@@ -3,14 +3,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
 import { OpossumColors } from '../../shared-styles';
 
-export const useAttributionColumnStyles = makeStyles({
+export const attributionColumnClasses = {
   panel: {
-    marginBottom: 5,
-    padding: 6,
-    paddingBottom: 0,
+    marginBottom: '5px',
+    padding: '6px',
+    paddingBottom: '0px',
     background: OpossumColors.lightestBlue,
     border: `1px ${OpossumColors.lightestBlue} solid`,
   },
@@ -18,15 +17,15 @@ export const useAttributionColumnStyles = makeStyles({
     display: 'flex',
   },
   textBox: {
-    marginBottom: 10,
+    marginBottom: '4px',
     flex: 1,
   },
   rightTextBox: {
-    marginLeft: 8,
+    marginLeft: '8px',
   },
   textBoxInvalidInput: {
     '& textarea, input': {
       color: OpossumColors.orange,
     },
   },
-});
+};

--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -9,6 +9,8 @@ import makeStyles from '@mui/styles/makeStyles';
 import clsx from 'clsx';
 import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
+import { SxProps } from '@mui/material';
+import MuiBox from '@mui/material/Box';
 
 const useStyles = makeStyles({
   white: {
@@ -24,7 +26,7 @@ interface CheckboxProps {
   disabled?: boolean;
   checked: boolean;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
-  className?: string;
+  sx?: SxProps;
   white?: boolean;
 }
 
@@ -32,7 +34,7 @@ export function Checkbox(props: CheckboxProps): ReactElement {
   const classes = useStyles();
   const whiteMode = clsx(props.white && classes.white);
   return (
-    <div className={props.className}>
+    <MuiBox sx={props.sx}>
       <MuiCheckbox
         disabled={props.disabled}
         checked={props.checked}
@@ -54,6 +56,6 @@ export function Checkbox(props: CheckboxProps): ReactElement {
       >
         {props.label || ''}
       </MuiTypography>
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -7,12 +7,7 @@ import React, { ReactElement } from 'react';
 import MuiButtonBase from '@mui/material/ButtonBase';
 import MuiTooltip from '@mui/material/Tooltip';
 import { tooltipStyle } from '../../shared-styles';
-import { makeStyles } from '@mui/styles';
 import clsx from 'clsx';
-
-const useStyles = makeStyles({
-  tooltip: tooltipStyle,
-});
 
 interface IconButtonProps {
   tooltipTitle: string;
@@ -24,13 +19,12 @@ interface IconButtonProps {
 }
 
 export function IconButton(props: IconButtonProps): ReactElement {
-  const classes = useStyles();
   function wrapInTooltip(children: ReactElement): ReactElement {
     return props.disabled ? (
       <span>{children}</span>
     ) : (
       <MuiTooltip
-        classes={{ tooltip: classes.tooltip }}
+        sx={tooltipStyle}
         title={props.tooltipTitle}
         placement={props.placement}
       >

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
 import MuiTooltip from '@mui/material/Tooltip';
 import Filter1Icon from '@mui/icons-material/Filter1';
 import InsertCommentIcon from '@mui/icons-material/InsertComment';
@@ -16,7 +15,6 @@ import IndeterminateCheckBoxIcon from '@mui/icons-material/IndeterminateCheckBox
 import ReplayIcon from '@mui/icons-material/Replay';
 import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import SearchIcon from '@mui/icons-material/Search';
-import clsx from 'clsx';
 import React, { ReactElement } from 'react';
 import {
   baseIcon,
@@ -24,16 +22,17 @@ import {
   OpossumColors,
   tooltipStyle,
 } from '../../shared-styles';
+import { SxProps } from '@mui/material';
 
-const useStyles = makeStyles({
+const classes = {
   clickableIcon,
   nonClickableIcon: {
     ...baseIcon,
     color: OpossumColors.darkBlue,
   },
   resourceIcon: {
-    width: 18,
-    height: 18,
+    width: '18px',
+    height: '18px',
     paddingLeft: '2px',
     paddingRight: '2px',
   },
@@ -42,15 +41,15 @@ const useStyles = makeStyles({
   },
   tooltip: tooltipStyle,
   openCloseFolderIcons: {
-    margin: 0,
-    padding: 0,
-    width: 16,
-    height: 20,
+    margin: '0px',
+    padding: '0px',
+    width: '16px',
+    height: '20px',
   },
-});
+};
 
 interface IconProps {
-  className?: string;
+  sx?: SxProps;
 }
 
 interface LabelDetailIconProps extends IconProps {
@@ -59,129 +58,116 @@ interface LabelDetailIconProps extends IconProps {
 }
 
 export function FirstPartyIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="is first party">
+    <MuiTooltip sx={classes.tooltip} title="is first party">
       <Filter1Icon
         aria-label={'First party icon'}
-        className={clsx(classes.nonClickableIcon, props.className)}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
       />
     </MuiTooltip>
   );
 }
 
 export function CommentIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="has comment">
+    <MuiTooltip sx={classes.tooltip} title="has comment">
       <InsertCommentIcon
         aria-label={'Comment icon'}
-        className={clsx(classes.nonClickableIcon, props.className)}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
       />
     </MuiTooltip>
   );
 }
 
 export function ExcludeFromNoticeIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip
-      classes={{ tooltip: classes.tooltip }}
-      title="excluded from notice"
-    >
+    <MuiTooltip sx={classes.tooltip} title="excluded from notice">
       <IndeterminateCheckBoxIcon
         aria-label={'Exclude from notice icon'}
-        className={clsx(classes.nonClickableIcon, props.className)}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
       />
     </MuiTooltip>
   );
 }
 
 export function FollowUpIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="has follow-up">
+    <MuiTooltip sx={classes.tooltip} title="has follow-up">
       <ReplayIcon
         aria-label={'Follow-up icon'}
-        className={clsx(classes.nonClickableIcon, props.className)}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
       />
     </MuiTooltip>
   );
 }
 
 export function SignalIcon(): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="has signals">
+    <MuiTooltip sx={classes.tooltip} title="has signals">
       <AnnouncementIcon
         aria-label={'Signal icon'}
-        className={classes.nonClickableIcon}
+        sx={classes.nonClickableIcon}
       />
     </MuiTooltip>
   );
 }
 
 export function DirectoryIcon({
-  className,
+  sx,
   labelDetail,
 }: LabelDetailIconProps): ReactElement {
-  const classes = useStyles();
   return (
     <FolderOutlinedIcon
       aria-label={
         labelDetail ? `Directory icon ${labelDetail}` : 'Directory icon'
       }
-      className={clsx(
-        classes.resourceIcon,
-        className ?? classes.resourceDefaultColor
-      )}
+      sx={{
+        ...classes.resourceIcon,
+        ...(sx ?? classes.resourceDefaultColor),
+      }}
     />
   );
 }
 
 export function BreakpointIcon(): ReactElement {
-  const classes = useStyles();
   return (
     <WidgetsIcon
       aria-label={'Breakpoint icon'}
-      className={clsx(classes.resourceIcon, classes.resourceDefaultColor)}
+      sx={{ ...classes.resourceIcon, ...classes.resourceDefaultColor }}
     />
   );
 }
 
 export function FileIcon({
-  className,
+  sx,
   labelDetail,
 }: LabelDetailIconProps): ReactElement {
-  const classes = useStyles();
   return (
     <DescriptionIcon
       aria-label={labelDetail ? `File icon ${labelDetail}` : 'File icon'}
-      className={clsx(
-        classes.resourceIcon,
-        className ?? classes.resourceDefaultColor
-      )}
+      sx={{
+        ...classes.resourceIcon,
+        ...(sx ?? classes.resourceDefaultColor),
+      }}
     />
   );
 }
 
 export function PreSelectedIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
-    <MuiTooltip classes={{ tooltip: classes.tooltip }} title="was pre-selected">
+    <MuiTooltip sx={classes.tooltip} title="was pre-selected">
       <LocalParkingIcon
         aria-label={'Pre-selected icon'}
-        className={clsx(classes.nonClickableIcon, props.className)}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
       />
     </MuiTooltip>
   );
 }
 
 export function SearchPackagesIcon(props: IconProps): ReactElement {
-  const classes = useStyles();
   return (
     <SearchIcon
-      className={clsx(classes.nonClickableIcon, props.className)}
+      sx={{ ...classes.nonClickableIcon, ...props.sx }}
       aria-label={'Search packages icon'}
     />
   );

--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -4,31 +4,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent, ReactElement } from 'react';
-import { InputElementProps, useInputElementStyles } from './shared';
+import { InputElementProps, inputElementClasses } from './shared';
 import MuiAutocomplete from '@mui/material/Autocomplete';
 import MuiTextField from '@mui/material/TextField';
-import clsx from 'clsx';
 import MuiInputAdornment from '@mui/material/InputAdornment';
-import makeStyles from '@mui/styles/makeStyles';
-
+import MuiBox from '@mui/material/Box';
 interface AutoCompleteProps extends InputElementProps {
   options: Array<string>;
   endAdornmentText?: string;
 }
 
-const useStyles = makeStyles({
+const classes = {
+  ...inputElementClasses,
   endAdornment: {
-    paddingRight: 6,
+    paddingRight: '6px',
   },
-});
+};
 
 function enterWasPressed(event: KeyboardEvent): boolean {
   return event.which == 13 || event.keyCode == 13;
 }
 
 export function AutoComplete(props: AutoCompleteProps): ReactElement {
-  const classes = { ...useInputElementStyles(), ...useStyles() };
-
   function onInputChange(
     event: ChangeEvent<unknown> | KeyboardEvent,
     value: string
@@ -49,12 +46,14 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
   const isInputValueInOptions: boolean = inputValueIndexInOptions > -1;
 
   return (
-    <div className={props.className}>
+    <MuiBox sx={props.sx}>
       <MuiAutocomplete
         freeSolo
-        classes={{
-          root: props.isHighlighted ? classes.highlightedTextField : undefined,
-          popper: classes.popper,
+        sx={{
+          ...(props.isHighlighted
+            ? { '& root': classes.highlightedTextField }
+            : {}),
+          ...classes.popper,
         }}
         options={props.options}
         disableClearable={true}
@@ -68,10 +67,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
                 InputProps: {
                   ...params.InputProps,
                   endAdornment: (
-                    <MuiInputAdornment
-                      position="end"
-                      className={classes.endAdornment}
-                    >
+                    <MuiInputAdornment position="end" sx={classes.endAdornment}>
                       {props.endAdornmentText}
                     </MuiInputAdornment>
                   ),
@@ -83,10 +79,10 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
             <MuiTextField
               {...paramsWithAdornment}
               label={props.title}
-              className={clsx(
-                classes.textField,
-                isInputValueInOptions ? classes.textFieldBoldText : null
-              )}
+              sx={{
+                ...classes.textField,
+                ...(isInputValueInOptions ? classes.textFieldBoldText : {}),
+              }}
               variant="outlined"
               size="small"
               onChange={props.handleChange}
@@ -94,6 +90,6 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
           );
         }}
       />
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -4,11 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import { InputElementProps, useInputElementStyles } from './shared';
+import { InputElementProps, inputElementClasses } from './shared';
 import MuiTextField from '@mui/material/TextField';
 import MuiMenuItem from '@mui/material/MenuItem';
-import clsx from 'clsx';
-
+import MuiBox from '@mui/material/Box';
 interface DropdownProps extends InputElementProps {
   value: number;
   menuItems: Array<menuItem>;
@@ -20,7 +19,6 @@ interface menuItem {
 }
 
 export function Dropdown(props: DropdownProps): ReactElement {
-  const classes = useInputElementStyles();
   const menuItems = getMenuItemsWithSelectedValueIncluded();
 
   function getMenuItemsWithSelectedValueIncluded(): Array<menuItem> {
@@ -37,13 +35,15 @@ export function Dropdown(props: DropdownProps): ReactElement {
   }
 
   return (
-    <div className={props.className}>
+    <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
-        className={clsx(
-          classes.textField,
-          props.isHighlighted && classes.highlightedTextField
-        )}
+        sx={{
+          ...inputElementClasses.textField,
+          ...(props.isHighlighted
+            ? inputElementClasses.highlightedTextField
+            : {}),
+        }}
         select
         label={props.title}
         InputProps={{
@@ -65,6 +65,6 @@ export function Dropdown(props: DropdownProps): ReactElement {
           );
         })}
       </MuiTextField>
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/InputElements/NumberBox.tsx
+++ b/src/Frontend/Components/InputElements/NumberBox.tsx
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiTextField from '@mui/material/TextField';
-import clsx from 'clsx';
 import React, { ReactElement } from 'react';
-import { InputElementProps, useInputElementStyles } from './shared';
-
+import { InputElementProps, inputElementClasses } from './shared';
+import MuiBox from '@mui/material/Box';
 interface NumericProps extends InputElementProps {
   value?: number;
   min?: number;
@@ -16,16 +15,16 @@ interface NumericProps extends InputElementProps {
 }
 
 export function NumberBox(props: NumericProps): ReactElement {
-  const classes = useInputElementStyles();
-
   return (
-    <div className={props.className}>
+    <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
-        className={clsx(
-          classes.textField,
-          props.isHighlighted && classes.highlightedTextField
-        )}
+        sx={{
+          ...inputElementClasses.textField,
+          ...(props.isHighlighted
+            ? inputElementClasses.highlightedTextField
+            : {}),
+        }}
         label={props.title}
         InputProps={{
           inputProps: {
@@ -41,7 +40,7 @@ export function NumberBox(props: NumericProps): ReactElement {
         value={isFiniteNumber(props.value) ? props.value : ''}
         onChange={props.handleChange}
       />
-    </div>
+    </MuiBox>
   );
 }
 

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -5,12 +5,13 @@
 
 import MuiTextField from '@mui/material/TextField';
 import React, { ReactElement } from 'react';
-import { InputElementProps, useInputElementStyles } from './shared';
-import clsx from 'clsx';
+import { InputElementProps, inputElementClasses } from './shared';
 import MuiInputAdornment from '@mui/material/InputAdornment';
+import MuiBox from '@mui/material/Box';
+import { SxProps } from '@mui/material';
 
 interface TextProps extends InputElementProps {
-  textFieldClassname?: string;
+  textFieldSx?: SxProps;
   minRows?: number;
   maxRows?: number;
   endIcon?: ReactElement;
@@ -18,17 +19,17 @@ interface TextProps extends InputElementProps {
 }
 
 export function TextBox(props: TextProps): ReactElement {
-  const classes = useInputElementStyles();
-
   return (
-    <div className={props.className}>
+    <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
-        className={clsx(
-          props.textFieldClassname,
-          classes.textField,
-          props.isHighlighted && classes.highlightedTextField
-        )}
+        sx={{
+          ...props.textFieldSx,
+          ...inputElementClasses.textField,
+          ...(props.isHighlighted
+            ? inputElementClasses.highlightedTextField
+            : {}),
+        }}
         label={props.title}
         InputProps={{
           inputProps: {
@@ -48,6 +49,6 @@ export function TextBox(props: TextProps): ReactElement {
         value={props.text || ''}
         onChange={props.handleChange}
       />
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -3,11 +3,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
+import { SxProps } from '@mui/material';
 import { ChangeEvent } from 'react';
 import { OpossumColors } from '../../shared-styles';
 
-export const useInputElementStyles = makeStyles({
+export const inputElementClasses = {
   textFieldBoldText: {
     '& input': {
       fontWeight: 'bold',
@@ -17,7 +17,7 @@ export const useInputElementStyles = makeStyles({
     width: '100%',
     '& div': {
       backgroundColor: OpossumColors.white,
-      borderRadius: 0,
+      borderRadius: '0px',
     },
     '& label': {
       backgroundColor: OpossumColors.white,
@@ -25,20 +25,20 @@ export const useInputElementStyles = makeStyles({
       fontSize: '13px',
     },
     '& span': {
-      padding: 0,
+      padding: '0px',
     },
     '& legend': {
-      marginLeft: 6,
+      marginLeft: '6px',
       '& span': {
-        paddingLeft: 0,
-        paddingRight: 0,
+        paddingLeft: '0px',
+        paddingRight: '0px',
       },
     },
   },
   highlightedTextField: {
     '& div': {
       backgroundColor: OpossumColors.lightOrange,
-      borderRadius: 0,
+      borderRadius: '0px',
     },
     '& label': {
       backgroundColor: OpossumColors.lightOrange,
@@ -46,17 +46,19 @@ export const useInputElementStyles = makeStyles({
     },
   },
   popper: {
-    '& div': {
-      fontWeight: 'bold',
+    '& popper': {
+      '& div': {
+        fontWeight: 'bold',
+      },
     },
   },
-});
+};
 
 export interface InputElementProps {
   title?: string;
   isEditable?: boolean;
   text?: string;
-  className?: string;
+  sx?: SxProps;
   handleChange(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ): void;

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -6,12 +6,10 @@
 import React, { ReactElement, useState } from 'react';
 import { ListCard } from '../ListCard/ListCard';
 import { getCardLabels } from '../../util/get-card-labels';
-import makeStyles from '@mui/styles/makeStyles';
 import { ListCardConfig, ListCardContent } from '../../types/types';
-import { clickableIcon, OpossumColors } from '../../shared-styles';
+import { clickableIcon } from '../../shared-styles';
 import { IconButton } from '../IconButton/IconButton';
 import PlusIcon from '@mui/icons-material/Add';
-import clsx from 'clsx';
 import { ContextMenu, ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { ButtonText, PopupType, View } from '../../enums/enums';
 import { useSelector } from 'react-redux';
@@ -58,27 +56,22 @@ import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { PackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { getPackageInfoKeys } from '../../../shared/shared-util';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
   hiddenIcon: {
     visibility: 'hidden',
   },
-  followUpIcon: {
-    color: OpossumColors.orange,
-  },
-  excludeFromNoticeIcon: {
-    color: OpossumColors.grey,
-  },
   clickableIcon,
   multiSelectCheckbox: {
-    height: 40,
-    marginTop: 1,
+    height: '40px',
+    marginTop: '1px',
   },
   multiSelectPackageCard: {
     flexGrow: 1,
-    minWidth: 0,
+    minWidth: '0px',
   },
-});
+};
 
 interface PackageCardProps {
   cardContent: ListCardContent;
@@ -94,8 +87,6 @@ interface PackageCardProps {
 }
 
 export function PackageCard(props: PackageCardProps): ReactElement | null {
-  const classes = useStyles();
-
   const dispatch = useAppDispatch();
   const temporaryPackageInfo = useSelector(getTemporaryPackageInfo);
   const selectedView = useSelector(getSelectedView);
@@ -361,7 +352,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       <Checkbox
         checked={multiSelectSelectedAttributionIds.includes(attributionId)}
         onChange={handleMultiSelectAttributionSelected}
-        className={classes.multiSelectCheckbox}
+        sx={classes.multiSelectCheckbox}
       />
     ) : undefined;
 
@@ -373,10 +364,10 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       key={getKey('add-icon', props.cardContent)}
       icon={
         <PlusIcon
-          className={clsx(
-            props.cardConfig.isResolved ? classes.hiddenIcon : undefined,
-            classes.clickableIcon
-          )}
+          sx={{
+            ...(props.cardConfig.isResolved ? classes.hiddenIcon : {}),
+            ...classes.clickableIcon,
+          }}
           aria-label={`add ${packageLabels[0] || ''}`}
         />
       }
@@ -393,7 +384,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       key={`open-resources-icon-${props.cardContent.name}-${props.cardContent.packageVersion}`}
       icon={
         <OpenInBrowserIcon
-          className={classes.clickableIcon}
+          sx={classes.clickableIcon}
           aria-label={'show resources'}
         />
       }
@@ -401,9 +392,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   ) : undefined;
 
   return (
-    <div
-      className={clsx(!props.showCheckBox && classes.multiSelectPackageCard)}
-    >
+    <MuiBox sx={!props.showCheckBox ? classes.multiSelectPackageCard : {}}>
       {!Boolean(props.hideContextMenuAndMultiSelect) && (
         <ResourcePathPopup
           isOpen={showAssociatedResourcesPopup}
@@ -431,13 +420,12 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           rightIcons={getRightIcons(
             props.cardContent,
             props.cardConfig,
-            classes,
             openResourcesIcon
           )}
           leftElement={leftElement}
           highlightedCard={highlightedAttribution}
         />
       </ContextMenu>
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ListCardConfig, ListCardContent } from '../../types/types';
-import { ClassNameMap } from '@mui/styles';
 import React, { ReactElement } from 'react';
 import {
   ExcludeFromNoticeIcon,
@@ -12,15 +11,24 @@ import {
   FollowUpIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
+import { OpossumColors } from '../../shared-styles';
 
 export function getKey(prefix: string, cardContent: ListCardContent): string {
   return `${prefix}-${cardContent.id}`;
 }
 
+const classes = {
+  followUpIcon: {
+    color: OpossumColors.orange,
+  },
+  excludeFromNoticeIcon: {
+    color: OpossumColors.grey,
+  },
+};
+
 export function getRightIcons(
   cardContent: ListCardContent,
   cardConfig: ListCardConfig,
-  classes: ClassNameMap<'followUpIcon' | 'excludeFromNoticeIcon'>,
   openResourcesIcon?: JSX.Element
 ): Array<ReactElement> {
   const rightIcons: Array<JSX.Element> = [];
@@ -38,7 +46,7 @@ export function getRightIcons(
     rightIcons.push(
       <ExcludeFromNoticeIcon
         key={getKey('exclude-icon', cardContent)}
-        className={classes.excludeFromNoticeIcon}
+        sx={classes.excludeFromNoticeIcon}
       />
     );
   }
@@ -46,7 +54,7 @@ export function getRightIcons(
     rightIcons.push(
       <FollowUpIcon
         key={getKey('follow-up-icon', cardContent)}
-        className={classes.followUpIcon}
+        sx={classes.followUpIcon}
       />
     );
   }

--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
 import MuiTypography from '@mui/material/Typography';
 import MuiTooltip from '@mui/material/Tooltip';
 import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
@@ -14,11 +13,12 @@ import { GoToLinkButton } from '../GoToLinkButton/GoToLinkButton';
 import { useAppSelector } from '../../state/hooks';
 import { getFilesWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
   root: {
-    paddingLeft: 6,
-    height: 24,
+    paddingLeft: '6px',
+    height: '24px',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -31,24 +31,23 @@ const useStyles = makeStyles({
     direction: 'rtl',
   },
   tooltip: tooltipStyle,
-});
+};
 
 export function PathBar(): ReactElement | null {
-  const classes = useStyles();
   const path = useAppSelector(getSelectedResourceId);
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
 
   return path ? (
-    <div className={classes.root}>
-      <MuiTooltip classes={{ tooltip: classes.tooltip }} title={path}>
-        <MuiTypography className={classes.leftEllipsis} variant={'subtitle1'}>
+    <MuiBox sx={classes.root}>
+      <MuiTooltip sx={classes.tooltip} title={path}>
+        <MuiTypography sx={classes.leftEllipsis} variant={'subtitle1'}>
           <bdi>
             {removeTrailingSlashIfFileWithChildren(path, isFileWithChildren)}
           </bdi>
         </MuiTypography>
       </MuiTooltip>
       <GoToLinkButton />
-    </div>
+    </MuiBox>
   ) : null;
 }

--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -7,7 +7,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import MuiTooltip from '@mui/material/Tooltip';
 import React, { ReactElement } from 'react';
 import { ProgressBarData } from '../../types/types';
-import { OpossumColors, tooltipStyle } from '../../shared-styles';
+import { OpossumColors } from '../../shared-styles';
 import {
   getProgressBarBackground,
   getProgressBarTooltipText,
@@ -17,7 +17,7 @@ import clsx from 'clsx';
 
 const useStyles = makeStyles({
   tooltip: {
-    ...tooltipStyle,
+    fontSize: '12px',
     whiteSpace: 'pre-wrap',
     display: 'flex',
   },

--- a/src/Frontend/Components/ReportTableHeader/ReportTableHeader.tsx
+++ b/src/Frontend/Components/ReportTableHeader/ReportTableHeader.tsx
@@ -4,66 +4,62 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import clsx from 'clsx';
 import MuiTypography from '@mui/material/Typography';
 import { tableConfigs } from '../Table/Table';
-import makeStyles from '@mui/styles/makeStyles';
 import { OpossumColors } from '../../shared-styles';
+import MuiBox from '@mui/material/Box';
 
-export const useStylesReportTableHeader = makeStyles({
+export const reportTableClasses = {
   tableHeader: {
     backgroundColor: OpossumColors.darkBlue,
     position: 'sticky',
-    top: 10,
+    top: '10px',
     textAlign: 'left',
   },
   topHeader: {
-    height: 10,
+    height: '10px',
     backgroundColor: OpossumColors.lightestBlue,
     position: 'sticky',
-    top: 0,
-    border: `0.5px ${OpossumColors.lightestBlue} solid`,
+    top: '0px',
   },
   headerData: {
     fontWeight: 'bold',
     color: OpossumColors.white,
   },
   tableCell: {
-    padding: 10,
+    padding: '10px',
     flex: '1 1 auto',
   },
   emptyTableCell: {
-    paddingTop: 10,
+    paddingTop: '10px',
     flex: '1 1 auto',
   },
   emptyTableCellNoFlexGrow: {
     flex: '0 1 auto',
   },
   wideTableCell: {
-    width: 380,
+    width: '380px',
   },
   mediumTableCell: {
-    width: 250,
+    width: '250px',
   },
   smallTableCell: {
-    width: 120,
+    width: '120px',
   },
   verySmallTableCell: {
-    width: 30,
-    maxWidth: 40,
+    width: '30px',
+    maxWidth: '40px',
   },
   tableRow: {
     display: 'flex',
     alignItems: 'stretch',
   },
   tableWidth: {
-    minWidth: 2500,
+    minWidth: '2500px',
   },
-});
+};
 
 export function ReportTableHeader(): ReactElement {
-  const classes = useStylesReportTableHeader();
-
   function getTableHeader(): ReactElement {
     return (
       <div>
@@ -71,46 +67,56 @@ export function ReportTableHeader(): ReactElement {
           {
             // this elements implements the top padding
           }
-          <div className={clsx(classes.topHeader, classes.tableHeader)}>
+          <MuiBox
+            sx={{
+              ...reportTableClasses.topHeader,
+              ...reportTableClasses.tableHeader,
+            }}
+          >
             {''}
-          </div>
+          </MuiBox>
         </div>
-        <div className={clsx(classes.tableRow, classes.tableWidth)}>
+        <MuiBox
+          sx={{
+            ...reportTableClasses.tableRow,
+            ...reportTableClasses.tableWidth,
+          }}
+        >
           {tableConfigs.map((config) => (
-            <div
-              className={clsx(
-                config.attributionProperty === 'icons'
-                  ? classes.emptyTableCell
-                  : classes.tableCell,
-                config.width === 'small'
-                  ? classes.smallTableCell
+            <MuiBox
+              sx={{
+                ...(config.attributionProperty === 'icons'
+                  ? reportTableClasses.emptyTableCell
+                  : reportTableClasses.tableCell),
+                ...(config.width === 'small'
+                  ? reportTableClasses.smallTableCell
                   : config.width === 'wide'
-                  ? classes.wideTableCell
+                  ? reportTableClasses.wideTableCell
                   : config.width === 'medium'
-                  ? classes.mediumTableCell
+                  ? reportTableClasses.mediumTableCell
                   : config.width === 'verySmall'
-                  ? classes.verySmallTableCell
-                  : undefined,
-                classes.tableHeader
-              )}
+                  ? reportTableClasses.verySmallTableCell
+                  : {}),
+                ...reportTableClasses.tableHeader,
+              }}
               key={`table-header-${config.attributionProperty}-${config.displayName}`}
             >
-              <MuiTypography className={classes.headerData}>
+              <MuiTypography sx={reportTableClasses.headerData}>
                 {config.displayName}
               </MuiTypography>
-            </div>
+            </MuiBox>
           ))}
-          <div
-            className={clsx(
-              classes.tableHeader,
-              classes.emptyTableCellNoFlexGrow
-            )}
+          <MuiBox
+            sx={{
+              ...reportTableClasses.tableHeader,
+              ...reportTableClasses.emptyTableCellNoFlexGrow,
+            }}
           >
             {
               // This element offsets the additional spacing by the virtualized list
             }
-          </div>
-        </div>
+          </MuiBox>
+        </MuiBox>
       </div>
     );
   }

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -15,10 +15,9 @@ import {
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { TableConfig, tableConfigs } from '../Table/Table';
-import makeStyles from '@mui/styles/makeStyles';
 import { clickableIcon, OpossumColors } from '../../shared-styles';
 import { PathPredicate } from '../../types/types';
-import { useStylesReportTableHeader } from '../ReportTableHeader/ReportTableHeader';
+import { reportTableClasses } from '../ReportTableHeader/ReportTableHeader';
 import { AttributionInfo } from '../../../shared/shared-types';
 import { IconButton } from '../IconButton/IconButton';
 import EditorIcon from '@mui/icons-material/Edit';
@@ -26,16 +25,17 @@ import { isImportantAttributionInformationMissing } from '../../util/is-importan
 import { getPackageInfoKeys } from '../../../shared/shared-util';
 import { getFrequentLicensesTexts } from '../../state/selectors/all-views-resource-selectors';
 import { useAppSelector } from '../../state/hooks';
+import MuiBox from '@mui/material/Box';
 
 export const reportTableRowHeight = 190;
 const padding = 10;
 
-const useStyles = makeStyles({
+const classes = {
   tableData: {
     overflow: 'auto',
     whiteSpace: 'pre-line',
-    padding,
-    height: reportTableRowHeight - 2 * padding,
+    padding: `${padding}px`,
+    height: `${reportTableRowHeight - 2 * padding}px`,
   },
   noWrap: {
     whiteSpace: 'pre',
@@ -49,9 +49,9 @@ const useStyles = makeStyles({
   iconTableData: {
     overflow: 'hidden',
     whiteSpace: 'pre-line',
-    paddingTop: 7,
-    paddingBottom: 7,
-    height: reportTableRowHeight - 2 * padding,
+    paddingTop: '7px',
+    paddingBottom: '7px',
+    height: `${reportTableRowHeight - 2 * padding}px`,
     textAlign: 'center',
   },
   tableCell: {
@@ -64,18 +64,18 @@ const useStyles = makeStyles({
     flex: '1 1 auto',
     overflowY: 'auto',
     verticalAlign: 'text-top',
-    borderRightWidth: 0.5,
+    borderRightWidth: '0.5px',
   },
   borders: {
     border: `0.5px ${OpossumColors.lightBlue} solid`,
   },
   icon: {
-    width: 15,
-    height: 15,
-    margin: 1,
+    width: '15px',
+    height: '15px',
+    margin: '1px',
   },
   iconButton: {
-    marginBottom: 5,
+    marginBottom: '5px',
   },
   editIcon: {
     backgroundColor: OpossumColors.white,
@@ -106,7 +106,7 @@ const useStyles = makeStyles({
   },
   tableRow: {
     display: 'flex',
-    minWidth: 2480,
+    minWidth: '2480px',
     backgroundColor: OpossumColors.white,
     alignItems: 'stretch',
   },
@@ -114,7 +114,7 @@ const useStyles = makeStyles({
     whiteSpace: 'nowrap',
   },
   clickableIcon,
-});
+};
 
 const CELLS_WITHOUT_TEXT_WRAP = [
   'resources',
@@ -131,7 +131,7 @@ interface ReportTableItemProps {
 }
 
 export function ReportTableItem(props: ReportTableItemProps): ReactElement {
-  const classes = { ...useStylesReportTableHeader(), ...useStyles() };
+  const reportTableItemClasses = { ...reportTableClasses, ...classes };
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
 
   function isPackageInfoIncomplete(attributionInfo: AttributionInfo): boolean {
@@ -148,14 +148,14 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
     attributionId: string
   ): ReactElement {
     return (
-      <div
+      <MuiBox
         key={`table-row-${attributionInfo.packageName}-${attributionId}`}
-        className={classes.tableRow}
+        sx={reportTableItemClasses.tableRow}
       >
         {tableConfigs.map((config, index) =>
           getTableCell(attributionInfo, attributionId, config, index)
         )}
-      </div>
+      </MuiBox>
     );
   }
 
@@ -185,48 +185,54 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
     );
 
     return (
-      <div
-        className={clsx(
-          classes.borders,
-          classes.scrollableTableCell,
-          config.attributionProperty === 'icons'
-            ? [
-                classes.iconTableCell,
-                isPackageInfoIncomplete(attributionInfo) &&
-                  classes.markedTableCell,
-              ]
-            : [
-                classes.tableCell,
-                isImportantAttributionInformationMissing(
+      <MuiBox
+        sx={{
+          ...reportTableItemClasses.borders,
+          ...reportTableItemClasses.scrollableTableCell,
+          ...(config.attributionProperty === 'icons'
+            ? {
+                ...classes.iconTableCell,
+                ...(isPackageInfoIncomplete(attributionInfo)
+                  ? classes.markedTableCell
+                  : {}),
+              }
+            : {
+                ...classes.tableCell,
+                ...(isImportantAttributionInformationMissing(
                   config.attributionProperty,
                   attributionInfo
-                ) && classes.markedTableCell,
-              ],
-          config.width === 'small'
-            ? classes.smallTableCell
+                )
+                  ? classes.markedTableCell
+                  : {}),
+              }),
+          ...(config.width === 'small'
+            ? reportTableItemClasses.smallTableCell
             : config.width === 'wide'
-            ? classes.wideTableCell
+            ? reportTableItemClasses.wideTableCell
             : config.width === 'medium'
-            ? classes.mediumTableCell
+            ? reportTableItemClasses.mediumTableCell
             : config.width === 'verySmall'
-            ? classes.verySmallTableCell
-            : undefined
-        )}
+            ? reportTableItemClasses.verySmallTableCell
+            : {}),
+        }}
         key={`table-row-${config.attributionProperty}-${index}`}
       >
         {config.attributionProperty !== 'icons' && (
           <MuiTypography
-            className={clsx(
-              classes.tableData,
-              CELLS_WITHOUT_TEXT_WRAP.includes(config.attributionProperty) &&
-                classes.noWrap,
-              config.attributionProperty === 'licenseName' &&
-                hasFrequentLicenseName &&
-                classes.bold,
-              config.attributionProperty === 'licenseText' &&
-                isFrequentLicenseAndHasNoText &&
-                classes.greyText
-            )}
+            sx={{
+              ...classes.tableData,
+              ...(CELLS_WITHOUT_TEXT_WRAP.includes(config.attributionProperty)
+                ? classes.noWrap
+                : {}),
+              ...(config.attributionProperty === 'licenseName' &&
+              hasFrequentLicenseName
+                ? classes.bold
+                : {}),
+              ...(config.attributionProperty === 'licenseText' &&
+              isFrequentLicenseAndHasNoText
+                ? classes.greyText
+                : {}),
+            }}
             component={'div'}
           >
             {getCellData(cellData, config.attributionProperty)}
@@ -234,7 +240,7 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
         )}
         {config.attributionProperty === 'icons' &&
           getIcons(attributionInfo, attributionId)}
-      </div>
+      </MuiBox>
     );
   }
 
@@ -246,18 +252,20 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
       return (
         <div>
           {cellData.split('\n').map((path, index) => (
-            <div
+            <MuiBox
               key={`table-cell-content-${attributionProperty}-${index}`}
-              className={classes.containerWithoutLineBreak}
+              sx={reportTableItemClasses.containerWithoutLineBreak}
             >
               {path}
-            </div>
+            </MuiBox>
           ))}
         </div>
       );
     } else if (attributionProperty === 'url') {
       return (
-        <div className={classes.containerWithoutLineBreak}>{cellData}</div>
+        <MuiBox sx={reportTableItemClasses.containerWithoutLineBreak}>
+          {cellData}
+        </MuiBox>
       );
     }
     return <div>{cellData}</div>;
@@ -268,7 +276,7 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
     attributionId: string
   ): ReactElement {
     return (
-      <div className={classes.iconTableData}>
+      <MuiBox sx={reportTableItemClasses.iconTableData}>
         <>
           <IconButton
             tooltipTitle="edit"
@@ -279,11 +287,11 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
             }}
             icon={
               <EditorIcon
-                className={clsx(
-                  classes.editIcon,
-                  classes.icon,
-                  classes.clickableIcon
-                )}
+                sx={{
+                  ...reportTableItemClasses.editIcon,
+                  ...reportTableItemClasses.icon,
+                  ...reportTableItemClasses.clickableIcon,
+                }}
                 aria-label={`edit ${attributionInfo['packageName'] || ''}`}
               />
             }
@@ -293,21 +301,32 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
         {attributionInfo.followUp && (
           <>
             <FollowUpIcon
-              className={clsx(classes.icon, classes.followUpIcon)}
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.followUpIcon,
+              }}
             />{' '}
             <br />
           </>
         )}
         {attributionInfo.comment && (
           <>
-            <CommentIcon className={clsx(classes.icon, classes.commentIcon)} />{' '}
+            <CommentIcon
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.commentIcon,
+              }}
+            />{' '}
             <br />
           </>
         )}
         {attributionInfo.firstParty && (
           <>
             <FirstPartyIcon
-              className={clsx(classes.icon, classes.firstPartyIcon)}
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.firstPartyIcon,
+              }}
             />{' '}
             <br />
           </>
@@ -315,7 +334,10 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
         {attributionInfo.excludeFromNotice && (
           <>
             <ExcludeFromNoticeIcon
-              className={clsx(classes.icon, classes.excludeFromNoticeIcon)}
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.excludeFromNoticeIcon,
+              }}
             />{' '}
             <br />
           </>
@@ -323,12 +345,15 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
         {attributionInfo.preSelected && (
           <>
             <PreSelectedIcon
-              className={clsx(classes.icon, classes.preSelectedIcon)}
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.preSelectedIcon,
+              }}
             />{' '}
             <br />
           </>
         )}
-      </div>
+      </MuiBox>
     );
   }
 

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import MuiTabs from '@mui/material/Tabs';
 import MuiTab from '@mui/material/Tab';
@@ -19,7 +18,7 @@ import {
 import { OpossumColors } from '../../shared-styles';
 import { useAppSelector } from '../../state/hooks';
 
-const useStyles = makeStyles({
+const classes = {
   tabsRoot: {
     minHeight: 'fit-content',
   },
@@ -39,7 +38,7 @@ const useStyles = makeStyles({
   indicator: {
     backgroundColor: OpossumColors.darkBlue,
   },
-});
+};
 
 interface ResourceDetailsTabsProps {
   isGlobalTabEnabled: boolean;
@@ -49,8 +48,6 @@ interface ResourceDetailsTabsProps {
 export function ResourceDetailsTabs(
   props: ResourceDetailsTabsProps
 ): ReactElement | null {
-  const classes = useStyles();
-
   const manualData = useAppSelector(getManualData);
 
   const selectedPackage = useAppSelector(getDisplayedPackage);
@@ -99,14 +96,13 @@ export function ResourceDetailsTabs(
           setSelectedTab(newTab);
         }}
         aria-label="Add To Tabs"
-        className={classes.tabsRoot}
-        classes={{ indicator: classes.indicator }}
+        sx={{ ...classes.tabsRoot, indicator: classes.indicator }}
       >
         <MuiTab
           label={tabLabels[Tabs.Local]}
           aria-label={'Local Tab'}
           id={`tab-${Tabs.Local}`}
-          className={classes.tab}
+          sx={classes.tab}
         />
         <MuiTab
           label={tabLabels[Tabs.Global]}
@@ -115,7 +111,7 @@ export function ResourceDetailsTabs(
           disabled={
             !props.isGlobalTabEnabled || assignableAttributionIds.length < 1
           }
-          className={classes.tab}
+          sx={classes.tab}
         />
       </MuiTabs>
       {selectedTab === Tabs.Local ? (

--- a/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
 import MuiTypography from '@mui/material/Typography';
 import React, { ReactElement } from 'react';
 import {
@@ -13,18 +12,19 @@ import {
   SignalIcon,
 } from '../Icons/Icons';
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
-import clsx from 'clsx';
+import { SxProps } from '@mui/material';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
   manualIcon: {
     color: OpossumColors.darkBlue,
-    height: 20,
-    width: 20,
+    height: '20px',
+    width: '20px',
   },
   externalIcon: {
     color: OpossumColors.black,
-    height: 20,
-    width: 20,
+    height: '20px',
+    width: '20px',
   },
   labelRoot: {
     display: 'flex',
@@ -34,11 +34,11 @@ const useStyles = makeStyles({
     flex: 1,
   },
   arrowPlaceholder: {
-    height: 20,
-    width: 20,
+    height: '20px',
+    width: '20px',
   },
   text: {
-    paddingRight: 5,
+    paddingRight: '5px',
   },
   breakpoint: {
     fontWeight: 'bold',
@@ -69,7 +69,7 @@ const useStyles = makeStyles({
     color: OpossumColors.pastelMiddleGreen,
   },
   tooltip: tooltipStyle,
-});
+};
 
 interface StyledTreeItemProps {
   labelText: string;
@@ -86,9 +86,7 @@ interface StyledTreeItemProps {
 }
 
 export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
-  const classes = useStyles();
-
-  let iconClassName: string | undefined;
+  let iconClassName: SxProps | undefined;
   let labelDetail: string | undefined;
   if (props.hasManualAttribution) {
     iconClassName = classes.hasAttribution;
@@ -129,25 +127,25 @@ export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
   }
 
   return (
-    <div className={classes.labelRoot}>
+    <MuiBox sx={classes.labelRoot}>
       {props.showFolderIcon ? (
         props.isAttributionBreakpoint ? (
           <BreakpointIcon />
         ) : (
-          <DirectoryIcon className={iconClassName} labelDetail={labelDetail} />
+          <DirectoryIcon sx={iconClassName} labelDetail={labelDetail} />
         )
       ) : (
-        <FileIcon className={iconClassName} labelDetail={labelDetail} />
+        <FileIcon sx={iconClassName} labelDetail={labelDetail} />
       )}
       <MuiTypography
-        className={clsx(
-          classes.text,
-          props.isAttributionBreakpoint && classes.breakpoint
-        )}
+        sx={{
+          ...classes.text,
+          ...(props.isAttributionBreakpoint ? classes.breakpoint : {}),
+        }}
       >
         {props.labelText}
       </MuiTypography>
       {props.hasExternalAttribution ? <SignalIcon /> : null}
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/Table/Table.tsx
+++ b/src/Frontend/Components/Table/Table.tsx
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
 import React, { ReactElement, useMemo } from 'react';
 import {
   AttributionInfo,
@@ -12,7 +11,7 @@ import {
 import { PathPredicate } from '../../types/types';
 import {
   ReportTableHeader,
-  useStylesReportTableHeader,
+  reportTableClasses,
 } from '../ReportTableHeader/ReportTableHeader';
 import { List } from '../List/List';
 import {
@@ -20,15 +19,16 @@ import {
   reportTableRowHeight,
 } from '../ReportTableItem/ReportTableItem';
 import { useWindowHeight } from '../../util/use-window-height';
-import clsx from 'clsx';
 import { OpossumColors } from '../../shared-styles';
 import { topBarHeight } from '../TopBar/TopBar';
+import MuiBox from '@mui/material/Box';
 
-const useStyles = makeStyles({
+const classes = {
+  ...reportTableClasses,
   root: {
-    paddingLeft: 10,
-    paddingRight: 10,
-    paddingBottom: 10,
+    paddingLeft: '10px',
+    paddingRight: '10px',
+    paddingBottom: '10px',
     width: 'calc(100% - 20px)',
   },
   tableAndHeader: {
@@ -37,9 +37,9 @@ const useStyles = makeStyles({
   table: {
     backgroundColor: OpossumColors.white,
     borderCollapse: 'separate',
-    borderSpacing: 0,
+    borderSpacing: '0px',
   },
-});
+};
 
 export interface TableConfig {
   attributionProperty: keyof AttributionInfo | 'icons';
@@ -115,7 +115,6 @@ interface TableProps {
 }
 
 export function Table(props: TableProps): ReactElement | null {
-  const classes = { ...useStylesReportTableHeader(), ...useStyles() };
   const tableHeaderOffset = 110;
   const maxHeight = useWindowHeight() - topBarHeight - tableHeaderOffset;
   const attributionsIds = useMemo(() => {
@@ -135,14 +134,14 @@ export function Table(props: TableProps): ReactElement | null {
   }
 
   return (
-    <div className={classes.root}>
+    <MuiBox sx={classes.root}>
       {props.topElement}
       {attributionsIds.length ? (
-        <div className={classes.tableAndHeader}>
-          <div className={clsx(classes.tableWidth, classes.table)}>
+        <MuiBox sx={classes.tableAndHeader}>
+          <MuiBox sx={{ ...classes.tableWidth, ...classes.table }}>
             <ReportTableHeader />
-          </div>
-          <div className={classes.tableWidth}>
+          </MuiBox>
+          <MuiBox sx={classes.tableWidth}>
             <List
               length={attributionsIds.length}
               cardVerticalDistance={reportTableRowHeight}
@@ -150,9 +149,9 @@ export function Table(props: TableProps): ReactElement | null {
               getListItem={getReportTableItem}
               leftScrollBar={true}
             />
-          </div>
-        </div>
+          </MuiBox>
+        </MuiBox>
       ) : null}
-    </div>
+    </MuiBox>
   );
 }

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -3,8 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import makeStyles from '@mui/styles/makeStyles';
-
 export const OpossumColors = {
   almostWhiteBlue: 'hsl(220, 41%, 97%)',
   lightestBlue: 'hsl(220, 41%, 92%)',
@@ -40,13 +38,15 @@ export const OpossumColors = {
 export const resourceBrowserWidthInPixels = 420;
 
 export const tooltipStyle = {
-  fontSize: 12,
+  '& tooltip': {
+    fontSize: '12px',
+  },
 };
 
 export const baseIcon = {
-  width: 15,
-  height: 15,
-  padding: 2,
+  width: '15px',
+  height: '15px',
+  padding: '2px',
   margin: '0 2px',
 };
 
@@ -62,16 +62,6 @@ export const disabledIcon = {
   ...baseIcon,
   color: OpossumColors.disabledButtonGrey,
 };
-
-export const useCheckboxStyles = makeStyles({
-  checkBox: {
-    height: 40,
-    display: 'flex',
-    alignItems: 'center',
-    marginRight: 12,
-    marginLeft: -2,
-  },
-});
 
 export const checkboxClass = {
   checkBox: {


### PR DESCRIPTION
### Summary of changes

Replace usage of `makestyles` with `sx`

### Context and reason for change
MUI will deprecate `makestyles`.

### How can the changes be tested
Open the app and check the styling.
