### PR TITLE
Exclude files from mini bom

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -59,8 +59,8 @@ To view project metadata, open the `File` menu and select `Show Project Metadata
 It is possible to directly export data to files. The following formats are available:
 
 - Follow-Up: Just the items marked as follow-up are present in this file as csv file.
-- Compact component list: All attributions are present as csv file.
-- Detailed component list: All attributions are present as csv file.
+- Compact component list: All attributions not marked as follow-up or 1st Party are exported to a csv file. Attributions marked as "exclude from notice" are not exported.
+- Detailed component list: All attributions not marked as follow-up or 1st Party are exported to a csv file.
 - SPDX JSON: All attributions are listed as JSON file.
 - SPDX YAML: All attributions are listed as YAML file.
 

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -176,24 +176,6 @@ export function BackendCommunication(): ReactElement | null {
     });
   }
 
-  function getBomAttributions(
-    attributions: Attributions,
-    exportType: ExportType
-  ): Attributions {
-    return pick(
-      attributions,
-      Object.keys(attributions).filter(
-        (attributionId) =>
-          !attributions[attributionId].followUp &&
-          !attributions[attributionId].firstParty &&
-          !(
-            exportType == ExportType.CompactBom &&
-            attributions[attributionId].excludeFromNotice
-          )
-      )
-    );
-  }
-
   function resetLoadedFileListener(
     event: IpcRendererEvent,
     resetState: boolean
@@ -284,4 +266,22 @@ export function BackendCommunication(): ReactElement | null {
   );
 
   return null;
+}
+
+export function getBomAttributions(
+  attributions: Attributions,
+  exportType: ExportType
+): Attributions {
+  return pick(
+    attributions,
+    Object.keys(attributions).filter(
+      (attributionId) =>
+        !attributions[attributionId].followUp &&
+        !attributions[attributionId].firstParty &&
+        !(
+          exportType == ExportType.CompactBom &&
+          attributions[attributionId].excludeFromNotice
+        )
+    )
+  );
 }

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -144,7 +144,10 @@ export function BackendCommunication(): ReactElement | null {
   }
 
   function getDetailedBomExportListener(): void {
-    const bomAttributions = getBomAttributions(manualData.attributions);
+    const bomAttributions = getBomAttributions(
+      manualData.attributions,
+      ExportType.DetailedBom
+    );
 
     const bomAttributionsWithResources = getAttributionsWithResources(
       bomAttributions,
@@ -166,17 +169,27 @@ export function BackendCommunication(): ReactElement | null {
   function getCompactBomExportListener(): void {
     window.ipcRenderer.invoke(IpcChannel.ExportFile, {
       type: ExportType.CompactBom,
-      bomAttributions: getBomAttributions(manualData.attributions),
+      bomAttributions: getBomAttributions(
+        manualData.attributions,
+        ExportType.CompactBom
+      ),
     });
   }
 
-  function getBomAttributions(attributions: Attributions): Attributions {
+  function getBomAttributions(
+    attributions: Attributions,
+    exportType: ExportType
+  ): Attributions {
     return pick(
       attributions,
       Object.keys(attributions).filter(
         (attributionId) =>
           !attributions[attributionId].followUp &&
-          !attributions[attributionId].firstParty
+          !attributions[attributionId].firstParty &&
+          !(
+            exportType == ExportType.CompactBom &&
+            attributions[attributionId].excludeFromNotice
+          )
       )
     );
   }

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -6,7 +6,11 @@
 import React from 'react';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { IpcChannel } from '../../../../shared/ipc-channels';
-import { BackendCommunication } from '../BackendCommunication';
+import {
+  BackendCommunication,
+  getBomAttributions,
+} from '../BackendCommunication';
+import { ExportType, Attributions } from '../../../../shared/shared-types';
 
 describe('BackendCommunication', () => {
   test('renders an Open file icon', () => {
@@ -44,5 +48,63 @@ describe('BackendCommunication', () => {
       IpcChannel.ToggleHighlightForCriticalSignals,
       expect.anything()
     );
+  });
+
+  test('filters the correct BOM attributions', () => {
+    const testAttributions: Attributions = {
+      genericAttrib: {},
+      firstPartyAttrib: { firstParty: true },
+      followupAttrib: { followUp: 'FOLLOW_UP' },
+      excludeAttrib: { excludeFromNotice: true },
+      firstPartyExcludeAttrib: { firstParty: true, excludeFromNotice: true },
+    };
+
+    const detailedBomAttributions = getBomAttributions(
+      testAttributions,
+      ExportType.DetailedBom
+    );
+    expect(detailedBomAttributions).toEqual({
+      genericAttrib: {},
+      excludeAttrib: { excludeFromNotice: true },
+    });
+
+    const compactBomAttributions = getBomAttributions(
+      testAttributions,
+      ExportType.CompactBom
+    );
+    expect(compactBomAttributions).toEqual({
+      genericAttrib: {},
+    });
+
+    const completeTestAttributions: Attributions = {
+      completeAttrib: {
+        attributionConfidence: 1,
+        comment: 'Test',
+        packageName: 'Test component',
+        packageVersion: '',
+        packageNamespace: 'org.apache.xmlgraphics',
+        packageType: 'maven',
+        packagePURLAppendix:
+          '?repository_url=repo.spring.io/release#everybody/loves/dogs',
+        url: '',
+        copyright: '(c) John Doe',
+        licenseName: '',
+        licenseText: 'Permission is hereby granted, free of charge, to...',
+        originId: '',
+        preSelected: true,
+      },
+    };
+
+    const compactBomCompleteAttributions = getBomAttributions(
+      completeTestAttributions,
+      ExportType.CompactBom
+    );
+    expect(compactBomCompleteAttributions).toEqual(completeTestAttributions);
+
+    const detailedBomCompleteAttributions = getBomAttributions(
+      completeTestAttributions,
+      ExportType.DetailedBom
+    );
+    expect(detailedBomCompleteAttributions).toEqual(completeTestAttributions);
   });
 });


### PR DESCRIPTION
### Summary of changes

Attributions with "exclude from notice"=True are now excluded from the Mini-BOM (aka "Compact component list") that can be exported in Opossum UI