### PR TITLE
Add Pie chart for signal numbers clustered by criticality

### DIFF
--- a/setupTests.ts
+++ b/setupTests.ts
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom/extend-expect';
+import {mockResizeObserver} from "./src/Frontend/test-helpers/popup-test-helpers";
+
+mockResizeObserver();
 
 const TEST_TIMEOUT = 15000;
 const SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_INFO = [

--- a/src/Frontend/Components/ProjectStatisticsPopup/AccordionWithPieChart.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/AccordionWithPieChart.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import MuiAccordion from '@mui/material/Accordion';
+import MuiAccordionSummary from '@mui/material/AccordionSummary';
+import MuiTypography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import MuiAccordionDetails from '@mui/material/AccordionDetails';
+import { CustomizedPieChart } from './CustomizedPieChart';
+import { PieChartData } from './project-statistics-popup-helpers';
+import { projectStatisticsPopupClasses } from './shared-project-statistics-popup-styles';
+
+interface AccordionProps {
+  data: Array<PieChartData>;
+  title: string;
+}
+
+export function AccordionWithPieChart(
+  props: AccordionProps
+): ReactElement | null {
+  if (props.data.length === 0) {
+    return null;
+  }
+
+  return (
+    <MuiAccordion sx={projectStatisticsPopupClasses.accordion} disableGutters>
+      <MuiAccordionSummary
+        sx={projectStatisticsPopupClasses.accordionSummary}
+        expandIcon={
+          <ExpandMoreIcon sx={projectStatisticsPopupClasses.accordionTitle} />
+        }
+      >
+        <MuiTypography sx={projectStatisticsPopupClasses.accordionTitle}>
+          {props.title}
+        </MuiTypography>
+      </MuiAccordionSummary>
+      <MuiAccordionDetails sx={projectStatisticsPopupClasses.accordionDetails}>
+        <CustomizedPieChart data={props.data} title={props.title} />
+      </MuiAccordionDetails>
+    </MuiAccordion>
+  );
+}

--- a/src/Frontend/Components/ProjectStatisticsPopup/CustomizedPieChart.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/CustomizedPieChart.tsx
@@ -13,23 +13,29 @@ import {
   Tooltip,
 } from 'recharts';
 import MuiBox from '@mui/material/Box';
-import MuiTypography from '@mui/material/Typography';
 import { PieChartData } from './project-statistics-popup-helpers';
 import { OpossumColors } from '../../shared-styles';
+import { ProjectStatisticsPopupTitle } from '../../enums/enums';
 
 interface PieChartProps {
   data: Array<PieChartData>;
   title: string;
 }
 
-const COLORS = [
-  OpossumColors.orange,
-  OpossumColors.mediumOrange,
-  OpossumColors.darkBlue,
+const defaultPieChartColors = [
+  OpossumColors.purple,
   OpossumColors.brown,
   OpossumColors.green,
-  OpossumColors.lightBlue,
+  OpossumColors.darkBlue,
+  OpossumColors.pastelRed,
+  OpossumColors.disabledGrey,
 ];
+
+const criticalColors: { [criticality: string]: string } = {
+  High: OpossumColors.orange,
+  Medium: OpossumColors.mediumOrange,
+  'Not critical': OpossumColors.darkBlue,
+};
 
 const classes = {
   root: {
@@ -37,14 +43,9 @@ const classes = {
   },
 };
 
-export function CustomizedPieChart(props: PieChartProps): ReactElement | null {
-  if (props.data.length === 0) {
-    return null;
-  }
-
+export function CustomizedPieChart(props: PieChartProps): ReactElement {
   return (
     <MuiBox sx={classes.root}>
-      <MuiTypography variant="subtitle1">{props.title}</MuiTypography>
       <ResponsiveContainer maxHeight={200} aspect={2}>
         <PieChart>
           <Pie
@@ -56,14 +57,26 @@ export function CustomizedPieChart(props: PieChartProps): ReactElement | null {
             paddingAngle={1}
             minAngle={5}
             outerRadius={70}
-            isAnimationActive={true}
           >
-            {props.data.map((_, index) => (
-              <Cell key={`cell-${index}`} fill={COLORS[index]} />
+            {props.data.map((record, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={
+                  props.title ===
+                  ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart
+                    ? criticalColors[record.name]
+                    : defaultPieChartColors[index]
+                }
+              />
             ))}
           </Pie>
           <Tooltip />
-          <Legend verticalAlign="middle" align="right" layout="vertical" />
+          <Legend
+            verticalAlign="middle"
+            align="right"
+            layout="vertical"
+            width={250}
+          />
         </PieChart>
       </ResponsiveContainer>
     </MuiBox>

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { ButtonText, ProjectStatisticsPopupTitle } from '../../enums/enums';
 import MuiBox from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
 import {
   getExternalAttributions,
   getExternalAttributionSources,
@@ -17,14 +18,15 @@ import {
 import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
+  getCriticalSignalsCount,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
   sortAttributionPropertiesEntries,
 } from './project-statistics-popup-helpers';
 import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerSourcePerLicenseTable';
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
-import { CustomizedPieChart } from './PieCharts';
 import { CriticalLicensesTable } from './CriticalLicensesTable';
+import { AccordionWithPieChart } from './AccordionWithPieChart';
 
 const classes = {
   panels: { display: 'flex' },
@@ -61,6 +63,15 @@ export function ProjectStatisticsPopup(): ReactElement {
     attributionCountPerSourcePerLicense
   );
 
+  const criticalSignalsCountData = getCriticalSignalsCount(
+    attributionCountPerSourcePerLicense,
+    licenseNamesWithCriticality
+  );
+
+  const isThereAnyPieChartData =
+    mostFrequentLicenseCountData.length > 0 ||
+    criticalSignalsCountData.length > 0;
+
   function close(): void {
     dispatch(closePopup());
   }
@@ -88,11 +99,20 @@ export function ProjectStatisticsPopup(): ReactElement {
               />
             </MuiBox>
             <MuiBox style={classes.rightPanel}>
-              <CustomizedPieChart
+              <MuiTypography variant="subtitle1">
+                {isThereAnyPieChartData
+                  ? ProjectStatisticsPopupTitle.PieChartsSectionHeader
+                  : null}
+              </MuiTypography>
+              <AccordionWithPieChart
                 data={mostFrequentLicenseCountData}
                 title={
                   ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart
                 }
+              />
+              <AccordionWithPieChart
+                data={criticalSignalsCountData}
+                title={ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart}
               />
             </MuiBox>
           </MuiBox>

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -98,6 +98,51 @@ describe('The ProjectStatisticsPopup', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders the Critical Signals pie chart when there are attributions', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 10,
+        },
+        licenseName: 'Apache License Version 2.0',
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'The MIT License (MIT)',
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
+  });
+
+  it('does not render the Critical Signals pie chart when there are no attributions', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {};
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+    expect(screen.queryByText('Critical Signals')).not.toBeInTheDocument();
+  });
+
   it('renders when there are no attributions', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {};

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -6,6 +6,7 @@
 import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
+  getCriticalSignalsCount,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
 } from '../project-statistics-popup-helpers';
@@ -434,6 +435,37 @@ describe('The ProjectStatisticsPopup helper', () => {
     expect(sortedMostFrequentLicenses).toEqual(
       expectedSortedMostFrequentLicenses
     );
+  });
+
+  it('counts number of critical signals across all licenses - testAttributions_3', () => {
+    const expectedCriticalSignalCount = [
+      {
+        name: 'High',
+        count: 3,
+      },
+      {
+        name: 'Medium',
+        count: 4,
+      },
+      {
+        name: 'Not critical',
+        count: 2,
+      },
+    ];
+
+    const strippedLicenseNameToAttribution =
+      getUniqueLicenseNameToAttribution(testAttributions_3);
+    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
+      aggregateLicensesAndSourcesFromAttributions(
+        testAttributions_3,
+        strippedLicenseNameToAttribution,
+        attributionSources
+      );
+    const criticalSignalsCount = getCriticalSignalsCount(
+      attributionCountPerSourcePerLicense,
+      licenseNamesWithCriticality
+    );
+    expect(criticalSignalsCount).toEqual(expectedCriticalSignalCount);
   });
 
   it('counts attribution properties - testAttributions_1', () => {

--- a/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/shared-project-statistics-popup-styles.ts
@@ -41,4 +41,18 @@ export const projectStatisticsPopupClasses = {
     maxWidth: '500px',
     marginBottom: 3,
   },
+  accordion: {
+    marginBottom: 1,
+    maxWidth: '600px',
+  },
+  accordionSummary: {
+    background: OpossumColors.darkBlue,
+  },
+  accordionTitle: {
+    color: OpossumColors.white,
+  },
+  accordionDetails: {
+    padding: 0,
+    background: OpossumColors.lightBlue,
+  },
 };

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -86,4 +86,6 @@ export enum ProjectStatisticsPopupTitle {
   AttributionPropertyCountTable = 'First Party and Follow Up Attributions',
   CriticalLicensesTable = 'Critical Licenses',
   MostFrequentLicenseCountPieChart = 'Most Frequent Licenses',
+  CriticalSignalsCountPieChart = 'Critical Signals',
+  PieChartsSectionHeader = 'View Pie Charts',
 }

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -33,6 +33,7 @@ export const OpossumColors = {
   red: 'hsl(0, 100%, 45%)',
   green: 'hsl(146, 50%, 45%)',
   brown: 'hsl(25, 76%, 31%)',
+  purple: 'hsl(270, 50%, 40%)',
 };
 
 export const resourceBrowserWidthInPixels = 420;


### PR DESCRIPTION
### Summary of changes

Add Pie chart for signal numbers clustered by criticality

### Context and reason for change

- Use Accordion for better utilization of space, compactness, and prevent overcrowding of visual data.
- Accordion will permit addition of Pie charts to the popup in future without having to change the page styles or layout. Thus, it should be future-proof.
- Add expansion icon to Accordion to indicate when accordion is expanded. Better UX.
- Add custom colors for different Pie Charts.
- Add tests for rendering the new Pie Chart component.
- Add function that provides the data needed by the new Pie chart.
- Add tests for the new data-providing function.
- Fix existing test by adding ResizeObserver package. See https://github.com/opossum-tool/OpossumUI/pull/1066#issuecomment-1275748639 and https://github.com/opossum-tool/OpossumUI/pull/1066#issuecomment-1275815744

Fix: #945

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>