### PR TITLE
Suppress console output in tests

### DIFF
--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -136,7 +136,6 @@ describe('The ResourceDetailsTabs', () => {
         })
       )
     );
-    console.log(store.getState().resourceState.allViews.manualData);
     act(() => {
       store.dispatch(setSelectedResourceId('/root/fileWithoutAttribution'));
     });


### PR DESCRIPTION


### Summary of changes

Mock `console.error` for the relevant cases by matching substrings.

### Context and reason for change

Currently, the terminal is spammed when running tests. Here we suppress output to the terminal related to issue #938.


### How can the changes be tested

`yarn test:unit`
