### PR TITLE
License summary table

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "compile-all": "tsc -p ./ && tsc --noEmit -p src/ElectronBackend",
     "test:unit": "react-scripts test --watchAll=false --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testPathIgnorePatterns=src/Frontend/integration-tests",
     "test:local": "react-scripts test --watchAll=false src/ --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__tests__/**/*.ts?(x)\" ]",
+    "test:changed": "react-scripts test --watchAll=false --setupFilesAfterEnv=./setupTests.ts --onlyChanged",
     "test:all": "react-scripts test --watchAll=false src/ --setupFilesAfterEnv=./setupTests.ts --testPathIgnorePatterns=src/e2e-tests --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ] && yarn test:e2e",
     "test:integration-ci": "react-scripts test --watchAll=false src/Frontend/integration-tests --setupFilesAfterEnv=./setupTests.ts --testMatch=[ \"**/__(tests|tests-ci)__/**/*.ts?(x)\", \"**/?(*.)+(test).ts?(x)\" ]",
     "test:e2e": "run-script-os",

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -87,11 +87,21 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           ],
         },
         {
-          label: 'Show Project Metadata',
+          label: 'Project Metadata',
           click(): void {
             if (getGlobalBackendState().resourceFilePath) {
               webContents.send(IpcChannel.ShowProjectMetadataPopup, {
                 showProjectMetadataPopup: true,
+              });
+            }
+          },
+        },
+        {
+          label: 'Project Statistics',
+          click(): void {
+            if (getGlobalBackendState().resourceFilePath) {
+              webContents.send(IpcChannel.ShowProjectStatisticsPopup, {
+                showProjectStatisticsPopup: true,
               });
             }
           },

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -209,6 +209,15 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
+  function showProjectStatisticsPopupListener(
+    event: IpcRendererEvent,
+    showProjectStatisticsPopup: boolean
+  ): void {
+    if (showProjectStatisticsPopup) {
+      dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+    }
+  }
+
   function setBaseURLForRootListener(
     event: IpcRendererEvent,
     baseURLForRootArgs: BaseURLForRootArgs
@@ -247,6 +256,11 @@ export function BackendCommunication(): ReactElement | null {
   useIpcRenderer(
     IpcChannel.ShowProjectMetadataPopup,
     showProjectMetadataPopupListener,
+    [dispatch]
+  );
+  useIpcRenderer(
+    IpcChannel.ShowProjectStatisticsPopup,
+    showProjectStatisticsPopupListener,
     [dispatch]
   );
   useIpcRenderer(IpcChannel.SetBaseURLForRoot, setBaseURLForRootListener, [

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -15,7 +15,7 @@ import { ExportType, Attributions } from '../../../../shared/shared-types';
 describe('BackendCommunication', () => {
   test('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(8);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.FileLoaded,
       expect.anything()
@@ -38,6 +38,10 @@ describe('BackendCommunication', () => {
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.ShowProjectMetadataPopup,
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel.ShowProjectStatisticsPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -11,6 +11,7 @@ import { NotSavedPopup } from '../NotSavedPopup/NotSavedPopup';
 import { ErrorPopup } from '../ErrorPopup/ErrorPopup';
 import { FileSearchPopup } from '../FileSearchPopup/FileSearchPopup';
 import { ProjectMetadataPopup } from '../ProjectMetadataPopup/ProjectMetadataPopup';
+import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup/ProjectStatisticsPopup';
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttributionPopup';
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
@@ -31,6 +32,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <FileSearchPopup />;
     case PopupType.ProjectMetadataPopup:
       return <ProjectMetadataPopup />;
+    case PopupType.ProjectStatisticsPopup:
+      return <ProjectStatisticsPopup />;
     case PopupType.ReplaceAttributionPopup:
       return <ReplaceAttributionPopup />;
     case PopupType.ConfirmDeletionGloballyPopup:

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -63,6 +63,15 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Project Metadata')).toBeInTheDocument();
   });
 
+  test('opens the ProjectStatisticsPopup', () => {
+    const { store } = renderComponentWithStore(<GlobalPopup />);
+    act(() => {
+      store.dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+    });
+
+    expect(screen.getByText('Project Statistics')).toBeInTheDocument();
+  });
+
   test('opens the ReplaceAttributionPopup', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'name 1' },

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { ButtonText } from '../../enums/enums';
+import {
+  getExternalAttributions,
+  getExternalAttributionSources,
+} from '../../state/selectors/all-views-resource-selectors';
+import {
+  getProjectStatisticsTable,
+  aggregateLicensesAndSourcesFromSignals,
+} from './project-statistics-popup-helpers';
+
+export function ProjectStatisticsPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+
+  const signals = Object.values(useAppSelector(getExternalAttributions));
+  const attributionSources = useAppSelector(getExternalAttributionSources);
+
+  const [signalCountPerSourcePerLicense, licenseNames] =
+    aggregateLicensesAndSourcesFromSignals(signals, attributionSources);
+
+  function close(): void {
+    dispatch(closePopup());
+  }
+
+  const content = getProjectStatisticsTable(
+    signalCountPerSourcePerLicense,
+    licenseNames
+  );
+
+  return (
+    <NotificationPopup
+      content={content}
+      header={'Project Statistics'}
+      isOpen={true}
+      fullWidth={true}
+      rightButtonConfig={{
+        onClick: close,
+        buttonText: ButtonText.Close,
+      }}
+      onBackdropClick={close}
+      onEscapeKeyDown={close}
+    />
+  );
+}

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import React from 'react';
+import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup';
+import { Attributions } from '../../../../shared/shared-types';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import { screen } from '@testing-library/react';
+
+describe('The ProjectStatisticsPopup', () => {
+  test('displays license names and source names', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 10,
+        },
+        licenseName: 'test-license-name',
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'test-license-name_1',
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+    expect(screen.getByText('test-license-name')).toBeInTheDocument();
+    expect(screen.getByText('test-license-name_1')).toBeInTheDocument();
+    expect(screen.getByText('scancode'.toUpperCase())).toBeInTheDocument();
+    expect(screen.getByText('reuser'.toUpperCase())).toBeInTheDocument();
+  });
+
+  test('renders when there are no signals', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {};
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+    expect(screen.getByText('LICENSE')).toBeInTheDocument();
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { aggregateLicensesAndSourcesFromSignals } from '../project-statistics-popup-helpers';
+import { PackageInfo } from '../../../../shared/shared-types';
+
+describe('The ProjectStatisticsPopup helper', () => {
+  test('counts licenses and sources', () => {
+    const testExternalAttributions: PackageInfo[] = [
+      {
+        source: {
+          name: 'SC',
+          documentConfidence: 10,
+        },
+        licenseName: 'test-license-name',
+      },
+      {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'test-license-name',
+      },
+      {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'test-license-name_1',
+      },
+    ];
+
+    const externalAttributions = {
+      SC: {
+        name: 'ScanCode',
+        priority: 2,
+      },
+    };
+
+    const signalCountPerSourcePerLicense =
+      aggregateLicensesAndSourcesFromSignals(
+        testExternalAttributions,
+        externalAttributions
+      )[0];
+
+    expect(signalCountPerSourcePerLicense).toEqual({
+      'test-license-name': { Total: 2, reuser: 1, ScanCode: 1 },
+      'test-license-name_1': { Total: 1, reuser: 1 },
+      Total: { Total: 3, reuser: 2, ScanCode: 1 },
+    });
+  });
+});

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.tsx
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import Box from '@mui/material/Box';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableFooter from '@mui/material/TableFooter';
+import TableRow from '@mui/material/TableRow';
+import { styled } from '@mui/system';
+import {
+  PackageInfo,
+  ExternalAttributionSources,
+} from '../../../shared/shared-types';
+
+interface SignalCountPerSourcePerLicense {
+  [licenseNameOrTotal: string]: { [sourceNameOrTotal: string]: number };
+}
+
+export const SOURCE_TOTAL = 'Total';
+export const LICENSE_TOTAL = 'Total';
+const PLACEHOLDER = '-';
+
+const StyledTableCell = styled(TableCell)(() => ({
+  [`&.${tableCellClasses.head}`]: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  [`&.${tableCellClasses.footer}`]: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    background: 'white',
+    borderBottom: 0,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 16,
+  },
+}));
+
+export function aggregateLicensesAndSourcesFromSignals(
+  signals: Array<PackageInfo>,
+  attributionSources: ExternalAttributionSources
+): [SignalCountPerSourcePerLicense, Array<string>] {
+  const signalCountPerSourcePerLicense: SignalCountPerSourcePerLicense = {};
+
+  for (const signal of signals) {
+    const licenseName = signal.licenseName ?? PLACEHOLDER;
+    const sourceName = getSourceLongNameFromShortName(
+      signal.source?.name ?? PLACEHOLDER,
+      attributionSources
+    );
+
+    const sourcesCountForLicense =
+      signalCountPerSourcePerLicense[licenseName] ?? {};
+    sourcesCountForLicense[sourceName] =
+      (sourcesCountForLicense[sourceName] || 0) + 1;
+    signalCountPerSourcePerLicense[licenseName] = sourcesCountForLicense;
+  }
+
+  for (const licenseName of Object.keys(signalCountPerSourcePerLicense)) {
+    signalCountPerSourcePerLicense[licenseName][SOURCE_TOTAL] = Object.values(
+      signalCountPerSourcePerLicense[licenseName]
+    ).reduce((total, value) => {
+      return total + value;
+    });
+  }
+
+  const licenseNames: Array<string> = Object.keys(
+    signalCountPerSourcePerLicense
+  );
+
+  signalCountPerSourcePerLicense[LICENSE_TOTAL] = {};
+  for (const licenseName of Object.keys(signalCountPerSourcePerLicense)) {
+    if (licenseName !== LICENSE_TOTAL) {
+      for (const sourceName of Object.keys(
+        signalCountPerSourcePerLicense[licenseName]
+      )) {
+        signalCountPerSourcePerLicense[LICENSE_TOTAL][sourceName] =
+          (signalCountPerSourcePerLicense[LICENSE_TOTAL][sourceName] || 0) +
+          signalCountPerSourcePerLicense[licenseName][sourceName];
+      }
+    }
+  }
+  if (licenseNames.length === 0) {
+    signalCountPerSourcePerLicense[LICENSE_TOTAL][SOURCE_TOTAL] = 0;
+  }
+
+  return [signalCountPerSourcePerLicense, licenseNames];
+}
+
+function getSourceLongNameFromShortName(
+  sourceShortName: string,
+  externalAttributionSources: ExternalAttributionSources
+): string {
+  if (
+    Object.keys(externalAttributionSources).includes(sourceShortName) &&
+    sourceShortName !== PLACEHOLDER
+  ) {
+    return externalAttributionSources[sourceShortName]['name'];
+  }
+  return sourceShortName;
+}
+
+export function getProjectStatisticsTable(
+  signalCountPerSourcePerLicense: SignalCountPerSourcePerLicense,
+  licenseNames: Array<string>
+): ReactElement {
+  const sourceNamesOrTotal = Object.keys(
+    signalCountPerSourcePerLicense[LICENSE_TOTAL]
+  );
+  sourceNamesOrTotal.splice(sourceNamesOrTotal.indexOf(SOURCE_TOTAL), 1);
+  sourceNamesOrTotal.push(SOURCE_TOTAL);
+  const sourceNamesRow = ['LICENSE'].concat(sourceNamesOrTotal);
+
+  const valuesSourceTotals = sourceNamesOrTotal.map((sourceName) =>
+    String(signalCountPerSourcePerLicense[LICENSE_TOTAL][sourceName])
+  );
+  const totalsRow: Array<string> = [SOURCE_TOTAL].concat(valuesSourceTotals);
+
+  const sortedLicenseNames = licenseNames.slice().sort();
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <TableContainer style={{ maxHeight: 300 }}>
+        <Table sx={{ minWidth: 300 }} size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              {sourceNamesRow.map((sourceName, index) => (
+                <StyledTableCell key={index} align="center">
+                  {sourceName.toUpperCase()}
+                </StyledTableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            {sortedLicenseNames.map((licenseName, rowIndex) => (
+              <TableRow key={rowIndex}>
+                {sourceNamesRow.map((sourceName, index) => (
+                  <StyledTableCell key={index} align="center">
+                    {index === 0
+                      ? licenseName
+                      : signalCountPerSourcePerLicense[licenseName][
+                          sourceName
+                        ] || PLACEHOLDER}
+                  </StyledTableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+
+          <TableFooter style={{ position: 'sticky', bottom: 0 }}>
+            <TableRow>
+              {totalsRow.map((total, index) => (
+                <StyledTableCell key={index} align="center">
+                  {total}
+                </StyledTableCell>
+              ))}
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -18,7 +18,7 @@ import { IpcChannel } from '../../../../shared/ipc-channels';
 describe('TopBar', () => {
   test('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(8);
+    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.FileLoaded,
       expect.anything()
@@ -41,6 +41,10 @@ describe('TopBar', () => {
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(
       IpcChannel.ShowProjectMetadataPopup,
+      expect.anything()
+    );
+    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannel.ShowProjectStatisticsPopup,
       expect.anything()
     );
     expect(window.ipcRenderer.on).toHaveBeenCalledWith(

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -15,6 +15,7 @@ export enum PopupType {
   InvalidLinkPopup = 'InvalidLinkPopup',
   FileSearchPopup = 'FileSearchPopup',
   ProjectMetadataPopup = 'ProjectMetadataPopup',
+  ProjectStatisticsPopup = 'ProjectStatisticsPopup',
   NotSavedPopup = 'NotSavedPopup',
   ReplaceAttributionPopup = 'ReplaceAttributionPopup',
   ConfirmDeletionPopup = 'ConfirmDeletionPopup',

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -18,5 +18,6 @@ export enum IpcChannel {
   ToggleHighlightForCriticalSignals = 'toggle-highlight-for-critical-signals',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
+  ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',
   SetBaseURLForRoot = 'set-base-url-for-root',
 }


### PR DESCRIPTION
### Summary of changes

Created a Statistics popup window with a statistics table that can be opened from File -> Project Statistics. It displays the number of licenses for each source, and totals for each license and source.

### How can the changes be tested

You can open the window with an opossum input file.
Tests have been written in `src\Frontend\Components\ProjectStatisticsPopup\__tests__\ProjectStatisticsPopup.test.tsx`.
