### PR TITLE
fix: Disable nodeIntegration when creating window

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,7 +35,7 @@ export async function createWindow(): Promise<BrowserWindow> {
     height: 1080,
     webPreferences: {
       contextIsolation: false,
-      nodeIntegration: true,
+      nodeIntegration: false,
       preload: path.join(upath.toUnix(__dirname), '../preload.js'),
     },
     icon: getIconPath(),


### PR DESCRIPTION
### Summary of changes
Disable `nodeIntegration` when creating the window for electron.

### Context and reason for change

It is recommended to disable nodIntegration when creating the window for electron https://www.electronjs.org/docs/latest/tutorial/security#isolation-for-untrusted-content
There is no impact on the functionality of the app.

### How can the changes be tested
`yarn run test:all`
In addition I built the application on Linux and tested basic functionality.
 

