### PR TITLE
fix: Enable context isolation

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,35 +1,29 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom/extend-expect';
-import { IpcRenderer } from 'electron';
 
 const TEST_TIMEOUT = 15000;
 jest.setTimeout(TEST_TIMEOUT);
-
-let originalIpcRenderer: IpcRenderer;
 
 jest.mock('./src/Frontend/web-workers/get-new-accordion-workers');
 jest.mock('./src/Frontend/web-workers/get-new-folder-progress-bar-worker');
 
 beforeAll(() => {
-  originalIpcRenderer = global.window.ipcRenderer;
-  const mockInvoke = jest.fn();
-  mockInvoke.mockReturnValue(Promise.resolve());
-  global.window.ipcRenderer = {
+  global.window.electronAPI = {
+    openLink: jest.fn().mockReturnValue(Promise.resolve()),
+    openFile: jest.fn(),
+    sendErrorInformation: jest.fn(),
+    exportFile: jest.fn(),
+    saveFile: jest.fn(),
     on: jest.fn(),
     removeListener: jest.fn(),
-    invoke: mockInvoke,
-  } as unknown as IpcRenderer;
+  };
 
   jest.spyOn(console, 'info').mockImplementation();
 });
 
 beforeEach(() => jest.clearAllMocks());
-
-afterAll(() => {
-  // Important to restore the original value.
-  global.window.ipcRenderer = originalIpcRenderer;
-});

