### PR TITLE
Add attribution count to attribution view

### DIFF
--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -24,9 +24,14 @@ import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import { IconButton } from '../IconButton/IconButton';
 import { getActiveFilters } from '../../state/selectors/view-selector';
-import { FollowUpIcon } from '../Icons/Icons';
+import {
+  FollowUpIcon,
+  IncompletePackagesIcon,
+  PreSelectedIcon,
+} from '../Icons/Icons';
 import pickBy from 'lodash/pickBy';
 import MuiTypography from '@mui/material/Typography';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 
 const classes = {
   root: {
@@ -38,11 +43,19 @@ const classes = {
     width: '30%',
     margin: '5px',
   },
-  titleFollowUpIcon: {
-    color: OpossumColors.orange,
-    marginBottom: '-4.5px',
+  icons: {
+    marginBottom: '-3.5px',
     marginLeft: '-3px',
     marginRight: '-2.5px',
+  },
+  titleFollowUpIcon: {
+    color: OpossumColors.orange,
+  },
+  preselectedAttributionIcon: {
+    color: OpossumColors.darkBlue,
+  },
+  incompleteAttributionIcon: {
+    color: OpossumColors.lightOrange,
   },
   disabledIcon,
   clickableIcon,
@@ -60,27 +73,47 @@ export function AttributionView(): ReactElement {
 
   const filteredAttributions = useFilters(attributions);
 
-  function getAttributionPanelTitle(): JSX.Element {
+  function getAttributionPanelTitle(): ReactElement {
     const numberOfAttributions = Object.keys(attributions).length;
-    const titleWithFollowUp = (
+    const numberOfFollowUps = Object.keys(
+      pickBy(attributions, (value: PackageInfo) => value.followUp)
+    ).length;
+    const numberOfPreselectedAttributions = Object.keys(
+      pickBy(attributions, (value: PackageInfo) => value.preSelected)
+    ).length;
+
+    const numberOfIncompleteAttributions = Object.keys(
+      pickBy(attributions, (value: PackageInfo) =>
+        isPackageInfoIncomplete(value)
+      )
+    ).length;
+
+    return (
       <MuiTypography variant={'subtitle1'}>
-        {`Attributions (${numberOfAttributions} total, ${
-          Object.keys(
-            pickBy(attributions, (value: PackageInfo) => value.followUp)
-          ).length
-        }
-      `}
-        <FollowUpIcon sx={classes.titleFollowUpIcon} />)
+        {`Attributions (${numberOfAttributions} total, ${numberOfFollowUps}`}
+        <FollowUpIcon
+          sx={{
+            ...classes.titleFollowUpIcon,
+            ...classes.icons,
+          }}
+        />
+        {`, ${numberOfPreselectedAttributions}`}
+        <PreSelectedIcon
+          sx={{
+            ...classes.preselectedAttributionIcon,
+            ...classes.icons,
+          }}
+        />
+        {`, ${numberOfIncompleteAttributions}`}
+        <IncompletePackagesIcon
+          sx={{
+            ...classes.incompleteAttributionIcon,
+            ...classes.icons,
+          }}
+        />
+        )
       </MuiTypography>
     );
-
-    const titleWithoutFollowUp = (
-      <MuiTypography
-        variant={'subtitle1'}
-      >{`Attributions (${numberOfAttributions})`}</MuiTypography>
-    );
-
-    return numberOfAttributions ? titleWithFollowUp : titleWithoutFollowUp;
   }
 
   const activeFilters = Array.from(useAppSelector(getActiveFilters));

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -65,7 +65,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -90,7 +90,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -116,7 +116,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -144,7 +144,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -23,6 +23,7 @@ import {
   tooltipStyle,
 } from '../../shared-styles';
 import { SxProps } from '@mui/material';
+import RectangleIcon from '@mui/icons-material/Rectangle';
 
 const classes = {
   clickableIcon,
@@ -170,5 +171,16 @@ export function SearchPackagesIcon(props: IconProps): ReactElement {
       sx={{ ...classes.nonClickableIcon, ...props.sx }}
       aria-label={'Search packages icon'}
     />
+  );
+}
+
+export function IncompletePackagesIcon(props: IconProps): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="contains incomplete information">
+      <RectangleIcon
+        aria-label={'Incomplete icon'}
+        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+      />
+    </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -54,8 +54,7 @@ import { Checkbox } from '../Checkbox/Checkbox';
 import { getKey, getRightIcons } from './package-card-helpers';
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { PackageInfo } from '../../../shared/shared-types';
-import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
-import { getPackageInfoKeys } from '../../../shared/shared-util';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
 
 const classes = {
@@ -145,13 +144,6 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     return currentAttributionId === selectedAttributionId
       ? temporaryPackageInfo
       : manualAttributions[currentAttributionId];
-  }
-
-  function isPackageInfoIncomplete(packageInfo: PackageInfo): boolean {
-    if (!packageInfo) return false;
-    return getPackageInfoKeys().some((attributionProperty) =>
-      isImportantAttributionInformationMissing(attributionProperty, packageInfo)
-    );
   }
 
   const highlightedAttribution =

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -20,8 +20,10 @@ import { reportTableClasses } from '../ReportTableHeader/ReportTableHeader';
 import { AttributionInfo } from '../../../shared/shared-types';
 import { IconButton } from '../IconButton/IconButton';
 import EditorIcon from '@mui/icons-material/Edit';
-import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
-import { getPackageInfoKeys } from '../../../shared/shared-util';
+import {
+  isImportantAttributionInformationMissing,
+  isPackageInfoIncomplete,
+} from '../../util/is-important-attribution-information-missing';
 import { getFrequentLicensesTexts } from '../../state/selectors/all-views-resource-selectors';
 import { useAppSelector } from '../../state/hooks';
 import MuiBox from '@mui/material/Box';
@@ -132,15 +134,6 @@ interface ReportTableItemProps {
 export function ReportTableItem(props: ReportTableItemProps): ReactElement {
   const reportTableItemClasses = { ...reportTableClasses, ...classes };
   const frequentLicenseTexts = useAppSelector(getFrequentLicensesTexts);
-
-  function isPackageInfoIncomplete(attributionInfo: AttributionInfo): boolean {
-    return getPackageInfoKeys().some((attributionProperty) =>
-      isImportantAttributionInformationMissing(
-        attributionProperty,
-        attributionInfo
-      )
-    );
-  }
 
   function getTableRow(
     attributionInfo: AttributionInfo,

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -3,7 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { AttributionInfo } from '../../shared/shared-types';
+import { AttributionInfo, PackageInfo } from '../../shared/shared-types';
+import { getPackageInfoKeys } from '../../shared/shared-util';
 
 const TYPES_REQUIRING_NAMESPACE = [
   'bitbucket',
@@ -16,6 +17,14 @@ const TYPES_REQUIRING_NAMESPACE = [
 interface ExtendedAttributionInfo extends AttributionInfo {
   icons: unknown;
 }
+
+export function isPackageInfoIncomplete(packageInfo: PackageInfo): boolean {
+  if (!packageInfo) return false;
+  return getPackageInfoKeys().some((attributionProperty) =>
+    isImportantAttributionInformationMissing(attributionProperty, packageInfo)
+  );
+}
+
 export function isImportantAttributionInformationMissing(
   attributionProperty: keyof AttributionInfo | 'icons',
   extendedAttributionInfo: Partial<ExtendedAttributionInfo>


### PR DESCRIPTION
### Summary of changes

The counts of attributions that are marked as pre-selected or incomplete are shown in attribution view.

### Context and reason for change

Fix: #924

### How can the changes be tested

![image](https://user-images.githubusercontent.com/73667922/189072294-45df4e2d-4ea8-4cd3-b785-01885f707ec0.png)

