### PR TITLE
Allow only one popup of a kind

### DIFF
--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -228,4 +228,17 @@ describe('popup actions', () => {
     expect(getPopupAttributionId(testStore.getState())).toBeNull();
     expect(getOpenPopup(testStore.getState())).toBeNull();
   });
+
+  it('opens each popup only once', () => {
+    const testStore = createTestAppStore();
+    expect(getOpenPopup(testStore.getState())).toBeNull();
+    // open file search popup twice
+    testStore.dispatch(openPopup(PopupType.FileSearchPopup));
+    testStore.dispatch(openPopup(PopupType.FileSearchPopup));
+    expect(getOpenPopup(testStore.getState())).toBe(PopupType.FileSearchPopup);
+
+    // there should be only one search popup open
+    testStore.dispatch(closePopup());
+    expect(getOpenPopup(testStore.getState())).toBeNull();
+  });
 });

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -57,9 +57,13 @@ export function viewState(
         popupInfo: state.popupInfo.slice(0, -1),
       };
     case ACTION_OPEN_POPUP:
+      const openPopups = state.popupInfo.map((popupInfo) => popupInfo.popup);
+      const newPopupInfo = openPopups.includes(action.payload.popup)
+        ? state.popupInfo
+        : state.popupInfo.concat(action.payload);
       return {
         ...state,
-        popupInfo: state.popupInfo.concat(action.payload),
+        popupInfo: newPopupInfo,
       };
     case ACTION_UPDATE_ACTIVE_FILTERS:
       return {


### PR DESCRIPTION


### Summary of changes

Fix bug of allowing for several instances of a single popup kind to be open.

### Context and reason for change

Fix: #759

### How can the changes be tested

Open the same popup several times. E.g. press ctrl+F to open search popup several times and observe that now it closes once you click away once.