--- a/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
+++ b/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +14,7 @@ import {
   getMessageBoxForErrors,
   getMessageBoxForParsingError,
 } from '../errorHandling';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { JsonParsingError } from '../../types/types';
 
 jest.mock('electron', () => ({
@@ -135,7 +136,7 @@ describe('error handling', () => {
       );
       expect(mockCallback.mock.calls.length).toBe(1);
       expect(mockCallback.mock.calls[0][0]).toContain(
-        IpcChannel.RestoreFrontend
+        AllowedFrontendChannels.RestoreFrontend
       );
       expect(loadJsonFromFilePath).toBeCalled();
     });
@@ -176,7 +177,7 @@ describe('error handling', () => {
       );
       expect(mockCallback.mock.calls.length).toBe(1);
       expect(mockCallback.mock.calls[0][0]).toContain(
-        IpcChannel.RestoreFrontend
+        AllowedFrontendChannels.RestoreFrontend
       );
       expect(loadJsonFromFilePath).toBeCalled();
     });

--- a/src/ElectronBackend/errorHandling/errorHandling.ts
+++ b/src/ElectronBackend/errorHandling/errorHandling.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +12,7 @@ import {
   WebContents,
 } from 'electron';
 import log from 'electron-log';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import { loadJsonFromFilePath } from '../input/importFromFile';
 import { getGlobalBackendState } from '../main/globalBackendState';
 
@@ -120,7 +121,7 @@ function performButtonAction(
   const globalBackendState = getGlobalBackendState();
   switch (buttonIndex) {
     case 0:
-      webContents.send(IpcChannel.RestoreFrontend);
+      webContents.send(AllowedFrontendChannels.RestoreFrontend);
       loadJsonFromFilePath(
         webContents,
         globalBackendState.resourceFilePath as string

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +19,7 @@ import {
 } from '../../main/globalBackendState';
 import { writeJsonToFile } from '../../output/writeJsonToFile';
 import { OpossumOutputFile, ParsedOpossumInputFile } from '../../types/types';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { loadJsonFromFilePath } from '../importFromFile';
 import { EMPTY_PROJECT_METADATA } from '../../../Frontend/shared-constants';
 import * as fs from 'fs';
@@ -217,7 +218,7 @@ describe('Test of loading function', () => {
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(2);
       expect(mainWindow.webContents.send).toHaveBeenLastCalledWith(
-        IpcChannel.FileLoaded,
+        AllowedFrontendChannels.FileLoaded,
         expectedFileContent
       );
 
@@ -241,7 +242,7 @@ describe('Test of loading function', () => {
 
       expect(mainWindow.webContents.send).toHaveBeenCalledTimes(2);
       expect(mainWindow.webContents.send).toHaveBeenLastCalledWith(
-        IpcChannel.FileLoaded,
+        AllowedFrontendChannels.FileLoaded,
         expectedFileContent
       );
       expect(dialog.showMessageBox).not.toBeCalled();
@@ -439,7 +440,7 @@ describe('Test of loading function', () => {
     };
 
     expect(mainWindow.webContents.send).toBeCalledWith(
-      IpcChannel.FileLoaded,
+      AllowedFrontendChannels.FileLoaded,
       expectedLoadedFile
     );
     expect(dialog.showMessageBox).not.toBeCalled();
@@ -485,7 +486,7 @@ describe('Test of loading function', () => {
     };
 
     expect(mainWindow.webContents.send).toBeCalledWith(
-      IpcChannel.FileLoaded,
+      AllowedFrontendChannels.FileLoaded,
       expectedLoadedFile
     );
     expect(dialog.showMessageBox).not.toBeCalled();
@@ -512,7 +513,7 @@ function assertFileLoadedCorrectly(testUuid: string): void {
   };
 
   expect(mainWindow.webContents.send).toBeCalledWith(
-    IpcChannel.FileLoaded,
+    AllowedFrontendChannels.FileLoaded,
     expectedLoadedFile
   );
   expect(dialog.showMessageBox).not.toBeCalled();

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';
 import path from 'path';
 import upath from 'upath';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   Attributions,
   AttributionsToResources,
@@ -45,7 +46,7 @@ export async function loadJsonFromFilePath(
   webContents: WebContents,
   filePath: string
 ): Promise<void> {
-  webContents.send(IpcChannel.ResetLoadedFile, {
+  webContents.send(AllowedFrontendChannels.ResetLoadedFile, {
     resetState: true,
   });
 
@@ -131,7 +132,7 @@ export async function loadJsonFromFilePath(
     externalAttributionSources: parsingResult.externalAttributionSources ?? {},
   };
   log.info('Sending data to electron frontend');
-  webContents.send(IpcChannel.FileLoaded, parsedFileContent);
+  webContents.send(AllowedFrontendChannels.FileLoaded, parsedFileContent);
 
   log.info('Updating global backend state');
   const newGlobalBackendState: GlobalBackendState = {

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { WebContents } from 'electron';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   Attributions,
   BaseUrlsForSources,
@@ -93,7 +94,7 @@ export function cleanNonExistentAttributions(
         );
         if (filteredAttributionIds.length < entryAttributionIds.length) {
           webContents.send(
-            IpcChannel.Logging,
+            AllowedFrontendChannels.Logging,
             `WARNING: There were abandoned attributions for path ${path}.` +
               ' The import from the attribution file was cleaned up.'
           );
@@ -115,7 +116,7 @@ export function cleanNonExistentResolvedExternalSignals(
     if (!externalAttributionIds.has(resolvedExternalAttributionId)) {
       resolvedExternalAttributions.delete(resolvedExternalAttributionId);
       webContents.send(
-        IpcChannel.Logging,
+        AllowedFrontendChannels.Logging,
         `WARNING: There was an abandoned resolved external attribution: ${resolvedExternalAttributionId}.` +
           ' The import from the attribution file was cleaned up.'
       );

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { BrowserWindow, dialog, shell, WebContents } from 'electron';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import {
+  IpcChannel,
+  AllowedFrontendChannels,
+} from '../../../shared/ipc-channels';
 import {
   Attributions,
   AttributionsWithResources,
@@ -245,9 +249,12 @@ describe('getSelectBaseURLListener', () => {
     getSelectBaseURLListener(webContents)();
 
     expect(selectBaseURLDialog).toBeCalled();
-    expect(webContents.send).toBeCalledWith(IpcChannel.SetBaseURLForRoot, {
-      baseURLForRoot: expectedFormattedBaseURL,
-    });
+    expect(webContents.send).toBeCalledWith(
+      AllowedFrontendChannels.SetBaseURLForRoot,
+      {
+        baseURLForRoot: expectedFormattedBaseURL,
+      }
+    );
   });
 });
 
@@ -262,11 +269,14 @@ describe('getSaveFileListener', () => {
     const webContents = { send: mockCallback as unknown } as WebContents;
     setGlobalBackendState({});
 
-    await getSaveFileListener(webContents)(IpcChannel.SaveFileRequest, {
-      manualAttributions: {},
-      resourcesToAttributions: {},
-      resolvedExternalAttributions: new Set(),
-    });
+    await getSaveFileListener(webContents)(
+      AllowedFrontendChannels.SaveFileRequest,
+      {
+        manualAttributions: {},
+        resourcesToAttributions: {},
+        resolvedExternalAttributions: new Set(),
+      }
+    );
 
     expect(dialog.showMessageBox).toBeCalledWith(
       expect.objectContaining({
@@ -295,7 +305,7 @@ describe('getSaveFileListener', () => {
         projectId: 'uuid_1',
       });
 
-      listener(IpcChannel.SaveFileRequest, {
+      listener(AllowedFrontendChannels.SaveFileRequest, {
         manualAttributions: {},
         resourcesToAttributions: {},
         resolvedExternalAttributions: new Set<string>().add('id_1').add('id_2'),

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -34,7 +34,7 @@ export async function createWindow(): Promise<BrowserWindow> {
     width: 1920,
     height: 1080,
     webPreferences: {
-      contextIsolation: false,
+      contextIsolation: true,
       nodeIntegration: false,
       preload: path.join(upath.toUnix(__dirname), '../preload.js'),
     },

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { BrowserWindow, shell, WebContents } from 'electron';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   ExportArgsType,
   ExportCompactBomArgs,
@@ -104,7 +105,7 @@ export function getSelectBaseURLListener(webContents: WebContents): () => void {
     const baseURL = baseURLs[0];
     const formattedBaseURL = formatBaseURL(baseURL);
 
-    webContents.send(IpcChannel.SetBaseURLForRoot, {
+    webContents.send(AllowedFrontendChannels.SetBaseURLForRoot, {
       baseURLForRoot: formattedBaseURL,
     });
   });

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { app, BrowserWindow, Menu, shell } from 'electron';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import { getOpenFileListener, getSelectBaseURLListener } from './listeners';
 import { getGlobalBackendState } from './globalBackendState';
 import {
@@ -31,7 +32,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           label: 'Save',
           accelerator: 'CmdOrCtrl+S',
           click(): void {
-            webContents.send(IpcChannel.SaveFileRequest, {
+            webContents.send(AllowedFrontendChannels.SaveFileRequest, {
               saveFile: true,
             });
           },
@@ -43,7 +44,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               label: 'Follow-Up',
               click(): void {
                 webContents.send(
-                  IpcChannel.ExportFileRequest,
+                  AllowedFrontendChannels.ExportFileRequest,
                   ExportType.FollowUp
                 );
               },
@@ -52,7 +53,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               label: 'Compact component list',
               click(): void {
                 webContents.send(
-                  IpcChannel.ExportFileRequest,
+                  AllowedFrontendChannels.ExportFileRequest,
                   ExportType.CompactBom
                 );
               },
@@ -61,7 +62,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               label: 'Detailed component list',
               click(): void {
                 webContents.send(
-                  IpcChannel.ExportFileRequest,
+                  AllowedFrontendChannels.ExportFileRequest,
                   ExportType.DetailedBom
                 );
               },
@@ -70,7 +71,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               label: 'SPDX (yaml)',
               click(): void {
                 webContents.send(
-                  IpcChannel.ExportFileRequest,
+                  AllowedFrontendChannels.ExportFileRequest,
                   ExportType.SpdxDocumentYaml
                 );
               },
@@ -79,7 +80,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               label: 'SPDX (json)',
               click(): void {
                 webContents.send(
-                  IpcChannel.ExportFileRequest,
+                  AllowedFrontendChannels.ExportFileRequest,
                   ExportType.SpdxDocumentJson
                 );
               },
@@ -90,9 +91,12 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           label: 'Project Metadata',
           click(): void {
             if (getGlobalBackendState().resourceFilePath) {
-              webContents.send(IpcChannel.ShowProjectMetadataPopup, {
-                showProjectMetadataPopup: true,
-              });
+              webContents.send(
+                AllowedFrontendChannels.ShowProjectMetadataPopup,
+                {
+                  showProjectMetadataPopup: true,
+                }
+              );
             }
           },
         },
@@ -100,9 +104,12 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           label: 'Project Statistics',
           click(): void {
             if (getGlobalBackendState().resourceFilePath) {
-              webContents.send(IpcChannel.ShowProjectStatisticsPopup, {
-                showProjectStatisticsPopup: true,
-              });
+              webContents.send(
+                AllowedFrontendChannels.ShowProjectStatisticsPopup,
+                {
+                  showProjectStatisticsPopup: true,
+                }
+              );
             }
           },
         },
@@ -137,7 +144,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           accelerator: 'CmdOrCtrl+F',
           click(): void {
             if (getGlobalBackendState().resourceFilePath) {
-              webContents.send(IpcChannel.ShowSearchPopup, {
+              webContents.send(AllowedFrontendChannels.ShowSearchPopup, {
                 showSearchPopup: true,
               });
             }
@@ -156,9 +163,12 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           label: 'Highlight critical signals',
           type: 'checkbox',
           click(): void {
-            webContents.send(IpcChannel.ToggleHighlightForCriticalSignals, {
-              toggleHighlightForCriticalSignals: true,
-            });
+            webContents.send(
+              AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
+              {
+                toggleHighlightForCriticalSignals: true,
+              }
+            );
           },
         },
       ],

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -1,15 +1,47 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { ipcRenderer, contextBridge } from 'electron';
+import { AllowedFrontendChannels, IpcChannel } from '../shared/ipc-channels';
+import {
+  SendErrorInformationArgs,
+  IElectronAPI,
+  ExportArgsType,
+  Listener,
+  SaveFileArgs,
+} from '../shared/shared-types';
 
-// needed to get electron to work with react / webpack
-import { IpcRenderer, ipcRenderer } from 'electron';
-
-declare global {
-  interface Window {
-    ipcRenderer: IpcRenderer;
+function on(channel: AllowedFrontendChannels, listener: Listener): void {
+  if (Object.values(AllowedFrontendChannels).includes(channel)) {
+    ipcRenderer.on(channel, listener);
   }
 }
 
-window.ipcRenderer = ipcRenderer;
+function removeListener(
+  channel: AllowedFrontendChannels,
+  listener: Listener
+): void {
+  if (Object.values(AllowedFrontendChannels).includes(channel)) {
+    ipcRenderer.removeListener(channel, listener);
+  }
+}
+
+const electronAPI: IElectronAPI = {
+  openLink: (link: string) => ipcRenderer.invoke(IpcChannel.OpenLink, { link }),
+  openFile: () => ipcRenderer.invoke(IpcChannel.OpenFile),
+  sendErrorInformation: (errorInformationArgs: SendErrorInformationArgs) =>
+    ipcRenderer.invoke(IpcChannel.SendErrorInformation, errorInformationArgs),
+  exportFile: (args: ExportArgsType) =>
+    ipcRenderer.invoke(IpcChannel.ExportFile, args),
+  saveFile: (saveFileArgs: SaveFileArgs) =>
+    ipcRenderer.invoke(IpcChannel.SaveFile, saveFileArgs),
+  on,
+  removeListener,
+};
+
+// This exposes an API to communicate from the window in the frontend with the backend
+// Simply exposing ipcRenderer is discouraged as it is a quite powerful API
+// https://www.electronjs.org/de/docs/latest/tutorial/context-isolation
+contextBridge.exposeInMainWorld('electronAPI', electronAPI);

--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +22,7 @@ import {
 } from '../../state/selectors/audit-view-resource-selectors';
 import { IpcRendererEvent } from 'electron';
 import { useIpcRenderer } from '../../util/use-ipc-renderer';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import {
   getDiscreteConfidenceChangeHandler,
   getDisplayTexts,
@@ -236,7 +237,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       props.saveFileRequestListener();
     }
   }
-  useIpcRenderer(IpcChannel.SaveFileRequest, listener, [
+  useIpcRenderer(AllowedFrontendChannels.SaveFileRequest, listener, [
     props.saveFileRequestListener,
   ]);
 

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -6,7 +6,6 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { IpcChannel } from '../../../shared/ipc-channels';
 import { PackageInfo } from '../../../shared/shared-types';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
@@ -44,9 +43,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
       ) {
         urlString = 'https://' + urlString;
       }
-      window.ipcRenderer.invoke(IpcChannel.OpenLink, {
-        link: urlString,
-      });
+      window.electronAPI.openLink(urlString);
     }
   }
 

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +37,6 @@ import {
 } from '../../../test-helpers/general-test-helpers';
 import { doNothing } from '../../../util/do-nothing';
 import { AttributionColumn } from '../AttributionColumn';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import {
   clickGoToLinkIcon,
@@ -366,11 +366,8 @@ describe('The AttributionColumn', () => {
 
     expect(screen.getByLabelText('Url icon'));
     clickGoToLinkIcon(screen, 'Url icon');
-    expect(global.window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.OpenLink,
-      {
-        link: testTemporaryPackageInfo.url,
-      }
+    expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
+      testTemporaryPackageInfo.url
     );
   });
 
@@ -394,11 +391,8 @@ describe('The AttributionColumn', () => {
     );
 
     clickGoToLinkIcon(screen, 'Url icon');
-    expect(global.window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.OpenLink,
-      {
-        link: 'https://' + testTemporaryPackageInfo.url,
-      }
+    expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
+      'https://' + testTemporaryPackageInfo.url
     );
   });
 
@@ -422,7 +416,7 @@ describe('The AttributionColumn', () => {
     );
 
     clickGoToLinkIcon(screen, 'Url icon');
-    expect(global.window.ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(global.window.electronAPI.openLink).not.toHaveBeenCalled();
     expectGoToLinkButtonIsDisabled(screen);
   });
 
@@ -616,9 +610,8 @@ describe('The AttributionColumn', () => {
       });
 
       clickOnButton(screen, 'resolve attribution');
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-        IpcChannel.SaveFile,
+      expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+      expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
         expectedSaveFileArgs
       );
     });

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +8,7 @@ import { IpcRendererEvent } from 'electron';
 import { ReactElement } from 'react';
 import pick from 'lodash/pick';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import {
   Attributions,
   BaseURLForRootArgs,
@@ -104,7 +105,7 @@ export function BackendCommunication(): ReactElement | null {
         getFileWithChildrenCheck(filesWithChildren)
       );
 
-    window.ipcRenderer.invoke(IpcChannel.ExportFile, {
+    window.electronAPI.exportFile({
       type: ExportType.FollowUp,
       followUpAttributionsWithResources:
         followUpAttributionsWithFormattedResources,
@@ -140,7 +141,7 @@ export function BackendCommunication(): ReactElement | null {
       spdxAttributions: attributions,
     };
 
-    window.ipcRenderer.invoke(IpcChannel.ExportFile, args);
+    window.electronAPI.exportFile(args);
   }
 
   function getDetailedBomExportListener(): void {
@@ -160,14 +161,14 @@ export function BackendCommunication(): ReactElement | null {
         getFileWithChildrenCheck(filesWithChildren)
       );
 
-    window.ipcRenderer.invoke(IpcChannel.ExportFile, {
+    window.electronAPI.exportFile({
       type: ExportType.DetailedBom,
       bomAttributionsWithResources: bomAttributionsWithFormattedResources,
     });
   }
 
   function getCompactBomExportListener(): void {
-    window.ipcRenderer.invoke(IpcChannel.ExportFile, {
+    window.electronAPI.exportFile({
       type: ExportType.CompactBom,
       bomAttributions: getBomAttributions(
         manualData.attributions,
@@ -245,36 +246,47 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
-  useIpcRenderer(IpcChannel.FileLoaded, fileLoadedListener, [dispatch]);
-  useIpcRenderer(IpcChannel.ResetLoadedFile, resetLoadedFileListener, [
-    dispatch,
-  ]);
-  useIpcRenderer(IpcChannel.Logging, loggingListener, [dispatch]);
-  useIpcRenderer(IpcChannel.ShowSearchPopup, showSearchPopupListener, [
+  useIpcRenderer(AllowedFrontendChannels.FileLoaded, fileLoadedListener, [
     dispatch,
   ]);
   useIpcRenderer(
-    IpcChannel.ShowProjectMetadataPopup,
+    AllowedFrontendChannels.ResetLoadedFile,
+    resetLoadedFileListener,
+    [dispatch]
+  );
+  useIpcRenderer(AllowedFrontendChannels.Logging, loggingListener, [dispatch]);
+  useIpcRenderer(
+    AllowedFrontendChannels.ShowSearchPopup,
+    showSearchPopupListener,
+    [dispatch]
+  );
+  useIpcRenderer(
+    AllowedFrontendChannels.ShowProjectMetadataPopup,
     showProjectMetadataPopupListener,
     [dispatch]
   );
   useIpcRenderer(
-    IpcChannel.ShowProjectStatisticsPopup,
+    AllowedFrontendChannels.ShowProjectStatisticsPopup,
     showProjectStatisticsPopupListener,
     [dispatch]
   );
-  useIpcRenderer(IpcChannel.SetBaseURLForRoot, setBaseURLForRootListener, [
-    dispatch,
-    baseUrlsForSources,
-  ]);
-  useIpcRenderer(IpcChannel.ExportFileRequest, getExportFileRequestListener, [
-    manualData,
-    attributionBreakpoints,
-    frequentLicenseTexts,
-    filesWithChildren,
-  ]);
   useIpcRenderer(
-    IpcChannel.ToggleHighlightForCriticalSignals,
+    AllowedFrontendChannels.SetBaseURLForRoot,
+    setBaseURLForRootListener,
+    [dispatch, baseUrlsForSources]
+  );
+  useIpcRenderer(
+    AllowedFrontendChannels.ExportFileRequest,
+    getExportFileRequestListener,
+    [
+      manualData,
+      attributionBreakpoints,
+      frequentLicenseTexts,
+      filesWithChildren,
+    ]
+  );
+  useIpcRenderer(
+    AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
     setToggleHighlightForCriticalSignalsListener,
     [dispatch, showHighlightForCriticalSignals]
   );

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import { IpcChannel } from '../../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import {
   BackendCommunication,
   getBomAttributions,
@@ -15,41 +16,41 @@ import { ExportType, Attributions } from '../../../../shared/shared-types';
 describe('BackendCommunication', () => {
   test('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.FileLoaded,
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(9);
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.FileLoaded,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.Logging,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.Logging,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ResetLoadedFile,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ResetLoadedFile,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ExportFileRequest,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ExportFileRequest,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowSearchPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowSearchPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowProjectMetadataPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowProjectMetadataPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowProjectStatisticsPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowProjectStatisticsPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.SetBaseURLForRoot,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.SetBaseURLForRoot,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ToggleHighlightForCriticalSignals,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
       expect.anything()
     );
   });

--- a/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { Dispatch, ErrorInfo, ReactNode } from 'react';
 import { connect } from 'react-redux';
-import { IpcChannel } from '../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { SendErrorInformationArgs } from '../../../shared/shared-types';
 import { AnyAction } from 'redux';
 import { resetViewState } from '../../state/actions/view-actions/view-actions';
@@ -46,10 +47,7 @@ function sendErrorInfo(error: Error, errorInfo: ErrorInfo): void {
     error,
     errorInfo,
   };
-  window.ipcRenderer.invoke(
-    IpcChannel.SendErrorInformation,
-    sendErrorInformationArgs
-  );
+  window.electronAPI.sendErrorInformation(sendErrorInformationArgs);
 }
 
 class ProtoErrorBoundary extends React.Component<
@@ -62,17 +60,20 @@ class ProtoErrorBoundary extends React.Component<
   }
 
   componentDidMount(): void {
-    window.ipcRenderer.on(IpcChannel.RestoreFrontend, () => {
+    window.electronAPI.on(AllowedFrontendChannels.RestoreFrontend, () => {
       this.props.resetState();
       this.setState({ hasError: false });
     });
   }
 
   componentWillUnmount(): void {
-    window.ipcRenderer.removeListener(IpcChannel.RestoreFrontend, () => {
-      this.props.resetState();
-      this.setState({ hasError: false });
-    });
+    window.electronAPI.removeListener(
+      AllowedFrontendChannels.RestoreFrontend,
+      () => {
+        this.props.resetState();
+        this.setState({ hasError: false });
+      }
+    );
   }
 
   static getDerivedStateFromError(): ErrorBoundaryState {

--- a/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +9,7 @@ import { initialResourceState } from '../../../state/reducers/resource-reducer';
 import { initialViewState } from '../../../state/reducers/view-reducer';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { ErrorBoundary } from '../ErrorBoundary';
-import { IpcChannel } from '../../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { screen } from '@testing-library/react';
 
 describe('ErrorBoundary', () => {
@@ -27,8 +28,8 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
 
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(0);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(0);
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(1);
 
     screen.getByText('Test');
   });
@@ -43,14 +44,11 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
 
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(3);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.SendErrorInformation,
-      expect.anything()
-    );
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(1);
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.RestoreFrontend,
+    expect(window.electronAPI.sendErrorInformation).toHaveBeenCalledTimes(3);
+
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.RestoreFrontend,
       expect.anything()
     );
 

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,6 @@ import {
   getAttributionBreakpoints,
   getBaseUrlsForSources,
 } from '../../state/selectors/all-views-resource-selectors';
-import { IpcChannel } from '../../../shared/ipc-channels';
 import { getParents } from '../../state/helpers/get-parents';
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { OpenLinkArgs } from '../../../shared/shared-types';
@@ -79,13 +79,11 @@ export function GoToLinkButton(): ReactElement {
   const openLinkArgs = getOpenLinkArgs();
 
   function onClick(): void {
-    window.ipcRenderer
-      .invoke(IpcChannel.OpenLink, openLinkArgs)
-      .then((result) => {
-        if (result instanceof Error) {
-          dispatch(openPopup(PopupType.InvalidLinkPopup));
-        }
-      });
+    window.electronAPI.openLink(openLinkArgs.link).then((result) => {
+      if (result instanceof Error) {
+        dispatch(openPopup(PopupType.InvalidLinkPopup));
+      }
+    });
   }
 
   return (

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +11,6 @@ import { GoToLinkButton } from '../GoToLinkButton';
 import { BaseUrlsForSources } from '../../../../shared/shared-types';
 import { setBaseUrlsForSources } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { screen } from '@testing-library/react';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import each from 'jest-each';
 import { clickGoToLinkIcon } from '../../../test-helpers/attribution-column-test-helpers';
 import { act } from 'react-dom/test-utils';
@@ -39,15 +39,12 @@ describe('The GoToLinkButton', () => {
         store.dispatch(setBaseUrlsForSources(testBaseUrlsForSources));
       });
 
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(0);
+      expect(window.electronAPI.openLink).toHaveBeenCalledTimes(0);
       expect(screen.getByLabelText('link to open'));
       clickGoToLinkIcon(screen, 'link to open');
 
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-      expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-        IpcChannel.OpenLink,
-        { link: expected_link }
-      );
+      expect(window.electronAPI.openLink).toHaveBeenCalledTimes(1);
+      expect(window.electronAPI.openLink).toHaveBeenCalledWith(expected_link);
     }
   );
 

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +28,6 @@ import {
   setSelectedAttributionId,
 } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { Attributions, Resources } from '../../../../shared/shared-types';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 
 function setupTestState(store: EnhancedTestStore): void {
   const testResources: Resources = {
@@ -140,21 +140,18 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     fireEvent.click(screen.queryByText(ButtonText.Replace) as Element);
     expect(getOpenPopup(store.getState())).toBe(null);
 
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.SaveFile,
-      {
-        manualAttributions: {
-          test_selected_id: {
-            packageName: 'React',
-            attributionConfidence: DiscreteConfidence.High,
-          },
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith({
+      manualAttributions: {
+        test_selected_id: {
+          packageName: 'React',
+          attributionConfidence: DiscreteConfidence.High,
         },
-        resolvedExternalAttributions: new Set(),
-        resourcesToAttributions: {
-          'package_1.tr.gz': ['test_selected_id'],
-          'package_2.tr.gz': ['test_selected_id'],
-        },
-      }
-    );
+      },
+      resolvedExternalAttributions: new Set(),
+      resourcesToAttributions: {
+        'package_1.tr.gz': ['test_selected_id'],
+        'package_2.tr.gz': ['test_selected_id'],
+      },
+    });
   });
 });

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +8,6 @@ import MuiToggleButton from '@mui/material/ToggleButton';
 import MuiToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { IpcChannel } from '../../../shared/ipc-channels';
 import { View } from '../../enums/enums';
 import { setViewOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { getSelectedView } from '../../state/selectors/view-selector';
@@ -76,7 +76,7 @@ export function TopBar(): ReactElement {
         tooltipTitle="open file"
         placement="right"
         onClick={(): void => {
-          window.ipcRenderer.invoke(IpcChannel.OpenFile);
+          window.electronAPI.openFile();
         }}
         icon={
           <FolderOpenIcon

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,53 +14,53 @@ import {
 } from '../../../state/selectors/view-selector';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { TopBar } from '../TopBar';
-import { IpcChannel } from '../../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 
 describe('TopBar', () => {
   test('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.ipcRenderer.on).toHaveBeenCalledTimes(9);
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.FileLoaded,
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(9);
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.FileLoaded,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.Logging,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.Logging,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ResetLoadedFile,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ResetLoadedFile,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ExportFileRequest,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ExportFileRequest,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowSearchPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowSearchPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowProjectMetadataPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowProjectMetadataPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ShowProjectStatisticsPopup,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowProjectStatisticsPopup,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.SetBaseURLForRoot,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.SetBaseURLForRoot,
       expect.anything()
     );
-    expect(window.ipcRenderer.on).toHaveBeenCalledWith(
-      IpcChannel.ToggleHighlightForCriticalSignals,
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
       expect.anything()
     );
 
     fireEvent.click(screen.queryByLabelText('open file') as Element);
     expect(store.getState().resourceState).toMatchObject(initialResourceState);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(IpcChannel.OpenFile);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.openFile).toHaveBeenCalledWith();
   });
 
   test('switches between views', () => {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,6 @@ import {
   mockElectronBackend,
 } from '../../../test-helpers/general-test-helpers';
 import { ParsedFileContent } from '../../../../shared/shared-types';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { screen } from '@testing-library/react';
 import React from 'react';
@@ -49,19 +49,17 @@ describe('The go to link button', () => {
     clickOnElementInResourceBrowser(screen, 'parent');
     expectGoToLinkIconIsVisible(screen);
     clickGoToLinkIcon(screen, 'link to open');
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.OpenLink,
-      { link: expectedLinkForParent }
+    expect(window.electronAPI.openLink).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.openLink).toHaveBeenCalledWith(
+      expectedLinkForParent
     );
 
     clickOnElementInResourceBrowser(screen, 'something_else.js');
     expectGoToLinkIconIsVisible(screen);
     clickGoToLinkIcon(screen, 'link to open');
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(2);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.OpenLink,
-      { link: expectedLinkForFile }
+    expect(window.electronAPI.openLink).toHaveBeenCalledTimes(2);
+    expect(window.electronAPI.openLink).toHaveBeenCalledWith(
+      expectedLinkForFile
     );
   });
 });

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +13,7 @@ import {
   mockElectronBackend,
   mockElectronIpcRendererOn,
 } from '../../../test-helpers/general-test-helpers';
-import { IpcChannel } from '../../../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import {
   PackageInfo,
@@ -46,10 +47,10 @@ import {
 } from '../../../test-helpers/package-panel-helpers';
 
 function mockSaveFileRequestChannel(): void {
-  window.ipcRenderer.on
+  window.electronAPI.on
     // @ts-ignore
     .mockImplementationOnce(
-      mockElectronIpcRendererOn(IpcChannel.SaveFileRequest, true)
+      mockElectronIpcRendererOn(AllowedFrontendChannels.SaveFileRequest, true)
     );
 }
 
@@ -162,10 +163,10 @@ describe('Other popups of the app', () => {
       resolvedExternalAttributions: new Set(),
     };
 
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
     expectUnsavedChangesPopupIsNotShown(screen);
     expectValueNotInTextBox(screen, 'Name', testPackageName);
     expectButton(screen, ButtonText.Save, true);
@@ -223,10 +224,10 @@ describe('Other popups of the app', () => {
       },
       resolvedExternalAttributions: new Set(),
     };
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
     expectUnsavedChangesPopupIsNotShown(screen);
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
@@ -358,9 +359,9 @@ describe('Other popups of the app', () => {
       resolvedExternalAttributions: new Set(),
     };
 
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 });

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +22,6 @@ import {
   expectNoConfirmationButtonsShown,
   handleReplaceMarkedAttributionViaContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { ButtonText, DiscreteConfidence, View } from '../../../enums/enums';
 import {
@@ -222,10 +222,10 @@ describe('In Attribution View the ContextMenu', () => {
     screen.getByText('/root/src/file_2');
 
     // make sure resources are now linked to React attribution
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 
   test('deletes multi-selected attributions correctly', () => {

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +14,6 @@ import {
   mockElectronBackend,
 } from '../../../test-helpers/general-test-helpers';
 import { fireEvent, screen } from '@testing-library/react';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import {
   PackageInfo,
@@ -242,12 +242,11 @@ describe('The App in attribution view', () => {
         '/root/src/file_2': ['uuid_2'],
       },
     };
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.OpenFile],
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-      [IpcChannel.SaveFile, expect.anything()],
-    ]);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(2);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 
   test('saves an updated attribution to file', () => {
@@ -332,11 +331,11 @@ describe('The App in attribution view', () => {
     expectValueNotInTextBox(screen, 'Name', 'jQuery');
     expect(screen.getByText('Angular, 16.0.0'));
 
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.OpenFile],
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 
   test('deletes an attribution', () => {
@@ -395,11 +394,11 @@ describe('The App in attribution view', () => {
     clickOnButton(screen, ButtonText.Save);
 
     expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.OpenFile],
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 
   test('replaces attributions', () => {
@@ -478,10 +477,10 @@ describe('The App in attribution view', () => {
     screen.getByText('/root/src/file_2');
 
     // make sure resources are now linked to React attribution
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.OpenFile],
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,7 +30,6 @@ import {
   expectNoConfirmationButtonsShown,
   handleReplaceMarkedAttributionViaContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { addResolvedExternalAttribution } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { ButtonText, DiscreteConfidence } from '../../../enums/enums';
@@ -362,10 +362,10 @@ describe('In Audit View the ContextMenu', () => {
       expectValueInTextBox(screen, 'Name', 'React');
 
       // make sure resources are now linked to React attribution
-      // @ts-ignore
-      expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-        [IpcChannel.SaveFile, expectedSaveFileArgs],
-      ]);
+      expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+      expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+        expectedSaveFileArgs
+      );
     });
 
     test('in the attributions in folder content panel', () => {
@@ -407,10 +407,10 @@ describe('In Audit View the ContextMenu', () => {
       expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
 
       // make sure resources are now linked to React attribution
-      // @ts-ignore
-      expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-        [IpcChannel.SaveFile, expectedSaveFileArgs],
-      ]);
+      expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+      expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+        expectedSaveFileArgs
+      );
     });
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +15,6 @@ import {
   mockElectronBackend,
 } from '../../../test-helpers/general-test-helpers';
 import { screen } from '@testing-library/react';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import {
   ParsedFileContent,
@@ -110,10 +110,10 @@ describe('The App in Audit View', () => {
       resolvedExternalAttributions: new Set<string>(),
     };
 
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
 
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +15,6 @@ import {
 import { App } from '../../../Components/App/App';
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import {
   Attributions,
   ParsedFileContent,
@@ -491,9 +491,9 @@ describe('The App in Audit View', () => {
     expectValueInTextBox(screen, 'Name', 'React');
 
     // make sure resources are now linked to React attribution
-    // @ts-ignore
-    expect(window.ipcRenderer.invoke.mock.calls).toEqual([
-      [IpcChannel.SaveFile, expectedSaveFileArgs],
-    ]);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
+      expectedSaveFileArgs
+    );
   });
 });

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { IpcRenderer } from 'electron';
 import {
   DiscreteConfidence,
   PackagePanelTitle,
@@ -373,12 +373,6 @@ describe('The actions checking for unsaved changes', () => {
 describe('The actions called from the unsaved popup', () => {
   describe('unlinkAttributionAndSavePackageInfoAndNavigateToTargetView', () => {
     test('unlinks and navigates to target view', () => {
-      global.window.ipcRenderer = {
-        on: jest.fn(),
-        removeListener: jest.fn(),
-        invoke: jest.fn(),
-      } as unknown as IpcRenderer;
-
       const testReact = {
         packageName: 'React',
       };
@@ -438,12 +432,6 @@ describe('The actions called from the unsaved popup', () => {
   });
 
   describe('saveTemporaryPackageInfoAndNavigateToTargetView', () => {
-    global.window.ipcRenderer = {
-      on: jest.fn(),
-      removeListener: jest.fn(),
-      invoke: jest.fn(),
-    } as unknown as IpcRenderer;
-
     function prepareTestState(): State {
       const testStore = createTestAppStore();
       const testResources: Resources = {

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +63,6 @@ import {
   setIsSavingDisabled,
   unlinkAttributionAndSavePackageInfo,
 } from '../save-actions';
-import { IpcChannel } from '../../../../../shared/ipc-channels';
 import { getOpenPopup } from '../../../selectors/view-selector';
 
 const testResources: Resources = {
@@ -1254,9 +1254,8 @@ describe('The addToSelectedResource action', () => {
     };
 
     testStore.dispatch(saveManualAndResolvedAttributionsToFile());
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-    expect(window.ipcRenderer.invoke).toHaveBeenCalledWith(
-      IpcChannel.SaveFile,
+    expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
+    expect(window.electronAPI.saveFile).toHaveBeenCalledWith(
       expectedSaveFileArgs
     );
   });

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +25,6 @@ import {
   getResourcesToManualAttributions,
   wereTemporaryPackageInfoModified,
 } from '../../selectors/all-views-resource-selectors';
-import { IpcChannel } from '../../../../shared/ipc-channels';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
   resetSelectedPackagePanelIfContainedAttributionWasRemoved,
@@ -192,7 +192,7 @@ export function saveManualAndResolvedAttributionsToFile(): AppThunkAction {
       resolvedExternalAttributions: getResolvedExternalAttributions(getState()),
     };
 
-    window.ipcRenderer.invoke(IpcChannel.SaveFile, saveFileArgs);
+    window.electronAPI.saveFile(saveFileArgs);
   };
 }
 

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,15 +25,18 @@ import isEmpty from 'lodash/isEmpty';
 
 import { ButtonText } from '../enums/enums';
 import { canResourceHaveChildren } from '../util/can-resource-have-children';
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 
 export function mockElectronBackend(
   mockChannelReturn: ParsedFileContent
 ): void {
-  window.ipcRenderer.on
+  window.electronAPI.on
     // @ts-ignore
     .mockImplementation(
-      mockElectronIpcRendererOn(IpcChannel.FileLoaded, mockChannelReturn)
+      mockElectronIpcRendererOn(
+        AllowedFrontendChannels.FileLoaded,
+        mockChannelReturn
+      )
     );
 }
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { IpcRenderer } from 'electron';
 import { PackagePanelTitle, PopupType } from '../enums/enums';
 import { ResourceState } from '../state/reducers/resource-reducer';
 import { ViewState } from '../state/reducers/view-reducer';
@@ -15,12 +15,6 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../shared/shared-types';
-
-declare global {
-  interface Window {
-    ipcRenderer: IpcRenderer;
-  }
-}
 
 export type State = {
   resourceState: ResourceState;

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { IpcRendererEvent } from 'electron';
 import { useEffect } from 'react';
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   BaseURLForRootArgs,
   ExportType,
@@ -48,15 +50,15 @@ type Listener =
   | ToggleHighlightForCriticalSignalsListener;
 
 export function useIpcRenderer(
-  channel: string,
+  channel: AllowedFrontendChannels,
   listener: Listener,
   dependencies: Array<unknown>
 ): void {
   useEffect(() => {
-    window.ipcRenderer.on(channel, listener);
+    window.electronAPI.on(channel, listener);
 
     return (): void => {
-      window.ipcRenderer.removeListener(channel, listener);
+      window.electronAPI.removeListener(channel, listener);
     };
     // eslint-disable-next-line
   }, dependencies);

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -1,20 +1,24 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 export enum IpcChannel {
   ExportFile = 'export-file',
+  OpenFile = 'open-file',
+  OpenLink = 'open-link',
+  SaveFile = 'save-file',
+  SendErrorInformation = 'send-error-information',
+}
+
+export enum AllowedFrontendChannels {
   ExportFileRequest = 'export-file-request',
   FileLoaded = 'file-loaded',
   Logging = 'logging',
-  OpenFile = 'open-file',
-  OpenLink = 'open-link',
   ResetLoadedFile = 'reset-loaded-file',
   RestoreFrontend = 'restore-frontend',
-  SaveFile = 'save-file',
   SaveFileRequest = 'save-file-request',
-  SendErrorInformation = 'send-error-information',
   ToggleHighlightForCriticalSignals = 'toggle-highlight-for-critical-signals',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { IpcRendererEvent } from 'electron';
 import { ErrorInfo } from 'react';
+import { AllowedFrontendChannels } from './ipc-channels';
 
 export interface Resources {
   [resourceName: string]: Resources | 1;
@@ -186,4 +189,27 @@ export interface ExternalAttributionSources {
     name: string;
     priority: number;
   };
+}
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export type Listener = (event: IpcRendererEvent, ...args: Array<any>) => void;
+
+export interface IElectronAPI {
+  openLink: (link: string) => Promise<unknown>;
+  openFile: () => void;
+  sendErrorInformation: (
+    errorInformationArgs: SendErrorInformationArgs
+  ) => void;
+  exportFile: (args: ExportArgsType) => void;
+  saveFile: (saveFileArgs: SaveFileArgs) => void;
+  on: (channel: AllowedFrontendChannels, listener: Listener) => void;
+  removeListener: (
+    channel: AllowedFrontendChannels,
+    listener: Listener
+  ) => void;
+}
+declare global {
+  interface Window {
+    electronAPI: IElectronAPI;
+  }
 }


### PR DESCRIPTION
### Summary of changes

- Activate context isolation
- Use a context bridge to expose the `ipcRenderer`
- Instead of exposing the full `ipcRenderer` API a subset of functions is exposed
    - for the ocassions where `.invoke` is called an API is defined, which describes the actual action, e.g. `openLink`
    - when listeners are used (`.on` and `.removeListener`) the respective part of the API is exposed but an allow list of channels is applied in the backend before passing anything through  

### Context and reason for change

Deactivating context isolation and exposing `ipcRenderer` globally is discouraged. An attacker could access it from the frontend with `window.ipcRenderer` and would have a rather powerful API. Instead it is recommended to use a preload script where a subset of APIs is exposed.
Details can be found [here](https://www.electronjs.org/docs/latest/tutorial/context-isolation).

### How can the changes be tested

- run all tests
- more importantly open the app and check the actions invoking the `ipcRenderer` are working (saving files, opening links, ...)
