### PR TITLE
Solve bug with height of left column in attribution view

### DIFF
--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -29,8 +29,6 @@ import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import { IconButton } from '../IconButton/IconButton';
 import { getActiveFilters } from '../../state/selectors/view-selector';
 
-const countAndSearchOffset = 119;
-
 const classes = {
   root: {
     width: '100%',
@@ -72,6 +70,8 @@ export function AttributionView(): ReactElement {
     setShowMultiselect(!showMultiSelect);
   }
 
+  const countAndSearchAndFilterOffset = showMultiSelect ? 137 : 80;
+
   return (
     <MuiBox sx={classes.root}>
       <AttributionList
@@ -80,7 +80,9 @@ export function AttributionView(): ReactElement {
         attributionIdMarkedForReplacement={attributionIdMarkedForReplacement}
         onCardClick={onCardClick}
         sx={classes.attributionList}
-        maxHeight={useWindowHeight() - topBarHeight - countAndSearchOffset}
+        maxHeight={
+          useWindowHeight() - topBarHeight - countAndSearchAndFilterOffset
+        }
         title={title}
         topRightElement={
           <IconButton


### PR DESCRIPTION
### Summary of changes

The height of the left column (list) in All Attributions view adjusts to have a constant margin in the bottom depending on filters field opened/closed.

### Context and reason for change

- if filters are not expanded, space on the lower left is unused
- if filters are expanded, the column is to high due to some margin around the box

