### PR TITLE
The menu point "Highlight critical signals" grayed out if no critical signals

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -381,8 +381,8 @@ describe('Test of loading function', () => {
     };
 
     setGlobalBackendState(globalBackendState);
-
     await loadJsonFromFilePath(mainWindow.webContents, jsonPath);
+
     const expectedLoadedFile: ParsedFileContent = {
       metadata: EMPTY_PROJECT_METADATA,
       resources: { a: 1 },

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -95,8 +95,12 @@ describe('sanitizeRawAttributions', () => {
         followUp: FollowUp,
       },
     };
+    const expectedCriticalSignalsFlag = false;
 
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedCriticalSignalsFlag,
+    ]);
   });
 
   test('removes unknown strings from followUp', () => {
@@ -108,8 +112,11 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
-
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    const expectedCriticalSignalsFlag = false;
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedCriticalSignalsFlag,
+    ]);
   });
 
   test('leaves non-empty comment unchanged', () => {
@@ -123,8 +130,12 @@ describe('sanitizeRawAttributions', () => {
         comment: 'Test comment',
       },
     };
+    const expectedcriticalSignalsFlag = false;
 
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedcriticalSignalsFlag,
+    ]);
   });
 
   test('removes empty comment', () => {
@@ -136,8 +147,12 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
+    const expectedCriticalSignalsFlag = false;
 
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedCriticalSignalsFlag,
+    ]);
   });
 
   test('leaves criticality unchanged', () => {
@@ -151,8 +166,12 @@ describe('sanitizeRawAttributions', () => {
         criticality: Criticality.High,
       },
     };
+    const expectedcriticalSignalsFlag = true;
 
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedcriticalSignalsFlag,
+    ]);
   });
 
   test('removes empty comment', () => {
@@ -164,8 +183,12 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
+    const expectedcriticalSignalsFlag = false;
 
-    expect(parseRawAttributions(rawAttributions)).toEqual(expectedAttributions);
+    expect(parseRawAttributions(rawAttributions)).toEqual([
+      expectedAttributions,
+      expectedcriticalSignalsFlag,
+    ]);
   });
 });
 

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -61,9 +61,8 @@ export async function loadJsonFromFilePath(
   }
 
   log.info('... Successfully parsed input file.');
-  const externalAttributions = parseRawAttributions(
-    parsingResult.externalAttributions
-  );
+  const [externalAttributions, inputContainsCriticalSignals] =
+    parseRawAttributions(parsingResult.externalAttributions);
 
   const manualAttributionFilePath = getFilePathWithAppendix(
     filePath,
@@ -84,7 +83,7 @@ export async function loadJsonFromFilePath(
 
   log.info(`Starting to parse output file ${manualAttributionFilePath} ...`);
   const opossumOutputData = parseOpossumOutputFile(manualAttributionFilePath);
-  const manualAttributions = parseRawAttributions(
+  const [manualAttributions] = parseRawAttributions(
     opossumOutputData.manualAttributions
   );
   log.info('... Successfully parsed output file.');
@@ -151,6 +150,7 @@ export async function loadJsonFromFilePath(
     spdxYamlFilePath: getFilePathWithAppendix(filePath, '.spdx.yaml'),
     spdxJsonFilePath: getFilePathWithAppendix(filePath, '.spdx.json'),
     projectTitle: parsingResult.metadata.projectTitle,
+    inputContainsCriticalSignals,
   };
   setGlobalBackendState(newGlobalBackendState);
 

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -128,7 +128,9 @@ export function cleanNonExistentResolvedExternalSignals(
 
 export function parseRawAttributions(
   rawAttributions: RawAttributions
-): Attributions {
+): [Attributions, boolean] {
+  let inputContainsCriticalSignals = false;
+
   for (const attributionId of Object.keys(rawAttributions)) {
     if (rawAttributions[attributionId]?.followUp !== FollowUp) {
       delete rawAttributions[attributionId].followUp;
@@ -140,9 +142,13 @@ export function parseRawAttributions(
     if (criticality && !Object.values(Criticality).includes(criticality)) {
       delete rawAttributions[attributionId].criticality;
     }
+
+    if (rawAttributions[attributionId]?.criticality) {
+      inputContainsCriticalSignals = true;
+    }
   }
 
-  return rawAttributions as Attributions;
+  return [rawAttributions as Attributions, inputContainsCriticalSignals];
 }
 
 export function parseFrequentLicenses(

--- a/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
@@ -31,6 +31,7 @@ jest.mock('electron', () => ({
   Menu: {
     setApplicationMenu: jest.fn(),
     buildFromTemplate: jest.fn(),
+    getApplicationMenu: jest.fn(),
   },
 }));
 

--- a/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
@@ -31,6 +31,7 @@ jest.mock('electron', () => ({
   Menu: {
     setApplicationMenu: jest.fn(),
     buildFromTemplate: jest.fn(),
+    getApplicationMenu: jest.fn(),
   },
 }));
 

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -75,6 +75,7 @@ jest.mock('electron', () => ({
   Menu: {
     setApplicationMenu: jest.fn(),
     buildFromTemplate: jest.fn(),
+    getApplicationMenu: jest.fn(),
   },
   dialog: {
     showOpenDialogSync: jest.fn(),

--- a/src/ElectronBackend/main/__tests__/main.test.ts
+++ b/src/ElectronBackend/main/__tests__/main.test.ts
@@ -44,6 +44,7 @@ jest.mock('electron', () => ({
   Menu: {
     setApplicationMenu: jest.fn(),
     buildFromTemplate: jest.fn(),
+    getApplicationMenu: jest.fn(),
   },
   dialog: {
     showMessageBox: jest.fn(),

--- a/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
+++ b/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
@@ -36,6 +36,7 @@ jest.mock('electron', () => ({
   Menu: {
     setApplicationMenu: jest.fn(),
     buildFromTemplate: jest.fn(),
+    getApplicationMenu: jest.fn(),
   },
   dialog: {
     showMessageBox: jest.fn(),

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { BrowserWindow, shell, WebContents } from 'electron';
+import { BrowserWindow, Menu, shell, WebContents } from 'electron';
 import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   ExportArgsType,
@@ -33,6 +33,7 @@ import { openFileDialog, selectBaseURLDialog } from './dialogs';
 import fs from 'fs';
 import { writeSpdxFile } from '../output/writeSpdxFile';
 import log from 'electron-log';
+import { createMenu } from './menu';
 
 export function getSaveFileListener(
   webContents: WebContents
@@ -135,6 +136,8 @@ export async function openFile(
   try {
     await loadJsonFromFilePath(mainWindow.webContents, filePath);
     setTitle(mainWindow, filePath);
+    mainWindow.removeMenu();
+    Menu.setApplicationMenu(createMenu(mainWindow));
   } finally {
     loadingWindow.close();
   }

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -29,6 +29,7 @@ export interface GlobalBackendState {
   spdxYamlFilePath?: string;
   spdxJsonFilePath?: string;
   projectId?: string;
+  inputContainsCriticalSignals?: boolean;
 }
 
 interface RawPackageInfo {


### PR DESCRIPTION
### Summary of changes

If the input file has no critical signals (none of the "medium" and "high"), the menu point "Highlight critical signals" is disabled.

### Context and reason for change

The menu point "Highlight critical signals" should be grayed out if none exists.

### How can the changes be tested

Open an input file without critical signals, e.g. `large_opossum_input.json` from example files.

