### PR TITLE
Fix opening app via cli

### DIFF
--- a/src/ElectronBackend/main/__tests__/openFileFromCliIfProvided.test.ts
+++ b/src/ElectronBackend/main/__tests__/openFileFromCliIfProvided.test.ts
@@ -6,9 +6,9 @@
 import { openFileFromCliIfProvided } from '../openFileFromCliIfProvided';
 import { BrowserWindow } from 'electron';
 
-const mockOpenFile = jest.fn();
+const mockHandleOpeningFile = jest.fn();
 jest.mock('../listeners', () => ({
-  openFile: (...args: never): void => mockOpenFile(args),
+  handleOpeningFile: (...args: never): void => mockHandleOpeningFile(args),
 }));
 
 describe('openFileFromCli', () => {
@@ -42,7 +42,7 @@ describe('openFileFromCli', () => {
       await openFileFromCliIfProvided(
         'mockBrowserWindow' as unknown as BrowserWindow
       );
-      expect(mockOpenFile).toHaveBeenCalledWith([
+      expect(mockHandleOpeningFile).toHaveBeenCalledWith([
         'mockBrowserWindow',
         inputFileName,
       ]);
@@ -67,7 +67,7 @@ describe('openFileFromCli', () => {
       await openFileFromCliIfProvided(
         'mockBrowserWindow' as unknown as BrowserWindow
       );
-      expect(mockOpenFile).not.toHaveBeenCalled();
+      expect(mockHandleOpeningFile).not.toHaveBeenCalled();
 
       process.argv = oldProcessArgv;
     }

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -103,17 +103,27 @@ export function getOpenFileListener(
         filePath = tryToGetInputFileFromOutputFile(filePath);
       }
 
-      const checksums = getActualAndParsedChecksums(filePath);
-
-      log.info('Initializing global backend state');
-      initializeGlobalBackendState(filePath, checksums.actualInputFileChecksum);
-
-      await openFileOrShowChangedInputFilePopup(
-        checksums,
-        mainWindow,
-        filePath
-      );
+      await handleOpeningFile(mainWindow, filePath);
     }
+  );
+}
+
+export async function handleOpeningFile(
+  mainWindow: BrowserWindow,
+  resourceFilePath: string
+): Promise<void> {
+  const checksums = getActualAndParsedChecksums(resourceFilePath);
+
+  log.info('Initializing global backend state');
+  initializeGlobalBackendState(
+    resourceFilePath,
+    checksums.actualInputFileChecksum
+  );
+
+  await openFileOrShowChangedInputFilePopup(
+    checksums,
+    mainWindow,
+    resourceFilePath
   );
 }
 

--- a/src/ElectronBackend/main/openFileFromCliIfProvided.ts
+++ b/src/ElectronBackend/main/openFileFromCliIfProvided.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { openFile } from './listeners';
+import { handleOpeningFile } from './listeners';
 import { BrowserWindow } from 'electron';
 
 export async function openFileFromCliIfProvided(
@@ -18,6 +18,6 @@ export async function openFileFromCliIfProvided(
   }
 
   if (inputFileName) {
-    await openFile(mainWindow, inputFileName);
+    await handleOpeningFile(mainWindow, inputFileName);
   }
 }


### PR DESCRIPTION


### Summary of changes

* extract required logic for opening a file into `handleOpeningFile`
* use `handleOpeningFile` when opening a file via cli

### Context and reason for change

When starting the app via cli the backend state was not updated correctly such that the app failed when attempting to save.

### How can the changes be tested

E.g. replace line 87 of `package.json` by 

```  
  "start:darwin:linux": "concurrently \"yarn build:dev; BROWSER=none ESLINT_NO_DEV_ERRORS=true react-scripts start\" \"wait-on http://127.0.0.1:3000 && electron . example-files/opossum_input.json\"",
```

and run `yarn start`.


