### PR TITLE
fix: Only open valid URLs

### DIFF
--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -25,6 +25,7 @@ import {
   getOpenLinkListener,
   getSaveFileListener,
   getSelectBaseURLListener,
+  linkHasHttpSchema,
 } from '../listeners';
 
 import * as MockDate from 'mockdate';
@@ -538,7 +539,7 @@ describe('getExportSpdxDocumentListener', () => {
 
 describe('getOpenLinkListener', () => {
   test('opens link', async () => {
-    const testLink = 'www.test.de/link';
+    const testLink = 'https://www.test.de/link';
     await getOpenLinkListener()(IpcChannel.OpenLink, {
       link: testLink,
     });
@@ -594,3 +595,23 @@ async function prepareBomSPdxAndFollowUpTest(): Promise<BrowserWindow> {
 
   return await createWindow();
 }
+
+describe('linkHasHttpSchema', () => {
+  it('throws for invalid url', () => {
+    expect(() => {
+      linkHasHttpSchema('/some/local/file');
+    }).toThrow();
+  });
+
+  it('returns true for http', () => {
+    expect(linkHasHttpSchema('http://opossum.de')).toBeTruthy();
+  });
+
+  it('return true for https', () => {
+    expect(linkHasHttpSchema('https://opossum.de')).toBeTruthy();
+  });
+
+  it('returns false for ftp', () => {
+    expect(linkHasHttpSchema('ftp://opossum.de')).toBeFalsy();
+  });
+});

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -161,12 +161,20 @@ export function getSendErrorInformationListener(
   };
 }
 
+export function linkHasHttpSchema(link: string): boolean {
+  const url = new URL(link);
+  return url.protocol === 'https:' || url.protocol === 'http:';
+}
+
 export function getOpenLinkListener(): (
   _: unknown,
   args: OpenLinkArgs
 ) => Promise<Error | void> {
   return async (_, args: OpenLinkArgs): Promise<Error | void> => {
     try {
+      if (!linkHasHttpSchema(args.link)) {
+        throw new Error(`Invalid URL ${args.link}`);
+      }
       // Does not throw on Linux if link cannot be opened.
       // see https://github.com/electron/electron/issues/28183
       return await shell.openExternal(args.link);


### PR DESCRIPTION
### Summary of changes

Validate links before opening them with `open.shellExternal`.

### Context and reason for change

It is generally not recommended to open untrusted content with `open.shellExternal`. Details can be found [here](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content).

