### PR TITLE
Accordion end-to-end test

### DIFF
--- a/src/e2e-tests/__tests__/e2e.test.ts
+++ b/src/e2e-tests/__tests__/e2e.test.ts
@@ -7,6 +7,7 @@ import { ElectronApplication, Page } from 'playwright';
 import {
   conditionalIt,
   E2E_TEST_TIMEOUT,
+  EXPECT_TIMEOUT,
   getApp,
   getElementWithAriaLabel,
   getElementWithText,
@@ -67,11 +68,29 @@ describe('Open file via command line', () => {
       'ElectronBackend'
     );
     await electronBackendEntry.click();
+  });
 
-    const mainTsEntry = await getElementWithText(window, 'main.ts');
-    await mainTsEntry.click();
+  it('should show signals and attributions in accordions', async () => {
+    const electronBackendEntry = await getElementWithText(
+      window,
+      'ElectronBackend'
+    );
+    await electronBackendEntry.click();
 
-    await getElementWithText(window, 'jQuery, 16.13.1');
+    await expect(window.locator(`text=${'jQuery, 16.13.1'}`)).toBeVisible();
+
+    // Apache appears in both 'signals in folder content' and 'attributions in folder content' accordions
+    await expect(window.locator(`text=${'Apache'}`)).toHaveCount(2, {
+      timeout: EXPECT_TIMEOUT,
+    });
+
+    const signalsInFolderContentEntry = await getElementWithText(
+      window,
+      'Signals in Folder Content'
+    );
+    await signalsInFolderContentEntry.click();
+
+    await expect(window.locator(`text=${'jQuery, 16.13.1'}`)).toBeHidden();
   });
 
   // getOpenLinkListener does not work properly on Linux

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -7,9 +7,9 @@ import { _electron, ElectronApplication, Page } from 'playwright';
 import { expect, Locator } from '@playwright/test';
 
 const ELECTRON_LAUNCH_TEST_TIMEOUT = 75000;
-export const E2E_TEST_TIMEOUT = 100000;
+export const E2E_TEST_TIMEOUT = 120000;
 export const E2E_LARGE_TEST_TIMEOUT = 600000;
-const EXPECT_TIMEOUT = 15000;
+export const EXPECT_TIMEOUT = 15000;
 
 export async function getApp(
   commandLineArg?: string

--- a/src/e2e-tests/test-resources/opossum_input_e2e.json
+++ b/src/e2e-tests/test-resources/opossum_input_e2e.json
@@ -123,7 +123,7 @@
       "attributionConfidence": 100.0,
       "comment": "",
       "originId": "1eb75f3b-fc84-e781-ad9d-d46d6d61a667",
-      "packageName": "Test component",
+      "packageName": "Apache",
       "packageNamespace": "org.apache.xmlgraphics",
       "packagePURLAppendix": "?repository_url=repo.spring.io/release#everybody/loves/dogs",
       "packageType": "maven",


### PR DESCRIPTION
### Summary of changes

Accordion end-to-end test

### Context and reason for changes

Checked whether the correct signals and attributions are shown on the audit detailed view column. The e2e test output file is also attached to avoid having 2 identical attributions. Note: Please avoid uploading or modifying the e2e output file in the future as it might cause error in the e2e test

Fix: #950

Signed-off-by: Billwuzl <wu.zhuolin2000@gmail.com>
Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
