### PR TITLE
Fix removal of listeners

### DIFF
--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -19,12 +19,12 @@ function on(channel: AllowedFrontendChannels, listener: Listener): void {
   }
 }
 
-function removeListener(
-  channel: AllowedFrontendChannels,
-  listener: Listener
-): void {
+function removeListener(channel: AllowedFrontendChannels): void {
   if (Object.values(AllowedFrontendChannels).includes(channel)) {
-    ipcRenderer.removeListener(channel, listener);
+    // we remove all listeners to fix a bug we had with using
+    // ipcRenderer.removeListener in combination with the
+    // context bridge.
+    ipcRenderer.removeAllListeners(channel);
   }
 }
 

--- a/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/Frontend/Components/ErrorBoundary/ErrorBoundary.tsx
@@ -67,13 +67,7 @@ class ProtoErrorBoundary extends React.Component<
   }
 
   componentWillUnmount(): void {
-    window.electronAPI.removeListener(
-      AllowedFrontendChannels.RestoreFrontend,
-      () => {
-        this.props.resetState();
-        this.setState({ hasError: false });
-      }
-    );
+    window.electronAPI.removeListener(AllowedFrontendChannels.RestoreFrontend);
   }
 
   static getDerivedStateFromError(): ErrorBoundaryState {

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -58,7 +58,7 @@ export function useIpcRenderer(
     window.electronAPI.on(channel, listener);
 
     return (): void => {
-      window.electronAPI.removeListener(channel, listener);
+      window.electronAPI.removeListener(channel);
     };
     // eslint-disable-next-line
   }, dependencies);

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -203,10 +203,7 @@ export interface IElectronAPI {
   exportFile: (args: ExportArgsType) => void;
   saveFile: (saveFileArgs: SaveFileArgs) => void;
   on: (channel: AllowedFrontendChannels, listener: Listener) => void;
-  removeListener: (
-    channel: AllowedFrontendChannels,
-    listener: Listener
-  ) => void;
+  removeListener: (channel: AllowedFrontendChannels) => void;
 }
 declare global {
   interface Window {


### PR DESCRIPTION
### Summary of changes

Always remove all listeners of a channel.

### Context and reason for change

When we introduced the contextBridge the removal of listeners broke, causing e.g. the export of follow-ups to be triggered multiple times.  For details see #825.


### How can the changes be tested

Carefully test file exports and saving operations (everything that relys on listeners).

