### PR TITLE
Remove attribution file created in e2e tests

### DIFF
--- a/src/e2e-tests/__tests__/e2e.test.ts
+++ b/src/e2e-tests/__tests__/e2e.test.ts
@@ -13,6 +13,7 @@ import {
   getElementWithText,
 } from '../test-helpers/test-helpers';
 import * as os from 'os';
+import fs from 'fs';
 import { expect, test } from '@playwright/test';
 
 test.setTimeout(E2E_TEST_TIMEOUT);
@@ -57,6 +58,9 @@ test.describe('Open file via command line', () => {
   test.afterEach(async () => {
     if (app) {
       await app.close();
+      fs.unlinkSync(
+        'src/e2e-tests/test-resources/opossum_input_e2e_attributions.json'
+      );
     }
   });
 


### PR DESCRIPTION
### Summary of changes
Now attribution file is deleted after each e2e test, where it was created.

### Context and reason for change
Fix #1147

### How can the changes be tested
`yarn test:e2e`
File "src/e2e-tests/test-resources/opossum_input_e2e_attributions.json" is removed.
