### PR TITLE
Feature show attribution counts in report view

### DIFF
--- a/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { useAppSelector } from '../../state/hooks';
+import { Attributions, PackageInfo } from '../../../shared/shared-types';
+import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
+import { OpossumColors } from '../../shared-styles';
+import {
+  FollowUpIcon,
+  IncompletePackagesIcon,
+  PreSelectedIcon,
+} from '../Icons/Icons';
+import pickBy from 'lodash/pickBy';
+import MuiTypography from '@mui/material/Typography';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
+import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
+
+const classes = {
+  icons: {
+    marginBottom: '-3.5px',
+    marginLeft: '-3px',
+    marginRight: '-2.5px',
+    width: '13px',
+    height: '13px',
+  },
+  titleFollowUpIcon: {
+    color: OpossumColors.orange,
+  },
+  preselectedAttributionIcon: {
+    color: OpossumColors.darkBlue,
+  },
+  incompleteAttributionIcon: {
+    color: OpossumColors.lightOrange,
+  },
+};
+
+interface AttributionCountsPanelProps {
+  sx?: SxProps;
+}
+
+export function AttributionCountsPanel(
+  props: AttributionCountsPanelProps
+): ReactElement {
+  const attributions: Attributions = useAppSelector(getManualAttributions);
+  const numberOfAttributions = Object.keys(attributions).length;
+  const numberOfFollowUps = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.followUp)
+  ).length;
+  const numberOfPreselectedAttributions = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.preSelected)
+  ).length;
+
+  const numberOfIncompleteAttributions = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
+  ).length;
+
+  return (
+    <MuiTypography
+      variant={'subtitle2'}
+      sx={getSxFromPropsAndClasses({
+        sxProps: props.sx,
+      })}
+    >
+      {`Attributions (${numberOfAttributions} total, ${numberOfFollowUps}`}
+      <FollowUpIcon
+        sx={{
+          ...classes.titleFollowUpIcon,
+          ...classes.icons,
+        }}
+      />
+      {`, ${numberOfPreselectedAttributions}`}
+      <PreSelectedIcon
+        sx={{
+          ...classes.preselectedAttributionIcon,
+          ...classes.icons,
+        }}
+      />
+      {`, ${numberOfIncompleteAttributions}`}
+      <IncompletePackagesIcon
+        sx={{
+          ...classes.incompleteAttributionIcon,
+          ...classes.icons,
+        }}
+      />
+      )
+    </MuiTypography>
+  );
+}

