### PR TITLE
Include pie chart with incomplete attributions

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -19,7 +19,7 @@ import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
   getCriticalSignalsCount,
-  getIncompleteAttributions,
+  getIncompleteAttributionsCount,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
   sortAttributionPropertiesEntries,
@@ -28,9 +28,6 @@ import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerS
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
 import { CriticalLicensesTable } from './CriticalLicensesTable';
 import { AccordionWithPieChart } from './AccordionWithPieChart';
-import { Attributions, PackageInfo } from '../../../shared/shared-types';
-import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
-import pickBy from 'lodash/pickBy';
 
 const classes = {
   panels: { display: 'flex' },
@@ -41,18 +38,7 @@ const classes = {
 export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
-  const attributions: Attributions = useAppSelector(getManualAttributions);
-  const manualAttributionValues = Object.values(attributions);
-
-  const numberOfAttributions = Object.keys(attributions).length;
-  const numberOfIncompleteAttributions = Object.keys(
-    pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
-  ).length;
-  const incompleteAttributionsData = getIncompleteAttributions(
-    numberOfAttributions,
-    numberOfIncompleteAttributions
-  );
-
+  const attributions = useAppSelector(getManualAttributions);
   const externalAttributions = useAppSelector(getExternalAttributions);
   const attributionSources = useAppSelector(getExternalAttributionSources);
   const strippedLicenseNameToAttribution =
@@ -66,7 +52,7 @@ export function ProjectStatisticsPopup(): ReactElement {
     );
 
   const manualAttributionPropertyCounts =
-    aggregateAttributionPropertiesFromAttributions(manualAttributionValues);
+    aggregateAttributionPropertiesFromAttributions(attributions);
   const sortedManualAttributionPropertyCountsEntries =
     sortAttributionPropertiesEntries(
       Object.entries(manualAttributionPropertyCounts)
@@ -81,9 +67,13 @@ export function ProjectStatisticsPopup(): ReactElement {
     licenseNamesWithCriticality
   );
 
+  const incompleteAttributionsData =
+    getIncompleteAttributionsCount(attributions);
+
   const isThereAnyPieChartData =
     mostFrequentLicenseCountData.length > 0 ||
-    criticalSignalsCountData.length > 0;
+    criticalSignalsCountData.length > 0 ||
+    incompleteAttributionsData.length > 0;
 
   function close(): void {
     dispatch(closePopup());

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -19,6 +19,7 @@ import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
   getCriticalSignalsCount,
+  getIncompleteAttributions,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
   sortAttributionPropertiesEntries,
@@ -27,6 +28,9 @@ import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerS
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
 import { CriticalLicensesTable } from './CriticalLicensesTable';
 import { AccordionWithPieChart } from './AccordionWithPieChart';
+import { Attributions, PackageInfo } from '../../../shared/shared-types';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
+import pickBy from 'lodash/pickBy';
 
 const classes = {
   panels: { display: 'flex' },
@@ -37,10 +41,19 @@ const classes = {
 export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
-  const externalAttributions = useAppSelector(getExternalAttributions);
-  const manualAttributionValues = Object.values(
-    useAppSelector(getManualAttributions)
+  const attributions: Attributions = useAppSelector(getManualAttributions);
+  const manualAttributionValues = Object.values(attributions);
+
+  const numberOfAttributions = Object.keys(attributions).length;
+  const numberOfIncompleteAttributions = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
+  ).length;
+  const incompleteAttributionsData = getIncompleteAttributions(
+    numberOfAttributions,
+    numberOfIncompleteAttributions
   );
+
+  const externalAttributions = useAppSelector(getExternalAttributions);
   const attributionSources = useAppSelector(getExternalAttributionSources);
   const strippedLicenseNameToAttribution =
     getUniqueLicenseNameToAttribution(externalAttributions);
@@ -113,6 +126,10 @@ export function ProjectStatisticsPopup(): ReactElement {
               <AccordionWithPieChart
                 data={criticalSignalsCountData}
                 title={ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart}
+              />
+              <AccordionWithPieChart
+                data={incompleteAttributionsData}
+                title={ProjectStatisticsPopupTitle.IncompleteLicensesPieChart}
               />
             </MuiBox>
           </MuiBox>

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -38,7 +38,7 @@ const classes = {
 export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
-  const attributions = useAppSelector(getManualAttributions);
+  const manualAttributions = useAppSelector(getManualAttributions);
   const externalAttributions = useAppSelector(getExternalAttributions);
   const attributionSources = useAppSelector(getExternalAttributionSources);
   const strippedLicenseNameToAttribution =
@@ -52,7 +52,7 @@ export function ProjectStatisticsPopup(): ReactElement {
     );
 
   const manualAttributionPropertyCounts =
-    aggregateAttributionPropertiesFromAttributions(attributions);
+    aggregateAttributionPropertiesFromAttributions(manualAttributions);
   const sortedManualAttributionPropertyCountsEntries =
     sortAttributionPropertiesEntries(
       Object.entries(manualAttributionPropertyCounts)
@@ -68,7 +68,7 @@ export function ProjectStatisticsPopup(): ReactElement {
   );
 
   const incompleteAttributionsData =
-    getIncompleteAttributionsCount(attributions);
+    getIncompleteAttributionsCount(manualAttributions);
 
   const isThereAnyPieChartData =
     mostFrequentLicenseCountData.length > 0 ||

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -53,7 +53,7 @@ describe('The ProjectStatisticsPopup', () => {
 
   it('renders pie charts when there are attributions', () => {
     const store = createTestAppStore();
-    const testExternalAttributions: Attributions = {
+    const testAttributions: Attributions = {
       uuid_1: {
         source: {
           name: 'scancode',
@@ -72,7 +72,8 @@ describe('The ProjectStatisticsPopup', () => {
     store.dispatch(
       loadFromFile(
         getParsedInputFileEnrichedWithTestData({
-          externalAttributions: testExternalAttributions,
+          manualAttributions: testAttributions,
+          externalAttributions: testAttributions,
         })
       )
     );

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -53,7 +53,7 @@ describe('The ProjectStatisticsPopup', () => {
 
   it('renders pie charts when there are attributions', () => {
     const store = createTestAppStore();
-    const testAttributions: Attributions = {
+    const testManualAttributions: Attributions = {
       uuid_1: {
         source: {
           name: 'scancode',
@@ -69,11 +69,28 @@ describe('The ProjectStatisticsPopup', () => {
         licenseName: 'The MIT License (MIT)',
       },
     };
+    const testExternalAttributions: Attributions = {
+      uuid_3: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 90,
+        },
+        licenseName: 'Apache License Version 3.0',
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'The MIT License (MIT)',
+      },
+    };
+
     store.dispatch(
       loadFromFile(
         getParsedInputFileEnrichedWithTestData({
-          manualAttributions: testAttributions,
-          externalAttributions: testAttributions,
+          manualAttributions: testManualAttributions,
+          externalAttributions: testExternalAttributions,
         })
       )
     );
@@ -81,7 +98,7 @@ describe('The ProjectStatisticsPopup', () => {
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
     expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
     expect(screen.getByText('Critical Signals')).toBeInTheDocument();
-    expect(screen.getByText('Incomplete attributions')).toBeInTheDocument();
+    expect(screen.getByText('Incomplete Attributions')).toBeInTheDocument();
   });
 
   it('does not render pie charts when there are no attributions', () => {
@@ -101,7 +118,43 @@ describe('The ProjectStatisticsPopup', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText('Critical Signals')).not.toBeInTheDocument();
     expect(
-      screen.queryByText('Incomplete attributions')
+      screen.queryByText('Incomplete Attributions')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders pie charts pie charts related to signals even if there are no attributions', () => {
+    const store = createTestAppStore();
+    const testManualAttributions: Attributions = {};
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 10,
+        },
+        licenseName: 'Apache License Version 2.0',
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'The MIT License (MIT)',
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          manualAttributions: testManualAttributions,
+          externalAttributions: testExternalAttributions,
+        })
+      )
+    );
+
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+    expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
+    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Incomplete Attributions')
     ).not.toBeInTheDocument();
   });
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -51,7 +51,7 @@ describe('The ProjectStatisticsPopup', () => {
     expect(screen.getByText('Reuser')).toBeInTheDocument();
   });
 
-  it('renders the Most Frequent Licenses pie chart when there are attributions', () => {
+  it('renders pie charts when there are attributions', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {
       uuid_1: {
@@ -79,9 +79,11 @@ describe('The ProjectStatisticsPopup', () => {
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
     expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
+    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
+    expect(screen.getByText('Incomplete attributions')).toBeInTheDocument();
   });
 
-  it('does not render the Most Frequent Licenses pie chart when there is no attribution', () => {
+  it('does not render pie charts when there are no attributions', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {};
     store.dispatch(
@@ -96,54 +98,13 @@ describe('The ProjectStatisticsPopup', () => {
     expect(
       screen.queryByText('Most Frequent Licenses')
     ).not.toBeInTheDocument();
-  });
-
-  it('renders the Critical Signals pie chart when there are attributions', () => {
-    const store = createTestAppStore();
-    const testExternalAttributions: Attributions = {
-      uuid_1: {
-        source: {
-          name: 'scancode',
-          documentConfidence: 10,
-        },
-        licenseName: 'Apache License Version 2.0',
-      },
-      uuid_2: {
-        source: {
-          name: 'reuser',
-          documentConfidence: 90,
-        },
-        licenseName: 'The MIT License (MIT)',
-      },
-    };
-    store.dispatch(
-      loadFromFile(
-        getParsedInputFileEnrichedWithTestData({
-          externalAttributions: testExternalAttributions,
-        })
-      )
-    );
-
-    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
-    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
-  });
-
-  it('does not render the Critical Signals pie chart when there are no attributions', () => {
-    const store = createTestAppStore();
-    const testExternalAttributions: Attributions = {};
-    store.dispatch(
-      loadFromFile(
-        getParsedInputFileEnrichedWithTestData({
-          externalAttributions: testExternalAttributions,
-        })
-      )
-    );
-
-    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
     expect(screen.queryByText('Critical Signals')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Incomplete attributions')
+    ).not.toBeInTheDocument();
   });
 
-  it('renders when there are no attributions', () => {
+  it('renders tables when there are no attributions', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {};
     store.dispatch(

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -7,7 +7,7 @@ import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
   getCriticalSignalsCount,
-  getIncompleteAttributions,
+  getIncompleteAttributionsCount,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
 } from '../project-statistics-popup-helpers';
@@ -75,7 +75,6 @@ const testAttributions_2: Attributions = {
     },
     criticality: Criticality.Medium,
     licenseName: 'Apache License Version 2.0',
-    firstParty: true,
   },
   uuid2: {
     source: {
@@ -477,11 +476,12 @@ describe('The ProjectStatisticsPopup helper', () => {
       },
       {
         name: 'Incomplete attributions',
-        count: 3,
+        count: 4,
       },
     ];
 
-    const incompleteAttributionCount = getIncompleteAttributions(5, 3);
+    const incompleteAttributionCount =
+      getIncompleteAttributionsCount(testAttributions_1);
     expect(incompleteAttributionCount).toEqual(
       expectedIncompleteAttributionCount
     );
@@ -491,11 +491,12 @@ describe('The ProjectStatisticsPopup helper', () => {
     const expectedIncompleteAttributionCount = [
       {
         name: 'Incomplete attributions',
-        count: 3,
+        count: 5,
       },
     ];
 
-    const incompleteAttributionCount = getIncompleteAttributions(3, 3);
+    const incompleteAttributionCount =
+      getIncompleteAttributionsCount(testAttributions_2);
     expect(incompleteAttributionCount).toEqual(
       expectedIncompleteAttributionCount
     );
@@ -509,26 +510,22 @@ describe('The ProjectStatisticsPopup helper', () => {
     };
 
     const attributionPropertyCounts =
-      aggregateAttributionPropertiesFromAttributions(
-        Object.values(testAttributions_1)
-      );
+      aggregateAttributionPropertiesFromAttributions(testAttributions_1);
 
     expect(attributionPropertyCounts).toEqual(
       expectedAttributionPropertyCounts
     );
   });
 
-  it('counts attribution properties - testAttributions_2', () => {
+  it('finds no follow up and first party attributions - testAttributions_2', () => {
     const expectedAttributionPropertyCounts = {
       followUp: 0,
-      firstParty: 1,
+      firstParty: 0,
       'Total Attributions': 5,
     };
 
     const attributionPropertyCounts =
-      aggregateAttributionPropertiesFromAttributions(
-        Object.values(testAttributions_2)
-      );
+      aggregateAttributionPropertiesFromAttributions(testAttributions_2);
 
     expect(attributionPropertyCounts).toEqual(
       expectedAttributionPropertyCounts

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -7,6 +7,7 @@ import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
   getCriticalSignalsCount,
+  getIncompleteAttributions,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
 } from '../project-statistics-popup-helpers';
@@ -466,6 +467,38 @@ describe('The ProjectStatisticsPopup helper', () => {
       licenseNamesWithCriticality
     );
     expect(criticalSignalsCount).toEqual(expectedCriticalSignalCount);
+  });
+
+  it('counts complete and incomplete attributions', () => {
+    const expectedIncompleteAttributionCount = [
+      {
+        name: 'Complete attributions',
+        count: 2,
+      },
+      {
+        name: 'Incomplete attributions',
+        count: 3,
+      },
+    ];
+
+    const incompleteAttributionCount = getIncompleteAttributions(5, 3);
+    expect(incompleteAttributionCount).toEqual(
+      expectedIncompleteAttributionCount
+    );
+  });
+
+  it('counts only incomplete attributions', () => {
+    const expectedIncompleteAttributionCount = [
+      {
+        name: 'Incomplete attributions',
+        count: 3,
+      },
+    ];
+
+    const incompleteAttributionCount = getIncompleteAttributions(3, 3);
+    expect(incompleteAttributionCount).toEqual(
+      expectedIncompleteAttributionCount
+    );
   });
 
   it('counts attribution properties - testAttributions_1', () => {

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -328,3 +328,23 @@ export function getCriticalSignalsCount(
   }
   return filteredCriticalityData;
 }
+
+export function getIncompleteAttributions(
+  numberOfAttributions: number,
+  numberOfIncompleteAttributions: number
+): Array<PieChartData> {
+  const incompleteAttributionsData: Array<PieChartData> = [];
+  if (numberOfAttributions - numberOfIncompleteAttributions !== 0) {
+    incompleteAttributionsData.push({
+      name: 'Complete attributions',
+      count: numberOfAttributions - numberOfIncompleteAttributions,
+    });
+  }
+  if (numberOfIncompleteAttributions !== 0) {
+    incompleteAttributionsData.push({
+      name: 'Incomplete attributions',
+      count: numberOfIncompleteAttributions,
+    });
+  }
+  return incompleteAttributionsData;
+}

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -9,7 +9,8 @@ import {
   ExternalAttributionSources,
   PackageInfo,
 } from '../../../shared/shared-types';
-import { isEmpty } from 'lodash';
+import { isEmpty, pickBy } from 'lodash';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 
 export interface AttributionCountPerSourcePerLicense {
   [licenseNameOrTotal: string]: { [sourceNameOrTotal: string]: number };
@@ -214,10 +215,11 @@ export function getUniqueLicenseNameToAttribution(
 }
 
 export function aggregateAttributionPropertiesFromAttributions(
-  attributionValues: Array<PackageInfo>
+  attributions: Attributions
 ): {
   [attributionPropertyOrTotal: string]: number;
 } {
+  const attributionValues = Object.values(attributions);
   const attributionPropertyCounts: {
     [attributionPropertyOrTotal: string]: number;
   } = {};
@@ -329,11 +331,15 @@ export function getCriticalSignalsCount(
   return filteredCriticalityData;
 }
 
-export function getIncompleteAttributions(
-  numberOfAttributions: number,
-  numberOfIncompleteAttributions: number
+export function getIncompleteAttributionsCount(
+  attributions: Attributions
 ): Array<PieChartData> {
   const incompleteAttributionsData: Array<PieChartData> = [];
+  const numberOfAttributions = Object.keys(attributions).length;
+  const numberOfIncompleteAttributions = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
+  ).length;
+
   if (numberOfAttributions - numberOfIncompleteAttributions !== 0) {
     incompleteAttributionsData.push({
       name: 'Complete attributions',

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -85,7 +85,8 @@ export enum ProjectStatisticsPopupTitle {
   AttributionCountPerSourcePerLicenseTable = 'Signals per Sources',
   AttributionPropertyCountTable = 'First Party and Follow Up Attributions',
   CriticalLicensesTable = 'Critical Licenses',
+  PieChartsSectionHeader = 'View Pie Charts',
   MostFrequentLicenseCountPieChart = 'Most Frequent Licenses',
   CriticalSignalsCountPieChart = 'Critical Signals',
-  PieChartsSectionHeader = 'View Pie Charts',
+  IncompleteLicensesPieChart = 'Incomplete attributions',
 }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -85,8 +85,8 @@ export enum ProjectStatisticsPopupTitle {
   AttributionCountPerSourcePerLicenseTable = 'Signals per Sources',
   AttributionPropertyCountTable = 'First Party and Follow Up Attributions',
   CriticalLicensesTable = 'Critical Licenses',
-  PieChartsSectionHeader = 'View Pie Charts',
+  PieChartsSectionHeader = 'Pie Charts',
   MostFrequentLicenseCountPieChart = 'Most Frequent Licenses',
   CriticalSignalsCountPieChart = 'Critical Signals',
-  IncompleteLicensesPieChart = 'Incomplete attributions',
+  IncompleteLicensesPieChart = 'Incomplete Attributions',
 }


### PR DESCRIPTION
### Summary of changes
Included pie chart and corresponding tests.
Also optimized the existing statistics popup tests.

### Context and reason for change
Fix #946
![image](https://user-images.githubusercontent.com/85183359/197710891-40c6b726-4301-4dd2-a818-301148ebec9b.png)


### How can the changes be tested
Manual UI testing
Added more unit tests

