### PR TITLE
Add critical licenses table to statistics popup

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/AttributionCountPerSourcePerLicenseTable.tsx
@@ -6,8 +6,9 @@
 import React, { ReactElement } from 'react';
 import {
   AttributionCountPerSourcePerLicense,
-  LicenseNamesWithCriticality,
   LICENSE_TOTAL_HEADER,
+  LicenseNamesWithCriticality,
+  PLACEHOLDER_ATTRIBUTION_COUNT,
   SOURCE_TOTAL_HEADER,
 } from './project-statistics-popup-helpers';
 import MuiTypography from '@mui/material/Typography';
@@ -21,8 +22,7 @@ import MuiTableFooter from '@mui/material/TableFooter';
 import MuiTableRow from '@mui/material/TableRow';
 import { projectStatisticsPopupClasses } from './shared-project-statistics-popup-styles';
 import { OpossumColors } from '../../shared-styles';
-
-const PLACEHOLDER_ATTRIBUTION_COUNT = '-';
+import { Criticality } from '../../../shared/shared-types';
 
 interface AttributionCountPerSourcePerLicenseTableProps {
   attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
@@ -85,10 +85,10 @@ export function AttributionCountPerSourcePerLicenseTable(
                       ...projectStatisticsPopupClasses.body,
                       ...(index === 0
                         ? props.licenseNamesWithCriticality[licenseName] ===
-                          'high'
+                          Criticality.High
                           ? { color: OpossumColors.orange }
                           : props.licenseNamesWithCriticality[licenseName] ===
-                            'medium'
+                            Criticality.Medium
                           ? { color: OpossumColors.mediumOrange }
                           : {}
                         : {}),
@@ -107,7 +107,7 @@ export function AttributionCountPerSourcePerLicenseTable(
             ))}
           </MuiTableBody>
 
