### PR TITLE
Improve styling of existing components in statistics popup

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/AttributionCountPerSourcePerLicenseTable.tsx
@@ -54,9 +54,13 @@ export function AttributionCountPerSourcePerLicenseTable(
     .sort();
 
   return (
-    <MuiBox sx={projectStatisticsPopupClasses.marginTop}>
+    <MuiBox>
       <MuiTypography variant="subtitle1">{props.title}</MuiTypography>
-      <MuiTableContainer sx={projectStatisticsPopupClasses.bigTable}>
+      <MuiTableContainer
+        sx={
+          projectStatisticsPopupClasses.attributionCountPerSourcePerLicenseTable
+        }
+      >
         <MuiTable size="small" stickyHeader>
           <MuiTableHead>
             <MuiTableRow>
@@ -64,7 +68,7 @@ export function AttributionCountPerSourcePerLicenseTable(
                 <MuiTableCell
                   sx={projectStatisticsPopupClasses.head}
                   key={index}
-                  align="center"
+                  align={index === 0 ? 'left' : 'center'}
                 >
                   {sourceName.toUpperCase()}
                 </MuiTableCell>
@@ -90,7 +94,7 @@ export function AttributionCountPerSourcePerLicenseTable(
                         : {}),
                     }}
                     key={index}
-                    align="center"
+                    align={index === 0 ? 'left' : 'center'}
                   >
                     {index === 0
                       ? licenseName
@@ -103,13 +107,13 @@ export function AttributionCountPerSourcePerLicenseTable(
             ))}
           </MuiTableBody>
 
-          <MuiTableFooter sx={projectStatisticsPopupClasses.footer}>
+          <MuiTableFooter sx={projectStatisticsPopupClasses.tableFooter}>
             <MuiTableRow>
               {totalsRow.map((total, index) => (
                 <MuiTableCell
                   sx={projectStatisticsPopupClasses.footer}
                   key={index}
-                  align="center"
+                  align={index === 0 ? 'left' : 'center'}
                 >
                   {total}
                 </MuiTableCell>

--- a/src/Frontend/Components/ProjectStatisticsPopup/AttributionPropertyCountTable.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/AttributionPropertyCountTable.tsx
@@ -7,12 +7,13 @@ import React, { ReactElement } from 'react';
 import MuiTypography from '@mui/material/Typography';
 import MuiBox from '@mui/material/Box';
 import MuiTable from '@mui/material/Table';
-import MuiTableBody from '@mui/material/TableBody';
 import MuiTableCell from '@mui/material/TableCell';
 import MuiTableContainer from '@mui/material/TableContainer';
 import MuiTableRow from '@mui/material/TableRow';
 import { getAttributionPropertyDisplayNameFromId } from './project-statistics-popup-helpers';
 import { projectStatisticsPopupClasses } from './shared-project-statistics-popup-styles';
+import MuiTableHead from '@mui/material/TableHead';
+import MuiTableFooter from '@mui/material/TableFooter';
 
 interface AttributionPropertyCountTableProps {
   attributionPropertyCountsEntries: Array<Array<string | number>>;
@@ -22,33 +23,51 @@ interface AttributionPropertyCountTableProps {
 export function AttributionPropertyCountTable(
   props: AttributionPropertyCountTableProps
 ): ReactElement {
+  const attributionPropertyDisplayNames =
+    props.attributionPropertyCountsEntries.map((entry) =>
+      getAttributionPropertyDisplayNameFromId(entry[0].toString())
+    );
+  const attributionPropertyCounts = props.attributionPropertyCountsEntries.map(
+    (entry) => entry[1].toString()
+  );
+
   return (
     <MuiBox>
       <MuiTypography variant="subtitle1">{props.title}</MuiTypography>
-      <MuiTableContainer sx={projectStatisticsPopupClasses.smallTable}>
-        <MuiTable size="small">
-          <MuiTableBody>
-            {props.attributionPropertyCountsEntries.map(
-              ([attributionProperty, count], index) => (
-                <MuiTableRow key={index}>
+      <MuiTableContainer
+        sx={projectStatisticsPopupClasses.attributionPropertyCountTable}
+      >
+        <MuiTable size="small" stickyHeader>
+          <MuiTableHead>
+            <MuiTableRow>
+              {attributionPropertyDisplayNames.map(
+                (attributionPropertyDisplayName, index) => (
                   <MuiTableCell
-                    sx={projectStatisticsPopupClasses.body}
+                    sx={projectStatisticsPopupClasses.head}
+                    key={index}
                     align="center"
                   >
-                    {getAttributionPropertyDisplayNameFromId(
-                      attributionProperty.toString()
-                    )}
+                    {attributionPropertyDisplayName}
                   </MuiTableCell>
+                )
+              )}
+            </MuiTableRow>
+          </MuiTableHead>
+          <MuiTableFooter sx={projectStatisticsPopupClasses.tableFooter}>
+            <MuiTableRow>
+              {attributionPropertyCounts.map(
+                (attributionPropertyCount, index) => (
                   <MuiTableCell
                     sx={projectStatisticsPopupClasses.body}
+                    key={index}
                     align="center"
                   >
-                    {count}
+                    {attributionPropertyCount}
                   </MuiTableCell>
-                </MuiTableRow>
-              )
-            )}
-          </MuiTableBody>
+                )
+              )}
+            </MuiTableRow>
+          </MuiTableFooter>
         </MuiTable>
       </MuiTableContainer>
     </MuiBox>

--- a/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
@@ -3,31 +3,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { OpossumColors } from '../../shared-styles';
+
 export const projectStatisticsPopupClasses = {
   head: {
-    fontWeight: 'bold',
-    fontSize: 15,
+    fontSize: 13,
+    background: OpossumColors.darkBlue,
+    color: OpossumColors.white,
   },
   footer: {
     fontWeight: 'bold',
-    fontSize: 14,
-    color: 'black',
-    background: 'white',
-    borderBottom: 0,
-    position: 'sticky',
-    bottom: 0,
+    fontSize: 12,
+    background: OpossumColors.lightBlue,
   },
   body: {
-    fontSize: 14,
+    fontSize: 11,
+    background: OpossumColors.lightestBlue,
   },
-  smallTable: {
-    width: '300px',
+  attributionCountPerSourcePerLicenseTable: {
+    maxHeight: '400px',
+    marginBottom: 3,
   },
-  bigTable: {
-    maxHeight: '54vh',
-    minWidth: '300px',
+  attributionPropertyCountTable: {
+    maxHeight: '100px',
+    maxWidth: '400px',
+    marginBottom: 3,
   },
-  marginTop: {
-    marginTop: '30px',
+  tableFooter: {
+    position: 'sticky',
+    bottom: 0,
   },
 };


### PR DESCRIPTION
### Summary of changes

Make tables in statistics popup look more modular

### Context and reason for change

- The existing components were not styled in a modular way.
- In future, more components can now be conveniently added to the popup.

Fix: #948

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>