### PR TITLE
Excluded files from Mini-BOM

### DIFF
--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -176,7 +176,8 @@ export function BackendCommunication(): ReactElement | null {
       Object.keys(attributions).filter(
         (attributionId) =>
           !attributions[attributionId].followUp &&
-          !attributions[attributionId].firstParty
+          !attributions[attributionId].firstParty &&
+          !attributions[attributionId].excludeFromNotice
       )
     );
   }


### PR DESCRIPTION
### Summary of changes

Attributions with "exclude from notice"=True are now excluded from the Mini-BOM (aka "Compact component list") that can be exported in Opossum UI.