-          <MuiTableFooter sx={projectStatisticsPopupClasses.tableFooter}>
+          <MuiTableFooter>
             <MuiTableRow>
               {totalsRow.map((total, index) => (
                 <MuiTableCell

--- a/src/Frontend/Components/ProjectStatisticsPopup/AttributionPropertyCountTable.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/AttributionPropertyCountTable.tsx
@@ -53,7 +53,7 @@ export function AttributionPropertyCountTable(
               )}
             </MuiTableRow>
           </MuiTableHead>
-          <MuiTableFooter sx={projectStatisticsPopupClasses.tableFooter}>
+          <MuiTableFooter>
             <MuiTableRow>
               {attributionPropertyCounts.map(
                 (attributionPropertyCount, index) => (

--- a/src/Frontend/Components/ProjectStatisticsPopup/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/CriticalLicensesTable.tsx
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import {
+  AttributionCountPerSourcePerLicense,
+  LICENSE_COLUMN_NAME_IN_TABLE_HEADER,
+  LicenseNamesWithCriticality,
+  PLACEHOLDER_ATTRIBUTION_COUNT,
+  SOURCE_TOTAL_HEADER,
+  TOTAL_COLUMN_NAME_IN_TABLE_HEADER,
+} from './project-statistics-popup-helpers';
+import MuiTypography from '@mui/material/Typography';
+import MuiBox from '@mui/material/Box';
+import MuiTable from '@mui/material/Table';
+import MuiTableBody from '@mui/material/TableBody';
+import MuiTableCell from '@mui/material/TableCell';
+import MuiTableContainer from '@mui/material/TableContainer';
+import MuiTableHead from '@mui/material/TableHead';
+import MuiTableFooter from '@mui/material/TableFooter';
+import MuiTableRow from '@mui/material/TableRow';
+import { projectStatisticsPopupClasses } from './shared-project-statistics-popup-styles';
+import { OpossumColors } from '../../shared-styles';
+import { Criticality } from '../../../shared/shared-types';
+
+function getLicenseNamesByCriticality(
+  allLicensesWithCriticality: Array<{
+    licenseName: string;
+    criticality: Criticality | undefined;
+  }>,
+  criticality: Criticality
+): Array<string> {
+  return allLicensesWithCriticality
+    .map((licenseNameAndCriticality) =>
+      licenseNameAndCriticality.criticality === criticality
+        ? licenseNameAndCriticality.licenseName
+        : ''
+    )
+    .filter((licenseName) => licenseName !== '');
+}
+
+function getCriticalLicenseNamesWithTheirTotalAttributions(
+  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense,
+  criticalLicenseNames: Array<string>
+): Array<{ licenseName: string; totalNumberOfAttributions: number }> {
+  const licenseNamesAndTheirTotalAttributions = criticalLicenseNames.map(
+    (criticalLicenseName) => {
+      return {
+        licenseName: criticalLicenseName,
+        totalNumberOfAttributions:
+          attributionCountPerSourcePerLicense[criticalLicenseName][
+            SOURCE_TOTAL_HEADER
+          ],
+      };
+    }
+  );
+  return licenseNamesAndTheirTotalAttributions.sort();
+}
+
+function getTotalNumberOfAttributions(
+  licenseNamesAndTheirTotalAttributions: Array<{
+    licenseName: string;
+    totalNumberOfAttributions: number;
+  }>
+): number {
+  return licenseNamesAndTheirTotalAttributions
+    .map(
+      (licenseNameAndTotalAttributions) =>
+        licenseNameAndTotalAttributions.totalNumberOfAttributions
+    )
+    .reduce((total, value) => total + value, 0);
+}
+
+interface CriticalLicensesTableProps {
+  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
+  licenseNamesWithCriticality: LicenseNamesWithCriticality;
+  title: string;
+}
+
+export function CriticalLicensesTable(
+  props: CriticalLicensesTableProps
+): ReactElement {
+  const allLicensesWithCriticality = Object.entries(
+    props.licenseNamesWithCriticality
+  ).map((licenseNameAndCriticality) => {
+    return {
+      licenseName: licenseNameAndCriticality[0],
+      criticality: licenseNameAndCriticality[1],
+    };
+  });
+  const highCriticalityLicenseNames = getLicenseNamesByCriticality(
+    allLicensesWithCriticality,
+    Criticality.High
+  );
+  const mediumCriticalityLicenseNames = getLicenseNamesByCriticality(
+    allLicensesWithCriticality,
+    Criticality.Medium
+  );
+  const highCriticalityLicensesTotalAttributions =
+    getCriticalLicenseNamesWithTheirTotalAttributions(
+      props.attributionCountPerSourcePerLicense,
+      highCriticalityLicenseNames
+    );
+  const mediumCriticalityLicensesTotalAttributions =
+    getCriticalLicenseNamesWithTheirTotalAttributions(
+      props.attributionCountPerSourcePerLicense,
+      mediumCriticalityLicenseNames
+    );
+  const criticalLicensesTotalAttributions =
+    highCriticalityLicensesTotalAttributions.concat(
+      mediumCriticalityLicensesTotalAttributions
+    );
+  const tableColumnNames = [
+    LICENSE_COLUMN_NAME_IN_TABLE_HEADER,
+    TOTAL_COLUMN_NAME_IN_TABLE_HEADER,
+  ];
+  const tableFooter = [SOURCE_TOTAL_HEADER].concat(
+    getTotalNumberOfAttributions(criticalLicensesTotalAttributions).toString()
+  );
+
+  return (
+    <MuiBox>
+      <MuiTypography variant="subtitle1">{props.title}</MuiTypography>
+      <MuiTableContainer
+        sx={projectStatisticsPopupClasses.criticalLicensesTable}
+      >
+        <MuiTable size="small" stickyHeader>
+          <MuiTableHead>
+            <MuiTableRow>
+              {tableColumnNames.map((columnName, index) => (
+                <MuiTableCell
+                  sx={projectStatisticsPopupClasses.head}
+                  key={index}
+                  align={index === 0 ? 'left' : 'center'}
+                >
+                  {columnName.toUpperCase()}
+                </MuiTableCell>
+              ))}
+            </MuiTableRow>
+          </MuiTableHead>
+
+          <MuiTableBody>
+            {criticalLicensesTotalAttributions.map(
+              ({ licenseName, totalNumberOfAttributions }, rowIndex) => (
+                <MuiTableRow key={rowIndex}>
+                  {tableColumnNames.map((columnName, index) => (
+                    <MuiTableCell
+                      sx={{
+                        ...projectStatisticsPopupClasses.body,
+                        ...(index === 0
+                          ? props.licenseNamesWithCriticality[licenseName] ===
+                            Criticality.High
+                            ? { color: OpossumColors.orange }
+                            : props.licenseNamesWithCriticality[licenseName] ===
+                              Criticality.Medium
+                            ? { color: OpossumColors.mediumOrange }
+                            : {}
+                          : {}),
+                      }}
+                      key={index}
+                      align={index === 0 ? 'left' : 'center'}
+                    >
+                      {index === 0
+                        ? licenseName
+                        : totalNumberOfAttributions ||
+                          PLACEHOLDER_ATTRIBUTION_COUNT}
+                    </MuiTableCell>
+                  ))}
+                </MuiTableRow>
+              )
+            )}
+          </MuiTableBody>
+
+          <MuiTableFooter>
+            <MuiTableRow>
+              {tableFooter.map((total, index) => (
+                <MuiTableCell
+                  sx={projectStatisticsPopupClasses.footer}
+                  key={index}
+                  align={index === 0 ? 'left' : 'center'}
+                >
+                  {total}
+                </MuiTableCell>
+              ))}
+            </MuiTableRow>
+          </MuiTableFooter>
+        </MuiTable>
+      </MuiTableContainer>
+    </MuiBox>
+  );
+}

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -21,10 +21,12 @@ import {
 } from './project-statistics-popup-helpers';
 import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerSourcePerLicenseTable';
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
+import { CriticalLicensesTable } from './CriticalLicensesTable';
 
 const attributionCountPerSourcePerLicenseTableTitle = 'Signals per Sources';
 const attributionPropertyCountTableTitle =
   'First Party and Follow Up Attributions';
+const criticalLicensesTableTitle = 'Critical Licenses';
 
 export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
@@ -64,6 +66,13 @@ export function ProjectStatisticsPopup(): ReactElement {
               sortedManualAttributionPropertyCountsEntries
             }
             title={attributionPropertyCountTableTitle}
+          />
+          <CriticalLicensesTable
+            attributionCountPerSourcePerLicense={
+              attributionCountPerSourcePerLicense
+            }
+            licenseNamesWithCriticality={licenseNamesWithCriticalities}
+            title={criticalLicensesTableTitle}
           />
           <AttributionCountPerSourcePerLicenseTable
             attributionCountPerSourcePerLicense={

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -60,8 +60,8 @@ describe('The ProjectStatisticsPopup', () => {
     );
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
-    expect(screen.getByText('LICENSE')).toBeInTheDocument();
-    expect(screen.getByText('Total')).toBeInTheDocument();
+    expect(screen.getAllByText('LICENSE')).toHaveLength(2);
+    expect(screen.getAllByText('TOTAL')).toHaveLength(2);
     expect(screen.getByText('Follow up')).toBeInTheDocument();
     expect(screen.getByText('First party')).toBeInTheDocument();
   });

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -30,6 +30,10 @@ const ATTRIBUTION_PROPERTIES_TO_DISPLAY: Array<keyof PackageInfo> = [
 export const SOURCE_TOTAL_HEADER = 'Total';
 export const LICENSE_TOTAL_HEADER = 'Total';
 export const ATTRIBUTION_TOTAL_HEADER = 'Total Attributions';
+export const LICENSE_COLUMN_NAME_IN_TABLE_HEADER = 'License';
+export const TOTAL_COLUMN_NAME_IN_TABLE_HEADER = 'Total';
+export const PLACEHOLDER_ATTRIBUTION_COUNT = '-';
+
 const UNKNOWN_SOURCE_PLACEHOLDER = '-';
 const ATTRIBUTION_PROPERTIES_ID_TO_DISPLAY_NAME: {
   [attributionProperty: string]: string;

--- a/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
@@ -15,10 +15,14 @@ export const projectStatisticsPopupClasses = {
     fontWeight: 'bold',
     fontSize: 12,
     background: OpossumColors.lightBlue,
+    position: 'sticky',
+    bottom: 0,
   },
   body: {
     fontSize: 11,
     background: OpossumColors.lightestBlue,
+    maxWidth: '100px',
+    overflow: 'auto',
   },
   attributionCountPerSourcePerLicenseTable: {
     maxHeight: '400px',
@@ -29,8 +33,9 @@ export const projectStatisticsPopupClasses = {
     maxWidth: '400px',
     marginBottom: 3,
   },
-  tableFooter: {
-    position: 'sticky',
-    bottom: 0,
+  criticalLicensesTable: {
+    maxHeight: '400px',
+    maxWidth: '400px',
+    marginBottom: 3,
   },
 };


### PR DESCRIPTION
### Summary of changes

Add critical licenses table to statistics popup

### Context and reason for change

- The table shows only high and medium critical licenses.
- The high critical licenses are placed above the medium critical ones.
- Both groups are sorted within themselves.

Fix: #947

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>