### PR TITLE
Project statistics table

### DIFF
--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -87,11 +87,21 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           ],
         },
         {
-          label: 'Show Project Metadata',
+          label: 'Project Metadata',
           click(): void {
             if (getGlobalBackendState().resourceFilePath) {
               webContents.send(IpcChannel.ShowProjectMetadataPopup, {
                 showProjectMetadataPopup: true,
+              });
+            }
+          },
+        },
+        {
+          label: 'Project Statistics',
+          click(): void {
+            if (getGlobalBackendState().resourceFilePath) {
+              webContents.send(IpcChannel.ShowProjectStatisticsPopup, {
+                showProjectStatisticsPopup: true,
               });
             }
           },

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -214,6 +214,15 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
+  function showProjectStatisticsPopupListener(
+    event: IpcRendererEvent,
+    showProjectStatisticsPopup: boolean
+  ): void {
+    if (showProjectStatisticsPopup) {
+      dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+    }
+  }
+
   function setBaseURLForRootListener(
     event: IpcRendererEvent,
     baseURLForRootArgs: BaseURLForRootArgs
@@ -252,6 +261,11 @@ export function BackendCommunication(): ReactElement | null {
   useIpcRenderer(
     IpcChannel.ShowProjectMetadataPopup,
     showProjectMetadataPopupListener,
+    [dispatch]
+  );
+  useIpcRenderer(
+    IpcChannel.ShowProjectStatisticsPopup,
+    showProjectStatisticsPopupListener,
     [dispatch]
   );
   useIpcRenderer(IpcChannel.SetBaseURLForRoot, setBaseURLForRootListener, [

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -11,7 +11,7 @@ import { BackendCommunication } from '../BackendCommunication';
 describe('BackendCommunication', () => {
   test('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(8);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.FileLoaded,
       expect.anything()
@@ -34,6 +34,10 @@ describe('BackendCommunication', () => {
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.ShowProjectMetadataPopup,
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel.ShowProjectStatisticsPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -11,6 +11,7 @@ import { NotSavedPopup } from '../NotSavedPopup/NotSavedPopup';
 import { ErrorPopup } from '../ErrorPopup/ErrorPopup';
 import { FileSearchPopup } from '../FileSearchPopup/FileSearchPopup';
 import { ProjectMetadataPopup } from '../ProjectMetadataPopup/ProjectMetadataPopup';
+import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup/ProjectStatisticsPopup';
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttributionPopup';
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
@@ -31,6 +32,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <FileSearchPopup />;
     case PopupType.ProjectMetadataPopup:
       return <ProjectMetadataPopup />;
+    case PopupType.ProjectStatisticsPopup:
+      return <ProjectStatisticsPopup />;
     case PopupType.ReplaceAttributionPopup:
       return <ReplaceAttributionPopup />;
     case PopupType.ConfirmDeletionGloballyPopup:

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -63,6 +63,15 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Project Metadata')).toBeInTheDocument();
   });
 
+  test('opens the ProjectStatisticsPopup', () => {
+    const { store } = renderComponentWithStore(<GlobalPopup />);
+    act(() => {
+      store.dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+    });
+
+    expect(screen.getByText('Project Statistics')).toBeInTheDocument();
+  });
+
   test('opens the ReplaceAttributionPopup', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'name 1' },

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -2,141 +2,39 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+
+import { getProjectStatisticsTableContent } from './project-statistics-popup-helper';
+
 import React, { ReactElement } from 'react';
-import { styled } from '@mui/material/styles';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
-import Box from '@mui/material/Box';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell, { tableCellClasses } from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import TableSortLabel from '@mui/material/TableSortLabel';
-import Paper from '@mui/material/Paper';
-import { visuallyHidden } from '@mui/utils';
-import { getProjectExternalData } from '../../state/selectors/all-views-resource-selectors';
-import { AttributionData } from '../../../shared/shared-types';
+import { getExternalAttributions } from '../../state/selectors/all-views-resource-selectors';
 import { ButtonText } from '../../enums/enums';
-
-const StyledTableCell = styled(TableCell)(() => ({
-  [`&.${tableCellClasses.head}`]: {
-    fontWeight: 'bold',
-    fontSize: 16,
-  },
-  [`&.${tableCellClasses.body}`]: {
-    fontSize: 16,
-  },
-}));
-
-interface sourcesTableDataInterface {
-  source: string;
-  numberOfEntries: number;
-}
-
-function descendingComparator<T>(a: T, b: T, orderBy: keyof T): number {
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
-
-type Order = 'asc' | 'desc';
-
-function getComparator<Key extends keyof number | string>(
-  order: Order,
-  orderBy: Key
-): (
-  a: { [key in Key]: number | string },
-  b: { [key in Key]: number | string }
-) => number {
-  return order === 'desc'
-    ? (a, b): number => descendingComparator(a, b, orderBy)
-    : (a, b): number => -descendingComparator(a, b, orderBy);
-}
-
-interface HeadCell {
-  id: keyof sourcesTableDataInterface;
-  label: string;
-  numeric: boolean;
-}
-
-const headCells: readonly HeadCell[] = [
-  {
-    id: 'source',
-    numeric: false,
-    label: 'Sources',
-  },
-  {
-    id: 'numberOfEntries',
-    numeric: true,
-    label: 'Signals',
-  },
-];
-
-interface EnhancedTableProps {
-  onRequestSort: (
-    event: React.MouseEvent<unknown>,
-    property: keyof sourcesTableDataInterface
-  ) => void;
-  order: Order;
-  orderBy: string;
-  rowCount: number;
-}
-
-function EnhancedTableHead(props: EnhancedTableProps): ReactElement {
-  const { order, orderBy, onRequestSort } = props;
-  const createSortHandler =
-    (property: keyof sourcesTableDataInterface) =>
-    (event: React.MouseEvent<unknown>) => {
-      onRequestSort(event, property);
-    };
-
-  return (
-    <TableHead>
-      <TableRow>
-        {headCells.map((headCell) => (
-          <StyledTableCell
-            key={headCell.id}
-            align={headCell.numeric ? 'right' : 'left'}
-            sortDirection={orderBy === headCell.id ? order : false}
-          >
-            <TableSortLabel
-              active={orderBy === headCell.id}
-              direction={orderBy === headCell.id ? order : 'asc'}
-              onClick={createSortHandler(headCell.id)}
-            >
-              {headCell.label}
-              {orderBy === headCell.id ? (
-                <Box component="span" sx={visuallyHidden}>
-                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                </Box>
-              ) : null}
-            </TableSortLabel>
-          </StyledTableCell>
-        ))}
-      </TableRow>
-    </TableHead>
-  );
-}
+import { SortingOrder, SignalsPerSource } from '../../types/types';
 
 export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
-  const ExternalData: AttributionData = useAppSelector(getProjectExternalData);
 
-  const signals = Object.values(ExternalData.attributions);
+  const signals = Object.values(useAppSelector(getExternalAttributions));
   const sources: { [key: string]: number } = {};
   signals.forEach((signal) => {
     sources[signal.source?.name ?? ''] =
       (sources[signal.source?.name ?? ''] || 0) + 1;
   });
 
-  const sourcesTableEntries = [];
+  const licensesForSources: { [key: string]: { [key: string]: number } } = {};
+  for (const signal of signals) {
+    const sourceName = signal.source?.name ?? '';
+    const licenseName = signal.licenseName ?? '';
+
+    const licenses = licensesForSources[sourceName] ?? {};
+    licenses[licenseName] = (licenses[licenseName] || 0) + 1;
+
+    licensesForSources[sourceName] = licenses;
+  }
+
+  const sourcesTableEntries: SignalsPerSource[] = [];
 
   for (const key in sources) {
     sourcesTableEntries.push({ source: key, numberOfEntries: sources[key] });
@@ -145,55 +43,24 @@ export function ProjectStatisticsPopup(): ReactElement {
   function close(): void {
     dispatch(closePopup());
   }
-  const [order, setOrder] = React.useState<Order>('desc');
+  const [order, setOrder] = React.useState<SortingOrder>('desc');
   const [orderBy, setOrderBy] =
-    React.useState<keyof sourcesTableDataInterface>('numberOfEntries');
+    React.useState<keyof SignalsPerSource>('numberOfEntries');
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,
-    property: keyof sourcesTableDataInterface
+    property: keyof SignalsPerSource
   ): void => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
   };
 
-  const content = (
-    <Box sx={{ width: '30%' }}>
-      <Paper sx={{ width: '100%', mb: 2 }}>
-        <TableContainer style={{ maxHeight: 300 }}>
-          <Table
-            sx={{ minWidth: 300 }}
-            aria-labelledby="tableTitle"
-            size="small"
-            stickyHeader
-          >
-            <EnhancedTableHead
-              order={order}
-              orderBy={orderBy}
-              onRequestSort={handleRequestSort}
-              rowCount={sourcesTableEntries.length}
-            />
-            <TableBody>
-              {sourcesTableEntries
-                .sort(getComparator(order, orderBy))
-                .map((row, index) => {
-                  const labelId = `enhanced-table-checkbox-${index}`;
-
-                  return (
-                    <TableRow hover tabIndex={-1} key={row.source}>
-                      <TableCell component="th" id={labelId} scope="row">
-                        {row.source}
-                      </TableCell>
-                      <TableCell align="right">{row.numberOfEntries}</TableCell>
-                    </TableRow>
-                  );
-                })}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Paper>
-    </Box>
+  const content = getProjectStatisticsTableContent(
+    order,
+    orderBy,
+    handleRequestSort,
+    sourcesTableEntries
   );
 
   return (

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import React, { ReactElement } from 'react';
+import { styled } from '@mui/material/styles';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import Paper from '@mui/material/Paper';
+import { visuallyHidden } from '@mui/utils';
+import { getProjectExternalData } from '../../state/selectors/all-views-resource-selectors';
+import { AttributionData } from '../../../shared/shared-types';
+import { ButtonText } from '../../enums/enums';
+
+const StyledTableCell = styled(TableCell)(() => ({
+  [`&.${tableCellClasses.head}`]: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 16,
+  },
+}));
+
+interface sourcesTableDataInterface {
+  source: string;
+  numberOfEntries: number;
+}
+
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T): number {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+type Order = 'asc' | 'desc';
+
+function getComparator<Key extends keyof number | string>(
+  order: Order,
+  orderBy: Key
+): (
+  a: { [key in Key]: number | string },
+  b: { [key in Key]: number | string }
+) => number {
+  return order === 'desc'
+    ? (a, b): number => descendingComparator(a, b, orderBy)
+    : (a, b): number => -descendingComparator(a, b, orderBy);
+}
+
+interface HeadCell {
+  id: keyof sourcesTableDataInterface;
+  label: string;
+  numeric: boolean;
+}
+
+const headCells: readonly HeadCell[] = [
+  {
+    id: 'source',
+    numeric: false,
+    label: 'Sources',
+  },
+  {
+    id: 'numberOfEntries',
+    numeric: true,
+    label: 'Signals',
+  },
+];
+
+interface EnhancedTableProps {
+  onRequestSort: (
+    event: React.MouseEvent<unknown>,
+    property: keyof sourcesTableDataInterface
+  ) => void;
+  order: Order;
+  orderBy: string;
+  rowCount: number;
+}
+
+function EnhancedTableHead(props: EnhancedTableProps): ReactElement {
+  const { order, orderBy, onRequestSort } = props;
+  const createSortHandler =
+    (property: keyof sourcesTableDataInterface) =>
+    (event: React.MouseEvent<unknown>) => {
+      onRequestSort(event, property);
+    };
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <StyledTableCell
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            sortDirection={orderBy === headCell.id ? order : false}
+          >
+            <TableSortLabel
+              active={orderBy === headCell.id}
+              direction={orderBy === headCell.id ? order : 'asc'}
+              onClick={createSortHandler(headCell.id)}
+            >
+              {headCell.label}
+              {orderBy === headCell.id ? (
+                <Box component="span" sx={visuallyHidden}>
+                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                </Box>
+              ) : null}
+            </TableSortLabel>
+          </StyledTableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+export function ProjectStatisticsPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+  const ExternalData: AttributionData = useAppSelector(getProjectExternalData);
+
+  const signals = Object.values(ExternalData.attributions);
+  const sources: { [key: string]: number } = {};
+  signals.forEach((signal) => {
+    sources[signal.source?.name ?? ''] =
+      (sources[signal.source?.name ?? ''] || 0) + 1;
+  });
+
+  const sourcesTableEntries = [];
+
+  for (const key in sources) {
+    sourcesTableEntries.push({ source: key, numberOfEntries: sources[key] });
+  }
+
+  function close(): void {
+    dispatch(closePopup());
+  }
+  const [order, setOrder] = React.useState<Order>('desc');
+  const [orderBy, setOrderBy] =
+    React.useState<keyof sourcesTableDataInterface>('numberOfEntries');
+
+  const handleRequestSort = (
+    event: React.MouseEvent<unknown>,
+    property: keyof sourcesTableDataInterface
+  ): void => {
+    const isAsc = orderBy === property && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+  };
+
+  const content = (
+    <Box sx={{ width: '30%' }}>
+      <Paper sx={{ width: '100%', mb: 2 }}>
+        <TableContainer style={{ maxHeight: 300 }}>
+          <Table
+            sx={{ minWidth: 300 }}
+            aria-labelledby="tableTitle"
+            size="small"
+            stickyHeader
+          >
+            <EnhancedTableHead
+              order={order}
+              orderBy={orderBy}
+              onRequestSort={handleRequestSort}
+              rowCount={sourcesTableEntries.length}
+            />
+            <TableBody>
+              {sourcesTableEntries
+                .sort(getComparator(order, orderBy))
+                .map((row, index) => {
+                  const labelId = `enhanced-table-checkbox-${index}`;
+
+                  return (
+                    <TableRow hover tabIndex={-1} key={row.source}>
+                      <TableCell component="th" id={labelId} scope="row">
+                        {row.source}
+                      </TableCell>
+                      <TableCell align="right">{row.numberOfEntries}</TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+    </Box>
+  );
+
+  return (
+    <NotificationPopup
+      content={content}
+      header={'Project Statistics'}
+      isOpen={true}
+      fullWidth={true}
+      rightButtonConfig={{
+        onClick: close,
+        buttonText: ButtonText.Close,
+      }}
+      onBackdropClick={close}
+      onEscapeKeyDown={close}
+    />
+  );
+}

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import React from 'react';
+import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup';
+import { Attributions } from '../../../../shared/shared-types';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+
+describe('The ProjectStatisticsPopup', () => {
+  test('counts sources correctly ', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 10,
+        },
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+      },
+    };
+
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+  });
+});

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helper.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helper.tsx
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import React, { ReactElement } from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TableSortLabel from '@mui/material/TableSortLabel';
+import Paper from '@mui/material/Paper';
+import { visuallyHidden } from '@mui/utils';
+import { SortingOrder, SignalsPerSource } from '../../types/types';
+
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T): number {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+function getComparator<Key extends keyof number | string>(
+  order: SortingOrder,
+  orderBy: Key
+): (
+  a: { [key in Key]: number | string },
+  b: { [key in Key]: number | string }
+) => number {
+  return order === 'desc'
+    ? (a, b): number => descendingComparator(a, b, orderBy)
+    : (a, b): number => -descendingComparator(a, b, orderBy);
+}
+
+const StyledTableCell = styled(TableCell)(() => ({
+  [`&.${tableCellClasses.head}`]: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 16,
+  },
+}));
+
+interface HeadCell {
+  id: keyof SignalsPerSource;
+  label: string;
+  numeric: boolean;
+}
+
+const headCells: readonly HeadCell[] = [
+  {
+    id: 'source',
+    numeric: false,
+    label: 'Sources',
+  },
+  {
+    id: 'numberOfEntries',
+    numeric: true,
+    label: 'Signals',
+  },
+];
+
+interface EnhancedTableProps {
+  onRequestSort: (
+    event: React.MouseEvent<unknown>,
+    property: keyof SignalsPerSource
+  ) => void;
+  order: SortingOrder;
+  orderBy: string;
+  rowCount: number;
+}
+
+function EnhancedTableHead(props: EnhancedTableProps): ReactElement {
+  const { order, orderBy, onRequestSort } = props;
+  const createSortHandler =
+    (property: keyof SignalsPerSource) =>
+    (event: React.MouseEvent<unknown>) => {
+      onRequestSort(event, property);
+    };
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <StyledTableCell
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            sortDirection={orderBy === headCell.id ? order : false}
+          >
+            <TableSortLabel
+              active={orderBy === headCell.id}
+              direction={orderBy === headCell.id ? order : 'asc'}
+              onClick={createSortHandler(headCell.id)}
+            >
+              {headCell.label}
+              {orderBy === headCell.id ? (
+                <Box component="span" sx={visuallyHidden}>
+                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                </Box>
+              ) : null}
+            </TableSortLabel>
+          </StyledTableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+export function getProjectStatisticsTableContent(
+  order: SortingOrder,
+  orderBy: string,
+  handleRequestSort: (
+    event: React.MouseEvent<unknown>,
+    property: keyof SignalsPerSource
+  ) => void,
+  sourcesTableEntries: SignalsPerSource[]
+): ReactElement {
+  return (
+    <Box sx={{ width: '30%' }}>
+      <Paper sx={{ width: '100%', mb: 2 }}>
+        <TableContainer style={{ maxHeight: 300 }}>
+          <Table
+            sx={{ minWidth: 300 }}
+            aria-labelledby="tableTitle"
+            size="small"
+            stickyHeader
+          >
+            <EnhancedTableHead
+              order={order}
+              orderBy={orderBy}
+              onRequestSort={handleRequestSort}
+              rowCount={sourcesTableEntries.length}
+            />
+            <TableBody>
+              {sourcesTableEntries
+                .sort(getComparator(order, orderBy))
+                .map((row, index) => {
+                  const labelId = `enhanced-table-checkbox-${index}`;
+
+                  return (
+                    <TableRow hover tabIndex={-1} key={row.source}>
+                      <TableCell component="th" id={labelId} scope="row">
+                        {row.source}
+                      </TableCell>
+                      <TableCell align="right">{row.numberOfEntries}</TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -18,7 +18,7 @@ import { IpcChannel } from '../../../../shared/ipc-channels';
 describe('TopBar', () => {
   test('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(8);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.FileLoaded,
       expect.anything()
@@ -41,6 +41,10 @@ describe('TopBar', () => {
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.ShowProjectMetadataPopup,
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel.ShowProjectStatisticsPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -15,6 +15,7 @@ export enum PopupType {
   InvalidLinkPopup = 'InvalidLinkPopup',
   FileSearchPopup = 'FileSearchPopup',
   ProjectMetadataPopup = 'ProjectMetadataPopup',
+  ProjectStatisticsPopup = 'ProjectStatisticsPopup',
   NotSavedPopup = 'NotSavedPopup',
   ReplaceAttributionPopup = 'ReplaceAttributionPopup',
   ConfirmDeletionPopup = 'ConfirmDeletionPopup',

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -114,10 +114,6 @@ export function getProjectMetadata(state: State): ProjectMetadata {
   return state.resourceState.allViews.metadata;
 }
 
-export function getProjectExternalData(state: State): AttributionData {
-  return state.resourceState.allViews.externalData;
-}
-
 export function getCurrentAttributionId(state: State): string | null {
   switch (getSelectedView(state)) {
     case View.Attribution:

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -114,6 +114,10 @@ export function getProjectMetadata(state: State): ProjectMetadata {
   return state.resourceState.allViews.metadata;
 }
 
+export function getProjectExternalData(state: State): AttributionData {
+  return state.resourceState.allViews.externalData;
+}
+
 export function getCurrentAttributionId(state: State): string | null {
   switch (getSelectedView(state)) {
     case View.Attribution:

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -27,6 +27,13 @@ export type State = {
   viewState: ViewState;
 };
 
+export type SortingOrder = 'asc' | 'desc';
+
+export type SignalsPerSource = {
+  source: string;
+  numberOfEntries: number;
+};
+
 export interface ProgressBarData {
   fileCount: number;
   filesWithManualAttributionCount: number;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -18,5 +18,6 @@ export enum IpcChannel {
   ToggleHighlightForCriticalSignals = 'toggle-highlight-for-critical-signals',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
+  ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',
   SetBaseURLForRoot = 'set-base-url-for-root',
 }


### PR DESCRIPTION
### Summary of changes

A new popup is introduced showing a table with the number of signals provided by the different sources for the current project. The table can be sorted either by the source names or the number of signals 

### Context and reason for change

As a user I want to be able to navigate (similar to how to navigate to project metadata) to a popup that lists charts and graphics describing the state of the project.

### How can the changes be tested

Load a project and navitgate to 'Menu'->'Project Statistics'. 
Click on the label of each column to sort the table by this column either ascending or descending.

