### PR TITLE
Add opening pull requests as trigger for Github workflow runs

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -5,7 +5,10 @@
 
 name: Build and E2E Test
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -5,7 +5,10 @@
 
 name: Lint and Test
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release
+
 on:
   release:
     types: [published]

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -5,7 +5,10 @@
 
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   test:


### PR DESCRIPTION
### Summary of changes

Add pull requests as triggers for Github workflow runs.

### Context and reason for change

Before, the tests in the CI ran only on push. The issue was that tests were not running for pull requests from forks.

### How can the changes be tested

Check that tests are executed on opening of pull requests (after merging this PR).

Note: Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

