### PR TITLE
Improve internal naming

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -288,7 +288,8 @@ describe('Test of loading function', () => {
     expect(getGlobalBackendState().projectId).toBe(
       inputFileContent.metadata.projectId
     );
-    expect(getGlobalBackendState().inputContainsCriticalSignals).toBeTruthy;
+    expect(getGlobalBackendState().inputContainsCriticalExternalAttributions)
+      .toBeTruthy;
     deleteFolder(temporaryPath);
   });
 

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../shared/shared-types';
 import {
   cleanNonExistentAttributions,
-  cleanNonExistentResolvedExternalSignals,
+  cleanNonExistentResolvedExternalAttributions,
   getAllResourcePaths,
   parseFrequentLicenses,
   parseRawAttributions,
@@ -60,7 +60,7 @@ describe('cleanNonExistentAttributions', () => {
   });
 });
 
-describe('cleanNonExistentResolvedExternalSignals', () => {
+describe('cleanNonExistentResolvedExternalAttributions', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -70,7 +70,7 @@ describe('cleanNonExistentResolvedExternalSignals', () => {
       .add('attr2')
       .add('invalid');
     const externalAttributions: Attributions = { attr2: {}, attr4: {} };
-    const result = cleanNonExistentResolvedExternalSignals(
+    const result = cleanNonExistentResolvedExternalAttributions(
       webContents,
       resolvedExternalAttributions,
       externalAttributions
@@ -95,11 +95,11 @@ describe('sanitizeRawAttributions', () => {
         followUp: FollowUp,
       },
     };
-    const expectedCriticalSignalsFlag = false;
+    const expectedCriticalExternalAttributionsFlag = false;
 
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedCriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 
@@ -112,10 +112,10 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
-    const expectedCriticalSignalsFlag = false;
+    const expectedCriticalExternalAttributionsFlag = false;
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedCriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 
@@ -130,11 +130,11 @@ describe('sanitizeRawAttributions', () => {
         comment: 'Test comment',
       },
     };
-    const expectedcriticalSignalsFlag = false;
+    const expectedCriticalExternalAttributionsFlag = false;
 
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedcriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 
@@ -147,11 +147,11 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
-    const expectedCriticalSignalsFlag = false;
+    const expectedCriticalExternalAttributionsFlag = false;
 
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedCriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 
@@ -166,11 +166,11 @@ describe('sanitizeRawAttributions', () => {
         criticality: Criticality.High,
       },
     };
-    const expectedcriticalSignalsFlag = true;
+    const expectedCriticalExternalAttributionsFlag = true;
 
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedcriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 
@@ -183,11 +183,11 @@ describe('sanitizeRawAttributions', () => {
     const expectedAttributions: Attributions = {
       id: {},
     };
-    const expectedcriticalSignalsFlag = false;
+    const expectedCriticalExternalAttributionsFlag = false;
 
     expect(parseRawAttributions(rawAttributions)).toEqual([
       expectedAttributions,
-      expectedcriticalSignalsFlag,
+      expectedCriticalExternalAttributionsFlag,
     ]);
   });
 });

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -14,7 +14,7 @@ import {
 import { getGlobalBackendState } from '../main/globalBackendState';
 import {
   cleanNonExistentAttributions,
-  cleanNonExistentResolvedExternalSignals,
+  cleanNonExistentResolvedExternalAttributions,
   parseFrequentLicenses,
   parseRawAttributions,
   sanitizeRawBaseUrlsForSources,
@@ -59,7 +59,7 @@ export async function loadJsonFromFilePath(
   }
 
   log.info('... Successfully parsed input file.');
-  const [externalAttributions, inputContainsCriticalSignals] =
+  const [externalAttributions, inputContainsCriticalExternalAttributions] =
     parseRawAttributions(parsingResult.externalAttributions);
 
   const manualAttributionFilePath = getFilePathWithAppendix(
@@ -115,7 +115,7 @@ export async function loadJsonFromFilePath(
       resourcesToAttributions: resourcesToExternalAttributions,
     },
     frequentLicenses,
-    resolvedExternalAttributions: cleanNonExistentResolvedExternalSignals(
+    resolvedExternalAttributions: cleanNonExistentResolvedExternalAttributions(
       webContents,
       opossumOutputData.resolvedExternalAttributions,
       externalAttributions
@@ -134,8 +134,8 @@ export async function loadJsonFromFilePath(
 
   getGlobalBackendState().projectTitle = parsingResult.metadata.projectTitle;
   getGlobalBackendState().projectId = projectId;
-  getGlobalBackendState().inputContainsCriticalSignals =
-    inputContainsCriticalSignals;
+  getGlobalBackendState().inputContainsCriticalExternalAttributions =
+    inputContainsCriticalExternalAttributions;
 
   log.info('File import finished successfully');
 }

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -105,7 +105,7 @@ export function cleanNonExistentAttributions(
   );
 }
 
-export function cleanNonExistentResolvedExternalSignals(
+export function cleanNonExistentResolvedExternalAttributions(
   webContents: WebContents,
   resolvedExternalAttributions: Set<string>,
   externalAttributions: Attributions
@@ -129,7 +129,7 @@ export function cleanNonExistentResolvedExternalSignals(
 export function parseRawAttributions(
   rawAttributions: RawAttributions
 ): [Attributions, boolean] {
-  let inputContainsCriticalSignals = false;
+  let inputContainsCriticalExternalAttributions = false;
 
   for (const attributionId of Object.keys(rawAttributions)) {
     if (rawAttributions[attributionId]?.followUp !== FollowUp) {
@@ -144,11 +144,14 @@ export function parseRawAttributions(
     }
 
     if (rawAttributions[attributionId]?.criticality) {
-      inputContainsCriticalSignals = true;
+      inputContainsCriticalExternalAttributions = true;
     }
   }
 
-  return [rawAttributions as Attributions, inputContainsCriticalSignals];
+  return [
+    rawAttributions as Attributions,
+    inputContainsCriticalExternalAttributions,
+  ];
 }
 
 export function parseFrequentLicenses(

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -16,11 +16,11 @@ import { ExportType } from '../../shared/shared-types';
 
 export function createMenu(mainWindow: BrowserWindow): Menu {
   const webContents = mainWindow.webContents;
-  const inputContainsCriticalSignals =
-    getGlobalBackendState().inputContainsCriticalSignals;
-  const isHighlightCriticalSignalMenuItemChecked =
+  const inputContainsCriticalExternalAttributions =
+    getGlobalBackendState().inputContainsCriticalExternalAttributions;
+  const isHighlightCriticalExternalAttributionMenuItemChecked =
     getCheckedStatusAndSyncWithFrontend(
-      inputContainsCriticalSignals,
+      inputContainsCriticalExternalAttributions,
       webContents
     );
 
@@ -168,15 +168,15 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         { label: 'Zoom Out', role: 'zoomOut' },
         {
           label: 'Highlight critical signals',
-          enabled: inputContainsCriticalSignals,
+          enabled: inputContainsCriticalExternalAttributions,
           id: 'highlightCritical',
           type: 'checkbox',
-          checked: isHighlightCriticalSignalMenuItemChecked,
+          checked: isHighlightCriticalExternalAttributionMenuItemChecked,
           click(): void {
             webContents.send(
-              AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
+              AllowedFrontendChannels.ToggleHighlightForCriticalExternalAttributions,
               {
-                toggleHighlightForCriticalSignals: true,
+                toggleHighlightForCriticalExternalAttributions: true,
               }
             );
           },
@@ -223,25 +223,25 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
 }
 
 function getCheckedStatusAndSyncWithFrontend(
-  inputContainsCriticalSignals = false,
+  inputContainsCriticalExternalAttributions = false,
   webContents: WebContents
 ): boolean {
-  let isHighlightCriticalSignalMenuItemChecked = Boolean(
+  let isHighlightCriticalExternalAttributionMenuItemChecked = Boolean(
     Menu.getApplicationMenu()?.getMenuItemById('highlightCritical')?.checked
   );
 
   if (
-    isHighlightCriticalSignalMenuItemChecked &&
-    !inputContainsCriticalSignals
+    isHighlightCriticalExternalAttributionMenuItemChecked &&
+    !inputContainsCriticalExternalAttributions
   ) {
     webContents.send(
-      AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
+      AllowedFrontendChannels.ToggleHighlightForCriticalExternalAttributions,
       {
-        toggleHighlightForCriticalSignals: true,
+        toggleHighlightForCriticalExternalAttributions: true,
       }
     );
-    isHighlightCriticalSignalMenuItemChecked = false;
+    isHighlightCriticalExternalAttributionMenuItemChecked = false;
   }
 
-  return isHighlightCriticalSignalMenuItemChecked;
+  return isHighlightCriticalExternalAttributionMenuItemChecked;
 }

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -29,7 +29,7 @@ export interface GlobalBackendState {
   spdxYamlFilePath?: string;
   spdxJsonFilePath?: string;
   projectId?: string;
-  inputContainsCriticalSignals?: boolean;
+  inputContainsCriticalExternalAttributions?: boolean;
   inputFileChecksum?: string;
 }
 

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -16,7 +16,7 @@ import {
   ExportSpdxDocumentYamlArgs,
   ExportType,
   ParsedFileContent,
-  ToggleHighlightForCriticalSignalsArgs,
+  ToggleHighlightForCriticalExternalAttributionsArgs,
 } from '../../../shared/shared-types';
 import { PopupType } from '../../enums/enums';
 import {
@@ -32,7 +32,7 @@ import {
   getManualData,
   getResources,
 } from '../../state/selectors/all-views-resource-selectors';
-import { getHighlightForCriticalSignals } from '../../state/selectors/view-selector';
+import { getHighlightForCriticalExternalAttributions } from '../../state/selectors/view-selector';
 import {
   getAttributionsWithAllChildResourcesWithoutFolders,
   getAttributionsWithResources,
@@ -43,7 +43,7 @@ import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpo
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import {
   openPopup,
-  setHighlightForCriticalSignals,
+  setHighlightForCriticalExternalAttributions,
 } from '../../state/actions/view-actions/view-actions';
 
 export function BackendCommunication(): ReactElement | null {
@@ -53,8 +53,8 @@ export function BackendCommunication(): ReactElement | null {
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
   const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
-  const showHighlightForCriticalSignals = useAppSelector(
-    getHighlightForCriticalSignals
+  const showHighlightForCriticalExternalAttributions = useAppSelector(
+    getHighlightForCriticalExternalAttributions
   );
   const dispatch = useAppDispatch();
 
@@ -242,15 +242,17 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
-  function setToggleHighlightForCriticalSignalsListener(
+  function setToggleHighlightForCriticalExternalAttributionsListener(
     event: IpcRendererEvent,
-    toggleHighlightForCriticalSignalsArgs: ToggleHighlightForCriticalSignalsArgs
+    toggleHighlightForCriticalExternalAttributionsArgs: ToggleHighlightForCriticalExternalAttributionsArgs
   ): void {
     if (
-      toggleHighlightForCriticalSignalsArgs?.toggleHighlightForCriticalSignals
+      toggleHighlightForCriticalExternalAttributionsArgs?.toggleHighlightForCriticalExternalAttributions
     ) {
       dispatch(
-        setHighlightForCriticalSignals(!showHighlightForCriticalSignals)
+        setHighlightForCriticalExternalAttributions(
+          !showHighlightForCriticalExternalAttributions
+        )
       );
     }
   }
@@ -300,9 +302,9 @@ export function BackendCommunication(): ReactElement | null {
     ]
   );
   useIpcRenderer(
-    AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
-    setToggleHighlightForCriticalSignalsListener,
-    [dispatch, showHighlightForCriticalSignals]
+    AllowedFrontendChannels.ToggleHighlightForCriticalExternalAttributions,
+    setToggleHighlightForCriticalExternalAttributionsListener,
+    [dispatch, showHighlightForCriticalExternalAttributions]
   );
 
   return null;

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -54,7 +54,7 @@ describe('BackendCommunication', () => {
       expect.anything()
     );
     expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
+      AllowedFrontendChannels.ToggleHighlightForCriticalExternalAttributions,
       expect.anything()
     );
   });

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -9,7 +9,7 @@ import { OpossumColors } from '../../shared-styles';
 import { ListCardConfig } from '../../types/types';
 import { Criticality } from '../../../shared/shared-types';
 import { useAppSelector } from '../../state/hooks';
-import { getHighlightForCriticalSignals } from '../../state/selectors/view-selector';
+import { getHighlightForCriticalExternalAttributions } from '../../state/selectors/view-selector';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
 import { merge } from 'lodash';
@@ -205,8 +205,8 @@ interface ListCardProps {
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
-  const showHighlightForCriticalSignals = useAppSelector(
-    getHighlightForCriticalSignals
+  const showHighlightForCriticalExternalAttributions = useAppSelector(
+    getHighlightForCriticalExternalAttributions
   );
 
   function getDisplayedCount(): string {
@@ -280,7 +280,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
           <MuiBox sx={classes.iconColumn}>{props.rightIcons}</MuiBox>
         ) : null}
       </MuiBox>
-      {showHighlightForCriticalSignals ? (
+      {showHighlightForCriticalExternalAttributions ? (
         <MuiBox
           sx={{
             ...(props.cardConfig.criticality === Criticality.High

--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -47,7 +47,7 @@ interface ProgressBarProps {
 
 export function ProgressBar(props: ProgressBarProps): ReactElement {
   const onProgressBarClick = useOnProgressBarClick(
-    props.progressBarData.resourcesWithNonInheritedSignalOnly
+    props.progressBarData.resourcesWithNonInheritedExternalAttributionOnly
   );
 
   return (

--- a/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
@@ -87,7 +87,11 @@ describe('ProgressBar helpers', () => {
       filesWithManualAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 3,
       filesWithOnlyExternalAttributionCount: 3,
-      resourcesWithNonInheritedSignalOnly: ['file1', 'file2', 'file3'],
+      resourcesWithNonInheritedExternalAttributionOnly: [
+        'file1',
+        'file2',
+        'file3',
+      ],
     };
     const expectedProgressBarBackground: string =
       'linear-gradient(to right,' +

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -141,7 +141,7 @@ export function ResourceDetailsAttributionColumn(
     displayedPackage?.panel === PackagePanelTitle.ManualPackages &&
     !props.showParentAttributions;
 
-  function shownDataIsFromSignal(): boolean {
+  function shownDataIsFromExternalAttribution(): boolean {
     const externalPackagePanels: Array<PackagePanelTitle> = [
       PackagePanelTitle.ExternalPackages,
       PackagePanelTitle.ContainedExternalPackages,
@@ -153,7 +153,7 @@ export function ResourceDetailsAttributionColumn(
   }
 
   const showManualAttributionData: boolean =
-    !shownDataIsFromSignal() || isShownDataEditable;
+    !shownDataIsFromExternalAttribution() || isShownDataEditable;
   const hideDeleteButtons =
     attributionIdOfSelectedPackageInManualPanel === '' ||
     props.showParentAttributions;

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -57,7 +57,7 @@ describe('TopBar', () => {
       expect.anything()
     );
     expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ToggleHighlightForCriticalSignals,
+      AllowedFrontendChannels.ToggleHighlightForCriticalExternalAttributions,
       expect.anything()
     );
 

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -302,7 +302,7 @@ describe('Other popups of the app', () => {
     mockSaveFileRequestChannel();
     insertValueIntoTextBox(screen, 'PURL', testInvalidPurl);
 
-    // Trigger sending signal in IpcChannel without the clicking on save button
+    // Trigger sending external attribution in IpcChannel without the clicking on save button
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
 
     expectErrorPopupIsShown(screen);
@@ -344,7 +344,7 @@ describe('Other popups of the app', () => {
     mockSaveFileRequestChannel();
     insertValueIntoTextBox(screen, 'PURL', testValidPurl);
 
-    // Trigger sending signal in IpcChannel without the clicking on save button
+    // Trigger sending external attribution in IpcChannel without the clicking on save button
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
 
     expectErrorPopupIsNotShown(screen);

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -254,7 +254,10 @@ describe('The load and navigation simple actions', () => {
       filesWithManualAttributionCount: 4,
       filesWithOnlyExternalAttributionCount: 3,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: ['/folder2/file2', '/folder3/'],
+      resourcesWithNonInheritedExternalAttributionOnly: [
+        '/folder2/file2',
+        '/folder3/',
+      ],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
@@ -88,7 +88,7 @@ describe('The audit view simple actions', () => {
     );
   });
 
-  it('add resolved signals to state', () => {
+  it('add resolved external attributions to state', () => {
     const testStore = createTestAppStore();
     const uuid1 = 'd3a753c0-5100-11eb-ae93-0242ac130002';
     const uuid2 = 'd3a7565e-5100-11eb-ae93-0242ac130002';
@@ -132,7 +132,7 @@ describe('The audit view simple actions', () => {
       getResourcesWithExternalAttributedChildren(testStore.getState())
     ).toMatchObject({});
 
-    // Test that signals are deduplicated
+    // Test that external attributions are deduplicated
     testStore.dispatch(addResolvedExternalAttribution(uuid1));
     expect(getResolvedExternalAttributions(testStore.getState())).toMatchObject(
       expectedResolvedExternalAttributions
@@ -142,7 +142,7 @@ describe('The audit view simple actions', () => {
     ).toMatchObject({});
   });
 
-  it('remove resolved signals from state', () => {
+  it('remove resolved external attributions from state', () => {
     const testStore = createTestAppStore();
     const uuid1 = 'd3a753c0-5100-11eb-ae93-0242ac130002';
     const uuid2 = 'd3a7565e-5100-11eb-ae93-0242ac130002';

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -191,7 +191,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 0,
       filesWithOnlyExternalAttributionCount: 2,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [
+      resourcesWithNonInheritedExternalAttributionOnly: [
         '/root/src/something.js',
         '/root/readme.md',
       ],
@@ -201,7 +201,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: ['/root/readme.md'],
+      resourcesWithNonInheritedExternalAttributionOnly: ['/root/readme.md'],
     };
 
     const testStore = createTestAppStore();
@@ -258,7 +258,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedExternalAttributionOnly: [],
     };
 
     testStore.dispatch(
@@ -349,14 +349,16 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedExternalAttributionOnly: [],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: ['/root/src/something.js'],
+      resourcesWithNonInheritedExternalAttributionOnly: [
+        '/root/src/something.js',
+      ],
     };
     const emptyTestTemporaryPackageInfo: PackageInfo = {};
 
@@ -587,7 +589,7 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedExternalAttributionOnly: [],
     };
 
     const testStore = createTestAppStore();
@@ -668,14 +670,16 @@ describe('The savePackageInfo action', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: ['/folder/somethingElse.js'],
+      resourcesWithNonInheritedExternalAttributionOnly: [
+        '/folder/somethingElse.js',
+      ],
     };
     const expectedFinalProgressBarData: ProgressBarData = {
       fileCount: 2,
       filesWithManualAttributionCount: 2,
       filesWithOnlyExternalAttributionCount: 0,
       filesWithOnlyPreSelectedAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedExternalAttributionOnly: [],
     };
 
     const testStore = createTestAppStore();
@@ -1188,7 +1192,7 @@ describe('The addToSelectedResource action', () => {
     expect(getOpenPopup(testStore.getState())).toEqual('NotSavedPopup');
   });
 
-  it('adds a signal to the selected resource', () => {
+  it('adds an external attribution to the selected resource', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -1239,7 +1243,7 @@ describe('The addToSelectedResource action', () => {
     expect(getOpenPopup(testStore.getState())).toBe(null);
   });
 
-  it('saves resolved external signals', () => {
+  it('saves resolved external attributions', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(setResources({}));
     testStore.dispatch(

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -8,7 +8,7 @@ import { FilterType, PopupType, View } from '../../../../enums/enums';
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
   getActiveFilters,
-  getHighlightForCriticalSignals,
+  getHighlightForCriticalExternalAttributions,
   getOpenPopup,
   getPopupAttributionId,
   getSelectedView,
@@ -22,7 +22,7 @@ import {
   navigateToView,
   openPopup,
   resetViewState,
-  setHighlightForCriticalSignals,
+  setHighlightForCriticalExternalAttributions,
   setTargetView,
   updateActiveFilters,
 } from '../view-actions';
@@ -151,12 +151,16 @@ describe('view actions', () => {
     ).toBe(true);
   });
 
-  it('sets showHighlightForCriticalSignals', () => {
+  it('sets showHighlightForCriticalExternalAttributions', () => {
     const testStore = createTestAppStore();
 
-    expect(getHighlightForCriticalSignals(testStore.getState())).toBe(false);
-    testStore.dispatch(setHighlightForCriticalSignals(true));
-    expect(getHighlightForCriticalSignals(testStore.getState())).toBe(true);
+    expect(
+      getHighlightForCriticalExternalAttributions(testStore.getState())
+    ).toBe(false);
+    testStore.dispatch(setHighlightForCriticalExternalAttributions(true));
+    expect(
+      getHighlightForCriticalExternalAttributions(testStore.getState())
+    ).toBe(true);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -12,8 +12,8 @@ export const ACTION_OPEN_POPUP = 'ACTION_OPEN_POPUP';
 export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
 export const ACTION_UPDATE_ACTIVE_FILTERS = 'ACTION_UPDATE_ACTIVE_FILTERS';
-export const ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS =
-  'ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS';
+export const ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS =
+  'ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS';
 
 export type ViewAction =
   | SetView
@@ -22,7 +22,7 @@ export type ViewAction =
   | ResetViewStateAction
   | OpenPopupAction
   | UpdateActiveFilters
-  | SetHighlightForCriticalSignalsAction;
+  | SetHighlightForCriticalExternalAttributionsAction;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -52,7 +52,7 @@ export interface UpdateActiveFilters {
   payload: FilterType;
 }
 
-export interface SetHighlightForCriticalSignalsAction {
-  type: typeof ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS;
+export interface SetHighlightForCriticalExternalAttributionsAction {
+  type: typeof ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS;
   payload: boolean;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -15,14 +15,14 @@ import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
-  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
+  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
   ClosePopupAction,
   OpenPopupAction,
   ResetViewStateAction,
-  SetHighlightForCriticalSignalsAction,
+  SetHighlightForCriticalExternalAttributionsAction,
   SetTargetView,
   SetView,
   UpdateActiveFilters,
@@ -91,11 +91,11 @@ export function updateActiveFilters(
   };
 }
 
-export function setHighlightForCriticalSignals(
-  showHighlightForCriticalSignals: boolean
-): SetHighlightForCriticalSignalsAction {
+export function setHighlightForCriticalExternalAttributions(
+  showHighlightForCriticalExternalAttributions: boolean
+): SetHighlightForCriticalExternalAttributionsAction {
   return {
-    type: ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
-    payload: showHighlightForCriticalSignals,
+    type: ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS,
+    payload: showHighlightForCriticalExternalAttributions,
   };
 }

--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -77,10 +77,9 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(2);
-    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
-      '/thirdParty/package_1.tr.gz',
-      '/thirdParty/package_2.tr.gz',
-    ]);
+    expect(
+      progressBarData.resourcesWithNonInheritedExternalAttributionOnly
+    ).toEqual(['/thirdParty/package_1.tr.gz', '/thirdParty/package_2.tr.gz']);
   });
 
   it('gets updated progress data without resolved external attributions', () => {
@@ -143,9 +142,9 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.fileCount).toEqual(4);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(1);
-    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
-      '/thirdParty/package_1.tr.gz',
-    ]);
+    expect(
+      progressBarData.resourcesWithNonInheritedExternalAttributionOnly
+    ).toEqual(['/thirdParty/package_1.tr.gz']);
   });
 
   it('stops inferring attributions at breakpoints', () => {
@@ -234,7 +233,9 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(5);
-    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([
+    expect(
+      progressBarData.resourcesWithNonInheritedExternalAttributionOnly
+    ).toEqual([
       '/folder1/breakpoint1/file1',
       '/folder2/',
       '/folder2/breakpoint2/file3',
@@ -290,7 +291,9 @@ describe('The getUpdatedProgressBarData function', () => {
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(0);
-    expect(progressBarData.resourcesWithNonInheritedSignalOnly).toEqual([]);
+    expect(
+      progressBarData.resourcesWithNonInheritedExternalAttributionOnly
+    ).toEqual([]);
   });
 
   it('resourceHasOnlyPreSelectedAttributions with only pre-selected attributions', () => {
@@ -340,7 +343,7 @@ describe('The getUpdatedProgressBarData function', () => {
       filesWithManualAttributionCount: 1,
       filesWithOnlyPreSelectedAttributionCount: 1,
       filesWithOnlyExternalAttributionCount: 0,
-      resourcesWithNonInheritedSignalOnly: [],
+      resourcesWithNonInheritedExternalAttributionOnly: [],
     };
 
     updateProgressBarDataForResources(
@@ -414,7 +417,9 @@ describe('The getFolderProgressBarData function', () => {
     expect(progressBarData?.fileCount).toEqual(2);
     expect(progressBarData?.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData?.filesWithOnlyExternalAttributionCount).toEqual(0);
-    expect(progressBarData?.resourcesWithNonInheritedSignalOnly).toEqual([]);
+    expect(
+      progressBarData?.resourcesWithNonInheritedExternalAttributionOnly
+    ).toEqual([]);
   });
 });
 

--- a/src/Frontend/state/helpers/progress-bar-data-helpers.ts
+++ b/src/Frontend/state/helpers/progress-bar-data-helpers.ts
@@ -111,7 +111,9 @@ export function updateProgressBarDataForResources(
         progressBarData.filesWithManualAttributionCount++;
       } else if (hasNonInheritedExternalAttributions) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
-        progressBarData.resourcesWithNonInheritedSignalOnly.push(path);
+        progressBarData.resourcesWithNonInheritedExternalAttributionOnly.push(
+          path
+        );
       } else if (hasParentExternalAttribution) {
         progressBarData.filesWithOnlyExternalAttributionCount++;
       }
@@ -123,7 +125,9 @@ export function updateProgressBarDataForResources(
         !hasManualAttribution &&
         hasNonInheritedExternalAttributions
       ) {
-        progressBarData.resourcesWithNonInheritedSignalOnly.push(path);
+        progressBarData.resourcesWithNonInheritedExternalAttributionOnly.push(
+          path
+        );
       }
 
       const isBreakpoint = isAttributionBreakpoint(path);
@@ -198,7 +202,7 @@ export function getEmptyProgressBarData(): ProgressBarData {
     filesWithManualAttributionCount: 0,
     filesWithOnlyPreSelectedAttributionCount: 0,
     filesWithOnlyExternalAttributionCount: 0,
-    resourcesWithNonInheritedSignalOnly: [],
+    resourcesWithNonInheritedExternalAttributionOnly: [],
   };
 }
 

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -10,7 +10,7 @@ import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
-  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS,
+  ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
@@ -23,7 +23,7 @@ export interface ViewState {
   targetView: View | null;
   popupInfo: Array<PopupInfo>;
   activeFilters: Set<FilterType>;
-  showHighlightForCriticalSignals: boolean;
+  showHighlightForCriticalExternalAttributions: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -31,7 +31,7 @@ export const initialViewState: ViewState = {
   targetView: null,
   popupInfo: [],
   activeFilters: new Set<FilterType>(),
-  showHighlightForCriticalSignals: false,
+  showHighlightForCriticalExternalAttributions: false,
 };
 
 export function viewState(
@@ -66,10 +66,10 @@ export function viewState(
         ...state,
         activeFilters: getUpdatedFilters(state.activeFilters, action.payload),
       };
-    case ACTION_SET_HIGHLIGHT_FOR_CRITICAL_SIGNALS:
+    case ACTION_SET_HIGHLIGHT_FOR_CRITICAL_EXTERNAL_ATTRIBUTIONS:
       return {
         ...state,
-        showHighlightForCriticalSignals: action.payload,
+        showHighlightForCriticalExternalAttributions: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -41,6 +41,8 @@ export function getPopupAttributionId(state: State): string | null {
   return popup.length === 1 ? popup[0].attributionId ?? null : null;
 }
 
-export function getHighlightForCriticalSignals(state: State): boolean {
-  return state.viewState.showHighlightForCriticalSignals;
+export function getHighlightForCriticalExternalAttributions(
+  state: State
+): boolean {
+  return state.viewState.showHighlightForCriticalExternalAttributions;
 }

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -268,7 +268,7 @@ export function expectValuesInTopProgressbarTooltip(
   numberOfFiles: number,
   filesWithAttribution: number,
   filesWithOnlyPreSelectedAttributions: number,
-  filesWithOnlySignals: number
+  filesWithOnlyExternalAttributions: number
 ): void {
   jest.useFakeTimers();
   const progressBar = screen.getByLabelText('TopProgressBar');
@@ -289,7 +289,9 @@ export function expectValuesInTopProgressbarTooltip(
         )
       ) &&
       screen.getByText(
-        new RegExp(`Files with only signals: ${filesWithOnlySignals}`)
+        new RegExp(
+          `Files with only signals: ${filesWithOnlyExternalAttributions}`
+        )
       )
   ).toBeDefined();
 }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -26,7 +26,7 @@ export interface ProgressBarData {
   filesWithManualAttributionCount: number;
   filesWithOnlyPreSelectedAttributionCount: number;
   filesWithOnlyExternalAttributionCount: number;
-  resourcesWithNonInheritedSignalOnly: Array<string>;
+  resourcesWithNonInheritedExternalAttributionOnly: Array<string>;
 }
 
 export interface PanelPackage {

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -11,7 +11,7 @@ import {
   BaseURLForRootArgs,
   ExportType,
   ParsedFileContent,
-  ToggleHighlightForCriticalSignalsArgs,
+  ToggleHighlightForCriticalExternalAttributionsArgs,
 } from '../../shared/shared-types';
 
 type ResetStateListener = (
@@ -36,9 +36,9 @@ type SetBaseURLForRootListener = (
   baseURLForRootArgs: BaseURLForRootArgs
 ) => void;
 
-type ToggleHighlightForCriticalSignalsListener = (
+type ToggleHighlightForCriticalExternalAttributionsListener = (
   event: IpcRendererEvent,
-  showHighlightForCriticalSignalsArgs: ToggleHighlightForCriticalSignalsArgs
+  showHighlightForCriticalExternalAttributionsArgs: ToggleHighlightForCriticalExternalAttributionsArgs
 ) => void;
 
 type Listener =
@@ -47,7 +47,7 @@ type Listener =
   | LoggingListener
   | ExportFileRequestListener
   | SetBaseURLForRootListener
-  | ToggleHighlightForCriticalSignalsListener;
+  | ToggleHighlightForCriticalExternalAttributionsListener;
 
 export function useIpcRenderer(
   channel: AllowedFrontendChannels,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -26,5 +26,5 @@ export enum AllowedFrontendChannels {
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
   ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',
-  ToggleHighlightForCriticalSignals = 'toggle-highlight-for-critical-signals',
+  ToggleHighlightForCriticalExternalAttributions = 'toggle-highlight-for-critical-external-attributions',
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -180,8 +180,8 @@ export interface BaseURLForRootArgs {
   baseURLForRoot: string;
 }
 
-export interface ToggleHighlightForCriticalSignalsArgs {
-  toggleHighlightForCriticalSignals: boolean;
+export interface ToggleHighlightForCriticalExternalAttributionsArgs {
+  toggleHighlightForCriticalExternalAttributions: boolean;
 }
 
 export interface ExternalAttributionSources {


### PR DESCRIPTION

### Summary of changes

Clean up some occurances of inconsistent naming.

### Context and reason for change

Internally we use "externalAttribution", while user facing it is "signals".




