### PR TITLE
New command that runs only tests related to changes in the current repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "compile-all": "tsc -p ./ && tsc --noEmit -p src/ElectronBackend",
     "test:unit": "react-scripts test --watchAll=false --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testPathIgnorePatterns=src/Frontend/integration-tests",
     "test:local": "react-scripts test --watchAll=false src/ --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__tests__/**/*.ts?(x)\" ]",
+    "test:changed": "react-scripts test --watchAll=false --setupFilesAfterEnv=./setupTests.ts --onlyChanged",
     "test:all": "react-scripts test --watchAll=false src/ --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ] && yarn test:e2e",
     "test:integration-ci": "react-scripts test --watchAll=false src/Frontend/integration-tests --setupFilesAfterEnv=./setupTests.ts --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ]",
     "test:e2e": "run-script-os",


### PR DESCRIPTION
### Summary of changes

Added the command `yarn test:changed`. This command uses the `--onlyChanged` flag to run only tests related to changes in the current repo.

### Context and reason for change

The current test commands run all tests within the repo. This can be quite time-consuming (40 seconds for me). The new command speeds up the process significantly (around 2 seconds) by only running necessary tests.

### How can the changes be tested

Make some changes and run `yarn test:changed`.

