### PR TITLE
Reconfigure follow-up export

### DIFF
--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -6,8 +6,8 @@
 
 import { BrowserWindow, dialog, shell, WebContents } from 'electron';
 import {
-  IpcChannel,
   AllowedFrontendChannels,
+  IpcChannel,
 } from '../../../shared/ipc-channels';
 import {
   Attributions,
@@ -376,14 +376,9 @@ describe('getExportFollowUpListener', () => {
       [
         'packageName',
         'packageVersion',
-        'packageNamespace',
-        'packageType',
-        'packagePURLAppendix',
         'url',
         'copyright',
         'licenseName',
-        'licenseText',
-        'excludeFromNotice',
         'resources',
       ],
       true

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -288,14 +288,9 @@ async function createFollowUp(
   const followUpColumnOrder: Array<KeysOfAttributionInfo> = [
     'packageName',
     'packageVersion',
-    'packageNamespace',
-    'packageType',
-    'packagePURLAppendix',
     'url',
     'copyright',
     'licenseName',
-    'licenseText',
-    'excludeFromNotice',
     'resources',
   ];
 


### PR DESCRIPTION

### Summary of changes

The follow-up export is configured to include fewer attributes.

### Context and reason for change

The follow-up export turned out to contain too much information.

