### PR TITLE
Fix test file

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -270,8 +270,7 @@
       "585bf5b2-4da7-4de4-8e8f-38d142e42079"
     ],
     "/Frontend/Types/types.ts": [
-      "5f1948d6-63fa-4f7e-b02b-7799083511fc",
-      "5f1948d6-63fa-4f7e-b02b-7799083511fd"
+      "5f1948d6-63fa-4f7e-b02b-7799083511fc"
     ],
     "/Frontend/Components/ResourcePanel/ResourcePanel.tsx": [
       "578b448b-2ba8-4285-810f-ce7b11ac260c"

--- a/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-tree-item-label.tsx
@@ -90,16 +90,17 @@ export function getCriticality(
 ): Criticality | undefined {
   if (hasExternalAttribution(nodeId, resourcesToExternalAttributions)) {
     const attributionsForResource = resourcesToExternalAttributions[nodeId];
-
-    for (const attribution of attributionsForResource) {
-      if (externalAttributions[attribution].criticality === Criticality.High) {
+    for (const attributionId of attributionsForResource) {
+      if (
+        externalAttributions[attributionId].criticality === Criticality.High
+      ) {
         return Criticality.High;
       }
     }
 
-    for (const attribution of attributionsForResource) {
+    for (const attributionId of attributionsForResource) {
       if (
-        externalAttributions[attribution].criticality === Criticality.Medium
+        externalAttributions[attributionId].criticality === Criticality.Medium
       ) {
         return Criticality.Medium;
       }


### PR DESCRIPTION


### Summary of changes

Clean up test file.

### Context and reason for change

The file "opossum_input.json" used for testing was corrupted. An attribution that did not exist was referenced there, leading to failures of the app.

Fix: #1081

### How can the changes be tested

Follow the steps described in #1081.