--- a/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import React from 'react';
+import {
+  Attributions,
+  FollowUp,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { View } from '../../../enums/enums';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { navigateToView } from '../../../state/actions/view-actions/view-actions';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import { AttributionCountsPanel } from '../AttributionCountsPanel';
+import { act } from 'react-dom/test-utils';
+
+describe('The Attribution Counts Panel', () => {
+  const testManualUuid = 'a32f2f96-f40e-11ea-adc1-0242ac120002';
+  const testOtherManualUuid = 'a32f2f96-f40e-11ea-adc1-0242ac120003';
+  const testManualAttributions: Attributions = {
+    [testManualUuid]: {
+      attributionConfidence: 0,
+      comment: 'Some comment',
+      packageName: 'Test package',
+      packageVersion: '1.0',
+      copyright: 'Copyright John Doe',
+      licenseText: 'Some license text',
+      firstParty: true,
+    },
+    [testOtherManualUuid]: {
+      attributionConfidence: 0,
+      comment: 'Some other comment',
+      packageName: 'Test other package',
+      packageVersion: '2.0',
+      copyright: 'other Copyright John Doe',
+      licenseText: 'Some other license text',
+      followUp: FollowUp,
+    },
+  };
+  const testResourcesToManualAttributions: ResourcesToAttributions = {
+    'test resource': [testManualUuid],
+    'test other resource': [testOtherManualUuid],
+  };
+
+  it('renders', () => {
+    const { store } = renderComponentWithStore(<AttributionCountsPanel />);
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: { ['test resource']: 1 },
+          manualAttributions: testManualAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
+      )
+    );
+    act(() => {
+      store.dispatch(navigateToView(View.Attribution));
+    });
+
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+  });
+});

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -6,7 +6,7 @@
 import MuiBox from '@mui/material/Box';
 import React, { ReactElement, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { Attributions, PackageInfo } from '../../../shared/shared-types';
+import { Attributions } from '../../../shared/shared-types';
 import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { getManualAttributions } from '../../state/selectors/all-views-resource-selectors';
 import { getSelectedAttributionId } from '../../state/selectors/attribution-view-resource-selectors';
@@ -24,14 +24,7 @@ import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import { IconButton } from '../IconButton/IconButton';
 import { getActiveFilters } from '../../state/selectors/view-selector';
-import {
-  FollowUpIcon,
-  IncompletePackagesIcon,
-  PreSelectedIcon,
-} from '../Icons/Icons';
-import pickBy from 'lodash/pickBy';
-import MuiTypography from '@mui/material/Typography';
-import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
+import { AttributionCountsPanel } from '../AttributionCountsPanel/AttributionCountsPanel';
 
 const classes = {
   root: {
@@ -42,20 +35,6 @@ const classes = {
   attributionList: {
     width: '30%',
     margin: '5px',
-  },
-  icons: {
-    marginBottom: '-3.5px',
-    marginLeft: '-3px',
-    marginRight: '-2.5px',
-  },
-  titleFollowUpIcon: {
-    color: OpossumColors.orange,
-  },
-  preselectedAttributionIcon: {
-    color: OpossumColors.darkBlue,
-  },
-  incompleteAttributionIcon: {
-    color: OpossumColors.lightOrange,
   },
   disabledIcon,
   clickableIcon,
@@ -72,52 +51,7 @@ export function AttributionView(): ReactElement {
   }
 
   const filteredAttributions = useFilters(attributions);
-
-  function getAttributionPanelTitle(): ReactElement {
-    const numberOfAttributions = Object.keys(attributions).length;
-    const numberOfFollowUps = Object.keys(
-      pickBy(attributions, (value: PackageInfo) => value.followUp)
-    ).length;
-    const numberOfPreselectedAttributions = Object.keys(
-      pickBy(attributions, (value: PackageInfo) => value.preSelected)
-    ).length;
-
-    const numberOfIncompleteAttributions = Object.keys(
-      pickBy(attributions, (value: PackageInfo) =>
-        isPackageInfoIncomplete(value)
-      )
-    ).length;
-
-    return (
-      <MuiTypography variant={'subtitle1'}>
-        {`Attributions (${numberOfAttributions} total, ${numberOfFollowUps}`}
-        <FollowUpIcon
-          sx={{
-            ...classes.titleFollowUpIcon,
-            ...classes.icons,
-          }}
-        />
-        {`, ${numberOfPreselectedAttributions}`}
-        <PreSelectedIcon
-          sx={{
-            ...classes.preselectedAttributionIcon,
-            ...classes.icons,
-          }}
-        />
-        {`, ${numberOfIncompleteAttributions}`}
-        <IncompletePackagesIcon
-          sx={{
-            ...classes.incompleteAttributionIcon,
-            ...classes.icons,
-          }}
-        />
-        )
-      </MuiTypography>
-    );
-  }
-
   const activeFilters = Array.from(useAppSelector(getActiveFilters));
-
   const [showMultiSelect, setShowMultiselect] = useState<boolean>(false);
 
   if (activeFilters.length !== 0 && !showMultiSelect) {
@@ -136,7 +70,7 @@ export function AttributionView(): ReactElement {
         maxHeight={
           useWindowHeight() - topBarHeight - countAndSearchAndFilterOffset
         }
-        title={getAttributionPanelTitle()}
+        title={<AttributionCountsPanel />}
         topRightElement={
           <IconButton
             tooltipTitle="Filters"

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -24,6 +24,7 @@ import { OpossumColors } from '../../shared-styles';
 import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import MuiBox from '@mui/material/Box';
+import { AttributionCountsPanel } from '../AttributionCountsPanel/AttributionCountsPanel';
 
 const classes = {
   root: {
@@ -60,7 +61,14 @@ export function ReportView(): ReactElement {
         attributionsWithResources={useFilters(attributionsWithResources)}
         isFileWithChildren={isFileWithChildren}
         onIconClick={getOnIconClick()}
-        topElement={<FilterMultiSelect sx={{ maxWidth: '300px' }} />}
+        topElement={
+          <>
+            <FilterMultiSelect sx={{ maxWidth: '300px' }} />
+            <AttributionCountsPanel
+              sx={{ display: 'inline-block', margin: '20px' }}
+            />
+          </>
+        }
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -71,6 +71,7 @@ describe('The ReportView', () => {
       );
       store.dispatch(setFrequentLicences(testFrequentLicenses));
     });
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('MIT text'));
     expect(screen.getByText('Test other package'));
@@ -90,6 +91,7 @@ describe('The ReportView', () => {
         )
       );
     });
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -113,6 +115,7 @@ describe('The ReportView', () => {
         )
       );
     });
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -140,6 +143,7 @@ describe('The ReportView', () => {
         )
       );
     });
+    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 


### PR DESCRIPTION
### Summary of changes

Show attribution counts in Report View

### Context and reason for change

- Moved a function out from Attribution View to construct a new component.
- This component can now be reused in the Report View as well. 

Fix: #925 

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>