### PR TITLE
Highlight resources with critical licenses

### DIFF
--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -50,12 +50,24 @@ const classes = {
   },
 };
 
+const criticalityTooltipText = {
+  high: 'has high criticality signals',
+  medium: 'has medium criticality signals',
+  undefined: 'has signals',
+};
+
+const criticalityColor = {
+  high: OpossumColors.orange,
+  medium: OpossumColors.mediumOrange,
+  undefined: OpossumColors.darkBlue,
+};
+
 interface IconProps {
   sx?: SxProps;
 }
 
 interface SignalIconProps {
-  criticality?: string;
+  criticality?: Criticality;
 }
 
 interface LabelDetailIconProps extends IconProps {
@@ -108,24 +120,16 @@ export function FollowUpIcon(props: IconProps): ReactElement {
 }
 
 export function SignalIcon(props: SignalIconProps): ReactElement {
-  const tooltipText =
-    props.criticality === Criticality.High
-      ? 'has highly critical signals'
-      : props.criticality === Criticality.Medium
-      ? 'has medium critical signals'
-      : 'has signals';
   return (
-    <MuiTooltip sx={classes.tooltip} title={tooltipText}>
+    <MuiTooltip
+      sx={classes.tooltip}
+      title={criticalityTooltipText[props.criticality ?? 'undefined']}
+    >
       <AnnouncementIcon
         aria-label={'Signal icon'}
         sx={{
           ...baseIcon,
-          color:
-            props.criticality === Criticality.High
-              ? OpossumColors.orange
-              : props.criticality === Criticality.Medium
-              ? OpossumColors.mediumOrange
-              : OpossumColors.darkBlue,
+          color: criticalityColor[props.criticality ?? 'undefined'],
         }}
       />
     </MuiTooltip>

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../shared-styles';
 import { SxProps } from '@mui/material';
 import RectangleIcon from '@mui/icons-material/Rectangle';
+import { Criticality } from '../../../shared/shared-types';
 
 const classes = {
   clickableIcon,
@@ -51,6 +52,10 @@ const classes = {
 
 interface IconProps {
   sx?: SxProps;
+}
+
+interface SignalIconProps {
+  criticality?: string;
 }
 
 interface LabelDetailIconProps extends IconProps {
@@ -102,12 +107,26 @@ export function FollowUpIcon(props: IconProps): ReactElement {
   );
 }
 
-export function SignalIcon(): ReactElement {
+export function SignalIcon(props: SignalIconProps): ReactElement {
+  const tooltipText =
+    props.criticality === Criticality.High
+      ? 'has highly critical signals'
+      : props.criticality === Criticality.Medium
+      ? 'has medium critical signals'
+      : 'has signals';
   return (
-    <MuiTooltip sx={classes.tooltip} title="has signals">
+    <MuiTooltip sx={classes.tooltip} title={tooltipText}>
       <AnnouncementIcon
         aria-label={'Signal icon'}
-        sx={classes.nonClickableIcon}
+        sx={{
+          ...baseIcon,
+          color:
+            props.criticality === Criticality.High
+              ? OpossumColors.red
+              : props.criticality === Criticality.Medium
+              ? OpossumColors.orange
+              : OpossumColors.darkBlue,
+        }}
       />
     </MuiTooltip>
   );

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -122,9 +122,9 @@ export function SignalIcon(props: SignalIconProps): ReactElement {
           ...baseIcon,
           color:
             props.criticality === Criticality.High
-              ? OpossumColors.red
-              : props.criticality === Criticality.Medium
               ? OpossumColors.orange
+              : props.criticality === Criticality.Medium
+              ? OpossumColors.mediumOrange
               : OpossumColors.darkBlue,
         }}
       />

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -3,15 +3,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { Criticality } from '../../../../shared/shared-types';
 import {
+  BreakpointIcon,
   CommentIcon,
   DirectoryIcon,
   ExcludeFromNoticeIcon,
   FileIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  IncompletePackagesIcon,
+  PreSelectedIcon,
+  SearchPackagesIcon,
+  SignalIcon,
 } from '../Icons';
 
 describe('The Icons', () => {
@@ -49,5 +55,71 @@ describe('The Icons', () => {
     render(<FileIcon />);
 
     expect(screen.getByLabelText('File icon'));
+  });
+
+  it('renders SignalIcon', () => {
+    render(<SignalIcon />);
+
+    expect(screen.getByLabelText('Signal icon'));
+  });
+
+  it('renders BreakpointIcon', () => {
+    render(<BreakpointIcon />);
+
+    expect(screen.getByLabelText('Breakpoint icon'));
+  });
+
+  it('renders IncompletePackagesIcon', () => {
+    render(<IncompletePackagesIcon />);
+
+    expect(screen.getByLabelText('Incomplete icon'));
+  });
+
+  it('renders PreSelectedIcon', () => {
+    render(<PreSelectedIcon />);
+
+    expect(screen.getByLabelText('Pre-selected icon'));
+  });
+
+  it('renders SearchPackagesIcon', () => {
+    render(<SearchPackagesIcon />);
+
+    expect(screen.getByLabelText('Search packages icon'));
+  });
+});
+
+describe('The SignalIcon', () => {
+  jest.useFakeTimers();
+  it('renders high criticality SignalIcon', () => {
+    render(<SignalIcon criticality={Criticality.High} />);
+
+    const icon = screen.getByLabelText('Signal icon');
+    fireEvent.mouseOver(icon);
+    act(() => {
+      jest.runAllTimers();
+    });
+    screen.getByText('has high criticality signals');
+  });
+
+  it('renders medium criticality SignalIcon', () => {
+    render(<SignalIcon criticality={Criticality.Medium} />);
+
+    const icon = screen.getByLabelText('Signal icon');
+    fireEvent.mouseOver(icon);
+    act(() => {
+      jest.runAllTimers();
+    });
+    screen.getByText('has medium criticality signals');
+  });
+
+  it('renders no criticality SignalIcon', () => {
+    render(<SignalIcon criticality={undefined} />);
+
+    const icon = screen.getByLabelText('Signal icon');
+    fireEvent.mouseOver(icon);
+    act(() => {
+      jest.runAllTimers();
+    });
+    screen.getByText('has signals');
   });
 });

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -8,6 +8,7 @@ import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionBreakpoints,
+  getExternalData,
   getFilesWithChildren,
   getManualAttributions,
   getResources,
@@ -101,7 +102,7 @@ export function ResourceBrowser(): ReactElement | null {
 
   const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
   const filesWithChildren = useAppSelector(getFilesWithChildren);
-
+  const externalData = useAppSelector(getExternalData);
   const dispatch = useAppDispatch();
 
   function handleToggle(nodeIdsToExpand: Array<string>): void {
@@ -140,7 +141,8 @@ export function ResourceBrowser(): ReactElement | null {
         resourcesWithManualAttributedChildren,
         resolvedExternalAttributions,
         getAttributionBreakpointCheck(attributionBreakpoints),
-        getFileWithChildrenCheck(filesWithChildren)
+        getFileWithChildrenCheck(filesWithChildren),
+        externalData
       );
   }
 

--- a/src/Frontend/Components/ResourceBrowser/__tests__/get-tree-item-label.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/get-tree-item-label.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Criticality } from '../../../../shared/shared-types';
+import { getCriticality } from '../get-tree-item-label';
+
+describe('Tree item labels', () => {
+  it('checks resource getCriticality', () => {
+    const resourcesToExternalAttributions = {
+      '/test_file1.ts': ['attr1', 'attr2'],
+      '/test_file2.ts': ['attr3'],
+      '/test_file3.ts': ['attr2', 'attr3'],
+    };
+    const externalAttributions = {
+      attr1: { criticality: Criticality.High },
+      attr2: { criticality: Criticality.Medium },
+      attr3: {},
+    };
+    const expectedCriticalities: {
+      [resource: string]: Criticality | undefined;
+    } = {
+      '/test_file1.ts': Criticality.High,
+      '/test_file2.ts': undefined,
+      '/test_file3.ts': Criticality.Medium,
+    };
+
+    for (const nodeId of Object.keys(resourcesToExternalAttributions)) {
+      const criticality = getCriticality(
+        nodeId,
+        resourcesToExternalAttributions,
+        externalAttributions
+      );
+      expect(criticality).toEqual(expectedCriticalities[nodeId]);
+    }
+  });
+});

--- a/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  AttributionData,
   Attributions,
+  Criticality,
   Resources,
   ResourcesToAttributions,
   ResourcesWithAttributedChildren,
@@ -25,7 +27,8 @@ export function getTreeItemLabel(
   resourcesWithManualAttributedChildren: ResourcesWithAttributedChildren,
   resolvedExternalAttributions: Set<string>,
   isAttributionBreakpoint: PathPredicate,
-  isFileWithChildren: PathPredicate
+  isFileWithChildren: PathPredicate,
+  externalData: AttributionData
 ): ReactElement {
   const canHaveChildren = resource !== 1;
 
@@ -60,6 +63,11 @@ export function getTreeItemLabel(
         nodeId,
         resourcesWithManualAttributedChildren
       )}
+      criticality={getCriticality(
+        nodeId,
+        resourcesToExternalAttributions,
+        externalData.attributions
+      )}
       isAttributionBreakpoint={isAttributionBreakpoint(nodeId)}
       showFolderIcon={canHaveChildren && !isFileWithChildren(nodeId)}
       containsResourcesWithOnlyExternalAttribution={
@@ -73,6 +81,27 @@ export function getTreeItemLabel(
       }
     />
   );
+}
+
+function getCriticality(
+  nodeId: string,
+  resourcesToExternalAttributions: ResourcesToAttributions,
+  externalAttributions: Attributions
+): string | undefined {
+  if (hasExternalAttribution(nodeId, resourcesToExternalAttributions)) {
+    let criticality;
+    const attributionsForResource = resourcesToExternalAttributions[nodeId];
+    for (const attribution of attributionsForResource) {
+      if (
+        externalAttributions[attribution].criticality === Criticality.High ||
+        (externalAttributions[attribution].criticality === Criticality.Medium &&
+          criticality === undefined)
+      ) {
+        criticality = externalAttributions[attribution].criticality;
+      }
+    }
+    return criticality;
+  }
 }
 
 function isRootResource(resourceName: string): boolean {
@@ -94,7 +123,6 @@ function hasExternalAttribution(
   nodeId: string,
   resourcesToExternalAttributions: ResourcesToAttributions
 ): boolean {
-  console.log(resourcesToExternalAttributions);
   return nodeId in resourcesToExternalAttributions;
 }
 

--- a/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
@@ -83,24 +83,29 @@ export function getTreeItemLabel(
   );
 }
 
-function getCriticality(
+export function getCriticality(
   nodeId: string,
   resourcesToExternalAttributions: ResourcesToAttributions,
   externalAttributions: Attributions
-): string | undefined {
+): Criticality | undefined {
   if (hasExternalAttribution(nodeId, resourcesToExternalAttributions)) {
-    let criticality;
     const attributionsForResource = resourcesToExternalAttributions[nodeId];
+
     for (const attribution of attributionsForResource) {
-      if (
-        externalAttributions[attribution].criticality === Criticality.High ||
-        (externalAttributions[attribution].criticality === Criticality.Medium &&
-          criticality === undefined)
-      ) {
-        criticality = externalAttributions[attribution].criticality;
+      if (externalAttributions[attribution].criticality === Criticality.High) {
+        return Criticality.High;
       }
     }
-    return criticality;
+
+    for (const attribution of attributionsForResource) {
+      if (
+        externalAttributions[attribution].criticality === Criticality.Medium
+      ) {
+        return Criticality.Medium;
+      }
+    }
+
+    return undefined;
   }
 }
 

--- a/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
@@ -94,6 +94,7 @@ function hasExternalAttribution(
   nodeId: string,
   resourcesToExternalAttributions: ResourcesToAttributions
 ): boolean {
+  console.log(resourcesToExternalAttributions);
   return nodeId in resourcesToExternalAttributions;
 }
 

--- a/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
@@ -145,7 +145,9 @@ export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
       >
         {props.labelText}
       </MuiTypography>
-      {props.hasExternalAttribution ? <SignalIcon /> : null}
+      {props.hasExternalAttribution ? (
+        <SignalIcon criticality={'high'} />
+      ) : null}
     </MuiBox>
   );
 }

--- a/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
@@ -14,6 +14,7 @@ import {
 import { OpossumColors, tooltipStyle } from '../../shared-styles';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
+import { Criticality } from '../../../shared/shared-types';
 
 const classes = {
   manualIcon: {
@@ -83,7 +84,7 @@ interface StyledTreeItemProps {
   isAttributionBreakpoint: boolean;
   showFolderIcon: boolean;
   containsResourcesWithOnlyExternalAttribution: boolean;
-  criticality?: string;
+  criticality?: Criticality;
 }
 
 export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {

--- a/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
+++ b/src/Frontend/Components/StyledTreeItemLabel/StyledTreeItemLabel.tsx
@@ -83,6 +83,7 @@ interface StyledTreeItemProps {
   isAttributionBreakpoint: boolean;
   showFolderIcon: boolean;
   containsResourcesWithOnlyExternalAttribution: boolean;
+  criticality?: string;
 }
 
 export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
@@ -146,7 +147,7 @@ export function StyledTreeItemLabel(props: StyledTreeItemProps): ReactElement {
         {props.labelText}
       </MuiTypography>
       {props.hasExternalAttribution ? (
-        <SignalIcon criticality={'high'} />
+        <SignalIcon criticality={props.criticality} />
       ) : null}
     </MuiBox>
   );


### PR DESCRIPTION
### Summary of changes

The icons indicating presence of signals are colored based on highest criticality for resources with critical signals and also their tooltip texts are modified.
Fix #1028
Part of #1012

**Before:**
![image](https://user-images.githubusercontent.com/85183359/195102967-bb387adf-446d-45cc-b011-b7d8cea418e5.png)

**After:**
![image](https://user-images.githubusercontent.com/85183359/195103200-b1be83ed-affb-47ff-90a9-e952e29d067f.png)

