### PR TITLE
Use it instead of test

### DIFF
--- a/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
+++ b/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
@@ -36,7 +36,7 @@ jest.mock('../../input/importFromFile', () => ({
 
 describe('error handling', () => {
   describe('createListenerCallbackWithErrorHandling', () => {
-    test('returns a wrapper that calls the input function with the same parameters', async () => {
+    it('returns a wrapper that calls the input function with the same parameters', async () => {
       const testFunction = jest.fn();
       const testArgs = {
         arg1: '1',
@@ -56,7 +56,7 @@ describe('error handling', () => {
       );
     });
 
-    test('shows errors from the input function in a messageBox', async () => {
+    it('shows errors from the input function in a messageBox', async () => {
       function testFunction(): void {
         throw new Error('TEST_ERROR');
       }
@@ -80,7 +80,7 @@ describe('error handling', () => {
   });
 
   describe('getMessageBoxContentForErrors', () => {
-    test('for backend errors', () => {
+    it('for backend errors', () => {
       const testError = new Error('TEST_ERROR');
       const messageBoxContentForBackendErrors =
         getMessageBoxContentForErrorsWrapper(
@@ -95,7 +95,7 @@ describe('error handling', () => {
       );
     });
 
-    test('for frontend errors', () => {
+    it('for frontend errors', () => {
       const testError = new Error('TEST_ERROR');
       const messageBoxContentForBackendErrors =
         getMessageBoxContentForErrorsWrapper(
@@ -112,7 +112,7 @@ describe('error handling', () => {
   });
 
   describe('getMessageBoxForErrors', () => {
-    test('returns a messageBox', async () => {
+    it('returns a messageBox', async () => {
       const sendErrorInformationArgs: SendErrorInformationArgs = {
         error: { message: 'errorMessage', name: 'Error' },
         errorInfo: { componentStack: 'componentStack' },
@@ -144,7 +144,7 @@ describe('error handling', () => {
   });
 
   describe('getMessageBoxContentForParsingErrors', () => {
-    test('display an error message', () => {
+    it('display an error message', () => {
       const testMessage = 'Test error message';
       const messageBoxContentForParsingErrors =
         getMessageBoxContentForParsingError(testMessage);
@@ -158,7 +158,7 @@ describe('error handling', () => {
   });
 
   describe('getMessageBoxForParsingError', () => {
-    test('returns a messageBox', async () => {
+    it('returns a messageBox', async () => {
       const parsingError: JsonParsingError = {
         message: 'parsingErrorMessage',
         type: 'jsonParsingError',

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -169,7 +169,7 @@ describe('Test of loading function', () => {
     jest.resetAllMocks();
   });
 
-  test('handles Parsing error correctly', async () => {
+  it('handles Parsing error correctly', async () => {
     const temporaryPath: string = createTempFolder();
     const corruptJsonPath = path.join(
       upath.toUnix(temporaryPath),
@@ -205,7 +205,7 @@ describe('Test of loading function', () => {
   });
 
   describe('Load file and parse file successfully, no attribution file', () => {
-    test('for json file', async () => {
+    it('for json file', async () => {
       const temporaryPath: string = createTempFolder();
       const jsonPath = path.join(upath.toUnix(temporaryPath), 'test.json');
       writeJsonToFile(jsonPath, inputFileContent);
@@ -225,7 +225,7 @@ describe('Test of loading function', () => {
       deleteFolder(temporaryPath);
     });
 
-    test('for json.gz file', async () => {
+    it('for json.gz file', async () => {
       const temporaryPath: string = createTempFolder();
       const jsonPath = path.join(upath.toUnix(temporaryPath), 'test.json.gz');
       fs.writeFileSync(
@@ -421,7 +421,7 @@ describe('Test of loading function', () => {
     }
   );
 
-  test('loads file and parses json successfully, custom metadata', async () => {
+  it('loads file and parses json successfully, custom metadata', async () => {
     const inputFileContentWithCustomMetadata: ParsedOpossumInputFile = {
       ...inputFileContent,
       metadata: {

--- a/src/ElectronBackend/input/__tests__/parseFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseFile.test.ts
@@ -107,7 +107,7 @@ describe('parseResources', () => {
     jest.resetAllMocks();
   });
 
-  test('reads an input.json file correctly', async () => {
+  it('reads an input.json file correctly', async () => {
     const testFileContent = correctInput;
     const temporaryPath: string = createTempFolder();
     const resourcesPath = path.join(
@@ -121,7 +121,7 @@ describe('parseResources', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('reads custom metadata correctly', async () => {
+  it('reads custom metadata correctly', async () => {
     const testFileContent = {
       ...correctInput,
       metadata: {
@@ -147,7 +147,7 @@ describe('parseResources', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('returns JSONParsingError on an incorrect Resource.json file', async () => {
+  it('returns JSONParsingError on an incorrect Resource.json file', async () => {
     const testFileContent = corruptInput;
     const temporaryPath: string = createTempFolder();
     const resourcesPath = path.join(
@@ -164,7 +164,7 @@ describe('parseResources', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('reads an input.json.gz file correctly', async () => {
+  it('reads an input.json.gz file correctly', async () => {
     const testFileContent = zlib.gzipSync(JSON.stringify(correctInput));
     const temporaryPath: string = createTempFolder();
     const resourcesPath = path.join(
@@ -178,7 +178,7 @@ describe('parseResources', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('returns JSONParsingError on an incorrect Resource.json.gz file', async () => {
+  it('returns JSONParsingError on an incorrect Resource.json.gz file', async () => {
     const testFileContent = zlib.gzipSync(JSON.stringify(corruptInput));
     const temporaryPath: string = createTempFolder();
     const resourcesPath = path.join(
@@ -224,7 +224,7 @@ describe('parseOpossumOutputFile', () => {
     jest.resetAllMocks();
   });
 
-  test('reads a correct file', () => {
+  it('reads a correct file', () => {
     const temporaryPath: string = createTempFolder();
     const attributionPath = path.join(
       upath.toUnix(temporaryPath),
@@ -238,7 +238,7 @@ describe('parseOpossumOutputFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('throws when reading an incorrect file', () => {
+  it('throws when reading an incorrect file', () => {
     const temporaryPath: string = createTempFolder();
     const attributionPath = path.join(
       upath.toUnix(temporaryPath),
@@ -255,7 +255,7 @@ describe('parseOpossumOutputFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('tolerates an attribution file with wrong projectId', () => {
+  it('tolerates an attribution file with wrong projectId', () => {
     const temporaryPath: string = createTempFolder();
     const attributionPath = path.join(
       upath.toUnix(temporaryPath),

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -36,7 +36,7 @@ describe('cleanNonExistentAttributions', () => {
     jest.resetAllMocks();
   });
 
-  test('removes non-existent attributions', () => {
+  it('removes non-existent attributions', () => {
     const resourcesToAttributions: ResourcesToAttributions = {
       '/file1': ['attr1', 'attr2', 'attr3', 'attr4'],
       '/file2': ['attr3'],
@@ -65,7 +65,7 @@ describe('cleanNonExistentResolvedExternalSignals', () => {
     jest.resetAllMocks();
   });
 
-  test('removes non-existent resolved external attributions', () => {
+  it('removes non-existent resolved external attributions', () => {
     const resolvedExternalAttributions: Set<string> = new Set<string>()
       .add('attr2')
       .add('invalid');
@@ -84,7 +84,7 @@ describe('cleanNonExistentResolvedExternalSignals', () => {
 });
 
 describe('sanitizeRawAttributions', () => {
-  test('leaves FollowUp as followUp', () => {
+  it('leaves FollowUp as followUp', () => {
     const rawAttributions: RawAttributions = {
       id: {
         followUp: FollowUp,
@@ -103,7 +103,7 @@ describe('sanitizeRawAttributions', () => {
     ]);
   });
 
-  test('removes unknown strings from followUp', () => {
+  it('removes unknown strings from followUp', () => {
     const rawAttributions: RawAttributions = {
       id: {
         followUp: 'UNKNOWN_STRING',
@@ -119,7 +119,7 @@ describe('sanitizeRawAttributions', () => {
     ]);
   });
 
-  test('leaves non-empty comment unchanged', () => {
+  it('leaves non-empty comment unchanged', () => {
     const rawAttributions: RawAttributions = {
       id: {
         comment: 'Test comment',
@@ -138,7 +138,7 @@ describe('sanitizeRawAttributions', () => {
     ]);
   });
 
-  test('removes empty comment', () => {
+  it('removes empty comment', () => {
     const rawAttributions: RawAttributions = {
       id: {
         comment: '',
@@ -155,7 +155,7 @@ describe('sanitizeRawAttributions', () => {
     ]);
   });
 
-  test('leaves criticality unchanged', () => {
+  it('leaves criticality unchanged', () => {
     const rawAttributions: RawAttributions = {
       id: {
         criticality: 'high' as Criticality,
@@ -174,7 +174,7 @@ describe('sanitizeRawAttributions', () => {
     ]);
   });
 
-  test('removes empty comment', () => {
+  it('removes empty comment', () => {
     const rawAttributions: RawAttributions = {
       id: {
         criticality: 'invalid value' as Criticality,
@@ -193,7 +193,7 @@ describe('sanitizeRawAttributions', () => {
 });
 
 describe('sanitizeRawBaseUrlsForSources', () => {
-  test('adds / to path', () => {
+  it('adds / to path', () => {
     const rawBaseUrlsForSources: RawBaseUrlsForSources = {
       'test/path': 'www.test.it',
     };
@@ -206,13 +206,13 @@ describe('sanitizeRawBaseUrlsForSources', () => {
     );
   });
 
-  test('works with undefined', () => {
+  it('works with undefined', () => {
     expect(sanitizeRawBaseUrlsForSources(undefined)).toEqual({});
   });
 });
 
 describe('parseFrequentLicenses', () => {
-  test('handles undefined', () => {
+  it('handles undefined', () => {
     const rawFrequentLicenses = undefined;
     const expectedFrequentLicenses: FrequentLicences = {
       nameOrder: [],
@@ -224,7 +224,7 @@ describe('parseFrequentLicenses', () => {
     );
   });
 
-  test('handles empty array', () => {
+  it('handles empty array', () => {
     const rawFrequentLicenses: Array<RawFrequentLicense> = [];
     const expectedFrequentLicenses: FrequentLicences = {
       nameOrder: [],
@@ -236,7 +236,7 @@ describe('parseFrequentLicenses', () => {
     );
   });
 
-  test('handles non-empty array', () => {
+  it('handles non-empty array', () => {
     const rawFrequentLicenses: Array<RawFrequentLicense> = [
       {
         shortName: 'MIT',

--- a/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
@@ -40,7 +40,7 @@ jest.mock('electron-is-dev', () => true);
 describe('createWindow', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  test('returns correct BrowserWindow in devMode', async () => {
+  it('returns correct BrowserWindow in devMode', async () => {
     const browserWindow = await createWindow();
     expect(browserWindow.webContents.openDevTools).toHaveBeenCalled();
     expect(browserWindow.loadURL).toHaveBeenCalledWith('http://localhost:3000');

--- a/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
@@ -45,7 +45,7 @@ jest.mock('../iconHelpers', () => ({
 describe('createWindow', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  test('returns correct BrowserWindow in production', async () => {
+  it('returns correct BrowserWindow in production', async () => {
     const browserWindow = await createWindow();
     expect(browserWindow.webContents.openDevTools).not.toHaveBeenCalled();
     expect(browserWindow.loadURL).not.toHaveBeenCalledWith(

--- a/src/ElectronBackend/main/__tests__/globalBackendState.test.ts
+++ b/src/ElectronBackend/main/__tests__/globalBackendState.test.ts
@@ -16,10 +16,10 @@ describe('The global backend state', () => {
     projectId: 'uuid_1',
   };
 
-  test('is empty upon initialization.', () => {
+  it('is empty upon initialization.', () => {
     expect(getGlobalBackendState()).toMatchObject({});
   });
-  test('can be set and read', () => {
+  it('can be set and read', () => {
     setGlobalBackendState(newGlobalBackendState);
     expect(getGlobalBackendState()).toMatchObject(newGlobalBackendState);
   });

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -27,12 +27,12 @@ import {
   _exportFileAndOpenFolder,
   getDeleteAndCreateNewAttributionFileListener,
   getExportFileListener,
+  getKeepFileListener,
   getOpenFileListener,
   getOpenLinkListener,
   getSaveFileListener,
   getSelectBaseURLListener,
   linkHasHttpSchema,
-  getKeepFileListener,
 } from '../listeners';
 
 import * as MockDate from 'mockdate';
@@ -129,7 +129,7 @@ describe('getOpenFileListener', () => {
   each([
     ['path.json', 'path.json'],
     ['path%20with%2Fencoding.json', 'path with/encoding.json'],
-  ]).test(
+  ]).it(
     'calls loadJsonFromFilePath and handles %s correctly',
     async (filePath: string, expectedTitle: string) => {
       const mainWindow = {
@@ -170,7 +170,7 @@ describe('getOpenFileListener', () => {
     }
   );
 
-  test('handles _attributions.json files correctly if .json present', async () => {
+  it('handles _attributions.json files correctly if .json present', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -206,7 +206,7 @@ describe('getOpenFileListener', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('checks the case with non-matching checksums', async () => {
+  it('checks the case with non-matching checksums', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -279,7 +279,7 @@ describe('getOpenFileListener', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('handles _attributions.json files correctly if .json.gz present', async () => {
+  it('handles _attributions.json files correctly if .json.gz present', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -315,7 +315,7 @@ describe('getOpenFileListener', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('sets title to project title if available', async () => {
+  it('sets title to project title if available', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -363,7 +363,7 @@ describe('getOpenFileListener', () => {
 });
 
 describe('getDeleteAndCreateNewAttributionFileListener', () => {
-  test('deletes attribution file and calls loadJsonFromFilePath', async () => {
+  it('deletes attribution file and calls loadJsonFromFilePath', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -396,7 +396,7 @@ describe('getDeleteAndCreateNewAttributionFileListener', () => {
 });
 
 describe('getKeepFileListener', () => {
-  test('calls loadJsonFromFilePath with a correct path', async () => {
+  it('calls loadJsonFromFilePath with a correct path', async () => {
     const mainWindow = {
       webContents: {
         send: jest.fn(),
@@ -418,7 +418,7 @@ describe('getKeepFileListener', () => {
 });
 
 describe('getSelectBaseURLListener', () => {
-  test('opens base url dialog and sends selected path to frontend', () => {
+  it('opens base url dialog and sends selected path to frontend', () => {
     const mockCallback = jest.fn();
     const webContents = { send: mockCallback as unknown } as WebContents;
     const baseURL = '/Users/path/to/sources';
@@ -445,7 +445,7 @@ describe('getSaveFileListener', () => {
     writeJsonToFile.mockReset();
   });
 
-  test('throws error when attributionFilePath and projectId are not set', async () => {
+  it('throws error when attributionFilePath and projectId are not set', async () => {
     const mockCallback = jest.fn();
     const webContents = { send: mockCallback as unknown } as WebContents;
     setGlobalBackendState({});
@@ -471,7 +471,7 @@ describe('getSaveFileListener', () => {
     expect(writeJsonToFile).not.toBeCalled();
   });
 
-  test(
+  it(
     'calls createListenerCallBackWithErrorHandling when ' +
       'attributionFilePath and projectId are set',
     () => {
@@ -506,8 +506,8 @@ describe('getSaveFileListener', () => {
 });
 
 describe('getExportFollowUpListener', () => {
-  test('throws error when followUpFilePath is not set', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+  it('throws error when followUpFilePath is not set', async () => {
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
 
     await getExportFileListener(mainWindow)(IpcChannel.ExportFile, {
       type: ExportType.FollowUp,
@@ -524,8 +524,8 @@ describe('getExportFollowUpListener', () => {
     expect(writeCsvToFile).not.toBeCalled();
   });
 
-  test('calls getExportFollowUpListener', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+  it('calls getExportFollowUpListener', async () => {
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
     setGlobalBackendState({
       followUpFilePath: '/somefile.csv',
     });
@@ -567,8 +567,8 @@ describe('getExportFollowUpListener', () => {
 });
 
 describe('getExportBomListener', () => {
-  test('throws error when bomFilePath is not set', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+  it('throws error when bomFilePath is not set', async () => {
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
 
     await getExportFileListener(mainWindow)(IpcChannel.ExportFile, {
       type: ExportType.CompactBom,
@@ -585,8 +585,8 @@ describe('getExportBomListener', () => {
     expect(writeCsvToFile).not.toBeCalled();
   });
 
-  test('calls getExportBomListener for compact bom', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+  it('calls getExportBomListener for compact bom', async () => {
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
 
     const listener = getExportFileListener(mainWindow);
 
@@ -618,8 +618,8 @@ describe('getExportBomListener', () => {
     );
   });
 
-  test('calls getExportBomListener for detailed bom', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+  it('calls getExportBomListener for detailed bom', async () => {
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
 
     const listener = getExportFileListener(mainWindow);
 
@@ -672,7 +672,7 @@ describe('getExportSpdxDocumentListener', () => {
   });
 
   it('throws if path is not set', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
 
     await getExportFileListener(mainWindow)(IpcChannel.ExportFile, {
       type: ExportType.SpdxDocumentYaml,
@@ -690,7 +690,7 @@ describe('getExportSpdxDocumentListener', () => {
   });
 
   it('calls getExportSpdxDocumentListener for yaml', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
     const testArgs: ExportSpdxDocumentYamlArgs = {
       type: ExportType.SpdxDocumentYaml,
       spdxAttributions: {},
@@ -706,7 +706,7 @@ describe('getExportSpdxDocumentListener', () => {
   });
 
   it('calls getExportSpdxDocumentListener for json', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
     const testArgs: ExportSpdxDocumentJsonArgs = {
       type: ExportType.SpdxDocumentJson,
       spdxAttributions: {},
@@ -723,7 +723,7 @@ describe('getExportSpdxDocumentListener', () => {
 });
 
 describe('getOpenLinkListener', () => {
-  test('opens link', async () => {
+  it('opens link', async () => {
     const testLink = 'https://www.test.de/link';
     await getOpenLinkListener()(IpcChannel.OpenLink, {
       link: testLink,
@@ -739,7 +739,7 @@ describe('_exportFileAndOpenFolder', () => {
   });
 
   it('calls the createFile function', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
     const testSpdxDocumentYamlFilePath = '/some/path.json';
     setGlobalBackendState({ spdxYamlFilePath: testSpdxDocumentYamlFilePath });
     const testArgs: ExportSpdxDocumentYamlArgs = {
@@ -758,7 +758,7 @@ describe('_exportFileAndOpenFolder', () => {
   });
 
   it('throws if outputFilePath is not set', async () => {
-    const mainWindow = await prepareBomSPdxAndFollowUpTest();
+    const mainWindow = await prepareBomSPdxAndFollowUpit();
     setGlobalBackendState({ spdxYamlFilePath: undefined });
     const testArgs: ExportSpdxDocumentYamlArgs = {
       type: ExportType.SpdxDocumentYaml,
@@ -773,7 +773,7 @@ describe('_exportFileAndOpenFolder', () => {
   });
 });
 
-async function prepareBomSPdxAndFollowUpTest(): Promise<BrowserWindow> {
+async function prepareBomSPdxAndFollowUpit(): Promise<BrowserWindow> {
   // @ts-ignore
   writeCsvToFile.mockReset();
   setGlobalBackendState({});

--- a/src/ElectronBackend/main/__tests__/main.test.ts
+++ b/src/ElectronBackend/main/__tests__/main.test.ts
@@ -55,7 +55,7 @@ jest.mock('electron', () => ({
 }));
 
 describe('The App backend', () => {
-  test('calls ipc handler', async () => {
+  it('calls ipc handler', async () => {
     await main();
 
     expect(ipcMain.handle).toHaveBeenCalledTimes(7);

--- a/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
+++ b/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
@@ -43,7 +43,7 @@ jest.mock('electron', () => ({
   },
 }));
 describe('The App backend', () => {
-  test('handles errors', async () => {
+  it('handles errors', async () => {
     // we expect warnings that we do not want to see
     jest.spyOn(console, 'log');
 

--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -22,7 +22,7 @@ const testCsvHeader =
   '"Follow-up";"Origin Attribution ID";"pre-selected";"exclude-from-notice";"criticality";"Resources"';
 
 describe('writeCsvToFile', () => {
-  test('writeCsvToFile short', async () => {
+  it('writeCsvToFile short', async () => {
     const testFollowUpAttributionsWithResources: AttributionsWithResources = {
       key1: {
         followUp: undefined,
@@ -57,7 +57,7 @@ describe('writeCsvToFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('writeCsvToFile custom header', async () => {
+  it('writeCsvToFile custom header', async () => {
     const testFollowUpAttributionsWithResources: AttributionsWithResources = {
       key1: {
         followUp: undefined,
@@ -91,7 +91,7 @@ describe('writeCsvToFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('writeCsvToFile shorten resources', async () => {
+  it('writeCsvToFile shorten resources', async () => {
     const testFollowUpAttributionsWithResources: AttributionsWithResources = {
       key1: {
         followUp: undefined,
@@ -126,7 +126,7 @@ describe('writeCsvToFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('writeCsvToFile shorten resources long', async () => {
+  it('writeCsvToFile shorten resources long', async () => {
     const manyResources = Array.from(
       { length: 250 },
       (_, i) =>
@@ -170,7 +170,7 @@ describe('writeCsvToFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('writeCsvToFile for attributions', async () => {
+  it('writeCsvToFile for attributions', async () => {
     const columns: Array<KeysOfAttributionInfo> = [
       'packageName',
       'licenseText',
@@ -199,7 +199,7 @@ describe('writeCsvToFile', () => {
     deleteFolder(temporaryPath);
   });
 
-  test('writeCsvToFile long', async () => {
+  it('writeCsvToFile long', async () => {
     const testLicenseText =
       ' Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.\n' +
       'Preamble\n' +
@@ -476,7 +476,7 @@ describe('writeCsvToFile', () => {
 });
 
 describe('getHeadersFromColumnOrder', () => {
-  test('returns an header dictionary for keys in package info', () => {
+  it('returns an header dictionary for keys in package info', () => {
     const columns: Array<KeysOfAttributionInfo> = [
       'copyright',
       'licenseName',

--- a/src/ElectronBackend/output/__tests__/writeJsonToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeJsonToFile.test.ts
@@ -46,7 +46,7 @@ const attributions: OpossumOutputFile = {
 };
 
 describe('writeJsonToFile', () => {
-  test('Test writeJsonToFile', () => {
+  it('Test writeJsonToFile', () => {
     const temporaryPath: string = createTempFolder();
     const jsonPath = path.join(upath.toUnix(temporaryPath), 'test.json');
     writeJsonToFile(jsonPath, attributions);

--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AggregatedAttributionsPanel.test.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AggregatedAttributionsPanel.test.tsx
@@ -28,7 +28,7 @@ import {
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
 describe('The AggregatedAttributionsPanel', () => {
-  test('renders', () => {
+  it('renders', () => {
     const testResources: Resources = { file: 1 };
 
     const testManualAttributions: Attributions = {
@@ -93,7 +93,7 @@ describe('The AggregatedAttributionsPanel', () => {
     );
   });
 
-  test('shows correct replace attribution buttons in the context menu', () => {
+  it('shows correct replace attribution buttons in the context menu', () => {
     const testResources: Resources = {
       root: { src: { file_1: 1, file_2: 1 } },
       file: 1,

--- a/src/Frontend/Components/AllAttributionsPanel/__tests__/AllAttributionsPanel.test.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/__tests__/AllAttributionsPanel.test.tsx
@@ -48,7 +48,7 @@ describe('The AllAttributionsPanel', () => {
     },
   };
 
-  test('renders empty list', () => {
+  it('renders empty list', () => {
     renderComponentWithStore(
       <AllAttributionsPanel
         attributions={{}}
@@ -59,7 +59,7 @@ describe('The AllAttributionsPanel', () => {
     );
   });
 
-  test('renders non-empty list', () => {
+  it('renders non-empty list', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'name 1' },
       uuid2: { packageName: 'name 2' },
@@ -85,7 +85,7 @@ describe('The AllAttributionsPanel', () => {
     screen.getByText('name 2');
   });
 
-  test('does not show resource attribution of selected resource and next attributed parent', () => {
+  it('does not show resource attribution of selected resource and next attributed parent', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -113,7 +113,7 @@ describe('The AllAttributionsPanel', () => {
     expect(screen.getByText('Vue, 3.0')).toBeInTheDocument();
   });
 
-  test('has search functionality', () => {
+  it('has search functionality', () => {
     const testAttributions: Attributions = {
       uuid1: {
         packageName: 'name 1',
@@ -154,7 +154,7 @@ describe('The AllAttributionsPanel', () => {
     screen.getByText('name 2');
   });
 
-  test('shows correct replace attribution buttons in the context menu', () => {
+  it('shows correct replace attribution buttons in the context menu', () => {
     const testResources: Resources = {
       root: { src: { file_1: 1, file_2: 1 } },
       file: 1,

--- a/src/Frontend/Components/AppContainer/__tests__/AppContainer.test.tsx
+++ b/src/Frontend/Components/AppContainer/__tests__/AppContainer.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
 describe('The AppContainer', () => {
-  test('renders AppContainer', () => {
+  it('renders AppContainer', () => {
     renderComponentWithStore(<AppContainer />);
   });
 });

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -47,7 +47,7 @@ import {
 import { act } from 'react-dom/test-utils';
 
 describe('The AttributionColumn', () => {
-  test('renders TextBoxes with right titles and content', () => {
+  it('renders TextBoxes with right titles and content', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
@@ -127,7 +127,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('renders qualifier in the purl correctly', () => {
+  it('renders qualifier in the purl correctly', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
@@ -173,7 +173,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('sorts qualifier in the purl alphabetically', () => {
+  it('sorts qualifier in the purl alphabetically', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
@@ -219,7 +219,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('removes special symbol from the end of the purl if nothing follows', () => {
+  it('removes special symbol from the end of the purl if nothing follows', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
@@ -257,7 +257,7 @@ describe('The AttributionColumn', () => {
     expectValueInTextBox(screen, 'PURL', 'pkg:type/namespace/jQuery@16.5.0');
   });
 
-  test('renders a TextBox for the source, if it is defined', () => {
+  it('renders a TextBox for the source, if it is defined', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       source: { name: 'The Source', documentConfidence: 10 },
     };
@@ -285,7 +285,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('renders a checkbox for Follow-up', () => {
+  it('renders a checkbox for Follow-up', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
     };
@@ -313,7 +313,7 @@ describe('The AttributionColumn', () => {
     expect(getTemporaryPackageInfo(store.getState()).followUp).toBe(FollowUp);
   });
 
-  test('renders a checkbox for Exclude from notice', () => {
+  it('renders a checkbox for Exclude from notice', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
     };
@@ -345,7 +345,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('renders an url icon and opens a link in browser', () => {
+  it('renders an url icon and opens a link in browser', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       url: 'https://www.testurl.com/',
     };
@@ -371,7 +371,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('opens a link without protocol', () => {
+  it('opens a link without protocol', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       url: 'www.testurl.com',
     };
@@ -396,7 +396,7 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  test('disables url icon if empty url', () => {
+  it('disables url icon if empty url', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       url: '',
     };
@@ -421,7 +421,7 @@ describe('The AttributionColumn', () => {
   });
 
   describe('there are different license text labels', () => {
-    test('shows standard text if editable and non frequent license', () => {
+    it('shows standard text if editable and non frequent license', () => {
       const testTemporaryPackageInfo: PackageInfo = { packageName: 'jQuery' };
       renderComponentWithStore(
         <AttributionColumn
@@ -445,7 +445,7 @@ describe('The AttributionColumn', () => {
       );
     });
 
-    test('shows shortened text if not editable and frequent license', () => {
+    it('shows shortened text if not editable and frequent license', () => {
       const testTemporaryPackageInfo: PackageInfo = {
         packageName: 'jQuery',
         licenseName: 'Mit',
@@ -475,7 +475,7 @@ describe('The AttributionColumn', () => {
       expect(screen.getByLabelText('Standard license text implied.'));
     });
 
-    test('shows long text if editable and frequent license', () => {
+    it('shows long text if editable and frequent license', () => {
       const testTemporaryPackageInfo: PackageInfo = {
         packageName: 'jQuery',
         licenseName: 'mit',
@@ -511,7 +511,7 @@ describe('The AttributionColumn', () => {
   });
 
   describe('while changing the first party value', () => {
-    test('sets first party flag when checking first party', () => {
+    it('sets first party flag when checking first party', () => {
       const testTemporaryPackageInfo: PackageInfo = {};
       const { store } = renderComponentWithStore(
         <AttributionColumn
@@ -536,7 +536,7 @@ describe('The AttributionColumn', () => {
       expect(getTemporaryPackageInfo(store.getState()).firstParty).toBe(true);
     });
 
-    test('leaves copyright unchanged when checking first party', () => {
+    it('leaves copyright unchanged when checking first party', () => {
       const testCopyright = 'Test Copyright';
       const testTemporaryPackageInfo: PackageInfo = {
         copyright: testCopyright,
@@ -572,7 +572,7 @@ describe('The AttributionColumn', () => {
   });
 
   describe('The ResolveButton', () => {
-    test('saves resolved external attributions', () => {
+    it('saves resolved external attributions', () => {
       const testTemporaryPackageInfo: PackageInfo = {};
       const expectedSaveFileArgs: SaveFileArgs = {
         manualAttributions: {},

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -11,27 +11,27 @@ import {
 } from '../attribution-column-helpers';
 
 describe('The AttributionColumn helpers', () => {
-  test('getLicenseTextMaxRows in audit view', () => {
+  it('getLicenseTextMaxRows in audit view', () => {
     expect(getLicenseTextMaxRows(1080, View.Audit)).toEqual(29);
   });
 
-  test('getLicenseTextMaxRows in attribution view', () => {
+  it('getLicenseTextMaxRows in attribution view', () => {
     expect(getLicenseTextMaxRows(1080, View.Attribution)).toEqual(31);
   });
 
-  test('selectedPackageIsResolved returns true', () => {
+  it('selectedPackageIsResolved returns true', () => {
     expect(
       selectedPackageIsResolved('123', new Set<string>().add('123'))
     ).toEqual(true);
   });
 
-  test('selectedPackageIsResolved returns false if empty attributionId', () => {
+  it('selectedPackageIsResolved returns false if empty attributionId', () => {
     expect(selectedPackageIsResolved('', new Set<string>().add('123'))).toEqual(
       false
     );
   });
 
-  test('selectedPackageIsResolved returns false if id does not match', () => {
+  it('selectedPackageIsResolved returns false if id does not match', () => {
     expect(
       selectedPackageIsResolved('123', new Set<string>().add('321'))
     ).toEqual(false);

--- a/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
@@ -17,7 +17,7 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { setTemporaryPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
 
 describe('The AttributionDetailsViewer', () => {
-  test('renders TextBoxes with right titles and content', () => {
+  it('renders TextBoxes with right titles and content', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       comment: 'some comment',
@@ -66,7 +66,7 @@ describe('The AttributionDetailsViewer', () => {
     );
   });
 
-  test('saves temporary info', () => {
+  it('saves temporary info', () => {
     const expectedPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageName: 'React',

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -58,7 +58,7 @@ describe('The AttributionList', () => {
     jest.clearAllMocks();
   });
 
-  test('renders', () => {
+  it('renders', () => {
     renderComponentWithStore(
       <AttributionList
         attributions={packages}
@@ -74,7 +74,7 @@ describe('The AttributionList', () => {
     expect(mockCallback.mock.calls.length).toBe(0);
   });
 
-  test('renders first party icon', () => {
+  it('renders first party icon', () => {
     renderComponentWithStore(
       <AttributionList
         attributions={packages}
@@ -90,7 +90,7 @@ describe('The AttributionList', () => {
     expect(screen.getByLabelText('First party icon'));
   });
 
-  test('sets selectedAttributionId on click', () => {
+  it('sets selectedAttributionId on click', () => {
     renderComponentWithStore(
       <AttributionList
         attributions={packages}
@@ -109,7 +109,7 @@ describe('The AttributionList', () => {
     expect(mockCallback.mock.calls[0][0]).toBe('1');
   });
 
-  test('sorts its elements', () => {
+  it('sorts its elements', () => {
     const testPackages: Attributions = {
       '1': {
         packageName: 'zz Test package',
@@ -145,7 +145,7 @@ describe('The AttributionList', () => {
     expect(container.childNodes[0]).toHaveTextContent(/Copyright John Doe 2/);
   });
 
-  test('shows correct replace attribution buttons in the context menu', () => {
+  it('shows correct replace attribution buttons in the context menu', () => {
     const testResources: Resources = {
       root: { src: { file_1: 1, file_2: 1 } },
       file: 1,

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -50,7 +50,7 @@ describe('The Attribution View', () => {
     testOtherManualUuid,
   ];
 
-  test('renders', () => {
+  it('renders', () => {
     const { store } = renderComponentWithStore(<AttributionView />);
     store.dispatch(
       loadFromFile(
@@ -75,7 +75,7 @@ describe('The Attribution View', () => {
     expect(screen.getByText('test resource'));
   });
 
-  test('filters Follow-ups', () => {
+  it('filters Follow-ups', () => {
     const { store } = renderComponentWithStore(<AttributionView />);
     store.dispatch(
       loadFromFile(
@@ -101,7 +101,7 @@ describe('The Attribution View', () => {
     expect(screen.queryByText('Test package, 1.0')).not.toBeInTheDocument();
   });
 
-  test('filters Only First Party', () => {
+  it('filters Only First Party', () => {
     const { store } = renderComponentWithStore(<AttributionView />);
     store.dispatch(
       loadFromFile(
@@ -129,7 +129,7 @@ describe('The Attribution View', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('filters Only First Party and follow ups and then hide first party and follow ups', () => {
+  it('filters Only First Party and follow ups and then hide first party and follow ups', () => {
     const { store } = renderComponentWithStore(<AttributionView />);
     store.dispatch(
       loadFromFile(

--- a/src/Frontend/Components/AuditView/__tests__/AuditView.test.tsx
+++ b/src/Frontend/Components/AuditView/__tests__/AuditView.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
 describe('The AuditView', () => {
-  test('renders AuditView', () => {
+  it('renders AuditView', () => {
     renderComponentWithStore(<AuditView />);
   });
 });

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -14,7 +14,7 @@ import {
 import { Attributions, ExportType } from '../../../../shared/shared-types';
 
 describe('BackendCommunication', () => {
-  test('renders an Open file icon', () => {
+  it('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
     expect(window.electronAPI.on).toHaveBeenCalledTimes(10);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
@@ -59,7 +59,7 @@ describe('BackendCommunication', () => {
     );
   });
 
-  test('filters the correct BOM attributions', () => {
+  it('filters the correct BOM attributions', () => {
     const testAttributions: Attributions = {
       genericAttrib: {},
       firstPartyAttrib: { firstParty: true },

--- a/src/Frontend/Components/Button/__tests__/Button.test.tsx
+++ b/src/Frontend/Components/Button/__tests__/Button.test.tsx
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('Button', () => {
-  test('renders a button', () => {
+  it('renders a button', () => {
     render(
       <Button
         buttonText={'Test'}

--- a/src/Frontend/Components/ButtonGroup/__tests__/ButtonGroup.test.tsx
+++ b/src/Frontend/Components/ButtonGroup/__tests__/ButtonGroup.test.tsx
@@ -32,7 +32,7 @@ describe('Button group', () => {
     },
   ];
 
-  test('renders buttons', () => {
+  it('renders buttons', () => {
     render(<ButtonGroup mainButtonConfigs={mainButtonConfigs} />);
 
     screen.getByText('Test');
@@ -40,7 +40,7 @@ describe('Button group', () => {
     expect(screen.queryByText('Test 3')).not.toBeInTheDocument();
   });
 
-  test('renders context menu', () => {
+  it('renders context menu', () => {
     const contextMenuItems: Array<ContextMenuItem> = [
       {
         buttonText: ButtonText.Save,

--- a/src/Frontend/Components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/src/Frontend/Components/Checkbox/__tests__/Checkbox.test.tsx
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { clickOnCheckbox } from '../../../test-helpers/general-test-helpers';
 
 describe('The Checkbox', () => {
-  test('renders', () => {
+  it('renders', () => {
     const mockOnChange = jest.fn();
     const testLabel = 'Test Label';
     render(

--- a/src/Frontend/Components/ConfirmDeletionGloballyPopup/__tests__/ConfirmDeletionGloballyPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmDeletionGloballyPopup/__tests__/ConfirmDeletionGloballyPopup.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup';
 
 describe('The ConfirmDeletionGloballyPopup', () => {
-  test('renders', () => {
+  it('renders', () => {
     const expectedContent =
       'Do you really want to delete this attribution for all files?';
     const expectedHeader = 'Confirm Deletion';

--- a/src/Frontend/Components/ConfirmDeletionPopup/__tests__/ConfirmDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmDeletionPopup/__tests__/ConfirmDeletionPopup.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup';
 
 describe('The ConfirmDeletionPopup', () => {
-  test('renders', () => {
+  it('renders', () => {
     const expectedContent =
       'Do you really want to delete this attribution for the current file?';
     const expectedHeader = 'Confirm Deletion';

--- a/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmMultiSelectDeletionPopup/__tests__/ConfirmMultiSelectDeletionPopup.test.tsx
@@ -25,7 +25,7 @@ import { ButtonText } from '../../../enums/enums';
 import { getManualAttributions } from '../../../state/selectors/all-views-resource-selectors';
 
 describe('The ConfirmMultiSelectDeletionPopup', () => {
-  test('renders', () => {
+  it('renders', () => {
     const expectedContent =
       'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
     const expectedHeader = 'Confirm Deletion';
@@ -43,7 +43,7 @@ describe('The ConfirmMultiSelectDeletionPopup', () => {
     expect(screen.getByText(expectedHeader)).toBeInTheDocument();
   });
 
-  test('deletes attributions', () => {
+  it('deletes attributions', () => {
     const expectedContent =
       'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.';
     const expectedHeader = 'Confirm Deletion';

--- a/src/Frontend/Components/ConfirmationPopup/__tests__/ConfirmationPopup.test.tsx
+++ b/src/Frontend/Components/ConfirmationPopup/__tests__/ConfirmationPopup.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { ButtonText } from '../../../enums/enums';
 
 describe('The ConfirmationPopup', () => {
-  test('renders and calls onClick function', () => {
+  it('renders and calls onClick function', () => {
     const onClick = jest.fn();
     const content = 'Confirmation Popup';
     const header = 'Confirmation Header';

--- a/src/Frontend/Components/ContextMenu/__tests__/ContextMenu.test.tsx
+++ b/src/Frontend/Components/ContextMenu/__tests__/ContextMenu.test.tsx
@@ -46,7 +46,7 @@ describe('The ContextMenu', () => {
     jest.clearAllMocks();
   });
 
-  test('renders and handles left clicks correctly', () => {
+  it('renders and handles left clicks correctly', () => {
     const testElementText = 'Test Element';
     render(
       <ContextMenu menuItems={testMenuItems} activation={'onLeftClick'}>
@@ -67,7 +67,7 @@ describe('The ContextMenu', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  test('renders and handles right clicks correctly', () => {
+  it('renders and handles right clicks correctly', () => {
     const testElementText = 'Test Element';
     render(
       <ContextMenu menuItems={testMenuItems} activation={'onRightClick'}>
@@ -88,7 +88,7 @@ describe('The ContextMenu', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  test('renders and handles left clicks correctly for both activated', () => {
+  it('renders and handles left clicks correctly for both activated', () => {
     const testElementText = 'Test Element';
     render(
       <ContextMenu menuItems={testMenuItems} activation={'both'}>
@@ -105,7 +105,7 @@ describe('The ContextMenu', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  test('renders and handles right clicks correctly for both clicks activated', () => {
+  it('renders and handles right clicks correctly for both clicks activated', () => {
     const testElementText = 'Test Element';
     render(
       <ContextMenu menuItems={testMenuItems} activation={'both'}>
@@ -122,7 +122,7 @@ describe('The ContextMenu', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  test('renders and calls onOpen and onClose correctly', () => {
+  it('renders and calls onOpen and onClose correctly', () => {
     const testElementText = 'Test Element';
     const onCloseMock = jest.fn();
     const onOpenMock = jest.fn();

--- a/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
@@ -54,7 +54,7 @@ describe('The EditAttributionPopup', () => {
     'package_2.tr.gz': ['test_marked_id'],
   };
 
-  test('renders and clicks cancel closes the popup', () => {
+  it('renders and clicks cancel closes the popup', () => {
     const expectedHeader = 'Edit Attribution';
     const { store } = renderComponentWithStore(<EditAttributionPopup />);
     store.dispatch(navigateToView(View.Report));
@@ -82,7 +82,7 @@ describe('The EditAttributionPopup', () => {
     expect(getOpenPopup(store.getState())).toBe(null);
   });
 
-  test('renders and clicks cancel opens NotSavedPopup if package info has been changed', () => {
+  it('renders and clicks cancel opens NotSavedPopup if package info has been changed', () => {
     const expectedHeader = 'Edit Attribution';
     const { store } = renderComponentWithStore(<EditAttributionPopup />);
     store.dispatch(navigateToView(View.Report));
@@ -115,7 +115,7 @@ describe('The EditAttributionPopup', () => {
     expect(getOpenPopup(store.getState())).toBe(PopupType.NotSavedPopup);
   });
 
-  test('renders and clicks save saves changed  package info', () => {
+  it('renders and clicks save saves changed  package info', () => {
     const expectedHeader = 'Edit Attribution';
     const { store } = renderComponentWithStore(<EditAttributionPopup />);
     store.dispatch(navigateToView(View.Report));

--- a/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -21,7 +21,7 @@ describe('ErrorBoundary', () => {
     return <div>{'Test'}</div>;
   }
 
-  test('renders its children', () => {
+  it('renders its children', () => {
     renderComponentWithStore(
       <ErrorBoundary>
         <TestComponent throws={false} />
@@ -34,7 +34,7 @@ describe('ErrorBoundary', () => {
     screen.getByText('Test');
   });
 
-  test('renders fallback and restores state', () => {
+  it('renders fallback and restores state', () => {
     // we expect warnings that we do not want to see
     jest.spyOn(console, 'error').mockImplementation();
 

--- a/src/Frontend/Components/ErrorPopup/__tests__/ErrorPopup.test.tsx
+++ b/src/Frontend/Components/ErrorPopup/__tests__/ErrorPopup.test.tsx
@@ -9,7 +9,7 @@ import { ErrorPopup } from '../ErrorPopup';
 import { screen } from '@testing-library/react';
 
 describe('Error popup ', () => {
-  test('renders', () => {
+  it('renders', () => {
     renderComponentWithStore(<ErrorPopup content="Invalid link." />);
 
     expect(screen.getByText('Error')).toBeInTheDocument();

--- a/src/Frontend/Components/FileSearchPopup/__tests__/FileSearchPopup.test.tsx
+++ b/src/Frontend/Components/FileSearchPopup/__tests__/FileSearchPopup.test.tsx
@@ -35,7 +35,7 @@ describe('FileSearch popup ', () => {
 
   jest.useFakeTimers('modern');
 
-  test('renders', () => {
+  it('renders', () => {
     renderComponentWithStore(<FileSearchPopup />);
     expect(
       screen.getByText('Search for Files and Directories', { exact: false })
@@ -47,7 +47,7 @@ describe('FileSearch popup ', () => {
     ['test.js', 2],
     ['non-existing-file', 0],
     ['eagleblu', 4],
-  ]).test(
+  ]).it(
     'search for %s results in %s results',
     (search: string, expected_results: number) => {
       const store = createTestAppStore();
@@ -82,7 +82,7 @@ describe('FileSearch popup ', () => {
     }
   );
 
-  test('has debounced search', () => {
+  it('has debounced search', () => {
     const store = createTestAppStore();
     store.dispatch(
       loadFromFile(
@@ -113,7 +113,7 @@ describe('FileSearch popup ', () => {
     expect(screen.queryByText('/', { exact: false })).not.toBeInTheDocument();
   });
 
-  test('has search with state', () => {
+  it('has search with state', () => {
     const store = createTestAppStore();
     store.dispatch(
       loadFromFile(

--- a/src/Frontend/Components/FileSearchTextField/__tests__/FileSearchTextField.test.tsx
+++ b/src/Frontend/Components/FileSearchTextField/__tests__/FileSearchTextField.test.tsx
@@ -13,7 +13,7 @@ describe('The FileSearchTextField', () => {
   jest.useFakeTimers('modern');
   const debounceDelayInMs = 200;
 
-  test('renders', () => {
+  it('renders', () => {
     const setFilteredPaths = jest.fn();
     renderComponentWithStore(
       <FileSearchTextField setFilteredPaths={setFilteredPaths} />
@@ -21,7 +21,7 @@ describe('The FileSearchTextField', () => {
     screen.getAllByText('Search');
   });
 
-  test('calls callback after debounce time', () => {
+  it('calls callback after debounce time', () => {
     const setFilteredPaths = jest.fn();
     renderComponentWithStore(
       <FileSearchTextField setFilteredPaths={setFilteredPaths} />

--- a/src/Frontend/Components/Filter/__tests__/FilterMultiSelect.test.tsx
+++ b/src/Frontend/Components/Filter/__tests__/FilterMultiSelect.test.tsx
@@ -15,7 +15,7 @@ import { Provider } from 'react-redux';
 import { createAppStore } from '../../../state/configure-store';
 
 describe('FilterMultiSelect', () => {
-  test('renders the filters in a dropdown', () => {
+  it('renders the filters in a dropdown', () => {
     const store = createAppStore();
     render(
       <Provider store={store}>

--- a/src/Frontend/Components/FilteredList/__tests__/FilteredList.test.tsx
+++ b/src/Frontend/Components/FilteredList/__tests__/FilteredList.test.tsx
@@ -10,7 +10,7 @@ import { renderComponentWithStore } from '../../../test-helpers/render-component
 import { FilteredList } from '../FilteredList';
 
 describe('The FilteredList', () => {
-  test('has search functionality', () => {
+  it('has search functionality', () => {
     const testAttributions: Attributions = {
       uuid1: {
         packageName: 'name 1',

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -19,13 +19,13 @@ import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/res
 import { act } from 'react-dom/test-utils';
 
 describe('The GlobalPopUp', () => {
-  test('does not open by default', () => {
+  it('does not open by default', () => {
     renderComponentWithStore(<GlobalPopup />);
 
     expect(screen.queryByText('Warning')).not.toBeInTheDocument();
   });
 
-  test('opens the NotSavedPopup', () => {
+  it('opens the NotSavedPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.NotSavedPopup));
@@ -34,7 +34,7 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Warning')).toBeInTheDocument();
   });
 
-  test('opens the ErrorPopup', () => {
+  it('opens the ErrorPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.UnableToSavePopup));
@@ -43,7 +43,7 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Error')).toBeInTheDocument();
   });
 
-  test('opens the FileSearchPopup', () => {
+  it('opens the FileSearchPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.FileSearchPopup));
@@ -54,7 +54,7 @@ describe('The GlobalPopUp', () => {
     ).toBeInTheDocument();
   });
 
-  test('opens the ProjectMetadataPopup', () => {
+  it('opens the ProjectMetadataPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.ProjectMetadataPopup));
@@ -63,7 +63,7 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Project Metadata')).toBeInTheDocument();
   });
 
-  test('opens the ProjectStatisticsPopup', () => {
+  it('opens the ProjectStatisticsPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.ProjectStatisticsPopup));
@@ -72,7 +72,7 @@ describe('The GlobalPopUp', () => {
     expect(screen.getByText('Project Statistics')).toBeInTheDocument();
   });
 
-  test('opens the ReplaceAttributionPopup', () => {
+  it('opens the ReplaceAttributionPopup', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'name 1' },
     };
@@ -97,7 +97,7 @@ describe('The GlobalPopUp', () => {
     ).toBeInTheDocument();
   });
 
-  test('opens the ConfirmDeletionPopup', () => {
+  it('opens the ConfirmDeletionPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.ConfirmDeletionPopup, 'test'));
@@ -110,7 +110,7 @@ describe('The GlobalPopUp', () => {
     ).toBeInTheDocument();
   });
 
-  test('opens the ConfirmDeletionGloballyPopup', () => {
+  it('opens the ConfirmDeletionGloballyPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.ConfirmDeletionGloballyPopup, 'test'));
@@ -123,7 +123,7 @@ describe('The GlobalPopUp', () => {
     ).toBeInTheDocument();
   });
 
-  test('opens the ConfirmMultiSelectDeletionPopup', () => {
+  it('opens the ConfirmMultiSelectDeletionPopup', () => {
     const { store } = renderComponentWithStore(<GlobalPopup />);
     act(() => {
       store.dispatch(openPopup(PopupType.ConfirmMultiSelectDeletionPopup));

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -25,7 +25,7 @@ describe('The GoToLinkButton', () => {
       '/parent_directory/child_directory/',
       'https://www.testurl.com/code/?base=123456789',
     ],
-  ]).test(
+  ]).it(
     'navigates to correct link for %s',
     (path: string, expected_link: string) => {
       const testBaseUrlsForSources: BaseUrlsForSources = {

--- a/src/Frontend/Components/HamburgerMenu/__tests__/HamburgerMenu.test.tsx
+++ b/src/Frontend/Components/HamburgerMenu/__tests__/HamburgerMenu.test.tsx
@@ -11,7 +11,7 @@ import { ButtonText } from '../../../enums/enums';
 import { ContextMenuItem } from '../../ContextMenu/ContextMenu';
 
 describe('The HamburgerMenu', () => {
-  test('is disabled if no enabled button present', () => {
+  it('is disabled if no enabled button present', () => {
     const menuItems: Array<ContextMenuItem> = [
       {
         buttonText: ButtonText.Undo,

--- a/src/Frontend/Components/IconButton/__tests__/IconButton.test.tsx
+++ b/src/Frontend/Components/IconButton/__tests__/IconButton.test.tsx
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('Button', () => {
-  test('renders a button', () => {
+  it('renders a button', () => {
     render(
       <IconButton
         tooltipTitle={'Test'}

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -15,37 +15,37 @@ import {
 } from '../Icons';
 
 describe('The Icons', () => {
-  test('renders CommentIcon', () => {
+  it('renders CommentIcon', () => {
     render(<CommentIcon />);
 
     expect(screen.getByLabelText('Comment icon'));
   });
 
-  test('renders ExcludeFromNoticeIcon', () => {
+  it('renders ExcludeFromNoticeIcon', () => {
     render(<ExcludeFromNoticeIcon />);
 
     expect(screen.getByLabelText('Exclude from notice icon'));
   });
 
-  test('renders FollowUpIcon', () => {
+  it('renders FollowUpIcon', () => {
     render(<FollowUpIcon />);
 
     expect(screen.getByLabelText('Follow-up icon'));
   });
 
-  test('renders FirstPartyIcon', () => {
+  it('renders FirstPartyIcon', () => {
     render(<FirstPartyIcon />);
 
     expect(screen.getByLabelText('First party icon'));
   });
 
-  test('renders DirectoryIcon', () => {
+  it('renders DirectoryIcon', () => {
     render(<DirectoryIcon />);
 
     expect(screen.getByLabelText('Directory icon'));
   });
 
-  test('renders FileIcon', () => {
+  it('renders FileIcon', () => {
     render(<FileIcon />);
 
     expect(screen.getByLabelText('File icon'));

--- a/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
@@ -10,7 +10,7 @@ import { AutoComplete } from '../AutoComplete';
 import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
 
 describe('The AutoComplete', () => {
-  test('renders text and label', () => {
+  it('renders text and label', () => {
     const testLicenseNames = ['MIT', 'GPL'];
     render(
       <AutoComplete
@@ -29,7 +29,7 @@ describe('The AutoComplete', () => {
     expectElementsInAutoCompleteAndSelectFirst(screen, testLicenseNames);
   });
 
-  test('renders end adornment', () => {
+  it('renders end adornment', () => {
     const testLicenseNames = ['MIT', 'GPL'];
     render(
       <AutoComplete

--- a/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
@@ -10,7 +10,7 @@ import { Dropdown } from '../Dropdown';
 import { DiscreteConfidence } from '../../../enums/enums';
 
 describe('The Dropdown', () => {
-  test('renders value ', () => {
+  it('renders value ', () => {
     render(
       <Dropdown
         isEditable={true}
@@ -37,7 +37,7 @@ describe('The Dropdown', () => {
     expect(screen.getByText('High (80)'));
   });
 
-  test('renders value not in menuItems', () => {
+  it('renders value not in menuItems', () => {
     render(
       <Dropdown
         isEditable={true}

--- a/src/Frontend/Components/InputElements/__tests__/NumberBox.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/NumberBox.test.tsx
@@ -9,7 +9,7 @@ import { NumberBox } from '../NumberBox';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('The NumberBox', () => {
-  test('renders value and label', () => {
+  it('renders value and label', () => {
     render(
       <NumberBox
         title={'Test Title'}

--- a/src/Frontend/Components/InputElements/__tests__/TextBox.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/TextBox.test.tsx
@@ -9,7 +9,7 @@ import { TextBox } from '../TextBox';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('The TextBox', () => {
-  test('renders text and label', () => {
+  it('renders text and label', () => {
     render(
       <TextBox
         title={'Test Title'}
@@ -26,7 +26,7 @@ describe('The TextBox', () => {
     expect(screen.getByDisplayValue('Test Content'));
   });
 
-  test('renders icon', () => {
+  it('renders icon', () => {
     render(
       <TextBox
         title={'Test Title'}

--- a/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
+++ b/src/Frontend/Components/ListCard/__tests__/ListCard.test.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from '../../Checkbox/Checkbox';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
 describe('The ListCard', () => {
-  test('renders text with no count', () => {
+  it('renders text with no count', () => {
     renderComponentWithStore(
       <ListCard
         text={'card text'}
@@ -25,7 +25,7 @@ describe('The ListCard', () => {
     expect(screen.getByText('card text of second line'));
   });
 
-  test('renders text with small count', () => {
+  it('renders text with small count', () => {
     renderComponentWithStore(
       <ListCard
         text={'card text'}
@@ -41,7 +41,7 @@ describe('The ListCard', () => {
     expect(screen.getByText('13'));
   });
 
-  test('renders text with medium count', () => {
+  it('renders text with medium count', () => {
     renderComponentWithStore(
       <ListCard
         text={'card text'}
@@ -57,7 +57,7 @@ describe('The ListCard', () => {
     expect(screen.getByText('13k'));
   });
 
-  test('renders text with large count', () => {
+  it('renders text with large count', () => {
     renderComponentWithStore(
       <ListCard
         text={'card text'}
@@ -73,7 +73,7 @@ describe('The ListCard', () => {
     expect(screen.getByText('1M'));
   });
 
-  test('renders leftElement if provided as input', () => {
+  it('renders leftElement if provided as input', () => {
     const leftElement = <Checkbox checked={false} onChange={jest.fn()} />;
     renderComponentWithStore(
       <ListCard

--- a/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
+++ b/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
@@ -59,7 +59,7 @@ describe('The ManualAttributionList', () => {
     jest.clearAllMocks();
   });
 
-  test('renders', () => {
+  it('renders', () => {
     renderComponentWithStore(
       <ManualAttributionList
         selectedResourceId="/folder/"
@@ -73,7 +73,7 @@ describe('The ManualAttributionList', () => {
     expect(mockCallback.mock.calls.length).toBe(0);
   });
 
-  test('renders first party icon and show resources icon', () => {
+  it('renders first party icon and show resources icon', () => {
     renderComponentWithStore(
       <ManualAttributionList
         selectedResourceId="/folder/"
@@ -88,7 +88,7 @@ describe('The ManualAttributionList', () => {
     expect(screen.getAllByLabelText('show resources'));
   });
 
-  test('renders button', () => {
+  it('renders button', () => {
     renderComponentWithStore(
       <ManualAttributionList
         selectedResourceId="/folder/"
@@ -104,7 +104,7 @@ describe('The ManualAttributionList', () => {
     expect(mockCallback.mock.calls.length).toBe(0);
   });
 
-  test('sets selectedAttributionId on click', () => {
+  it('sets selectedAttributionId on click', () => {
     renderComponentWithStore(
       <ManualAttributionList
         selectedResourceId="/folder/"
@@ -121,7 +121,7 @@ describe('The ManualAttributionList', () => {
     expect(mockCallback.mock.calls[0][0]).toBe('1');
   });
 
-  test('sorts its elements', () => {
+  it('sorts its elements', () => {
     const testPackages: Attributions = {
       '1': {
         packageName: 'zz Test package',
@@ -157,7 +157,7 @@ describe('The ManualAttributionList', () => {
     );
   });
 
-  test('shows correct replace attribution buttons in the context menu', () => {
+  it('shows correct replace attribution buttons in the context menu', () => {
     const testResources: Resources = {
       root: { src: { file_1: 1, file_2: 1 } },
       file: 1,

--- a/src/Frontend/Components/ManualPackagePanel/__tests__/ManualPackagePanel.test.tsx
+++ b/src/Frontend/Components/ManualPackagePanel/__tests__/ManualPackagePanel.test.tsx
@@ -13,7 +13,7 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { act } from 'react-dom/test-utils';
 
 describe('The ManualPackagePanel', () => {
-  test('shows default and input attributions', () => {
+  it('shows default and input attributions', () => {
     const mockOnOverride = jest.fn();
     const { store } = renderComponentWithStore(
       <ManualPackagePanel
@@ -43,7 +43,7 @@ describe('The ManualPackagePanel', () => {
     expect(screen.getByText('Add new attribution'));
   });
 
-  test('Shows hint and override button for parent attribution', () => {
+  it('Shows hint and override button for parent attribution', () => {
     const mockOnOverride = jest.fn();
     renderComponentWithStore(
       <ManualPackagePanel

--- a/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
+++ b/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
@@ -44,7 +44,7 @@ function setupTestState(
 }
 
 describe('NotSavedPopup and do not change view', () => {
-  test('renders a NotSavedPopup', () => {
+  it('renders a NotSavedPopup', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store);
 
@@ -55,7 +55,7 @@ describe('NotSavedPopup and do not change view', () => {
     expect(isAuditViewSelected(store.getState())).toBe(true);
   });
 
-  test('renders a NotSavedPopup and click cancel', () => {
+  it('renders a NotSavedPopup and click cancel', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store);
 
@@ -66,7 +66,7 @@ describe('NotSavedPopup and do not change view', () => {
     expect(isAuditViewSelected(store.getState())).toBe(true);
   });
 
-  test('renders a NotSavedPopup and click reset', () => {
+  it('renders a NotSavedPopup and click reset', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store);
     store.dispatch(setTemporaryPackageInfo({ packageName: 'test name' }));
@@ -83,7 +83,7 @@ describe('NotSavedPopup and do not change view', () => {
     expect(isAuditViewSelected(store.getState())).toBe(true);
   });
 
-  test('renders a NotSavedPopup and click cancel in Report view reopens EditAttribuionPopup', () => {
+  it('renders a NotSavedPopup and click cancel in Report view reopens EditAttribuionPopup', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     store.dispatch(navigateToView(View.Report));
     store.dispatch(
@@ -98,7 +98,7 @@ describe('NotSavedPopup and do not change view', () => {
 });
 
 describe('NotSavedPopup and change view', () => {
-  test('renders a NotSavedPopup', () => {
+  it('renders a NotSavedPopup', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store, View.Attribution);
 
@@ -109,7 +109,7 @@ describe('NotSavedPopup and change view', () => {
     expect(isAttributionViewSelected(store.getState())).toBe(true);
   });
 
-  test('renders a NotSavedPopup and click cancel', () => {
+  it('renders a NotSavedPopup and click cancel', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store, View.Attribution);
 
@@ -120,7 +120,7 @@ describe('NotSavedPopup and change view', () => {
     expect(isAuditViewSelected(store.getState())).toBe(true);
   });
 
-  test('renders a NotSavedPopup and click reset', () => {
+  it('renders a NotSavedPopup and click reset', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store, View.Attribution);
     store.dispatch(setTemporaryPackageInfo({ packageName: 'test name' }));

--- a/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
+++ b/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
@@ -9,7 +9,7 @@ import { NotificationPopup } from '../NotificationPopup';
 import { ButtonConfig } from '../../../types/types';
 
 describe('NotificationPopup', () => {
-  test('renders open popup with text', () => {
+  it('renders open popup with text', () => {
     const onLeftButtonClick = jest.fn();
     const onRightButtonClick = jest.fn();
     const onCenterLeftButtonClick = jest.fn();
@@ -56,7 +56,7 @@ describe('NotificationPopup', () => {
     expect(onCenterRightButtonClick).toHaveBeenCalled();
   });
 
-  test('renders open popup with component', () => {
+  it('renders open popup with component', () => {
     render(
       <NotificationPopup
         content={<div>{'test component'}</div>}
@@ -69,7 +69,7 @@ describe('NotificationPopup', () => {
     expect(screen.getByText('test component')).toBeInTheDocument();
   });
 
-  test('executes function on escape key', () => {
+  it('executes function on escape key', () => {
     const onEscapeKeyDown = jest.fn();
     render(
       <NotificationPopup

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -38,7 +38,7 @@ const testAttributions: Attributions = {
 };
 
 describe('The PackageCard', () => {
-  test('has working confirm button', () => {
+  it('has working confirm button', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
     };
@@ -89,7 +89,7 @@ describe('The PackageCard', () => {
     });
   });
 
-  test('has working confirm globally button', () => {
+  it('has working confirm globally button', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
       'package_2.tr.gz': [testAttributionId],
@@ -141,7 +141,7 @@ describe('The PackageCard', () => {
     });
   });
 
-  test('has working multi-select box in multi-select mode', () => {
+  it('has working multi-select box in multi-select mode', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
       'package_2.tr.gz': [testAttributionId],
@@ -190,7 +190,7 @@ describe('The PackageCard', () => {
     ).toStrictEqual([anotherAttributionId]);
   });
 
-  test('has working confirm selected globally button', () => {
+  it('has working confirm selected globally button', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
       'package_2.tr.gz': [testAttributionId],

--- a/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
+++ b/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
@@ -22,7 +22,7 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 
 describe('The PackagePanel', () => {
-  test('renders TextBoxes with right content', () => {
+  it('renders TextBoxes with right content', () => {
     const testSource = { name: 'HC', documentConfidence: 1 };
     const testAttributionIds: Array<AttributionIdWithCount> = [
       { attributionId: 'uuid1' },
@@ -64,7 +64,7 @@ describe('The PackagePanel', () => {
     expect(screen.getAllByLabelText('show resources'));
   });
 
-  test('groups by source and prettifies known sources', () => {
+  it('groups by source and prettifies known sources', () => {
     const testAttributionIds: Array<AttributionIdWithCount> = [
       { attributionId: 'uuid1' },
       { attributionId: 'uuid2' },

--- a/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
@@ -87,7 +87,7 @@ describe('PackagePanel helpers', () => {
     },
   };
 
-  test('getAttributionIdsWithCountForSource returns attributionIdsWithCountForSource', () => {
+  it('getAttributionIdsWithCountForSource returns attributionIdsWithCountForSource', () => {
     const sourceName = 'MERGER';
     const expectedAttributionIdsWithCountForSource: Array<AttributionIdWithCount> =
       [
@@ -105,7 +105,7 @@ describe('PackagePanel helpers', () => {
     ).toEqual(expectedAttributionIdsWithCountForSource);
   });
 
-  test('getAttributionIdsWithCountForSource returns empty array', () => {
+  it('getAttributionIdsWithCountForSource returns empty array', () => {
     const sourceName = 'something';
     expect(
       getAttributionIdsWithCountForSource(
@@ -116,7 +116,7 @@ describe('PackagePanel helpers', () => {
     ).toEqual([]);
   });
 
-  test('getSources returns sorted sources', () => {
+  it('getSources returns sorted sources', () => {
     const expectedSortedSources = [
       'MERGER',
       'REUSER:HHC',
@@ -135,19 +135,19 @@ describe('PackagePanel helpers', () => {
     ).toEqual(expectedSortedSources);
   });
 
-  test('getSources returns empty array for no attributionIds', () => {
+  it('getSources returns empty array for no attributionIds', () => {
     expect(
       getSortedSources(testAttributions, [], testAttributionSources)
     ).toEqual([]);
   });
 
-  test('getSources returns empty string for no attributions', () => {
+  it('getSources returns empty string for no attributions', () => {
     expect(
       getSortedSources({}, testAttributionIds, testAttributionSources)
     ).toEqual(['']);
   });
 
-  test('getSources sorts alphabetically if priority is identical', () => {
+  it('getSources sorts alphabetically if priority is identical', () => {
     const testAttributionSourcesEqualPrio: ExternalAttributionSources = {
       MERGER: { name: 'Suggested', priority: 1 },
       HHC: { name: 'High High Compute', priority: 1 },

--- a/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
+++ b/src/Frontend/Components/PackagePanelCard/__tests__/PackagePanelCard.test.tsx
@@ -42,7 +42,7 @@ describe('The PackagePanelCard', () => {
     },
   };
 
-  test('renders content', () => {
+  it('renders content', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -64,7 +64,7 @@ describe('The PackagePanelCard', () => {
     expect(screen.getByText('Test'));
   });
 
-  test('renders only first party icon and show resources icon', () => {
+  it('renders only first party icon and show resources icon', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -94,7 +94,7 @@ describe('The PackagePanelCard', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders many icons at once', () => {
+  it('renders many icons at once', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -119,7 +119,7 @@ describe('The PackagePanelCard', () => {
     expect(screen.getByLabelText('Follow-up icon'));
   });
 
-  test('renders pre-selected icon and show resources icon', () => {
+  it('renders pre-selected icon and show resources icon', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -142,7 +142,7 @@ describe('The PackagePanelCard', () => {
     expect(screen.getAllByLabelText('show resources'));
   });
 
-  test('has working resources icon', () => {
+  it('has working resources icon', () => {
     const manualAttributions: Attributions = {
       uuid_1: { packageName: 'Test package' },
     };

--- a/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
+++ b/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
@@ -11,7 +11,7 @@ import { setFilesWithChildren } from '../../../state/actions/resource-actions/al
 import { act, screen } from '@testing-library/react';
 
 describe('The PathBar', () => {
-  test('renders a path', () => {
+  it('renders a path', () => {
     const testPath = '/test_path';
 
     const { store } = renderComponentWithStore(<PathBar />);
@@ -22,7 +22,7 @@ describe('The PathBar', () => {
     expect(screen.getByText(testPath));
   });
 
-  test('renders a path of a file with children', () => {
+  it('renders a path of a file with children', () => {
     const testPath = '/test_path/';
 
     const { store } = renderComponentWithStore(<PathBar />);

--- a/src/Frontend/Components/ProgressBar/__tests__/FolderProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/FolderProgressBar.test.tsx
@@ -28,7 +28,7 @@ import { FolderProgressBar } from '../FolderProgressBar';
 
 describe('FolderProgressBar', () => {
   jest.useFakeTimers();
-  test('renders correctly', () => {
+  it('renders correctly', () => {
     const testResources: Resources = {
       folder1: { file1: 1, file2: 1 },
       folder2: { file1: 1, file2: 1 },
@@ -106,7 +106,7 @@ describe('FolderProgressBar', () => {
     ).toBeDefined();
   });
 
-  test('renders correctly if folder has an attribution', () => {
+  it('renders correctly if folder has an attribution', () => {
     const testResources: Resources = {
       folder1: { file1: 1, file2: 1 },
       folder2: { file1: 1, file2: 1 },

--- a/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
@@ -18,7 +18,7 @@ import { DiscreteConfidence } from '../../../enums/enums';
 
 describe('TopProgressBar', () => {
   jest.useFakeTimers();
-  test('TopProgressBar renders', () => {
+  it('TopProgressBar renders', () => {
     const testResources: Resources = {
       folder1: { file1: 1, file2: 1 },
       folder2: { file1: 1, file2: 1 },
@@ -82,7 +82,7 @@ describe('TopProgressBar', () => {
     ).toBeDefined();
   });
 
-  test('TopProgressBar renders without progress data', () => {
+  it('TopProgressBar renders without progress data', () => {
     renderComponentWithStore(<TopProgressBar />);
     expect(screen.queryByLabelText('TopProgressBar')).not.toBeInTheDocument();
   });

--- a/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
@@ -31,7 +31,7 @@ function TestComponent(props: { resourceIds: Array<string> }): JSX.Element {
 }
 
 describe('ProgressBar helpers', () => {
-  test('useOnProgressBarClickHook sets correct resourceId', () => {
+  it('useOnProgressBarClickHook sets correct resourceId', () => {
     const { store } = renderComponentWithStore(
       <TestComponent resourceIds={['id_1', 'id_2']} />
     );
@@ -52,7 +52,7 @@ describe('ProgressBar helpers', () => {
     expect(getExpandedIds(store.getState())).toEqual(['id_1']);
   });
 
-  test('useOnProgressBarClickHook selects audit view', () => {
+  it('useOnProgressBarClickHook selects audit view', () => {
     const { store } = renderComponentWithStore(
       <TestComponent resourceIds={['id_1']} />
     );
@@ -68,7 +68,7 @@ describe('ProgressBar helpers', () => {
     expect(getSelectedView(store.getState())).toEqual(View.Audit);
   });
 
-  test('useOnProgressBarClickHook works with empty list', () => {
+  it('useOnProgressBarClickHook works with empty list', () => {
     const { store } = renderComponentWithStore(
       <TestComponent resourceIds={[]} />
     );
@@ -81,7 +81,7 @@ describe('ProgressBar helpers', () => {
     expect(getExpandedIds(store.getState())).toEqual(['test_id']);
   });
 
-  test('getProgressBarBackground returns correct distribution', () => {
+  it('getProgressBarBackground returns correct distribution', () => {
     const testProgressBarData: ProgressBarData = {
       fileCount: 9,
       filesWithManualAttributionCount: 3,
@@ -122,7 +122,7 @@ describe('ProgressBar helpers', () => {
       [33, 33, 1, 33],
       [33, 33, 1, 33],
     ],
-  ]).test(
+  ]).it(
     'roundToAtLeastOnePercentAndNormalize rounds and subtracts difference from the maximum',
     (input: Array<number>, expectedOutput: Array<number>) => {
       expect(roundToAtLeastOnePercentAndNormalize(input)).toEqual(

--- a/src/Frontend/Components/ProjectMetadataPopup/__tests__/ProjectMetadataPopup.test.tsx
+++ b/src/Frontend/Components/ProjectMetadataPopup/__tests__/ProjectMetadataPopup.test.tsx
@@ -14,7 +14,7 @@ import { ProjectMetadata } from '../../../../shared/shared-types';
 import { setProjectMetadata } from '../../../state/actions/resource-actions/all-views-simple-actions';
 
 describe('The ProjectMetadataPopup', () => {
-  test('displays metadata', () => {
+  it('displays metadata', () => {
     const store = createTestAppStore();
     const testMetadata: ProjectMetadata = {
       projectId: 'test-id',
@@ -27,7 +27,7 @@ describe('The ProjectMetadataPopup', () => {
     expect(screen.getByText('test-id')).toBeInTheDocument();
   });
 
-  test('formats projectId, projectTitle and fileCreationDate', () => {
+  it('formats projectId, projectTitle and fileCreationDate', () => {
     const store = createTestAppStore();
     const testMetadata: ProjectMetadata = {
       projectTitle: 'Title',
@@ -43,7 +43,7 @@ describe('The ProjectMetadataPopup', () => {
     expect(screen.getByText('File Creation Date')).toBeInTheDocument();
   });
 
-  test('displays custom user metadata', () => {
+  it('displays custom user metadata', () => {
     const store = createTestAppStore();
     const testMetadata: ProjectMetadata = {
       projectId: 'test-id',

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -15,7 +15,7 @@ import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/ge
 import { screen } from '@testing-library/react';
 
 describe('The ProjectStatisticsPopup', () => {
-  test('displays license names and source names', () => {
+  it('displays license names and source names', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {
       uuid_1: {
@@ -48,7 +48,7 @@ describe('The ProjectStatisticsPopup', () => {
     expect(screen.getByText('reuser'.toUpperCase())).toBeInTheDocument();
   });
 
-  test('renders when there are no attributions', () => {
+  it('renders when there are no attributions', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {};
     store.dispatch(

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -10,7 +10,7 @@ import {
 import { FollowUp, PackageInfo } from '../../../../shared/shared-types';
 
 describe('The ProjectStatisticsPopup helper', () => {
-  test('counts licenses, sources and attribution propertes', () => {
+  it('counts licenses, sources and attribution propertes', () => {
     const testAttributions: Array<PackageInfo> = [
       {
         source: {

--- a/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/__tests__/ReplaceAttributionPopup.test.tsx
@@ -65,7 +65,7 @@ function setupTestState(store: EnhancedTestStore): void {
 }
 
 describe('ReplaceAttributionPopup and do not change view', () => {
-  test('renders a ReplaceAttributionPopup and click cancel', () => {
+  it('renders a ReplaceAttributionPopup and click cancel', () => {
     const testStore = createTestAppStore();
     setupTestState(testStore);
 
@@ -81,7 +81,7 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     expect(getOpenPopup(store.getState())).toBe(null);
   });
 
-  test('does not show ContextMenu for attributions', () => {
+  it('does not show ContextMenu for attributions', () => {
     const testStore = createTestAppStore();
     setupTestState(testStore);
 
@@ -108,7 +108,7 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('does not show multi-select checkbox for attributions', () => {
+  it('does not show multi-select checkbox for attributions', () => {
     const testStore = createTestAppStore();
     setupTestState(testStore);
     testStore.dispatch(
@@ -125,7 +125,7 @@ describe('ReplaceAttributionPopup and do not change view', () => {
     expect(screen.queryByText('checkbox')).not.toBeInTheDocument();
   });
 
-  test('renders a ReplaceAttributionPopup and click replace', () => {
+  it('renders a ReplaceAttributionPopup and click replace', () => {
     const testStore = createTestAppStore();
     setupTestState(testStore);
 

--- a/src/Frontend/Components/ReportTableHeader/__tests__/ReportTableHeader.test.tsx
+++ b/src/Frontend/Components/ReportTableHeader/__tests__/ReportTableHeader.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { ReportTableHeader } from '../ReportTableHeader';
 
 describe('The report view table header', () => {
-  test('renders', () => {
+  it('renders', () => {
     renderComponentWithStore(<ReportTableHeader />);
 
     expect(screen.getByText('License'));

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -12,7 +12,7 @@ import { ReportTableItem } from '../ReportTableItem';
 import { DiscreteConfidence } from '../../../enums/enums';
 
 describe('The ReportTableItem', () => {
-  test('renders', () => {
+  it('renders', () => {
     const testAttributionsWithResources: AttributionsWithResources = {
       uuid1: {
         packageName: 'React',
@@ -59,7 +59,7 @@ describe('The ReportTableItem', () => {
     expect(screen.getByText('/'));
   });
 
-  test('renders icons correctly', () => {
+  it('renders icons correctly', () => {
     const testAttributionsWithResources: AttributionsWithResources = {
       uuid1: {
         packageName: 'React',

--- a/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
@@ -13,7 +13,7 @@ describe('The table helpers', () => {
   const testIsFileWithChildren = (path: string): boolean =>
     path === testPathOfFileWithChildren;
 
-  test('getFormattedCellData replaces undefined by empty string', () => {
+  it('getFormattedCellData replaces undefined by empty string', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'attributionConfidence',
       displayName: 'confidence',
@@ -30,7 +30,7 @@ describe('The table helpers', () => {
     ).toEqual('');
   });
 
-  test('getFormattedCellData formats resources', () => {
+  it('getFormattedCellData formats resources', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'resources',
       displayName: 'resources',
@@ -47,7 +47,7 @@ describe('The table helpers', () => {
     ).toEqual(testPathOfFileWithChildren.slice(0, -1) + '\nb');
   });
 
-  test('getFormattedCellData handles first-party boolean', () => {
+  it('getFormattedCellData handles first-party boolean', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'firstParty',
       displayName: 'First Party',
@@ -165,7 +165,7 @@ describe('The table helpers', () => {
     }
   );
 
-  test('isImportantAttributionInformationMissing does not mark first party or excluded attributions', () => {
+  it('isImportantAttributionInformationMissing does not mark first party or excluded attributions', () => {
     const testTableConfig: TableConfig = {
       attributionProperty: 'licenseName',
       displayName: 'Unimportant',

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -53,7 +53,7 @@ describe('The ReportView', () => {
     testOtherManualUuid,
   ];
 
-  test('renders', () => {
+  it('renders', () => {
     const testFrequentLicenses: FrequentLicences = {
       nameOrder: ['MIT', 'GPL'],
       texts: { MIT: 'MIT text', GPL: 'GPL text' },
@@ -77,7 +77,7 @@ describe('The ReportView', () => {
     expect(screen.getByText('Some other license text'));
   });
 
-  test('filters Follow-ups', () => {
+  it('filters Follow-ups', () => {
     const { store } = renderComponentWithStore(<ReportView />);
     act(() => {
       store.dispatch(
@@ -100,7 +100,7 @@ describe('The ReportView', () => {
     expect(screen.queryByText('Test package')).not.toBeInTheDocument();
   });
 
-  test('filters only first party', () => {
+  it('filters only first party', () => {
     const { store } = renderComponentWithStore(<ReportView />);
     act(() => {
       store.dispatch(
@@ -127,7 +127,7 @@ describe('The ReportView', () => {
     expect(screen.getByText('Test other package'));
   });
 
-  test('filters Only First Party and follow ups and then hide first party and follow ups', () => {
+  it('filters Only First Party and follow ups and then hide first party and follow ups', () => {
     const { store } = renderComponentWithStore(<ReportView />);
     act(() => {
       store.dispatch(

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -32,7 +32,7 @@ import { addResolvedExternalAttribution } from '../../../state/actions/resource-
 import { collapseFolderByClickingOnIcon } from '../../../test-helpers/resource-browser-test-helpers';
 
 describe('ResourceBrowser', () => {
-  test('renders working tree', () => {
+  it('renders working tree', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,
@@ -88,7 +88,7 @@ describe('ResourceBrowser', () => {
     expect(screen.getByText('src'));
   });
 
-  test('opens folders recursively', () => {
+  it('opens folders recursively', () => {
     const testResources: Resources = {
       parentDirectory: {
         childDirectory: {
@@ -121,7 +121,7 @@ describe('ResourceBrowser', () => {
     expect(screen.getByText('package_2.tr.gz'));
   });
 
-  test('Resource browser renders icons', () => {
+  it('Resource browser renders icons', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,
@@ -198,7 +198,7 @@ describe('ResourceBrowser', () => {
     );
   });
 
-  test('Resources are sorted in alphabetical order', () => {
+  it('Resources are sorted in alphabetical order', () => {
     const testResources: Resources = {
       'd_package.exe': 1,
       'c_package.exe': 1,
@@ -230,7 +230,7 @@ describe('ResourceBrowser', () => {
     expect(isEqual(actualSequence, expectedSequence)).toBeTruthy();
   });
 
-  test('Resource folders are sorted before files', () => {
+  it('Resource folders are sorted before files', () => {
     const testResources: Resources = {
       'a_package.exe': 1,
       'b_package.exe': 1,
@@ -262,7 +262,7 @@ describe('ResourceBrowser', () => {
     expect(isEqual(actualSequence, expectedSequence)).toBeTruthy();
   });
 
-  test('FileWithChildren are sorted with files', () => {
+  it('FileWithChildren are sorted with files', () => {
     const testResources: Resources = {
       'a_package.exe': 1,
       'z_package.exe': 1,

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
@@ -68,7 +68,7 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 }
 
 describe('The ResourceDetailsAttributionColumn', () => {
-  test('renders TextBoxes with right titles and content', () => {
+  it('renders TextBoxes with right titles and content', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       comment: 'some comment',
@@ -119,7 +119,7 @@ describe('The ResourceDetailsAttributionColumn', () => {
     );
   });
 
-  test('shows parent attribution if overrideParentMode is true', () => {
+  it('shows parent attribution if overrideParentMode is true', () => {
     const { store } = renderComponentWithStore(
       <ResourceDetailsAttributionColumn showParentAttributions={true} />
     );
@@ -134,7 +134,7 @@ describe('The ResourceDetailsAttributionColumn', () => {
     expect(screen.getByDisplayValue(testManualLicense));
   });
 
-  test('does not show parent attribution if overrideParentMode is false', () => {
+  it('does not show parent attribution if overrideParentMode is false', () => {
     const { store } = renderComponentWithStore(
       <ResourceDetailsAttributionColumn showParentAttributions={false} />
     );

--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -18,7 +18,7 @@ import { loadFromFile } from '../../../state/actions/resource-actions/load-actio
 import { clickOnTab } from '../../../test-helpers/package-panel-helpers';
 
 describe('The ResourceDetailsTabs', () => {
-  test('switches between tabs', () => {
+  it('switches between tabs', () => {
     const testResources: Resources = {
       root: {
         fileWithoutAttribution: 1,
@@ -55,7 +55,7 @@ describe('The ResourceDetailsTabs', () => {
     expect(screen.getByText('Signals'));
   });
 
-  test('has All Attributions Tab disabled when no addable attribution is present', () => {
+  it('has All Attributions Tab disabled when no addable attribution is present', () => {
     const testResources: Resources = {
       fileWithAttribution: 1,
     };

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -74,7 +74,7 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 }
 
 describe('The ResourceDetailsViewer', () => {
-  test('renders an Attribution column', () => {
+  it('renders an Attribution column', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       packageName: 'jQuery',
     };
@@ -90,7 +90,7 @@ describe('The ResourceDetailsViewer', () => {
     );
   });
 
-  test(
+  it(
     'preselects the first manual attribution and the first manual attribution from parent correctly, ' +
       'despite the alphabetical ordering',
     () => {
@@ -139,7 +139,7 @@ describe('The ResourceDetailsViewer', () => {
     }
   );
 
-  test('renders a ExternalPackageCard', () => {
+  it('renders a ExternalPackageCard', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     store.dispatch(setSelectedResourceId('/test_id'));
     const externalAttributions: Attributions = {
@@ -170,7 +170,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByText('JQuery'));
   });
 
-  test('renders Contained External Packages', () => {
+  it('renders Contained External Packages', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     const externalAttributions: Attributions = {
       uuid_2: {
@@ -203,7 +203,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByText('JQuery, 1.0'));
   });
 
-  test('selects an external package and a manual package, showing the right info', () => {
+  it('selects an external package and a manual package, showing the right info', () => {
     const manualAttributions = {
       uuid_1: testTemporaryPackageInfo,
     };
@@ -276,7 +276,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
   });
 
-  test('adds an external package to a manual package', () => {
+  it('adds an external package to a manual package', () => {
     const manualAttributions: Attributions = {
       uuid_1: testTemporaryPackageInfo,
     };
@@ -360,7 +360,7 @@ describe('The ResourceDetailsViewer', () => {
     );
   });
 
-  test('selects the manual package view after you added an external package', () => {
+  it('selects the manual package view after you added an external package', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
 
     const manualAttributions: Attributions = {
@@ -434,7 +434,7 @@ describe('The ResourceDetailsViewer', () => {
     );
   });
 
-  test('shows parent attribution if child has no other attribution', () => {
+  it('shows parent attribution if child has no other attribution', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     getTestTemporaryAndExternalStateWithParentAttribution(
       store,
@@ -451,7 +451,7 @@ describe('The ResourceDetailsViewer', () => {
     );
   });
 
-  test('does not show parent attribution if child has another attribution', () => {
+  it('does not show parent attribution if child has another attribution', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     getTestTemporaryAndExternalStateWithParentAttribution(
       store,
@@ -468,7 +468,7 @@ describe('The ResourceDetailsViewer', () => {
     );
   });
 
-  test('shows enabled add to package tab if assignable packages are present', () => {
+  it('shows enabled add to package tab if assignable packages are present', () => {
     const testResources: Resources = {
       root: {
         fileWithoutAttribution: 1,
@@ -506,7 +506,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.queryByText(manualPackagePanelLabel)).not.toBeInTheDocument();
   });
 
-  test('shows disabled add to package tab if no assignable package is present', () => {
+  it('shows disabled add to package tab if no assignable package is present', () => {
     const testResources: Resources = {
       fileWithAttribution: 1,
     };
@@ -535,7 +535,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByText('Signals'));
   });
 
-  test('shows disabled add to package tab if override parent has not been clicked', () => {
+  it('shows disabled add to package tab if override parent has not been clicked', () => {
     const testResources: Resources = {
       folderWithAttribution: { childrenFile: 1 },
     };
@@ -568,7 +568,7 @@ describe('The ResourceDetailsViewer', () => {
     expect(screen.getByText('Signals'));
   });
 
-  test('hides the package info for attribution breakpoints unless a signal is selected', () => {
+  it('hides the package info for attribution breakpoints unless a signal is selected', () => {
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
 
     const manualAttributions: Attributions = {};

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -55,7 +55,7 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
 describe('ResourcePathPopup', () => {
   const resourcesInOtherFoldersHeader = 'Resources in Other Folders';
 
-  test('renders resources for manual Attributions', () => {
+  it('renders resources for manual Attributions', () => {
     renderComponentWithStore(<HelperComponent isExternalAttribution={false} />);
 
     expect(
@@ -64,7 +64,7 @@ describe('ResourcePathPopup', () => {
     expect(screen.getByText('/thirdParty')).toBeInTheDocument();
   });
 
-  test('renders resources for external Attributions', () => {
+  it('renders resources for external Attributions', () => {
     renderComponentWithStore(<HelperComponent isExternalAttribution={true} />);
 
     expect(
@@ -73,7 +73,7 @@ describe('ResourcePathPopup', () => {
     expect(screen.getByText('/firstParty')).toBeInTheDocument();
   });
 
-  test('renders subheader, if resources in other folders exist', () => {
+  it('renders subheader, if resources in other folders exist', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setSelectedResourceId('/folder/anotherFirstParty'));
     renderComponentWithStore(<HelperComponent isExternalAttribution={true} />, {
@@ -85,7 +85,7 @@ describe('ResourcePathPopup', () => {
     expect(screen.getByText('/folder/anotherFirstParty')).toBeInTheDocument();
   });
 
-  test('renders no subheader, if no resources in other folders exist', () => {
+  it('renders no subheader, if no resources in other folders exist', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setSelectedResourceId('/thirdParty'));
     renderComponentWithStore(

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -6,7 +6,7 @@
 import { splitResourceIdsToCurrentAndOtherFolder } from '../resource-path-popup-helpers';
 
 describe('splitResourceItToCurrentAndOtherFolder', () => {
-  test('splits resource ids correctly', () => {
+  it('splits resource ids correctly', () => {
     const allResourceIds = [
       '/folder_1/',
       '/folder_1/resource_1',

--- a/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
+++ b/src/Frontend/Components/ResourcesList/__tests__/ResourcesList.test.tsx
@@ -34,7 +34,7 @@ describe('The ResourcesList', () => {
     '/folder1/folder2/resource_1',
   ];
 
-  test('component renders', () => {
+  it('component renders', () => {
     renderComponentWithStore(
       <ResourcesList resourcesListBatches={resourcesListBatches} />
     );
@@ -42,7 +42,7 @@ describe('The ResourcesList', () => {
     expect(screen.getByText('resource_2')).toBeInTheDocument();
   });
 
-  test('clicking on a path changes the view, selectedResourceId and expandedResources without user callback', () => {
+  it('clicking on a path changes the view, selectedResourceId and expandedResources without user callback', () => {
     const { store } = renderComponentWithStore(
       <ResourcesList resourcesListBatches={resourcesListBatches} />
     );
@@ -56,7 +56,7 @@ describe('The ResourcesList', () => {
     expect(getExpandedIds(store.getState())).toMatchObject(expectedExpandedIds);
   });
 
-  test('clicking on a path changes the view, selectedResourceId and expandedResources with user callback', () => {
+  it('clicking on a path changes the view, selectedResourceId and expandedResources with user callback', () => {
     const onClickCallback = jest.fn();
     const { store } = renderComponentWithStore(
       <ResourcesList
@@ -75,7 +75,7 @@ describe('The ResourcesList', () => {
     expect(getExpandedIds(store.getState())).toMatchObject(expectedExpandedIds);
   });
 
-  test('clicking on a header does nothing', () => {
+  it('clicking on a header does nothing', () => {
     const onClickCallback = jest.fn();
     const resourcesListBatchesWithHeader: Array<ResourcesListBatch> = [
       {

--- a/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
+++ b/src/Frontend/Components/ResourcesList/__tests__/resource-list-helpers.test.ts
@@ -8,7 +8,7 @@ import { ResourcesListItem } from '../ResourcesList';
 import { ResourcesListBatch } from '../../../types/types';
 
 describe('convertResourceListBatchesToResourceListItems', () => {
-  test('inserts headers correctly', () => {
+  it('inserts headers correctly', () => {
     const resourcesListBatches: Array<ResourcesListBatch> = [
       { resourceIds: ['resource_1'] },
       {
@@ -31,7 +31,7 @@ describe('convertResourceListBatchesToResourceListItems', () => {
     expect(resourcesListItems).toStrictEqual(expectedResourcesListItems);
   });
 
-  test('executes case insensitive sort on resourceIds of each batch', () => {
+  it('executes case insensitive sort on resourceIds of each batch', () => {
     const resourcesListBatches: Array<ResourcesListBatch> = [
       { resourceIds: ['README.md', 'package.json'] },
       {
@@ -55,7 +55,7 @@ describe('convertResourceListBatchesToResourceListItems', () => {
     expect(resourcesListItems).toStrictEqual(expectedResourcesListItems);
   });
 
-  test('inserts no empty line for header at start of table', () => {
+  it('inserts no empty line for header at start of table', () => {
     const resourcesListBatches: Array<ResourcesListBatch> = [
       { resourceIds: ['resource_1'], header: 'Header' },
     ];

--- a/src/Frontend/Components/SearchTextField/__tests__/SearchTextField.test.tsx
+++ b/src/Frontend/Components/SearchTextField/__tests__/SearchTextField.test.tsx
@@ -9,7 +9,7 @@ import { SearchTextField } from '../SearchTextField';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 
 describe('The SearchTextField', () => {
-  test('has search functionality', () => {
+  it('has search functionality', () => {
     const onInputchange = jest.fn();
     renderComponentWithStore(
       <SearchTextField onInputChange={onInputchange} search={'test-search'} />

--- a/src/Frontend/Components/StyledTreeItemLabel/__tests__/StyledTreeItemLabel.test.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/__tests__/StyledTreeItemLabel.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { StyledTreeItemLabel } from '../StyledTreeItemLabel';
 
 describe('StyledTreeItemLabel', () => {
-  test('renders a file without information', () => {
+  it('renders a file without information', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -33,7 +33,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with attribution', () => {
+  it('renders a folder with attribution', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -56,7 +56,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with signal and icon', () => {
+  it('renders a folder with signal and icon', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -80,7 +80,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with resolved signal and icon', () => {
+  it('renders a folder with resolved signal and icon', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -104,7 +104,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a file with resolved signal and icon', () => {
+  it('renders a file with resolved signal and icon', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -128,7 +128,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with contained signals', () => {
+  it('renders a folder with contained signals', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -151,7 +151,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with contained attributions', () => {
+  it('renders a folder with contained attributions', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -174,7 +174,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a file with parent attribution', () => {
+  it('renders a file with parent attribution', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -197,7 +197,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder without information', () => {
+  it('renders a folder without information', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -220,7 +220,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a folder with all children containing signal also containing attributions', () => {
+  it('renders a folder with all children containing signal also containing attributions', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}
@@ -245,7 +245,7 @@ describe('StyledTreeItemLabel', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders a breakpoint', () => {
+  it('renders a breakpoint', () => {
     render(
       <StyledTreeItemLabel
         labelText={'Test label'}

--- a/src/Frontend/Components/Table/__tests__/Table.test.tsx
+++ b/src/Frontend/Components/Table/__tests__/Table.test.tsx
@@ -12,7 +12,7 @@ import { screen } from '@testing-library/react';
 import { DiscreteConfidence } from '../../../enums/enums';
 
 describe('The Table', () => {
-  test('renders', () => {
+  it('renders', () => {
     const testAttributionsWithResources: AttributionsWithResources = {
       uuid1: {
         packageName: 'React',

--- a/src/Frontend/Components/ToggleButton/__tests__/ToggleButton.test.tsx
+++ b/src/Frontend/Components/ToggleButton/__tests__/ToggleButton.test.tsx
@@ -9,7 +9,7 @@ import { ToggleButton } from '../ToggleButton';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('ToggleButton', () => {
-  test('renders a button', () => {
+  it('renders a button', () => {
     render(
       <ToggleButton
         buttonText={'Test'}

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -17,7 +17,7 @@ import { TopBar } from '../TopBar';
 import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 
 describe('TopBar', () => {
-  test('renders an Open file icon', () => {
+  it('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
     expect(window.electronAPI.on).toHaveBeenCalledTimes(10);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
@@ -66,7 +66,7 @@ describe('TopBar', () => {
     expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
   });
 
-  test('switches between views', () => {
+  it('switches between views', () => {
     const { store } = renderComponentWithStore(<TopBar />);
 
     fireEvent.click(screen.queryByText('Audit') as Element);

--- a/src/Frontend/extracted/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
@@ -25,7 +25,7 @@ describe('The VirtualizedTree', () => {
     docs: { 'readme.md': 1 },
   };
 
-  test('renders VirtualizedTree', () => {
+  it('renders VirtualizedTree', () => {
     render(
       <VirtualizedTree
         expandedIds={['/', '/thirdParty/', '/root/', '/root/src/', 'docs/']}

--- a/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
+++ b/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
@@ -10,7 +10,7 @@ import {
 import { NodesForTree } from '../types';
 
 describe('renderTree', () => {
-  test('isChildOfSelected works as expected', () => {
+  it('isChildOfSelected works as expected', () => {
     const NodeId = '/adapters/';
     const firstChildNodeId = '/adapters/.settings/org';
     const secondChildNodeId = '/adapters/.settings/';
@@ -22,7 +22,7 @@ describe('renderTree', () => {
     expect(isChildOfSelected(secondNotChild, NodeId)).toBe(false);
   });
 
-  test('getNodeIdsToExpand returns correct nodeIds', () => {
+  it('getNodeIdsToExpand returns correct nodeIds', () => {
     const nodeId = '/parent/';
     const node: NodesForTree | 1 = {
       directory: {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -91,7 +91,7 @@ describe('The ContextMenu', () => {
       '/fifthResource.js': ['uuid_2'],
     };
 
-    test('work correctly for non-pre-selected attributions', () => {
+    it('work correctly for non-pre-selected attributions', () => {
       mockElectronBackend(
         getParsedInputFileEnrichedWithTestData({
           resources: testResources,
@@ -180,7 +180,7 @@ describe('The ContextMenu', () => {
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
     });
 
-    test('work correctly for pre-selected attributions', () => {
+    it('work correctly for pre-selected attributions', () => {
       const testManualAttributionsPreSelected = {
         ...testExpandedManualAttributions,
         uuid_1: {
@@ -280,7 +280,7 @@ describe('The ContextMenu', () => {
     });
   });
 
-  test('show resource button opens working popup with file list when clicking on show resources icon', () => {
+  it('show resource button opens working popup with file list when clicking on show resources icon', () => {
     const testResources: Resources = {
       folder1: { 'firstResource.js': 1 },
       'secondResource.js': 1,

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
@@ -79,7 +79,7 @@ describe('Not saved popup of the app', () => {
     mockElectronBackend(mockChannelReturn);
   }
 
-  test('switches between views', () => {
+  it('switches between views', () => {
     loadMockFileContent();
     renderComponentWithStore(<App />);
     clickOnOpenFileIcon(screen);
@@ -98,7 +98,7 @@ describe('Not saved popup of the app', () => {
     expectResourceBrowserIsNotShown(screen);
   });
 
-  test('shows working unsaved popup switching from standard view to attribution view', () => {
+  it('shows working unsaved popup switching from standard view to attribution view', () => {
     loadMockFileContent();
     renderComponentWithStore(<App />);
     clickOnOpenFileIcon(screen);
@@ -136,7 +136,7 @@ describe('Not saved popup of the app', () => {
     expectResourceBrowserIsNotShown(screen);
   });
 
-  test('shows working unsaved popup switching from standard view to Report', () => {
+  it('shows working unsaved popup switching from standard view to Report', () => {
     loadMockFileContent();
     renderComponentWithStore(<App />);
     clickOnOpenFileIcon(screen);
@@ -165,7 +165,7 @@ describe('Not saved popup of the app', () => {
     expectValueInTextBox(screen, 'Version', '1.1.1');
   });
 
-  test('shows unsaved popup switching from attribution view to standard view', () => {
+  it('shows unsaved popup switching from attribution view to standard view', () => {
     loadMockFileContent();
     renderComponentWithStore(<App />);
     clickOnOpenFileIcon(screen);
@@ -228,7 +228,7 @@ describe('Not saved popup of the app', () => {
     getElementInResourceBrowser(screen, 'root');
   });
 
-  test(
+  it(
     'shows working unsaved popup when adding attribution or signal' +
       ' while modified attribution exists',
     () => {
@@ -253,7 +253,7 @@ describe('Not saved popup of the app', () => {
     }
   );
 
-  test('does not show NotSavedPopup when nothing was modified', () => {
+  it('does not show NotSavedPopup when nothing was modified', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -300,7 +300,7 @@ describe('Not saved popup of the app', () => {
     expectUnsavedChangesPopupIsNotShown(screen);
   });
 
-  test('shows NotSavedPopup if something was modified and buttons work', () => {
+  it('shows NotSavedPopup if something was modified and buttons work', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/open-file-in-external-link.test.tsx
@@ -21,7 +21,7 @@ import {
 import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-browser-test-helpers';
 
 describe('The go to link button', () => {
-  test('is visible and opens link in external browser', () => {
+  it('is visible and opens link in external browser', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -55,7 +55,7 @@ function mockSaveFileRequestChannel(): void {
 }
 
 describe('Other popups of the app', () => {
-  test('warning popup appears and cancel button works', () => {
+  it('warning popup appears and cancel button works', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: { 'firstResource.js': 1, 'secondResource.js': 1 },
@@ -112,7 +112,7 @@ describe('Other popups of the app', () => {
     expectUnsavedChangesPopupIsShown(screen);
   });
 
-  test('warning popup appears and save button works', () => {
+  it('warning popup appears and save button works', () => {
     const testInitialPackageName = 'InitialPackageName';
     const testPackageName = 'React - changed';
     const expectedNewAttribution: PackageInfo = {
@@ -172,7 +172,7 @@ describe('Other popups of the app', () => {
     expectButton(screen, ButtonText.Save, true);
   });
 
-  test('warning popup appears and save for all button works', () => {
+  it('warning popup appears and save for all button works', () => {
     const testInitialPackageName = 'InitialPackageName';
     const testPackageName = 'React - changed';
     const expectedNewAttribution: PackageInfo = {
@@ -233,7 +233,7 @@ describe('Other popups of the app', () => {
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
   });
 
-  test('opens working popup with file list when clicking on show resources icon', () => {
+  it('opens working popup with file list when clicking on show resources icon', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -279,7 +279,7 @@ describe('Other popups of the app', () => {
   });
 
   jest.useFakeTimers();
-  test('error popup works correctly for invalid PURL entry', () => {
+  it('error popup works correctly for invalid PURL entry', () => {
     const testInvalidPurl = 'invalidPurl';
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
@@ -312,7 +312,7 @@ describe('Other popups of the app', () => {
     expectErrorPopupIsNotShown(screen);
   });
 
-  test('saving works correctly with valid PURL entry with no popup', () => {
+  it('saving works correctly with valid PURL entry with no popup', () => {
     const testValidPurl =
       'pkg:testtype/testnamespace/testname@testversion?testqualifiers#testsubpath';
     const expectedNewAttribution: PackageInfo = {

--- a/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
@@ -26,7 +26,7 @@ import React from 'react';
 import { clickOnCardInAttributionList } from '../../../test-helpers/package-panel-helpers';
 
 describe('The App integration', () => {
-  test('app persists filters when changing views', () => {
+  it('app persists filters when changing views', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -81,7 +81,7 @@ const testResourcesToManualAttributions: ResourcesToAttributions = {
 };
 
 describe('In Attribution View the ContextMenu', () => {
-  test('confirmation buttons work correctly', () => {
+  it('confirmation buttons work correctly', () => {
     mockElectronBackend(
       getParsedInputFileEnrichedWithTestData({
         resources: testResources,
@@ -122,7 +122,7 @@ describe('In Attribution View the ContextMenu', () => {
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
   });
 
-  test('replaces attributions correctly', () => {
+  it('replaces attributions correctly', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {
         uuid_2: {
@@ -228,7 +228,7 @@ describe('In Attribution View the ContextMenu', () => {
     );
   });
 
-  test('deletes multi-selected attributions correctly', () => {
+  it('deletes multi-selected attributions correctly', () => {
     mockElectronBackend(
       getParsedInputFileEnrichedWithTestData({
         resources: testResources,

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../../test-helpers/popup-test-helpers';
 
 describe('The App in attribution view', () => {
-  test('app shows empty AttributionsDetailsViewer for selected Signals', () => {
+  it('app shows empty AttributionsDetailsViewer for selected Signals', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -85,7 +85,7 @@ describe('The App in attribution view', () => {
     expect(screen.queryByText('Linked Resources')).not.toBeInTheDocument();
   });
 
-  test('allows to modify text in text boxes', () => {
+  it('allows to modify text in text boxes', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -140,7 +140,7 @@ describe('The App in attribution view', () => {
     expectValueInTextBox(screen, 'Name', 'jQuery');
   });
 
-  test('handles purls correctly', () => {
+  it('handles purls correctly', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -249,7 +249,7 @@ describe('The App in attribution view', () => {
     );
   });
 
-  test('saves an updated attribution to file', () => {
+  it('saves an updated attribution to file', () => {
     const testManualPackage: PackageInfo = {
       packageName: 'jQuery',
       packageVersion: '16.0.0',
@@ -338,7 +338,7 @@ describe('The App in attribution view', () => {
     );
   });
 
-  test('deletes an attribution', () => {
+  it('deletes an attribution', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {},
       resourcesToAttributions: {},
@@ -401,7 +401,7 @@ describe('The App in attribution view', () => {
     );
   });
 
-  test('replaces attributions', () => {
+  it('replaces attributions', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {
         uuid_2: {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -35,7 +35,7 @@ import {
 import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-browser-test-helpers';
 
 describe('Add to attribution', () => {
-  test(
+  it(
     'AddToAttribution shows attribution correctly, ' +
       'does not show parent attribution, and adds attribution',
     () => {
@@ -118,7 +118,7 @@ describe('Add to attribution', () => {
     }
   );
 
-  test('AddToAttribution removes abandoned attributions', () => {
+  it('AddToAttribution removes abandoned attributions', () => {
     const testResources: Resources = {
       folder1: { 'firstResource.js': 1 },
       'secondResource.js': 1,
@@ -178,7 +178,7 @@ describe('Add to attribution', () => {
     expectValueInAddToAttributionList(screen, 'Angular, 10');
   });
 
-  test('AddToAttribution and deletion updates attributed children', () => {
+  it('AddToAttribution and deletion updates attributed children', () => {
     const testResources: Resources = {
       folder1: { 'firstResource.js': 1 },
       'secondResource.js': 1,
@@ -247,7 +247,7 @@ describe('Add to attribution', () => {
     );
   });
 
-  test('AddToAttribution not shown for breakpoints', () => {
+  it('AddToAttribution not shown for breakpoints', () => {
     const testResources: Resources = {
       folder1: { 'firstResource.js': 1 },
       'secondResource.js': 1,

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -78,7 +78,7 @@ const testResourcesToManualAttributions: ResourcesToAttributions = {
 };
 
 describe('In Audit View the ContextMenu', () => {
-  test('is not shown for add new attribution PackageCard', () => {
+  it('is not shown for add new attribution PackageCard', () => {
     mockElectronBackend(
       getParsedInputFileEnrichedWithTestData({
         resources: testResources,
@@ -94,7 +94,7 @@ describe('In Audit View the ContextMenu', () => {
     expectContextMenuIsNotShown(screen, cardLabel);
   });
 
-  test('confirmation buttons work correctly', () => {
+  it('confirmation buttons work correctly', () => {
     const testResources: Resources = {
       'firstResource.js': 1,
       'secondResource.js': 1,
@@ -200,7 +200,7 @@ describe('In Audit View the ContextMenu', () => {
     );
   });
 
-  test('hide / unhide buttons work correctly', () => {
+  it('hide / unhide buttons work correctly', () => {
     const testResources: Resources = {
       'firstResource.js': 1,
       'secondResource.js': 1,
@@ -314,7 +314,7 @@ describe('In Audit View the ContextMenu', () => {
       '/root/src/file_2': ['uuid_2', 'uuid_3'],
     };
 
-    test('in the package panel', () => {
+    it('in the package panel', () => {
       mockElectronBackend(
         getParsedInputFileEnrichedWithTestData({
           resources: testResources,
@@ -368,7 +368,7 @@ describe('In Audit View the ContextMenu', () => {
       );
     });
 
-    test('in the attributions in folder content panel', () => {
+    it('in the attributions in folder content panel', () => {
       mockElectronBackend(
         getParsedInputFileEnrichedWithTestData({
           resources: testResources,

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../../test-helpers/popup-test-helpers';
 
 describe('The App in Audit View', () => {
-  test('delete buttons are shown and work for non-preselected with popup', () => {
+  it('delete buttons are shown and work for non-preselected with popup', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -119,7 +119,7 @@ describe('The App in Audit View', () => {
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
   });
 
-  test('delete buttons are shown and work for preselected without popup', () => {
+  it('delete buttons are shown and work for preselected without popup', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -40,7 +40,7 @@ import {
 import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-browser-test-helpers';
 
 describe('The App in Audit View', () => {
-  test('saves new attributions to file in AuditView', () => {
+  it('saves new attributions to file in AuditView', () => {
     const testPackageName = 'React';
     const testLicenseNames = ['MIT', 'MIT License'];
     const mockChannelReturn: ParsedFileContent = {
@@ -119,7 +119,7 @@ describe('The App in Audit View', () => {
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
   });
 
-  test('save and save for all buttons are shown and work', () => {
+  it('save and save for all buttons are shown and work', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: { 'firstResource.js': 1, 'secondResource.js': 1 },
@@ -187,7 +187,7 @@ describe('The App in Audit View', () => {
     expectValueInManualPackagePanel(screen, 'Typescript, 16.5.0');
   });
 
-  test('confirm buttons are shown and work', () => {
+  it('confirm buttons are shown and work', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -62,14 +62,14 @@ import {
 } from '../../../test-helpers/popup-test-helpers';
 
 describe('The App in Audit View', () => {
-  test('renders TopBar and no ResourceBrowser when no resource file has been loaded', () => {
+  it('renders TopBar and no ResourceBrowser when no resource file has been loaded', () => {
     renderComponentWithStore(<App />);
 
     expectResourceBrowserIsNotShown(screen);
     expect(getOpenFileIcon(screen));
   });
 
-  test('allows to modify text in text boxes', () => {
+  it('allows to modify text in text boxes', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: { 'something.js': 1 },
@@ -108,7 +108,7 @@ describe('The App in Audit View', () => {
     );
   });
 
-  test('shows aggregated and parent attributions correctly', () => {
+  it('shows aggregated and parent attributions correctly', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -180,7 +180,7 @@ describe('The App in Audit View', () => {
     expectValueInTextBox(screen, 'Name', 'Angular');
   });
 
-  test('show confidence correctly', () => {
+  it('show confidence correctly', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -245,7 +245,7 @@ describe('The App in Audit View', () => {
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
   });
 
-  test('allows to switch between resources by clicking the progress bar', () => {
+  it('allows to switch between resources by clicking the progress bar', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -311,7 +311,7 @@ describe('The App in Audit View', () => {
     expectPackageInPackagePanel(screen, 'React', 'Signals');
   });
 
-  test('resolve button is shown and works', () => {
+  it('resolve button is shown and works', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -399,7 +399,7 @@ describe('The App in Audit View', () => {
     expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
   });
 
-  test('replaces attributions', () => {
+  it('replaces attributions', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {
         uuid_2: {

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../test-helpers/resource-browser-test-helpers';
 
 describe('The report view', () => {
-  test('opens a EditAttributionPopup by clicking on edit and saves changes', () => {
+  it('opens a EditAttributionPopup by clicking on edit and saves changes', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: {
@@ -78,7 +78,7 @@ describe('The report view', () => {
     expect(screen.getByText('Test comment'));
   });
 
-  test('recognizes frequent licenses and shows full license text in report view', () => {
+  it('recognizes frequent licenses and shows full license text in report view', () => {
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: { 'something.js': 1 },

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -71,7 +71,7 @@ import {
 
 describe('The actions checking for unsaved changes', () => {
   describe('navigateToSelectedPathOrOpenUnsavedPopup', () => {
-    test('sets view, selectedResourceId and expandedResources', () => {
+    it('sets view, selectedResourceId and expandedResources', () => {
       const testStore = createTestAppStore();
       testStore.dispatch(navigateToView(View.Attribution));
       testStore.dispatch(
@@ -92,7 +92,7 @@ describe('The actions checking for unsaved changes', () => {
   });
 
   describe('changeSelectedAttributionIdOrOpenUnsavedPopup', () => {
-    test(
+    it(
       'setsTargetSelectedAttributionId and temporaryPackageInfo' +
         ' and opens popup if packageInfo were modified',
       () => {
@@ -138,7 +138,7 @@ describe('The actions checking for unsaved changes', () => {
       }
     );
 
-    test('setSelectedAttributionId and temporaryPackageInfo if packageInfo were not modified', () => {
+    it('setSelectedAttributionId and temporaryPackageInfo if packageInfo were not modified', () => {
       const testResources: Resources = {
         selectedResource: 1,
         newSelectedResource: 1,
@@ -180,14 +180,14 @@ describe('The actions checking for unsaved changes', () => {
   });
 
   describe('The setViewOrOpenUnsavedPopup action', () => {
-    test('sets view', () => {
+    it('sets view', () => {
       const testStore = createTestAppStore();
       testStore.dispatch(navigateToView(View.Audit));
       testStore.dispatch(setViewOrOpenUnsavedPopup(View.Attribution));
       expect(getSelectedView(testStore.getState())).toBe(View.Attribution);
     });
 
-    test('opens unsave-popup', () => {
+    it('opens unsave-popup', () => {
       const testStore = createTestAppStore();
       testStore.dispatch(navigateToView(View.Audit));
       testStore.dispatch(setSelectedResourceId('/testId/'));
@@ -237,7 +237,7 @@ describe('The actions checking for unsaved changes', () => {
       '/root/src/something.js': [testManualAttributionUuid_1],
     };
 
-    test('set selected resource id', () => {
+    it('set selected resource id', () => {
       const testStore = createTestAppStore();
       testStore.dispatch(
         loadFromFile(
@@ -256,7 +256,7 @@ describe('The actions checking for unsaved changes', () => {
       expect(getSelectedResourceId(testStore.getState())).toBe('/thirdParty/');
     });
 
-    test('open unsaved-popup', () => {
+    it('open unsaved-popup', () => {
       const testStore = createTestAppStore();
       testStore.dispatch(
         loadFromFile(
@@ -282,7 +282,7 @@ describe('The actions checking for unsaved changes', () => {
   });
 
   describe('selectAttributionInAccordionPanelOrOpenUnsavedPopup', () => {
-    test('selects an attribution in an accordion panel', () => {
+    it('selects an attribution in an accordion panel', () => {
       const testPackageInfo: PackageInfo = { packageName: 'test name' };
       const testResources: Resources = {
         file1: 1,
@@ -325,7 +325,7 @@ describe('The actions checking for unsaved changes', () => {
   });
 
   describe('selectAttributionInManualPackagePanelOrOpenUnsavedPopup', () => {
-    test('ss an attribution in the manual package panel', () => {
+    it('ss an attribution in the manual package panel', () => {
       const testPackageInfo: PackageInfo = { packageName: 'test name' };
       const testResources: Resources = {
         file1: 1,
@@ -372,7 +372,7 @@ describe('The actions checking for unsaved changes', () => {
 
 describe('The actions called from the unsaved popup', () => {
   describe('unlinkAttributionAndSavePackageInfoAndNavigateToTargetView', () => {
-    test('unlinks and navigates to target view', () => {
+    it('unlinks and navigates to target view', () => {
       const testReact = {
         packageName: 'React',
       };
@@ -452,22 +452,22 @@ describe('The actions called from the unsaved popup', () => {
       return testStore.getState();
     }
 
-    test('saves temporaryPackageInfo', () => {
+    it('saves temporaryPackageInfo', () => {
       const state: State = prepareTestState();
       expect(getTemporaryPackageInfo(state)).toMatchObject({});
     });
 
-    test('sets TargetSelectedResourceOrAttribution', () => {
+    it('sets TargetSelectedResourceOrAttribution', () => {
       const state: State = prepareTestState();
       expect(getSelectedResourceId(state)).toBe('newSelectedResource');
     });
 
-    test('sets View', () => {
+    it('sets View', () => {
       const state: State = prepareTestState();
       expect(getSelectedView(state)).toBe(View.Attribution);
     });
 
-    test('closesPopup', () => {
+    it('closesPopup', () => {
       const state: State = prepareTestState();
       expect(getOpenPopup(state)).toBeFalsy();
     });
@@ -489,27 +489,27 @@ describe('The actions called from the unsaved popup', () => {
       return testStore.getState();
     }
 
-    test('closesPopup', () => {
+    it('closesPopup', () => {
       const state: State = prepareTestState();
       expect(getOpenPopup(state)).toBeFalsy();
     });
 
-    test('sets the view', () => {
+    it('sets the view', () => {
       const state: State = prepareTestState();
       expect(getSelectedView(state)).toBe(View.Attribution);
     });
 
-    test('sets targetSelectedResourceOrAttribution', () => {
+    it('sets targetSelectedResourceOrAttribution', () => {
       const state: State = prepareTestState();
       expect(getSelectedResourceId(state)).toBe('newSelectedResource');
     });
 
-    test('sets temporaryPackageInfo', () => {
+    it('sets temporaryPackageInfo', () => {
       const state: State = prepareTestState();
       expect(getTemporaryPackageInfo(state)).toMatchObject({});
     });
 
-    test('does not save temporaryPackageInfo', () => {
+    it('does not save temporaryPackageInfo', () => {
       const state: State = prepareTestState();
       expect(getManualAttributions(state)).toMatchObject({});
     });

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -85,7 +85,7 @@ const testResourcesToManualAttributions: ResourcesToAttributions = {
 };
 
 describe('The load and navigation simple actions', () => {
-  test('resets the state', () => {
+  it('resets the state', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
@@ -105,13 +105,13 @@ describe('The load and navigation simple actions', () => {
     );
   });
 
-  test('sets and gets resources', () => {
+  it('sets and gets resources', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setResources(testResources));
     expect(getResources(testStore.getState())).toMatchObject(testResources);
   });
 
-  test('sets and gets manual attribution data', () => {
+  it('sets and gets manual attribution data', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Redux' },
@@ -155,7 +155,7 @@ describe('The load and navigation simple actions', () => {
     ).toEqual(expectedResourcesWithAttributedChildren);
   });
 
-  test('sets and gets external attribution data', () => {
+  it('sets and gets external attribution data', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Redux' },
@@ -203,7 +203,7 @@ describe('The load and navigation simple actions', () => {
     ).toEqual(expectedResourcesWithAttributedChildren);
   });
 
-  test('sets and gets frequentLicenses', () => {
+  it('sets and gets frequentLicenses', () => {
     const testFrequentLicenses: FrequentLicences = {
       nameOrder: ['MIT', 'GPL'],
       texts: { MIT: 'MIT text', GPL: 'GPL text' },
@@ -218,7 +218,7 @@ describe('The load and navigation simple actions', () => {
     );
   });
 
-  test('sets and gets progressBarData', () => {
+  it('sets and gets progressBarData', () => {
     const testResources: Resources = {
       folder1: { file1: 1, file2: 1 },
       folder2: { file1: 1, file2: 1 },
@@ -285,7 +285,7 @@ describe('The load and navigation simple actions', () => {
     );
   });
 
-  test('sets and gets temporaryPackageInfo', () => {
+  it('sets and gets temporaryPackageInfo', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'test',
       packageVersion: '1.0',
@@ -298,14 +298,14 @@ describe('The load and navigation simple actions', () => {
     );
   });
 
-  test('sets and gets isSavingDisabled', () => {
+  it('sets and gets isSavingDisabled', () => {
     const testStore = createTestAppStore();
     expect(getIsSavingDisabled(testStore.getState())).toBe(false);
     testStore.dispatch(setIsSavingDisabled(true));
     expect(getIsSavingDisabled(testStore.getState())).toBe(true);
   });
 
-  test('sets and gets baseUrlsForSources', () => {
+  it('sets and gets baseUrlsForSources', () => {
     const testStore = createTestAppStore();
     expect(getBaseUrlsForSources(testStore.getState())).toEqual({});
     testStore.dispatch(setBaseUrlsForSources({ '/': 'github.com' }));
@@ -314,7 +314,7 @@ describe('The load and navigation simple actions', () => {
     });
   });
 
-  test('sets and gets externalAttributionSources', () => {
+  it('sets and gets externalAttributionSources', () => {
     const testStore = createTestAppStore();
     expect(getExternalAttributionSources(testStore.getState())).toEqual({});
     testStore.dispatch(

--- a/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/attribution-view-simple-actions.test.ts
@@ -18,7 +18,7 @@ import {
 import { getAttributionIdMarkedForReplacement } from '../../../selectors/all-views-resource-selectors';
 
 describe('The load and navigation simple actions', () => {
-  test('sets and gets selectedAttributionId', () => {
+  it('sets and gets selectedAttributionId', () => {
     const testStore = createTestAppStore();
     expect(getSelectedAttributionId(testStore.getState())).toBe('');
 
@@ -26,7 +26,7 @@ describe('The load and navigation simple actions', () => {
     expect(getSelectedAttributionId(testStore.getState())).toBe('Test');
   });
 
-  test('sets and gets targetSelectedAttributionId', () => {
+  it('sets and gets targetSelectedAttributionId', () => {
     const testStore = createTestAppStore();
     expect(getTargetSelectedAttributionId(testStore.getState())).toBe(null);
 
@@ -34,7 +34,7 @@ describe('The load and navigation simple actions', () => {
     expect(getTargetSelectedAttributionId(testStore.getState())).toBe('test');
   });
 
-  test('sets and gets attributionIdMarkedForReplacement', () => {
+  it('sets and gets attributionIdMarkedForReplacement', () => {
     const testStore = createTestAppStore();
     expect(getAttributionIdMarkedForReplacement(testStore.getState())).toBe('');
 
@@ -44,7 +44,7 @@ describe('The load and navigation simple actions', () => {
     );
   });
 
-  test('sets and gets multiSelectSelectedAttributionIds', () => {
+  it('sets and gets multiSelectSelectedAttributionIds', () => {
     const testStore = createTestAppStore();
     expect(
       getMultiSelectSelectedAttributionIds(testStore.getState())

--- a/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
@@ -31,13 +31,13 @@ import {
 import { getResourcesWithExternalAttributedChildren } from '../../../selectors/all-views-resource-selectors';
 
 describe('The audit view simple actions', () => {
-  test('sets and gets selectedResourceId', () => {
+  it('sets and gets selectedResourceId', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setSelectedResourceId('test'));
     expect(getSelectedResourceId(testStore.getState())).toBe('test');
   });
 
-  test('sets and gets targetSelectedResourceId', () => {
+  it('sets and gets targetSelectedResourceId', () => {
     const testTargetSelectedResourceId = 'test_id';
     const testStore = createTestAppStore();
     testStore.dispatch(
@@ -48,7 +48,7 @@ describe('The audit view simple actions', () => {
     );
   });
 
-  test('sets and gets expandedIds', () => {
+  it('sets and gets expandedIds', () => {
     const testExpandedIds: Array<string> = ['/folder1/', '/folder2/'];
 
     const testStore = createTestAppStore();
@@ -58,7 +58,7 @@ describe('The audit view simple actions', () => {
     expect(getExpandedIds(testStore.getState())).toEqual(testExpandedIds);
   });
 
-  test('sets and gets displayedPackage', () => {
+  it('sets and gets displayedPackage', () => {
     const testSelectedPackage: PanelPackage = {
       panel: PackagePanelTitle.AllAttributions,
       attributionId: 'uuid',
@@ -73,7 +73,7 @@ describe('The audit view simple actions', () => {
     );
   });
 
-  test('sets and gets targetDisplayedPackage', () => {
+  it('sets and gets targetDisplayedPackage', () => {
     const testTargetSelectedPackage: PanelPackage = {
       panel: PackagePanelTitle.AllAttributions,
       attributionId: 'uuid',
@@ -88,7 +88,7 @@ describe('The audit view simple actions', () => {
     );
   });
 
-  test('add resolved signals to state', () => {
+  it('add resolved signals to state', () => {
     const testStore = createTestAppStore();
     const uuid1 = 'd3a753c0-5100-11eb-ae93-0242ac130002';
     const uuid2 = 'd3a7565e-5100-11eb-ae93-0242ac130002';
@@ -142,7 +142,7 @@ describe('The audit view simple actions', () => {
     ).toMatchObject({});
   });
 
-  test('remove resolved signals from state', () => {
+  it('remove resolved signals from state', () => {
     const testStore = createTestAppStore();
     const uuid1 = 'd3a753c0-5100-11eb-ae93-0242ac130002';
     const uuid2 = 'd3a7565e-5100-11eb-ae93-0242ac130002';

--- a/src/Frontend/state/actions/resource-actions/__tests__/file-search-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/file-search-actions.test.ts
@@ -8,7 +8,7 @@ import { getFileSearch } from '../../../selectors/file-search-selectors';
 import { setFileSearch } from '../file-search-actions';
 
 describe('The fileSearch actions', () => {
-  test('sets and gets fileSearch', () => {
+  it('sets and gets fileSearch', () => {
     const testStore = createTestAppStore();
     expect(getFileSearch(testStore.getState())).toBe('');
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -69,7 +69,7 @@ const testResourcesToManualAttributions: ResourcesToAttributions = {
 };
 
 describe('loadFromFile', () => {
-  test('loads from file into state', () => {
+  it('loads from file into state', () => {
     const testExternalAttributions: Attributions = {
       [testManualAttributionUuid_1]: {
         packageVersion: '1.0',

--- a/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
@@ -50,7 +50,7 @@ import {
 import { getSelectedAttributionId } from '../../../selectors/attribution-view-resource-selectors';
 
 describe('resetTemporaryPackageInfo', () => {
-  test('works correctly on audit view', () => {
+  it('works correctly on audit view', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
     };
@@ -93,7 +93,7 @@ describe('resetTemporaryPackageInfo', () => {
     expect(getTemporaryPackageInfo(testStore.getState())).toEqual(testReact);
   });
 
-  test('works correctly on attribution view', () => {
+  it('works correctly on attribution view', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
     };
@@ -125,7 +125,7 @@ describe('resetTemporaryPackageInfo', () => {
 });
 
 describe('setSelectedResourceOrAttributionIdFromTarget', () => {
-  test('setSelectedResourceId in case of Audit View', () => {
+  it('setSelectedResourceId in case of Audit View', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Audit));
     testStore.dispatch(setSelectedResourceId('previousResourceId'));
@@ -140,7 +140,7 @@ describe('setSelectedResourceOrAttributionIdFromTarget', () => {
     expect(getSelectedAttributionId(state)).toBe('previousAttributionId');
   });
 
-  test('setSelectedAttributionId in case of attribution view and targetView Resource', () => {
+  it('setSelectedAttributionId in case of attribution view and targetView Resource', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
     testStore.dispatch(setTargetView(View.Audit));
@@ -156,7 +156,7 @@ describe('setSelectedResourceOrAttributionIdFromTarget', () => {
     expect(getSelectedAttributionId(state)).toBe('newAttributionId');
   });
 
-  test('setSelectedAttributionId in case of attribution view and stay on attribution view', () => {
+  it('setSelectedAttributionId in case of attribution view and stay on attribution view', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
     testStore.dispatch(setTargetView(View.Attribution));
@@ -173,7 +173,7 @@ describe('setSelectedResourceOrAttributionIdFromTarget', () => {
     expect(getSelectedAttributionId(state)).toBe('newAttributionId');
   });
 
-  test('setDisplayedPackage in case of audit view', () => {
+  it('setDisplayedPackage in case of audit view', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Audit));
     testStore.dispatch(
@@ -198,7 +198,7 @@ describe('setSelectedResourceOrAttributionIdFromTarget', () => {
 });
 
 describe('setSelectedResourceIdAndExpand', () => {
-  test('sets the selectedResourceId', () => {
+  it('sets the selectedResourceId', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(openResourceInResourceBrowser('/folder1/folder2/test'));
     const state = testStore.getState();
@@ -206,7 +206,7 @@ describe('setSelectedResourceIdAndExpand', () => {
     expect(getSelectedView(state)).toEqual(View.Audit);
   });
 
-  test('sets the expandedIds', () => {
+  it('sets the expandedIds', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(openResourceInResourceBrowser('/folder1/folder2/test'));
     const state = testStore.getState();
@@ -220,7 +220,7 @@ describe('setSelectedResourceIdAndExpand', () => {
 });
 
 describe('setDisplayedPackageAndResetTemporaryPackageInfo', () => {
-  test('sets the displayedPackage and loads the right initial temporaryPackageInfo', () => {
+  it('sets the displayedPackage and loads the right initial temporaryPackageInfo', () => {
     const testPackageInfo: PackageInfo = { packageName: 'React' };
     const testResources: Resources = {
       file1: 1,
@@ -262,7 +262,7 @@ describe('setDisplayedPackageAndResetTemporaryPackageInfo', () => {
 });
 
 describe('resetSelectedPackagePanelIfContainedAttributionWasRemoved', () => {
-  test('resets the selectedPackage attributionId if the attribution has been removed from the resource', () => {
+  it('resets the selectedPackage attributionId if the attribution has been removed from the resource', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
       attributionConfidence: DiscreteConfidence.High,

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -107,7 +107,7 @@ const testResourcesToExternalAttributions: ResourcesToAttributions = {
 };
 
 describe('The savePackageInfo action', () => {
-  test('does not save if saving is disabled', () => {
+  it('does not save if saving is disabled', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
       packageName: 'test Package',
@@ -142,7 +142,7 @@ describe('The savePackageInfo action', () => {
     );
   });
 
-  test('throws an error if resource is a breakpoint', () => {
+  it('throws an error if resource is a breakpoint', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       packageName: 'test Package',
     };
@@ -174,7 +174,7 @@ describe('The savePackageInfo action', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
   });
 
-  test('creates a new attribution', () => {
+  it('creates a new attribution', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
       packageName: 'test Package',
@@ -245,7 +245,7 @@ describe('The savePackageInfo action', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
   });
 
-  test('updates an attribution', () => {
+  it('updates an attribution', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
@@ -309,7 +309,7 @@ describe('The savePackageInfo action', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
   });
 
-  test('removes an attribution', () => {
+  it('removes an attribution', () => {
     const testUuidA = '8ef8dff4-8e9d-4cab-b70b-44fa498957a9';
     const testUuidB = 'd8ff89ae-34d0-4899-9519-7f736e7fd7da';
     const testResources: Resources = {
@@ -409,7 +409,7 @@ describe('The savePackageInfo action', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
   });
 
-  test('removes an attribution keeping the selectedAttributionId when the attribution still exists', () => {
+  it('removes an attribution keeping the selectedAttributionId when the attribution still exists', () => {
     const testResources: Resources = {
       'something.js': 1,
       'somethingElse.js': 1,
@@ -456,7 +456,7 @@ describe('The savePackageInfo action', () => {
     expect(getSelectedAttributionId(testStore.getState())).toBe('uuid2');
   });
 
-  test('cleans up multiSelectSelectedAttributionIds if attribution was removed', () => {
+  it('cleans up multiSelectSelectedAttributionIds if attribution was removed', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -476,7 +476,7 @@ describe('The savePackageInfo action', () => {
     ).toStrictEqual([]);
   });
 
-  test('removes an attribution from child and removes all remaining attributions if parent has identical ones', () => {
+  it('removes an attribution from child and removes all remaining attributions if parent has identical ones', () => {
     const testResources: Resources = {
       parent: {
         'child.js': 1,
@@ -512,7 +512,7 @@ describe('The savePackageInfo action', () => {
     });
   });
 
-  test('removes an attribution from parent and removes all remaining attributions from child if has now same of parent', () => {
+  it('removes an attribution from parent and removes all remaining attributions from child if has now same of parent', () => {
     const testResources: Resources = {
       parent: {
         'child.js': 1,
@@ -548,7 +548,7 @@ describe('The savePackageInfo action', () => {
     });
   });
 
-  test('replaces an attribution with an existing one', () => {
+  it('replaces an attribution with an existing one', () => {
     const testPackageInfo = {
       packageName: 'React',
       attributionConfidence: DiscreteConfidence.High,
@@ -628,7 +628,7 @@ describe('The savePackageInfo action', () => {
     ).toStrictEqual(['uuid1']);
   });
 
-  test('links to an attribution when the attribution already exists', () => {
+  it('links to an attribution when the attribution already exists', () => {
     const testUuid = '8ef8dff4-8e9d-4cab-b70b-44fa498957a9';
     const testPackageInfo = {
       packageName: 'React',
@@ -703,7 +703,7 @@ describe('The savePackageInfo action', () => {
     );
   });
 
-  test('removes an attribution and keeps temporary package info for selected attribution', () => {
+  it('removes an attribution and keeps temporary package info for selected attribution', () => {
     const testUuidA = '8ef8dff4-8e9d-4cab-b70b-44fa498957a9';
     const testUuidB = 'd8ff89ae-34d0-4899-9519-7f736e7fd7da';
     const testResources: Resources = {
@@ -753,7 +753,7 @@ describe('The savePackageInfo action', () => {
     );
   });
 
-  test('replaces an attribution with an existing one, keeps temporary package info for selected attribution and stay at selected attribution', () => {
+  it('replaces an attribution with an existing one, keeps temporary package info for selected attribution and stay at selected attribution', () => {
     const testPackageInfo = {
       packageName: 'React',
       attributionConfidence: DiscreteConfidence.High,
@@ -810,7 +810,7 @@ describe('The savePackageInfo action', () => {
     expect(getSelectedAttributionId(testStore.getState())).toBe('uuid2');
   });
 
-  test('creates a new attribution, keeps temporary package info for selected attribution and stay at selected attribution', () => {
+  it('creates a new attribution, keeps temporary package info for selected attribution and stay at selected attribution', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
       packageName: 'test Package',
@@ -862,7 +862,7 @@ describe('The savePackageInfo action', () => {
     ).toBe('uuid1');
   });
 
-  test('updates an attribution and keeps temporary package info for selected attribution', () => {
+  it('updates an attribution and keeps temporary package info for selected attribution', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       packageName: 'test Package modified',
@@ -899,7 +899,7 @@ describe('The savePackageInfo action', () => {
 });
 
 describe('The unlinkAttributionAndSavePackageInfo action', () => {
-  test('saves attribution updates for a single resource', () => {
+  it('saves attribution updates for a single resource', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
       attributionConfidence: DiscreteConfidence.Low,
@@ -957,7 +957,7 @@ describe('The unlinkAttributionAndSavePackageInfo action', () => {
 });
 
 describe('The deleteAttributionAndSave action', () => {
-  test('unlinks resource from attribution with single linked attribution', () => {
+  it('unlinks resource from attribution with single linked attribution', () => {
     const testResources: Resources = {
       file1: 1,
     };
@@ -988,7 +988,7 @@ describe('The deleteAttributionAndSave action', () => {
     expect(getManualData(testStore.getState())).toEqual(expectedManualData);
   });
 
-  test('deletes attributions from multiSelectSelectedAttributionIds', () => {
+  it('deletes attributions from multiSelectSelectedAttributionIds', () => {
     const testResources: Resources = {
       file1: 1,
     };
@@ -1023,7 +1023,7 @@ describe('The deleteAttributionAndSave action', () => {
     ).toStrictEqual([]);
   });
 
-  test('unlinks resource from attribution multiple linked attribution', () => {
+  it('unlinks resource from attribution multiple linked attribution', () => {
     const testResources: Resources = {
       file1: 1,
     };
@@ -1067,7 +1067,7 @@ describe('The deleteAttributionAndSave action', () => {
 });
 
 describe('The deleteAttributionGloballyAndSave action', () => {
-  test('deletes attribution', () => {
+  it('deletes attribution', () => {
     const testReact: PackageInfo = {
       packageName: 'React',
       attributionConfidence: DiscreteConfidence.Low,
@@ -1133,7 +1133,7 @@ describe('The deleteAttributionGloballyAndSave action', () => {
 });
 
 describe('The addToSelectedResource action', () => {
-  test('links an already existing manual attribution to the selected resource', () => {
+  it('links an already existing manual attribution to the selected resource', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -1165,7 +1165,7 @@ describe('The addToSelectedResource action', () => {
     expect(getOpenPopup(testStore.getState())).toBe(null);
   });
 
-  test('opens popup', () => {
+  it('opens popup', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -1188,7 +1188,7 @@ describe('The addToSelectedResource action', () => {
     expect(getOpenPopup(testStore.getState())).toEqual('NotSavedPopup');
   });
 
-  test('adds a signal to the selected resource', () => {
+  it('adds a signal to the selected resource', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -1239,7 +1239,7 @@ describe('The addToSelectedResource action', () => {
     expect(getOpenPopup(testStore.getState())).toBe(null);
   });
 
-  test('saves resolved external signals', () => {
+  it('saves resolved external signals', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setResources({}));
     testStore.dispatch(

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -28,14 +28,14 @@ import {
 } from '../view-actions';
 
 describe('view actions', () => {
-  test('sets view to AuditView as initial value', () => {
+  it('sets view to AuditView as initial value', () => {
     const testStore = createTestAppStore();
     expect(isAuditViewSelected(testStore.getState())).toBe(true);
     expect(isReportViewSelected(testStore.getState())).toBe(false);
     expect(isAttributionViewSelected(testStore.getState())).toBe(false);
   });
 
-  test('sets view to AttributionView', () => {
+  it('sets view to AttributionView', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
 
@@ -44,7 +44,7 @@ describe('view actions', () => {
     expect(isAttributionViewSelected(testStore.getState())).toBe(true);
   });
 
-  test('sets view to ReportView', () => {
+  it('sets view to ReportView', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Report));
 
@@ -53,7 +53,7 @@ describe('view actions', () => {
     expect(isReportViewSelected(testStore.getState())).toBe(true);
   });
 
-  test('sets view to AttributionView and back to AuditView', () => {
+  it('sets view to AttributionView and back to AuditView', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
 
@@ -68,7 +68,7 @@ describe('view actions', () => {
     expect(isAttributionViewSelected(testStore.getState())).toBe(false);
   });
 
-  test('sets view to AuditView even if it is already set', () => {
+  it('sets view to AuditView even if it is already set', () => {
     const testStore = createTestAppStore();
 
     expect(isAuditViewSelected(testStore.getState())).toBe(true);
@@ -82,7 +82,7 @@ describe('view actions', () => {
     expect(isAttributionViewSelected(testStore.getState())).toBe(false);
   });
 
-  test('sets the selectedView', () => {
+  it('sets the selectedView', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
 
@@ -97,7 +97,7 @@ describe('view actions', () => {
     expect(getSelectedView(testStore.getState())).toBe(View.Report);
   });
 
-  test('resets view state', () => {
+  it('resets view state', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(navigateToView(View.Attribution));
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
@@ -120,7 +120,7 @@ describe('view actions', () => {
     ).toBe(false);
   });
 
-  test('sets filters correctly', () => {
+  it('sets filters correctly', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
     expect(
@@ -151,7 +151,7 @@ describe('view actions', () => {
     ).toBe(true);
   });
 
-  test('sets showHighlightForCriticalSignals', () => {
+  it('sets showHighlightForCriticalSignals', () => {
     const testStore = createTestAppStore();
 
     expect(getHighlightForCriticalSignals(testStore.getState())).toBe(false);
@@ -161,24 +161,24 @@ describe('view actions', () => {
 });
 
 describe('popup actions', () => {
-  test('popup is closed by default', () => {
+  it('popup is closed by default', () => {
     const testStore = createTestAppStore();
     expect(getOpenPopup(testStore.getState())).toBeFalsy();
   });
 
-  test('open NotSavedPopup', () => {
+  it('open NotSavedPopup', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     expect(getOpenPopup(testStore.getState())).toBe(PopupType.NotSavedPopup);
   });
 
-  test('close NotSavedPopup', () => {
+  it('close NotSavedPopup', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(closePopup());
     expect(getOpenPopup(testStore.getState())).toBeFalsy();
   });
-  test('sets targetAttributionId and popupType', () => {
+  it('sets targetAttributionId and popupType', () => {
     const testStore = createTestAppStore();
     expect(getPopupAttributionId(testStore.getState())).toEqual(null);
     const testAttributionId = 'test';
@@ -193,7 +193,7 @@ describe('popup actions', () => {
     );
   });
 
-  test('handles multiple opened popups', () => {
+  it('handles multiple opened popups', () => {
     const testStore = createTestAppStore();
     const testAttributionId = 'test';
     testStore.dispatch(

--- a/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
@@ -17,7 +17,7 @@ import { NIL as uuidNil } from 'uuid';
 import { computeChildrenWithAttributions } from '../action-and-reducer-helpers';
 
 describe('The attributionForTemporaryPackageInfoExists function', () => {
-  test('checks if manual attributions exist', () => {
+  it('checks if manual attributions exist', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,
@@ -93,7 +93,7 @@ describe('The attributionForTemporaryPackageInfoExists function', () => {
 });
 
 describe('computeChildrenWithAttributions', () => {
-  test('parses ResourcesWithAttributionsFromDb', () => {
+  it('parses ResourcesWithAttributionsFromDb', () => {
     const testUuid: string = uuidNil;
     const mockResourcesWithAttributionsFromDb: ResourcesToAttributions = {
       '/root/src/': [testUuid],

--- a/src/Frontend/state/helpers/__tests__/file-search-helpers.test.tsx
+++ b/src/Frontend/state/helpers/__tests__/file-search-helpers.test.tsx
@@ -20,11 +20,11 @@ describe('The getPathsFromResources function', () => {
     },
   };
 
-  test('returns only base path for empty resources', () => {
+  it('returns only base path for empty resources', () => {
     const paths = getPathsFromResources({});
     expect(paths).toEqual(['/']);
   });
-  test('returns all paths', () => {
+  it('returns all paths', () => {
     const paths = getPathsFromResources(testResources).sort();
     const expectedPaths = [
       '/',

--- a/src/Frontend/state/helpers/__tests__/get-parents.test.ts
+++ b/src/Frontend/state/helpers/__tests__/get-parents.test.ts
@@ -11,7 +11,7 @@ import {
 describe('Test getParents', () => {
   const testResource = '/first/second/third/fourth';
 
-  test('get parents of test string', () => {
+  it('get parents of test string', () => {
     const result = getParents(testResource);
     expect(result).toEqual([
       '/',
@@ -21,7 +21,7 @@ describe('Test getParents', () => {
     ]);
   });
 
-  test('get parents with breakpoints', () => {
+  it('get parents with breakpoints', () => {
     let result = getParentsUpToNextAttributionBreakpoint(
       testResource,
       (path) => path === '/first/'
@@ -64,7 +64,7 @@ describe('Test getParents', () => {
     ]);
   });
 
-  test('get parents with breakpoints, resource itself is breakpoint', () => {
+  it('get parents with breakpoints, resource itself is breakpoint', () => {
     const result = getParentsUpToNextAttributionBreakpoint(
       '/some/deep/folder/',
       (path) => path === '/some/deep/folder/'

--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -20,7 +20,7 @@ import { ProgressBarData } from '../../../types/types';
 import { DiscreteConfidence } from '../../../enums/enums';
 
 describe('The getUpdatedProgressBarData function', () => {
-  test('gets updated progress data', () => {
+  it('gets updated progress data', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,
@@ -83,7 +83,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ]);
   });
 
-  test('gets updated progress data without resolved external attributions', () => {
+  it('gets updated progress data without resolved external attributions', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,
@@ -148,7 +148,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ]);
   });
 
-  test('stops inferring attributions at breakpoints', () => {
+  it('stops inferring attributions at breakpoints', () => {
     const testResources: Resources = {
       folder1: {
         breakpoint1: { file1: 1, file2: 1 },
@@ -244,7 +244,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ]);
   });
 
-  test('infers fileWithChildren correctly', () => {
+  it('infers fileWithChildren correctly', () => {
     const testResources: Resources = {
       'package.json': {
         file1: 1,
@@ -293,7 +293,7 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([]);
   });
 
-  test('resourceHasOnlyPreSelectedAttributions with only pre-selected attributions', () => {
+  it('resourceHasOnlyPreSelectedAttributions with only pre-selected attributions', () => {
     const { testResourcesToManualAttributions, testManualAttributions } =
       getTestObjectsForResourcesWithPreSelectedAttributions();
     expect(
@@ -305,7 +305,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ).toBeTruthy();
   });
 
-  test('resourceHasOnlyPreSelectedAttributions with mixed attributions', () => {
+  it('resourceHasOnlyPreSelectedAttributions with mixed attributions', () => {
     const { testResourcesToManualAttributions, testManualAttributions } =
       getTestObjectsForResourcesWithPreSelectedAttributions();
     expect(
@@ -317,7 +317,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ).toBeFalsy();
   });
 
-  test('updateProgressBarDataForResources', () => {
+  it('updateProgressBarDataForResources', () => {
     const progressBarData = getEmptyProgressBarData();
     const resources: Resources = {
       dir1: { subdir1: { file1: 1 } },
@@ -357,7 +357,7 @@ describe('The getUpdatedProgressBarData function', () => {
 });
 
 describe('The getFolderProgressBarData function', () => {
-  test('gets updated progress data for current folder', () => {
+  it('gets updated progress data for current folder', () => {
     const testResources: Resources = {
       thirdParty: {
         'package_1.tr.gz': 1,

--- a/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
@@ -24,7 +24,7 @@ import {
 const testUuid: string = uuidNil;
 
 describe('The createManualAttribution function', () => {
-  test('adds a new manual attribution', () => {
+  it('adds a new manual attribution', () => {
     const testManualData: AttributionData = EMPTY_ATTRIBUTION_DATA;
     const testSelectedResourceId = '/something.js';
     const testTemporaryPackageInfo: PackageInfo = { packageName: 'React' };
@@ -44,7 +44,7 @@ describe('The createManualAttribution function', () => {
 });
 
 describe('The deleteManualAttribution function', () => {
-  test('deletes an empty manual attribution', () => {
+  it('deletes an empty manual attribution', () => {
     const testManualData: AttributionData = {
       attributions: {
         [testUuid]: {
@@ -74,7 +74,7 @@ describe('The deleteManualAttribution function', () => {
     expect(isEmpty(newManualData.resourcesWithAttributedChildren)).toBe(true);
   });
 
-  test('correctly maintains childrenFromAttributedResources', () => {
+  it('correctly maintains childrenFromAttributedResources', () => {
     const testAnotherUuid = '000';
     const testManualData: AttributionData = {
       attributions: {
@@ -119,7 +119,7 @@ describe('The deleteManualAttribution function', () => {
 });
 
 describe('The updateManualAttribution function', () => {
-  test('updates an existing manual attribution', () => {
+  it('updates an existing manual attribution', () => {
     const testPackageInfo: PackageInfo = { packageName: 'Vue' };
     const testTemporaryPackageInfo: PackageInfo = {
       packageName: 'React',
@@ -160,7 +160,7 @@ describe('The updateManualAttribution function', () => {
 });
 
 describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
-  test('three matching', () => {
+  it('three matching', () => {
     const testManualData: AttributionData = {
       attributions: {
         uuid1: {
@@ -212,7 +212,7 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
     expect(testManualData).toEqual(expectedStrippedManualData);
   });
 
-  test('matching and non-matching children attributions', () => {
+  it('matching and non-matching children attributions', () => {
     const testManualData: AttributionData = {
       attributions: {
         uuid1: {
@@ -318,7 +318,7 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
 });
 
 describe('_removeAttributionsFromChildrenAndParents', () => {
-  test('matching and non-matching children attributions', () => {
+  it('matching and non-matching children attributions', () => {
     const testManualData: AttributionData = {
       attributions: {
         uuid1: {
@@ -419,7 +419,7 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
     expect(testManualData).toEqual(expectedStrippedManualData);
   });
 
-  test('child has subset of attributions from parent', () => {
+  it('child has subset of attributions from parent', () => {
     const testManualData: AttributionData = {
       attributions: {
         uuid1: {
@@ -504,7 +504,7 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
 });
 
 describe('_getIdsOfResourcesThatMightHaveChildrenWithTheSameAttributions', () => {
-  test('returns only parents linked to the same attribution', () => {
+  it('returns only parents linked to the same attribution', () => {
     const testResourceId = '/parent/resource';
     const testAttributionId = 'ATTRIBUTION_ID';
     const expectedOutput = ['/parent/', testResourceId];
@@ -521,7 +521,7 @@ describe('_getIdsOfResourcesThatMightHaveChildrenWithTheSameAttributions', () =>
     ).toEqual(expectedOutput);
   });
 
-  test('returns only itself & parents if the resource cannot have children', () => {
+  it('returns only itself & parents if the resource cannot have children', () => {
     const testResourceId = '/parent/resource';
     const testAttributionId = 'ATTRIBUTION_ID';
     const expectedOutput = ['/parent/', testResourceId];
@@ -540,7 +540,7 @@ describe('_getIdsOfResourcesThatMightHaveChildrenWithTheSameAttributions', () =>
     ).toEqual(expectedOutput);
   });
 
-  test('returns itself & parents and children linked to the same attribution', () => {
+  it('returns itself & parents and children linked to the same attribution', () => {
     const testResourceId = '/parent/resource/';
     const testAttributionId = 'ATTRIBUTION_ID';
     const expectedOutput = [

--- a/src/Frontend/state/helpers/__tests__/set-filters.test.ts
+++ b/src/Frontend/state/helpers/__tests__/set-filters.test.ts
@@ -7,7 +7,7 @@ import { FilterType } from '../../../enums/enums';
 import { getFiltersToRemove, getUpdatedFilters } from '../set-filters';
 
 describe('The getUpdatedFilters function', () => {
-  test('adds non-existing filter', () => {
+  it('adds non-existing filter', () => {
     const activeFilters = new Set([FilterType.OnlyFollowUp]);
     const expectedFilters = new Set([
       FilterType.OnlyFollowUp,
@@ -18,7 +18,7 @@ describe('The getUpdatedFilters function', () => {
     );
   });
 
-  test('remove existing filter', () => {
+  it('remove existing filter', () => {
     const activeFilters = new Set([
       FilterType.OnlyFollowUp,
       FilterType.HideFirstParty,
@@ -31,21 +31,21 @@ describe('The getUpdatedFilters function', () => {
 });
 
 describe('The getFiltersToRemove function', () => {
-  test('returns only first party filter when the new filter is hide first party', () => {
+  it('returns only first party filter when the new filter is hide first party', () => {
     const filtersToRemove = new Set([FilterType.OnlyFirstParty]);
     expect(getFiltersToRemove(FilterType.HideFirstParty)).toEqual(
       filtersToRemove
     );
   });
 
-  test('returns hide first party filter when the new filter is only first party', () => {
+  it('returns hide first party filter when the new filter is only first party', () => {
     const filtersToRemove = new Set([FilterType.HideFirstParty]);
     expect(getFiltersToRemove(FilterType.OnlyFirstParty)).toEqual(
       filtersToRemove
     );
   });
 
-  test('returns no filter when the new filter is only follow up', () => {
+  it('returns no filter when the new filter is only follow up', () => {
     const filtersToRemove = new Set();
     expect(getFiltersToRemove(FilterType.OnlyFollowUp)).toEqual(
       filtersToRemove

--- a/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
@@ -41,7 +41,7 @@ describe('getPackageInfoOfSelectedAttribution', () => {
     '/root/src/something.js': [testManualAttributionUuid_1],
   };
 
-  test('returns temporary package info of selected attribution', () => {
+  it('returns temporary package info of selected attribution', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
@@ -52,7 +52,7 @@ describe('getPackageInfoOfSelectedAttribution', () => {
     );
   });
 
-  test('returns empty temporary package info if no selected attribution', () => {
+  it('returns empty temporary package info if no selected attribution', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
@@ -70,7 +70,7 @@ describe('Attribution breakpoints', () => {
     '/node_modules/',
   ]);
 
-  test('can be created and listed.', () => {
+  it('can be created and listed.', () => {
     const testStore = createTestAppStore();
     expect(getAttributionBreakpoints(testStore.getState())).toEqual(new Set());
 
@@ -88,7 +88,7 @@ describe('Files with children', () => {
     testFileWithChildren
   );
 
-  test('can be created, listed and checked.', () => {
+  it('can be created, listed and checked.', () => {
     const testStore = createTestAppStore();
 
     expect(getFilesWithChildren(testStore.getState())).toEqual(new Set());
@@ -108,7 +108,7 @@ describe('ProjectMetadata', () => {
     fileCreationDate: 'test-date',
   };
 
-  test('can be set and get from store.', () => {
+  it('can be set and get from store.', () => {
     const testStore = createTestAppStore();
     expect(getProjectMetadata(testStore.getState())).toEqual(
       EMPTY_PROJECT_METADATA

--- a/src/Frontend/state/selectors/__tests__/attribution-view-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/attribution-view-resource-selectors.test.ts
@@ -53,7 +53,7 @@ describe('The resource actions', () => {
     '/root/src/something.js': [testManualAttributionUuid_1],
   };
 
-  test('getResourceIdsForSelectedAttributionId returns correct Ids', () => {
+  it('getResourceIdsForSelectedAttributionId returns correct Ids', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setResources(testResources));
     testStore.dispatch(setSelectedAttributionId(testManualAttributionUuid_1));

--- a/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
@@ -49,7 +49,7 @@ describe('The audit view resource selectors', () => {
     '/root/src/something.js': [testManualAttributionUuid_1],
   };
 
-  test('sets Attributions and getsAttribution for a ResourceId', () => {
+  it('sets Attributions and getsAttribution for a ResourceId', () => {
     const testStore = createTestAppStore();
     const expectedPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
@@ -68,7 +68,7 @@ describe('The audit view resource selectors', () => {
     );
   });
 
-  test('gets attributions and attribution ids for the selected resource', () => {
+  it('gets attributions and attribution ids for the selected resource', () => {
     const testStore = createTestAppStore();
     const reactPackage: PackageInfo = { packageName: 'React' };
     testStore.dispatch(
@@ -95,7 +95,7 @@ describe('The audit view resource selectors', () => {
     });
   });
 
-  test('gets getSelectedPackageAttributionIdIfManualPackagePanel', () => {
+  it('gets getSelectedPackageAttributionIdIfManualPackagePanel', () => {
     const manualPackagesSelectedPackage: PanelPackage = {
       panel: PackagePanelTitle.ManualPackages,
       attributionId: 'uuid1',
@@ -132,7 +132,7 @@ describe('The audit view resource selectors', () => {
     ).toBeNull();
   });
 
-  test('sets and gets resolvedExternalAttributions', () => {
+  it('sets and gets resolvedExternalAttributions', () => {
     const testStore = createTestAppStore();
     const testResolvedExternalAttributions: Set<string> = new Set();
     testResolvedExternalAttributions

--- a/src/Frontend/state/selectors/__tests__/resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/resource-selectors.test.ts
@@ -58,7 +58,7 @@ describe('getWerePackageInfoModified', () => {
     '/root/src/something.js': [testManualAttributionUuid_1],
   };
 
-  test('returns true  when TemporaryPackageInfo have been modified', () => {
+  it('returns true  when TemporaryPackageInfo have been modified', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       packageVersion: '1.1',
@@ -75,7 +75,7 @@ describe('getWerePackageInfoModified', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
   });
 
-  test('returns true  when confidence is changed', () => {
+  it('returns true  when confidence is changed', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
@@ -93,7 +93,7 @@ describe('getWerePackageInfoModified', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
   });
 
-  test('returns false when only confidence is set and true when attribution is created', () => {
+  it('returns false when only confidence is set and true when attribution is created', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(getParsedInputFileEnrichedWithTestData(testResources))
@@ -113,7 +113,7 @@ describe('getWerePackageInfoModified', () => {
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
   });
 
-  test('returns false when TemporaryPackageInfo have not been modified', () => {
+  it('returns false when TemporaryPackageInfo have not been modified', () => {
     const testStore = createTestAppStore();
     const testTemporaryPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,

--- a/src/Frontend/util/__tests__/can-have-children.test.ts
+++ b/src/Frontend/util/__tests__/can-have-children.test.ts
@@ -10,13 +10,13 @@ import {
 } from '../can-resource-have-children';
 
 describe('canHaveChildren', () => {
-  test('returns true for a folder', () => {
+  it('returns true for a folder', () => {
     const testResources: Resources = {};
 
     expect(canResourceHaveChildren(testResources)).toBe(true);
   });
 
-  test('returns false for a file', () => {
+  it('returns false for a file', () => {
     const testFileFromResources = 1;
 
     expect(canResourceHaveChildren(testFileFromResources)).toBe(false);
@@ -24,13 +24,13 @@ describe('canHaveChildren', () => {
 });
 
 describe('isIdOfResourceWithChildren', () => {
-  test('returns true for a folder id', () => {
+  it('returns true for a folder id', () => {
     const testFolderPath = '/some_folder/';
 
     expect(isIdOfResourceWithChildren(testFolderPath)).toBe(true);
   });
 
-  test('returns false for a file id', () => {
+  it('returns false for a file id', () => {
     const testFilePath = '/some_folder/some_file';
 
     expect(isIdOfResourceWithChildren(testFilePath)).toBe(false);

--- a/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
+++ b/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
@@ -7,7 +7,7 @@ import { Attributions } from '../../../shared/shared-types';
 import { getAlphabeticalComparer } from '../get-alphabetical-comparer';
 
 describe('getAlphabeticalComparer', () => {
-  test('sorts alphabetically by list card title', () => {
+  it('sorts alphabetically by list card title', () => {
     const testAttributions: Attributions = {
       '1': {
         packageName: 'zz Test package',
@@ -40,7 +40,7 @@ describe('getAlphabeticalComparer', () => {
     expect(sortedAttributionIds).toEqual(['3', '5', '4', '2', '1']);
   });
 
-  test('sorts empty attributions to the end of the list', () => {
+  it('sorts empty attributions to the end of the list', () => {
     const testAttributions: Attributions = {
       '1': {},
       '2': {
@@ -60,7 +60,7 @@ describe('getAlphabeticalComparer', () => {
     expect(sortedAttributionIds).toEqual(['2', '3', '1']);
   });
 
-  test('sorts non-alphabetical chars behind alphabetical chars', () => {
+  it('sorts non-alphabetical chars behind alphabetical chars', () => {
     const testAttributions: Attributions = {
       '1': {
         packageName: 'Test package',

--- a/src/Frontend/util/__tests__/get-attributed-children.test.tsx
+++ b/src/Frontend/util/__tests__/get-attributed-children.test.tsx
@@ -21,7 +21,7 @@ describe('getAttributedChildren', () => {
   const expectedResult = new Set()
     .add('/directory/subdirectory')
     .add('/directory/subdirectory/secondsub/thirdsubdirectory');
-  test('with existing attributed children', () => {
+  it('with existing attributed children', () => {
     const result = getAttributedChildren(
       testResourcesWithExternalAttributedChildren,
       '/directory'
@@ -29,7 +29,7 @@ describe('getAttributedChildren', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  test('without existing attributed children', () => {
+  it('without existing attributed children', () => {
     const result = getAttributedChildren(
       testResourcesWithExternalAttributedChildren,
       'nonexistingdirectory'

--- a/src/Frontend/util/__tests__/get-attributions-with-resources.test.ts
+++ b/src/Frontend/util/__tests__/get-attributions-with-resources.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../get-attributions-with-resources';
 
 describe('getAttributionsWithResources', () => {
-  test('returns attributions with resources', () => {
+  it('returns attributions with resources', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Redux' },
@@ -52,13 +52,13 @@ describe('getAttributionsWithResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test('returns attributions with resources for empty attributions', () => {
+  it('returns attributions with resources for empty attributions', () => {
     expect(getAttributionsWithResources({}, {})).toEqual({});
   });
 });
 
 describe('getAttributionsWithAllChildResources', () => {
-  test('returns attributions with resources recursively', () => {
+  it('returns attributions with resources recursively', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Redux' },
@@ -122,7 +122,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test('returns attributions with resources recursively in the edge case of same folder names', () => {
+  it('returns attributions with resources recursively in the edge case of same folder names', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
     };
@@ -162,7 +162,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test('returns attributions with resources recursively for a deep file tree', () => {
+  it('returns attributions with resources recursively for a deep file tree', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
     };
@@ -228,7 +228,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test('returns attributions with resources for empty attributions recursively', () => {
+  it('returns attributions with resources for empty attributions recursively', () => {
     expect(
       getAttributionsWithAllChildResourcesWithoutFolders(
         {},
@@ -241,7 +241,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual({});
   });
 
-  test('does not return resources inside a breakpoint', () => {
+  it('does not return resources inside a breakpoint', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Vue' },
@@ -295,7 +295,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test('does return resources that are files with children', () => {
+  it('does return resources that are files with children', () => {
     const testAttributions: Attributions = {
       uuid1: { packageName: 'React' },
       uuid2: { packageName: 'Vue' },
@@ -343,7 +343,7 @@ describe('getAttributionsWithAllChildResources', () => {
     ).toEqual(expectedAttributionsWithResources);
   });
 
-  test(
+  it(
     'does return resources that are files with children' +
       ' if it has inferred attributions',
     () => {
@@ -396,7 +396,7 @@ describe('getAttributionsWithAllChildResources', () => {
 });
 
 describe('removeSlashesFromFilesWithChildren', () => {
-  test('formats files with children', () => {
+  it('formats files with children', () => {
     const testAttributionsWithResources: AttributionsWithResources = {
       uuid1: {
         packageName: 'React',

--- a/src/Frontend/util/__tests__/get-card-labels-test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels-test.ts
@@ -69,49 +69,49 @@ describe('Test getPackageLabel', () => {
     url: 'Test url',
   };
 
-  test('finds label for package', () => {
+  it('finds label for package', () => {
     expect(getCardLabels(testProps)).toEqual([
       'Test package name, 1.2',
       '(c) Test copyright',
     ]);
   });
-  test('finds label for package without version', () => {
+  it('finds label for package without version', () => {
     expect(getCardLabels(testPropsWithoutVersion)).toEqual([
       'Test package name',
       '(c) Test copyright',
     ]);
   });
-  test('finds label for package with undefined name', () => {
+  it('finds label for package with undefined name', () => {
     expect(getCardLabels(testPropsWithUndefinedName)).toEqual([
       'Test url',
       '(c) Test copyright',
     ]);
   });
-  test('finds label for package without name', () => {
+  it('finds label for package without name', () => {
     expect(getCardLabels(testPropsWithoutName)).toEqual([
       'Test url',
       '(c) Test copyright',
     ]);
   });
-  test('finds label for package with only copyright, licenseText and comment', () => {
+  it('finds label for package with only copyright, licenseText and comment', () => {
     expect(getCardLabels(testPropsCopyrightLicenseTextAndComment)).toEqual([
       '(c) Test copyright',
       'Test license text',
     ]);
   });
-  test('finds label for package with license text and comment', () => {
+  it('finds label for package with license text and comment', () => {
     expect(getCardLabels(testPropsWithLicenseTextAndComment)).toEqual([
       'Test license text',
       'Test comment',
     ]);
   });
-  test('finds label for package with just comment', () => {
+  it('finds label for package with just comment', () => {
     expect(getCardLabels(testPropsJustComment)).toEqual(['Test comment']);
   });
-  test('finds label for empty package', () => {
+  it('finds label for empty package', () => {
     expect(getCardLabels({ id: '9' })).toEqual([]);
   });
-  test('finds label for package with just url and copyright', () => {
+  it('finds label for package with just url and copyright', () => {
     expect(getCardLabels(testPropsJustUrlAndCopyright)).toEqual([
       'Test url',
       '(c) Test copyright',
@@ -140,7 +140,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     licenseName: 'Test license name',
   };
 
-  test('adds name and version', () => {
+  it('adds name and version', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
       'name',
@@ -149,7 +149,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['Test package name, 1.2']);
   });
-  test('adds name without version', () => {
+  it('adds name without version', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
       'name',
@@ -158,7 +158,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['Test package name']);
   });
-  test('adds copyright', () => {
+  it('adds copyright', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
       'copyright',
@@ -167,7 +167,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['(c) Test copyright']);
   });
-  test('adds url', () => {
+  it('adds url', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
       'url',
@@ -189,7 +189,7 @@ describe('Test addSecondLineOfPackageLabelFromAttribute', () => {
     url: 'Test url',
     licenseName: 'Test license name',
   };
-  test('adds copyright', () => {
+  it('adds copyright', () => {
     const testPackageLabels: Array<string> = ['Test package name'];
     addSecondLineOfPackageLabelFromAttribute(
       'copyright',
@@ -201,7 +201,7 @@ describe('Test addSecondLineOfPackageLabelFromAttribute', () => {
       '(c) Test copyright',
     ]);
   });
-  test('does not add url if already in first line', () => {
+  it('does not add url if already in first line', () => {
     const testPackageLabels: Array<string> = ['Test url'];
     addSecondLineOfPackageLabelFromAttribute(
       'url',
@@ -213,12 +213,12 @@ describe('Test addSecondLineOfPackageLabelFromAttribute', () => {
 });
 
 describe('Test addPreambleToCopyright', () => {
-  test('adds preamble to copyright', () => {
+  it('adds preamble to copyright', () => {
     expect(addPreambleToCopyright('Test copyright without preamble')).toEqual(
       '(c) Test copyright without preamble'
     );
   });
-  test('does not add preamble to copyright', () => {
+  it('does not add preamble to copyright', () => {
     expect(
       addPreambleToCopyright('(C)Test copyright without preamble')
     ).toEqual('(C)Test copyright without preamble');

--- a/src/Frontend/util/__tests__/get-closest-parent-attribution.test.ts
+++ b/src/Frontend/util/__tests__/get-closest-parent-attribution.test.ts
@@ -66,7 +66,7 @@ describe('The helper getClosestParentAttribution', () => {
         '/f1/f3': [otherPackageUuid],
       },
     ],
-  ]).test(
+  ]).it(
     'finds the closest parent package if one exists',
     (path: string, resourcesToManualAttributions: ResourcesToAttributions) => {
       const closest = getClosestParentAttributions(
@@ -102,7 +102,7 @@ describe('The helper getClosestParentAttribution', () => {
         '/f 1 ': [otherPackage],
       },
     ],
-  ]).test(
+  ]).it(
     'returns null if there is no parent package',
     (path: string, resourcesToManualAttributions: ResourcesToAttributions) => {
       const closest = getClosestParentAttributions(
@@ -115,7 +115,7 @@ describe('The helper getClosestParentAttribution', () => {
     }
   );
 
-  test('returns null for root folder', () => {
+  it('returns null for root folder', () => {
     const closest = getClosestParentAttributions(
       '/',
       {
@@ -129,7 +129,7 @@ describe('The helper getClosestParentAttribution', () => {
 });
 
 describe('getClosestParentWithAttributions', () => {
-  test('returns the id of the closest parent with attributions', () => {
+  it('returns the id of the closest parent with attributions', () => {
     const childId = '/parent1/parent2/parent3/child';
     const resourcesToAttributions: ResourcesToAttributions = {
       '/parent1/parent2/': ['uuid1'],
@@ -145,7 +145,7 @@ describe('getClosestParentWithAttributions', () => {
     ).toBe('/parent1/parent2/');
   });
 
-  test('respects breakpoints', () => {
+  it('respects breakpoints', () => {
     const childId = '/parent1/parent2/parent3/child';
     const resourcesToAttributions: ResourcesToAttributions = {
       '/parent1/parent2/': ['uuid1'],

--- a/src/Frontend/util/__tests__/get-contained-packages.ts
+++ b/src/Frontend/util/__tests__/get-contained-packages.ts
@@ -29,7 +29,7 @@ describe('computeAggregatedAttributionsFromChildren', () => {
     .add('samplepath/subfolder')
     .add('samplepath2/subfolder/subsubfolder');
 
-  test('selects aggregated children and sorts correctly', () => {
+  it('selects aggregated children and sorts correctly', () => {
     const expectedResult: Array<AttributionIdWithCount> = [
       {
         childrenWithAttributionCount: 2,
@@ -54,7 +54,7 @@ describe('computeAggregatedAttributionsFromChildren', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  test('filters resolved attributions correctly', () => {
+  it('filters resolved attributions correctly', () => {
     const expectedResult: Array<AttributionIdWithCount> = [
       {
         childrenWithAttributionCount: 2,
@@ -81,7 +81,7 @@ describe('computeAggregatedAttributionsFromChildren', () => {
 });
 
 describe('sortByCountAndPackageName', () => {
-  test('sorts items correctly', () => {
+  it('sorts items correctly', () => {
     const initialAttributionIdsWithCount: Array<AttributionIdWithCount> = [
       {
         attributionId: 'uuid1',

--- a/src/Frontend/util/__tests__/get-filtered-attributions-by-id.test.tsx
+++ b/src/Frontend/util/__tests__/get-filtered-attributions-by-id.test.tsx
@@ -23,7 +23,7 @@ describe('The helper getFilteredAttributionsById', () => {
     [secondExpectedPackageUuid]: secondExpectedPackage,
   };
 
-  test('return correct attributions', () => {
+  it('return correct attributions', () => {
     const filteredAttributions = getFilteredAttributionsById(
       [firstExpectedPackageUuid, secondExpectedPackageUuid],
       testManualAttributions

--- a/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
+++ b/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
@@ -7,7 +7,7 @@ import { Criticality, PackageInfo } from '../../../shared/shared-types';
 import { getStrippedPackageInfo } from '../get-stripped-package-info';
 
 describe('The getStrippedPackageInfo function', () => {
-  test('strips falsy values', () => {
+  it('strips falsy values', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'React',
       packageVersion: '',
@@ -18,7 +18,7 @@ describe('The getStrippedPackageInfo function', () => {
     });
   });
 
-  test('strips source ', () => {
+  it('strips source ', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'React',
       source: {
@@ -32,7 +32,7 @@ describe('The getStrippedPackageInfo function', () => {
     });
   });
 
-  test('strips preSelected ', () => {
+  it('strips preSelected ', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'React',
       preSelected: true,
@@ -43,7 +43,7 @@ describe('The getStrippedPackageInfo function', () => {
     });
   });
 
-  test('strips criticality ', () => {
+  it('strips criticality ', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'React',
       criticality: Criticality.High,
@@ -54,7 +54,7 @@ describe('The getStrippedPackageInfo function', () => {
     });
   });
 
-  test('strips excess values', () => {
+  it('strips excess values', () => {
     const testPackageInfo = {
       packageName: 'React',
       childrenWithAttributionCount: 0,

--- a/src/Frontend/util/__tests__/get-sx-from-props-and-classes.test.ts
+++ b/src/Frontend/util/__tests__/get-sx-from-props-and-classes.test.ts
@@ -11,7 +11,7 @@ import { SxProps } from '@mui/material';
 import { SystemStyleObject } from '@mui/system/styleFunctionSx';
 
 describe('getSxFromPropsAndClasses', () => {
-  test('takes styleClass as only input', () => {
+  it('takes styleClass as only input', () => {
     const testStyleClass: SystemStyleObject = { padding: '6px' };
     const expectedSx: MuiSx = [testStyleClass, {}];
 
@@ -20,7 +20,7 @@ describe('getSxFromPropsAndClasses', () => {
     );
   });
 
-  test('takes sxProps object as only input', () => {
+  it('takes sxProps object as only input', () => {
     const testSxProps: SxProps = { margin: '12px' };
     const expectedSx: MuiSx = [{}, testSxProps];
 
@@ -29,7 +29,7 @@ describe('getSxFromPropsAndClasses', () => {
     );
   });
 
-  test('takes sxProps array as only input', () => {
+  it('takes sxProps array as only input', () => {
     const testSxProps: SxProps = [{ margin: '12px' }, { border: '1.5px' }];
     const expectedSx: MuiSx = [{}, ...testSxProps];
 
@@ -38,7 +38,7 @@ describe('getSxFromPropsAndClasses', () => {
     );
   });
 
-  test('takes styleClass and sxProps as input', () => {
+  it('takes styleClass and sxProps as input', () => {
     const testStyleClass: SystemStyleObject = { padding: '6px' };
     const testSxProps: SxProps = { margin: '12px' };
     const expectedSx: MuiSx = [testStyleClass, testSxProps];

--- a/src/Frontend/util/__tests__/handle-purl.test.ts
+++ b/src/Frontend/util/__tests__/handle-purl.test.ts
@@ -13,7 +13,7 @@ import { PackageURL } from 'packageurl-js';
 import { PackageInfo } from '../../../shared/shared-types';
 
 describe('parsePurl', () => {
-  test('returns false for an invalid purl', () => {
+  it('returns false for an invalid purl', () => {
     const testPurl = 'pkg:xxx';
 
     const parsePurlReturn: ParsedPurl = parsePurl(testPurl);
@@ -21,7 +21,7 @@ describe('parsePurl', () => {
     expect(parsePurlReturn.purl).toBeUndefined();
   });
 
-  test('returns true and packageUrl for a valid purl', () => {
+  it('returns true and packageUrl for a valid purl', () => {
     const testPurl = 'pkg:type/namespace/name@version?qualifiers=#subpath';
     const expectedPackageUrl: Partial<PackageInfo> = {
       packageName: 'name',
@@ -38,7 +38,7 @@ describe('parsePurl', () => {
 });
 
 describe('generatePurlFromPackageInfo', () => {
-  test('generates a valid Purl', () => {
+  it('generates a valid Purl', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
@@ -51,7 +51,7 @@ describe('generatePurlFromPackageInfo', () => {
     expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
   });
 
-  test('generates a valid Purl without appendix', () => {
+  it('generates a valid Purl without appendix', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
@@ -63,7 +63,7 @@ describe('generatePurlFromPackageInfo', () => {
     expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
   });
 
-  test('returns undefined when no packageName is given', () => {
+  it('returns undefined when no packageName is given', () => {
     const testPackageInfo: PackageInfo = {
       packageNamespace: 'namespace',
       packageType: 'type',
@@ -73,7 +73,7 @@ describe('generatePurlFromPackageInfo', () => {
     expect(generatePurlFromPackageInfo(testPackageInfo)).toBe('');
   });
 
-  test('generates Purl with generic type when no packageType is given', () => {
+  it('generates Purl with generic type when no packageType is given', () => {
     const testPackageInfo: PackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
@@ -86,7 +86,7 @@ describe('generatePurlFromPackageInfo', () => {
 });
 
 describe('generatePurlAppendix', () => {
-  test('return the purl appendix without subpath', () => {
+  it('return the purl appendix without subpath', () => {
     const testPackageUrl = new PackageURL(
       'type',
       'namespace',
@@ -107,7 +107,7 @@ describe('generatePurlAppendix', () => {
     ).toBe(expectedPurlAppendix);
   });
 
-  test('return the purl appendix with subpath', () => {
+  it('return the purl appendix with subpath', () => {
     const testPackageUrl = new PackageURL(
       'type',
       'namespace',
@@ -126,7 +126,7 @@ describe('generatePurlAppendix', () => {
     ).toBe(expectedPurlAppendix);
   });
 
-  test('return the purl appendix', () => {
+  it('return the purl appendix', () => {
     const testPackageUrl = new PackageURL(
       'type',
       'namespace',

--- a/src/Frontend/util/__tests__/is-attribution-breakpoint.test.ts
+++ b/src/Frontend/util/__tests__/is-attribution-breakpoint.test.ts
@@ -6,7 +6,7 @@
 import { getAttributionBreakpointCheck } from '../is-attribution-breakpoint';
 
 describe('getAttributionBreakpointCheck', () => {
-  test('returns a function that correctly checks the path', () => {
+  it('returns a function that correctly checks the path', () => {
     const isAttributionBreakpoint = getAttributionBreakpointCheck(
       new Set(['/path1', '/path2'])
     );
@@ -14,7 +14,7 @@ describe('getAttributionBreakpointCheck', () => {
     expect(isAttributionBreakpoint('/path3')).toEqual(false);
   });
 
-  test('handles empty set correctly', () => {
+  it('handles empty set correctly', () => {
     const isAttributionBreakpoint = getAttributionBreakpointCheck(new Set());
     expect(isAttributionBreakpoint('/path1')).toEqual(false);
     expect(isAttributionBreakpoint('/path3')).toEqual(false);

--- a/src/Frontend/util/__tests__/is-file-with-children.test.ts
+++ b/src/Frontend/util/__tests__/is-file-with-children.test.ts
@@ -6,7 +6,7 @@
 import { getFileWithChildrenCheck } from '../is-file-with-children';
 
 describe('getFileWithChildrenCheck', () => {
-  test('returns a function that correctly checks the path', () => {
+  it('returns a function that correctly checks the path', () => {
     const isFileWithChildren = getFileWithChildrenCheck(
       new Set(['/path1', '/path2'])
     );
@@ -14,7 +14,7 @@ describe('getFileWithChildrenCheck', () => {
     expect(isFileWithChildren('/path3')).toEqual(false);
   });
 
-  test('handles empty set correctly', () => {
+  it('handles empty set correctly', () => {
     const isFileWithChildren = getFileWithChildrenCheck(new Set());
     expect(isFileWithChildren('/path1')).toEqual(false);
     expect(isFileWithChildren('/path3')).toEqual(false);

--- a/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
+++ b/src/Frontend/util/__tests__/is-important-attribution-information-misssing.test.ts
@@ -7,7 +7,7 @@ import { AttributionInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../is-important-attribution-information-missing';
 
 describe('isImportantAttributionInformationMissing', () => {
-  test('returns true for a github purl without namespace', () => {
+  it('returns true for a github purl without namespace', () => {
     const testAttributionInfo: AttributionInfo = {
       packageType: 'github',
       resources: ['1'],
@@ -20,7 +20,7 @@ describe('isImportantAttributionInformationMissing', () => {
     ).toEqual(true);
   });
 
-  test('returns false if exclude from notice', () => {
+  it('returns false if exclude from notice', () => {
     const testAttributionInfo: AttributionInfo = {
       excludeFromNotice: true,
       resources: ['1'],
@@ -33,7 +33,7 @@ describe('isImportantAttributionInformationMissing', () => {
     ).toEqual(false);
   });
 
-  test('returns true if package name is missing', () => {
+  it('returns true if package name is missing', () => {
     const testAttributionInfo: AttributionInfo = {
       resources: ['1'],
     };
@@ -45,7 +45,7 @@ describe('isImportantAttributionInformationMissing', () => {
     ).toEqual(true);
   });
 
-  test('returns false if copyright is not missing', () => {
+  it('returns false if copyright is not missing', () => {
     const testAttributionInfo: AttributionInfo = {
       copyright: 'test',
       resources: ['1'],

--- a/src/Frontend/util/__tests__/lodash-extension-utils.test.ts
+++ b/src/Frontend/util/__tests__/lodash-extension-utils.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../lodash-extension-utils';
 
 describe('replaceInArray', () => {
-  test('replaces several instances of an item in an array', () => {
+  it('replaces several instances of an item in an array', () => {
     const toBeReplaced = 'toBeReplaced';
     const replacement = 'replacement';
     const testArray: Array<string> = [toBeReplaced, 'x', toBeReplaced];
@@ -24,7 +24,7 @@ describe('replaceInArray', () => {
 });
 
 describe('removeFromArrayAndDeleteArrayFromObjectIfEmpty', () => {
-  test('removes value from array if other values are present', () => {
+  it('removes value from array if other values are present', () => {
     const testObjectToMutate = {
       toModify: ['y', 'x'],
       toLeaveUntouched: ['y', 'x'],
@@ -39,7 +39,7 @@ describe('removeFromArrayAndDeleteArrayFromObjectIfEmpty', () => {
     expect(testObjectToMutate).toEqual(expectedObject);
   });
 
-  test('removes key from object of the array is left empty after removal', () => {
+  it('removes key from object of the array is left empty after removal', () => {
     const testObjectToMutate = {
       toModify: ['y', 'y'],
       toLeaveUntouched: ['y', 'x'],
@@ -54,7 +54,7 @@ describe('removeFromArrayAndDeleteArrayFromObjectIfEmpty', () => {
     expect(testObjectToMutate).toEqual(expectedObject);
   });
 
-  test('does nothing if the key is not present in the object', () => {
+  it('does nothing if the key is not present in the object', () => {
     const testObjectToMutate = {
       toLeaveUntouched: ['y', 'x'],
     };
@@ -70,7 +70,7 @@ describe('removeFromArrayAndDeleteArrayFromObjectIfEmpty', () => {
 });
 
 describe('removeFromSetAndDeleteKeyFromObjectIfEmpty', () => {
-  test('removes value from set if other values are present', () => {
+  it('removes value from set if other values are present', () => {
     const testObjectToMutate = {
       toModify: new Set().add('y').add('x'),
       toLeaveUntouched: new Set().add('y').add('x'),
@@ -88,7 +88,7 @@ describe('removeFromSetAndDeleteKeyFromObjectIfEmpty', () => {
     expect(testObjectToMutate).toEqual(expectedObject);
   });
 
-  test('removes key from object of the set is left empty after removal', () => {
+  it('removes key from object of the set is left empty after removal', () => {
     const testObjectToMutate = {
       toModify: new Set().add('y'),
       toLeaveUntouched: new Set().add('y').add('x'),
@@ -103,7 +103,7 @@ describe('removeFromSetAndDeleteKeyFromObjectIfEmpty', () => {
     expect(testObjectToMutate).toEqual(expectedObject);
   });
 
-  test('does nothing if the key is not present in the object', () => {
+  it('does nothing if the key is not present in the object', () => {
     const testObjectToMutate = {
       toLeaveUntouched: new Set().add('y').add('x'),
     };

--- a/src/Frontend/util/__tests__/remove-trailing-slash-if-file-with-children.test.ts
+++ b/src/Frontend/util/__tests__/remove-trailing-slash-if-file-with-children.test.ts
@@ -6,19 +6,19 @@
 import { removeTrailingSlashIfFileWithChildren } from '../remove-trailing-slash-if-file-with-children';
 
 describe('removeTrailingSlashIfFileWithChildren', () => {
-  test('removes last character', () => {
+  it('removes last character', () => {
     expect(
       removeTrailingSlashIfFileWithChildren('/path1/', () => true)
     ).toEqual('/path1');
   });
 
-  test('does no remove last character', () => {
+  it('does no remove last character', () => {
     expect(
       removeTrailingSlashIfFileWithChildren('/path1/', () => false)
     ).toEqual('/path1/');
   });
 
-  test('does nothing if last character is not /', () => {
+  it('does nothing if last character is not /', () => {
     expect(
       removeTrailingSlashIfFileWithChildren('/path1/test', () => true)
     ).toEqual('/path1/test');

--- a/src/Frontend/util/__tests__/use-filters.test.tsx
+++ b/src/Frontend/util/__tests__/use-filters.test.tsx
@@ -45,7 +45,7 @@ describe('useFollowUpFilter', () => {
     followUp: FollowUp,
   };
 
-  test('returns working getFilteredAttributions with follow-up filter', () => {
+  it('returns working getFilteredAttributions with follow-up filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
     renderComponentWithStore(
@@ -57,7 +57,7 @@ describe('useFollowUpFilter', () => {
     });
   });
 
-  test('returns working getFilteredAttributions without filter', () => {
+  it('returns working getFilteredAttributions without filter', () => {
     const store = createTestAppStore();
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
@@ -66,7 +66,7 @@ describe('useFollowUpFilter', () => {
     expect(filteredAttributions).toBe(testManualAttributions);
   });
 
-  test('returns working getFilteredAttributions with only first party filter', () => {
+  it('returns working getFilteredAttributions with only first party filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
     renderComponentWithStore(
@@ -78,7 +78,7 @@ describe('useFollowUpFilter', () => {
     });
   });
 
-  test('returns working getFilteredAttributions with hide first party filter', () => {
+  it('returns working getFilteredAttributions with hide first party filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
     renderComponentWithStore(
@@ -90,7 +90,7 @@ describe('useFollowUpFilter', () => {
     });
   });
 
-  test('returns working getFilteredAttributions with only first party and follow up filter', () => {
+  it('returns working getFilteredAttributions with only first party and follow up filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
     store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
@@ -101,7 +101,7 @@ describe('useFollowUpFilter', () => {
     expect(filteredAttributions).toEqual({});
   });
 
-  test('returns working getFilteredAttributions with hide first party and follow up filter', () => {
+  it('returns working getFilteredAttributions with hide first party and follow up filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
     store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));


### PR DESCRIPTION
### Summary of changes

Use it instead of test

### Context and reason for change

The jest functions "it" and "test" are equivalent.
Stick to using only one of these.


