### PR TITLE
Display text if only first party flag

### DIFF
--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -74,6 +74,7 @@ export function AllAttributionsPanel(
           comment: packageInfo.comment,
           url: packageInfo.url,
           licenseName: packageInfo.licenseName,
+          firstParty: packageInfo.firstParty,
         }}
         hideResourceSpecificButtons={true}
         attributionId={attributionId}

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -78,6 +78,7 @@ export function ManualAttributionList(
           comment: attribution.comment,
           url: attribution.url,
           licenseName: attribution.licenseName,
+          firstParty: attribution.firstParty,
         }}
         showOpenResourcesIcon={!isButton}
       />

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -153,6 +153,7 @@ export function PackagePanel(
           comment: packageInfo.comment,
           url: packageInfo.url,
           licenseName: packageInfo.licenseName,
+          firstParty: packageInfo.firstParty,
         }}
         attributionId={attributionId}
         cardConfig={cardConfig}

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -53,6 +53,7 @@ export interface ListCardContent {
   comment?: string;
   url?: string;
   licenseName?: string;
+  firstParty?: boolean;
 }
 
 export interface ListCardConfig {

--- a/src/Frontend/util/__tests__/get-card-labels-test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels-test.ts
@@ -68,6 +68,10 @@ describe('Test getPackageLabel', () => {
     copyright: 'Test copyright',
     url: 'Test url',
   };
+  const testPropsJustFirstParty: ListCardContent = {
+    id: '9',
+    firstParty: true,
+  };
 
   it('finds label for package', () => {
     expect(getCardLabels(testProps)).toEqual([
@@ -116,6 +120,9 @@ describe('Test getPackageLabel', () => {
       'Test url',
       '(c) Test copyright',
     ]);
+  });
+  it('finds label for package with just first party', () => {
+    expect(getCardLabels(testPropsJustFirstParty)).toEqual(['First party']);
   });
 });
 

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -5,19 +5,21 @@
 
 import { ListCardContent } from '../types/types';
 
-const prioritizedPackageInfoAttributes: Array<
+const PRIORITIZED_PACKAGE_INFO_ATTRIBUTES: Array<
   'name' | 'copyright' | 'licenseName' | 'licenseText' | 'comment' | 'url'
 > = ['name', 'copyright', 'licenseName', 'licenseText', 'comment', 'url'];
+const FIRST_PARTY_TEXT = 'First party';
 
 export function getCardLabels(props: ListCardContent): Array<string> {
   const packageLabels: Array<string> = [];
-  for (const attribute of prioritizedPackageInfoAttributes) {
+  for (const attribute of PRIORITIZED_PACKAGE_INFO_ATTRIBUTES) {
     addPackageLabelsFromAttribute(props, attribute, packageLabels);
     if (packageLabels.length > 1) {
       break;
     }
   }
-  return packageLabels || [];
+  addFirstPartyTextIfNoOtherTextPresent(packageLabels, props);
+  return packageLabels;
 }
 
 function addPackageLabelsFromAttribute(
@@ -105,4 +107,13 @@ export function addPreambleToCopyright(originalCopyright: string): string {
     copyright = `(c) ${originalCopyright}`;
   }
   return copyright;
+}
+
+function addFirstPartyTextIfNoOtherTextPresent(
+  packageLabels: Array<string>,
+  props: ListCardContent
+): void {
+  if (packageLabels.length === 0 && props.firstParty) {
+    packageLabels.push(FIRST_PARTY_TEXT);
+  }
 }


### PR DESCRIPTION


### Summary of changes

In the past we did not display any text on package cards that had only the first party label set. Now a respective text is displayed in this case.

### Context and reason for change

Fix: #740

### How can the changes be tested

Before:
![Screenshot 2022-08-19 at 16 58 27](https://user-images.githubusercontent.com/46576389/185656575-bb6d5fa8-f2cc-4872-a3cb-0998c075f24a.png)

After:
![Screenshot 2022-08-19 at 16 58 07](https://user-images.githubusercontent.com/46576389/185656566-e9972e61-f477-478c-a607-02a6c1713b36.png)
