### PR TITLE
Use node v18

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 17
+          node-version: 18
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 17
+          node-version: 18
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         with:
-          node-version: 17
+          node-version: 18
       - run: yarn install --network-timeout 560000
       - run: yarn ${{ matrix.SHIP }}
       - name: Upload release asset

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Prettier is used as a code formatter.
 The following software is required for working on the repository:
 
 - [git](https://git-scm.com/),
-- [node.js](https://nodejs.org/) 17,
+- [node.js](https://nodejs.org/) 18,
 - [yarn](https://yarnpkg.com/en/),
 - [reuse.software](https://reuse.software/) (to check that copyright information is provided),
 - [wine](https://www.winehq.org/) (only to build the Windows version).


### PR DESCRIPTION

### Summary of changes

Use node v18 instead of node v17.

### Context and reason for change

v18 is the latest lts version of node. v17 is no longer maintained.

### How can the changes be tested

Build the app:
`yarn ship`
Run the app: 
`yarn start`

