### PR TITLE
Improve highlighting of criticality in statistics popup

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -14,10 +14,10 @@ import {
   getManualAttributions,
 } from '../../state/selectors/all-views-resource-selectors';
 import {
-  aggregateLicensesAndSourcesFromAttributions,
   aggregateAttributionPropertiesFromAttributions,
-  sortAttributionPropertiesEntries,
+  aggregateLicensesAndSourcesFromAttributions,
   getUniqueLicenseNameToAttribution,
+  sortAttributionPropertiesEntries,
 } from './project-statistics-popup-helpers';
 import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerSourcePerLicenseTable';
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
@@ -39,7 +39,7 @@ export function ProjectStatisticsPopup(): ReactElement {
   const strippedLicenseNameToAttribution =
     getUniqueLicenseNameToAttribution(externalAttributions);
 
-  const { attributionCountPerSourcePerLicense, licenseNamesWithCriticalities } =
+  const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
     aggregateLicensesAndSourcesFromAttributions(
       externalAttributions,
       strippedLicenseNameToAttribution,
@@ -71,14 +71,14 @@ export function ProjectStatisticsPopup(): ReactElement {
             attributionCountPerSourcePerLicense={
               attributionCountPerSourcePerLicense
             }
-            licenseNamesWithCriticality={licenseNamesWithCriticalities}
+            licenseNamesWithCriticality={licenseNamesWithCriticality}
             title={criticalLicensesTableTitle}
           />
           <AttributionCountPerSourcePerLicenseTable
             attributionCountPerSourcePerLicense={
               attributionCountPerSourcePerLicense
             }
-            licenseNamesWithCriticality={licenseNamesWithCriticalities}
+            licenseNamesWithCriticality={licenseNamesWithCriticality}
             title={attributionCountPerSourcePerLicenseTableTitle}
           />
         </>

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -142,63 +142,59 @@ describe('The ProjectStatisticsPopup helper', () => {
     );
   });
 
-  it('counts sources for licenses, criticalities - testAttributions_1', () => {
+  it('counts sources for licenses, criticality - testAttributions_1', () => {
     const expectedAttributionCountPerSourcePerLicense = {
       'Apache License Version 2.0': { ScanCode: 1, reuser: 2, Total: 3 },
       'The MIT License (MIT)': { ScanCode: 2, reuser: 1, Total: 3 },
       Total: { ScanCode: 3, reuser: 3, Total: 6 },
     };
-    const expectedLicenseNamesWithCriticalities = {
+    const expectedLicenseNamesWithCriticality = {
       'Apache License Version 2.0': Criticality.High,
       'The MIT License (MIT)': undefined,
     };
 
     const strippedLicenseNameToAttribution =
       getUniqueLicenseNameToAttribution(testAttributions_1);
-    const {
-      attributionCountPerSourcePerLicense,
-      licenseNamesWithCriticalities,
-    } = aggregateLicensesAndSourcesFromAttributions(
-      testAttributions_1,
-      strippedLicenseNameToAttribution,
-      attributionSources
-    );
+    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
+      aggregateLicensesAndSourcesFromAttributions(
+        testAttributions_1,
+        strippedLicenseNameToAttribution,
+        attributionSources
+      );
 
     expect(attributionCountPerSourcePerLicense).toEqual(
       expectedAttributionCountPerSourcePerLicense
     );
-    expect(licenseNamesWithCriticalities).toEqual(
-      expectedLicenseNamesWithCriticalities
+    expect(licenseNamesWithCriticality).toEqual(
+      expectedLicenseNamesWithCriticality
     );
   });
 
-  it('counts sources for licenses, criticalities - testAttributions_2', () => {
+  it('counts sources for licenses, criticality - testAttributions_2', () => {
     const expectedAttributionCountPerSourcePerLicense = {
       'Apache License Version 2.0': { ScanCode: 1, reuser: 1, HC: 1, Total: 3 },
       'The MIT License (MIT)': { ScanCode: 1, reuser: 1, Total: 2 },
       Total: { ScanCode: 2, reuser: 2, HC: 1, Total: 5 },
     };
-    const expectedLicenseNamesWithCriticalities = {
+    const expectedLicenseNamesWithCriticality = {
       'Apache License Version 2.0': Criticality.Medium,
-      'The MIT License (MIT)': Criticality.Medium,
+      'The MIT License (MIT)': undefined,
     };
 
     const strippedLicenseNameToAttribution =
       getUniqueLicenseNameToAttribution(testAttributions_2);
-    const {
-      attributionCountPerSourcePerLicense,
-      licenseNamesWithCriticalities,
-    } = aggregateLicensesAndSourcesFromAttributions(
-      testAttributions_2,
-      strippedLicenseNameToAttribution,
-      attributionSources
-    );
+    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
+      aggregateLicensesAndSourcesFromAttributions(
+        testAttributions_2,
+        strippedLicenseNameToAttribution,
+        attributionSources
+      );
 
     expect(attributionCountPerSourcePerLicense).toEqual(
       expectedAttributionCountPerSourcePerLicense
     );
-    expect(licenseNamesWithCriticalities).toEqual(
-      expectedLicenseNamesWithCriticalities
+    expect(licenseNamesWithCriticality).toEqual(
+      expectedLicenseNamesWithCriticality
     );
   });
 


### PR DESCRIPTION
### Summary of changes

In the tables in statistics popup we were very conservative and marked a license as critical if at least one of its variants was critical. Now we increased this threshold.

### Context and reason for change

So far if there were 1000 signals with license MIT and a single one was of some criticality the license in general got this criticality. The logic turned out to be too conservative.


