### PR TITLE
Replace fetch by axios

### DIFF
--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -23,6 +23,7 @@ import {
   getLicenseFetchingInformation,
   LicenseFetchingInformation,
 } from './license-fetching-helpers';
+import axios from 'axios';
 
 const classes = {
   clickableIcon,
@@ -63,7 +64,7 @@ export enum FetchStatus {
 export function useFetchPackageInfo(props: LicenseFetchingInformation): {
   fetchStatus: FetchStatus;
   errorMessage: string;
-  fetchData: () => void;
+  fetchData: () => Promise<void>;
 } {
   const dispatch = useAppDispatch();
   const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
@@ -75,13 +76,14 @@ export function useFetchPackageInfo(props: LicenseFetchingInformation): {
     packageInfo: PackageInfo;
   }>();
 
-  function fetchData(): void {
+  async function fetchData(): Promise<void> {
     setFetchStatus(FetchStatus.InFlight);
-    fetch(props.url)
-      .then(async (res) => {
+    await axios
+      .get(props.url)
+      .then((res) => {
         setFetchedPackageInfo({
           selectedResourceId,
-          packageInfo: await props.convertPayload(res),
+          packageInfo: props.convertPayload(res.data),
         });
         setFetchStatus(FetchStatus.Success);
       })

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/github-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/github-fetching-helpers.test.ts
@@ -31,30 +31,22 @@ describe('getGithubAPIUrl', () => {
 });
 
 describe('convertGithubPayload', () => {
-  it('raises for invalid payload', async () => {
+  it('raises for invalid payload', () => {
     const payload = { license: {} };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    await expect(
-      convertGithubPayload(mockResponse as unknown as Response)
-    ).rejects.toBeTruthy();
+    expect(() => convertGithubPayload(payload as unknown as Response)).toThrow(
+      'requires property "spdx_id"'
+    );
   });
 
-  it('parses payload correctly', async () => {
+  it('parses payload correctly', () => {
     const payload = {
       license: { spdx_id: 'Apache-2.0' },
       content: 'TGljZW5zZSBUZXh0', // "License Text" in base64
       html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
     };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    const packageInfo = await convertGithubPayload(
-      mockResponse as unknown as Response
-    );
+    const packageInfo = convertGithubPayload(payload as unknown as Response);
     expect(packageInfo).toStrictEqual({
       licenseName: 'Apache-2.0',
       licenseText: 'License Text',
@@ -65,18 +57,13 @@ describe('convertGithubPayload', () => {
     });
   });
 
-  it('handles non existing license text correctly', async () => {
+  it('handles non existing license text correctly', () => {
     const payload = {
       license: { spdx_id: 'Apache-2.0' },
       html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
     };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    const packageInfo = await convertGithubPayload(
-      mockResponse as unknown as Response
-    );
+    const packageInfo = convertGithubPayload(payload as unknown as Response);
     expect(packageInfo).toStrictEqual({
       licenseName: 'Apache-2.0',
       packageType: 'github',
@@ -87,19 +74,14 @@ describe('convertGithubPayload', () => {
     });
   });
 
-  it('handles empty license text correctly', async () => {
+  it('handles empty license text correctly', () => {
     const payload = {
       license: { spdx_id: 'Apache-2.0' },
       content: '',
       html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
     };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    const packageInfo = await convertGithubPayload(
-      mockResponse as unknown as Response
-    );
+    const packageInfo = convertGithubPayload(payload as unknown as Response);
     expect(packageInfo).toStrictEqual({
       licenseName: 'Apache-2.0',
       packageType: 'github',

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/npm-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/npm-fetching-helpers.test.ts
@@ -44,26 +44,18 @@ describe('getNpmAPIUrl', () => {
 });
 
 describe('convertNpmPayload', () => {
-  it('raises error for invalid payload', async () => {
+  it('raises error for invalid payload', () => {
     const payload = { name: 'test' };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    await expect(
-      convertNpmPayload(mockResponse as unknown as Response)
-    ).rejects.toBeTruthy();
+    expect(() => convertNpmPayload(payload as unknown as Response)).toThrow(
+      'requires property "license"'
+    );
   });
 
-  it('parses payload correctly', async () => {
+  it('parses payload correctly', () => {
     const payload = { name: 'test', license: 'MIT' };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    const packageInfo = await convertNpmPayload(
-      mockResponse as unknown as Response
-    );
+    const packageInfo = convertNpmPayload(payload as unknown as Response);
     expect(packageInfo).toStrictEqual({
       licenseName: 'MIT',
       packageName: 'test',

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/pypi-fetching-helpers.test.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/pypi-fetching-helpers.test.ts
@@ -22,30 +22,24 @@ describe('getPypiAPIUrl', () => {
 });
 
 describe('convertPypiPayload', () => {
-  it('raises for invalid payload', async () => {
+  it('raises for invalid payload', () => {
     const payload = {
       info: { packageName: 'test' },
     };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
-
-    await expect(
-      convertPypiPayload(mockResponse as unknown as Response)
-    ).rejects.toBeTruthy();
+    expect(() => convertPypiPayload(payload as unknown as Response)).toThrow(
+      'requires property "license"'
+    );
+    /*     await expect(
+      convertPypiPayload(payload as unknown as Response)
+    ).rejects.toBeTruthy(); */
   });
 
-  it('returns correct packageInfo', async () => {
+  it('returns correct packageInfo', () => {
     const payload = {
       info: { license: 'test', name: 'test package' },
     };
-    const mockResponse = {
-      json: (): typeof payload => payload,
-    };
 
-    const packageInfo = await convertPypiPayload(
-      mockResponse as unknown as Response
-    );
+    const packageInfo = convertPypiPayload(payload as unknown as Response);
     expect(packageInfo).toStrictEqual({
       licenseName: 'test',
       packageName: 'test package',

--- a/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
@@ -50,10 +50,8 @@ interface Payload {
   };
 }
 
-export async function convertGithubPayload(
-  payload: Response
-): Promise<PackageInfo> {
-  const convertedPayload = (await payload.json()) as Payload;
+export function convertGithubPayload(payload: Response): PackageInfo {
+  const convertedPayload = payload as unknown as Payload;
   jsonSchemaValidator.validate(convertedPayload, GITHUB_SCHEMA, {
     throwError: true,
   });

--- a/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/license-fetching-helpers.ts
@@ -21,7 +21,7 @@ const GITHUB_REGEX = new RegExp('^https://(www.)?github.com/[^/]+/[^/]+');
 
 export interface LicenseFetchingInformation {
   url: string;
-  convertPayload: (payload: Response) => Promise<PackageInfo>;
+  convertPayload: (payload: Response) => PackageInfo;
 }
 
 export function getLicenseFetchingInformation(

--- a/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/npm-fetching-helpers.ts
@@ -26,16 +26,19 @@ const NPM_SCHEMA: Schema = {
   required: ['name', 'license'],
 };
 
-export async function convertNpmPayload(
-  payload: Response
-): Promise<PackageInfo> {
-  const convertedPayload = await payload.json();
+interface Payload {
+  name: string;
+  license: string;
+}
+
+export function convertNpmPayload(payload: Response): PackageInfo {
+  const convertedPayload = payload as unknown as Payload;
   jsonSchemaValidator.validate(convertedPayload, NPM_SCHEMA, {
     throwError: true,
   });
   return {
-    licenseName: convertedPayload.license as string,
-    packageName: convertedPayload.name as string,
+    licenseName: convertedPayload.license,
+    packageName: convertedPayload.name,
     packageType: 'npm',
     packageNamespace: undefined,
     packagePURLAppendix: undefined,

--- a/src/Frontend/Components/FetchLicenseInformationButton/pypi-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/pypi-fetching-helpers.ts
@@ -36,16 +36,21 @@ const PYPI_SCHEMA: Schema = {
   required: ['info'],
 };
 
-export async function convertPypiPayload(
-  payload: Response
-): Promise<PackageInfo> {
-  const convertedPayload = await payload.json();
+interface Payload {
+  info: {
+    license: string;
+    name: string;
+  };
+}
+
+export function convertPypiPayload(payload: Response): PackageInfo {
+  const convertedPayload = payload as unknown as Payload;
   jsonSchemaValidator.validate(convertedPayload, PYPI_SCHEMA, {
     throwError: true,
   });
   return {
-    licenseName: convertedPayload.info.license as string,
-    packageName: convertedPayload.info.name as string,
+    licenseName: convertedPayload.info.license,
+    packageName: convertedPayload.info.name,
     packageType: 'pypi',
     packageNamespace: undefined,
     packagePURLAppendix: undefined,


### PR DESCRIPTION
Axios handles error codes for you and was therefore chosen to replace all implementations that used fetch.

Issue: #503
Signed-off-by: Florian Schepers <florian.schepers@tngtech.com>

### Summary of changes

Only remaining occurens of fetch found was in the `FetchLicenseInformationButton`.

### Context and reason for change

Previously we used both fetch and axios. We wanted to only use one of both and decided to use axios due to its integrated error handling.

### How can the changes be tested

- Run tests in the `FetchLicenseInformationButton\__tests__` folder
- Test for example with by fetching with 'https://github.com/opossum-tool/OpossumUI' 


