### PR TITLE
[Bug-Fix] Fix attributions sorting order

### DIFF
--- a/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
+++ b/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
@@ -8,14 +8,16 @@ import { Attributions } from '../../../shared/shared-types';
 import { Height, NumberOfDisplayedItems } from '../../types/types';
 import { List } from '../List/List';
 import { SearchTextField } from '../SearchTextField/SearchTextField';
-import { getSortedFilteredPackageIds } from './package-list-helpers';
+import { getFilteredPackageIds } from './package-list-helpers';
 
 const CARD_VERTICAL_DISTANCE = 41;
 
 interface AttributionsViewPackageListProps {
   attributions: Attributions;
   attributionIds: Array<string>;
+
   getAttributionCard(attributionId: string): ReactElement | null;
+
   max: NumberOfDisplayedItems | Height;
 }
 
@@ -24,13 +26,9 @@ export function AttributionsViewPackageList(
 ): ReactElement {
   const [search, setSearch] = useState('');
 
-  const sortedFilteredPackageIds: Array<string> = useMemo(
+  const filteredPackageIds: Array<string> = useMemo(
     () =>
-      getSortedFilteredPackageIds(
-        props.attributions,
-        props.attributionIds,
-        search
-      ),
+      getFilteredPackageIds(props.attributions, props.attributionIds, search),
     [props.attributions, props.attributionIds, search]
   );
 
@@ -43,10 +41,10 @@ export function AttributionsViewPackageList(
       />
       <List
         getListItem={(index: number): ReactElement | null =>
-          props.getAttributionCard(sortedFilteredPackageIds[index])
+          props.getAttributionCard(filteredPackageIds[index])
         }
         max={props.max}
-        length={sortedFilteredPackageIds.length}
+        length={filteredPackageIds.length}
         cardVerticalDistance={CARD_VERTICAL_DISTANCE}
       />
     </div>

--- a/src/Frontend/Components/PackageList/PackageList.tsx
+++ b/src/Frontend/Components/PackageList/PackageList.tsx
@@ -9,7 +9,7 @@ import MuiTypography from '@mui/material/Typography';
 import { List } from '../List/List';
 import { useAppSelector } from '../../state/hooks';
 import { getPackageSearchTerm } from '../../state/selectors/audit-view-resource-selectors';
-import { getSortedFilteredPackageIds } from './package-list-helpers';
+import { getFilteredPackageIds } from './package-list-helpers';
 
 const CARD_VERTICAL_DISTANCE = 41;
 const TYPICAL_SCROLLBAR_WIDTH = 13;
@@ -23,7 +23,9 @@ const classes = {
 interface PackageListProps {
   attributions: Attributions;
   attributionIds: Array<string>;
+
   getAttributionCard(attributionId: string): ReactElement | null;
+
   maxNumberOfDisplayedItems: number;
   listTitle: string;
 }
@@ -31,9 +33,9 @@ interface PackageListProps {
 export function PackageList(props: PackageListProps): ReactElement {
   const searchTerm = useAppSelector(getPackageSearchTerm);
 
-  const sortedFilteredPackageIds: Array<string> = useMemo(
+  const filteredPackageIds: Array<string> = useMemo(
     () =>
-      getSortedFilteredPackageIds(
+      getFilteredPackageIds(
         props.attributions,
         props.attributionIds,
         searchTerm
@@ -46,17 +48,17 @@ export function PackageList(props: PackageListProps): ReactElement {
 
   return (
     <>
-      {sortedFilteredPackageIds.length === 0 ? null : (
+      {filteredPackageIds.length === 0 ? null : (
         <>
           {props.listTitle ? (
             <MuiTypography variant={'body2'}>{props.listTitle}</MuiTypography>
           ) : null}
           <List
             getListItem={(index: number): ReactElement | null =>
-              props.getAttributionCard(sortedFilteredPackageIds[index])
+              props.getAttributionCard(filteredPackageIds[index])
             }
             max={{ numberOfDisplayedItems: props.maxNumberOfDisplayedItems }}
-            length={sortedFilteredPackageIds.length}
+            length={filteredPackageIds.length}
             cardVerticalDistance={CARD_VERTICAL_DISTANCE}
             sx={currentHeight < maxHeight ? classes.paddingRight : {}}
           />

--- a/src/Frontend/Components/PackageList/__tests__/package-list-helpers.test.ts
+++ b/src/Frontend/Components/PackageList/__tests__/package-list-helpers.test.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Attributions } from '../../../../shared/shared-types';
-import { getSortedFilteredPackageIds } from '../package-list-helpers';
+import { getFilteredPackageIds } from '../package-list-helpers';
 
 describe('The PackageListHelper', () => {
   it('filters Attributions', () => {
@@ -30,17 +30,17 @@ describe('The PackageListHelper', () => {
     const testAttributionIds = Object.entries(testAttributions).map(
       ([attributionId]) => attributionId
     );
-    const sortedFilteredTestAttributions = getSortedFilteredPackageIds(
+    const filteredTestAttributions = getFilteredPackageIds(
       testAttributions,
       testAttributionIds,
       'SeArCh_TeRm'
     );
 
-    expect(sortedFilteredTestAttributions).toContain('uuid1');
-    expect(sortedFilteredTestAttributions).toContain('uuid2');
-    expect(sortedFilteredTestAttributions).toContain('uuid3');
-    expect(sortedFilteredTestAttributions).toContain('uuid4');
-    expect(sortedFilteredTestAttributions).not.toContain('uuid5');
+    expect(filteredTestAttributions).toContain('uuid1');
+    expect(filteredTestAttributions).toContain('uuid2');
+    expect(filteredTestAttributions).toContain('uuid3');
+    expect(filteredTestAttributions).toContain('uuid4');
+    expect(filteredTestAttributions).not.toContain('uuid5');
   });
 
   it('sorts Attributions', () => {
@@ -58,11 +58,11 @@ describe('The PackageListHelper', () => {
     const testAttributionIds = Object.entries(testAttributions).map(
       ([attributionId]) => attributionId
     );
-    const sortedFilteredTestAttributions = getSortedFilteredPackageIds(
+    const filteredTestAttributions = getFilteredPackageIds(
       testAttributions,
       testAttributionIds,
       ''
     );
-    expect(sortedFilteredTestAttributions).toEqual(['uuid2', 'uuid3', 'uuid1']);
+    expect(filteredTestAttributions).toEqual(['uuid1', 'uuid2', 'uuid3']);
   });
 });

--- a/src/Frontend/Components/PackageList/package-list-helpers.ts
+++ b/src/Frontend/Components/PackageList/package-list-helpers.ts
@@ -4,16 +4,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Attributions, PackageInfo } from '../../../shared/shared-types';
-import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
 
-export function getSortedFilteredPackageIds(
+export function getFilteredPackageIds(
   attributions: Attributions,
   attributionIds: Array<string>,
   searchTerm: string
 ): Array<string> {
-  return attributionIds
-    .filter((id) => attributionContainsSearchTerm(attributions[id], searchTerm))
-    .sort(getAlphabeticalComparer(attributions));
+  return attributionIds.filter((id) =>
+    attributionContainsSearchTerm(attributions[id], searchTerm)
+  );
 }
 
 function attributionContainsSearchTerm(


### PR DESCRIPTION
### Summary of changes

Remove alphabetical sorting of attributions

### Context and reason for change

- Attributions need not be re-sorted alphabetically since we are already getting the correctly sorted attributions.
- The correct sorting order of attributions is in descending order of number of attributions.
- Bug was introduced in the commit: https://github.com/opossum-tool/OpossumUI/commit/94f7c52eedc30244c78219e41bb22b50a90d8fda

Fix: #989

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>