### PR TITLE
Refactor Tests for statistics popup helpers

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -22,7 +22,6 @@ import {
   getIncompleteAttributionsCount,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
-  sortAttributionPropertiesEntries,
 } from './project-statistics-popup-helpers';
 import { AttributionCountPerSourcePerLicenseTable } from './AttributionCountPerSourcePerLicenseTable';
 import { AttributionPropertyCountTable } from './AttributionPropertyCountTable';
@@ -53,10 +52,6 @@ export function ProjectStatisticsPopup(): ReactElement {
 
   const manualAttributionPropertyCounts =
     aggregateAttributionPropertiesFromAttributions(manualAttributions);
-  const sortedManualAttributionPropertyCountsEntries =
-    sortAttributionPropertiesEntries(
-      Object.entries(manualAttributionPropertyCounts)
-    );
 
   const mostFrequentLicenseCountData = getMostFrequentLicenses(
     attributionCountPerSourcePerLicense
@@ -86,9 +81,9 @@ export function ProjectStatisticsPopup(): ReactElement {
           <MuiBox style={classes.panels}>
             <MuiBox style={classes.leftPanel}>
               <AttributionPropertyCountTable
-                attributionPropertyCountsEntries={
-                  sortedManualAttributionPropertyCountsEntries
-                }
+                attributionPropertyCountsEntries={Object.entries(
+                  manualAttributionPropertyCounts
+                )}
                 title={
                   ProjectStatisticsPopupTitle.AttributionPropertyCountTable
                 }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -6,19 +6,26 @@
 import {
   aggregateAttributionPropertiesFromAttributions,
   aggregateLicensesAndSourcesFromAttributions,
+  ATTRIBUTION_TOTAL,
+  AttributionCountPerSourcePerLicense,
+  getAttributionPropertyDisplayNameFromId,
   getColorsForPieChart,
   getCriticalSignalsCount,
   getIncompleteAttributionsCount,
+  getLicenseCriticality,
   getMostFrequentLicenses,
   getUniqueLicenseNameToAttribution,
+  LicenseNamesWithCriticality,
 } from '../project-statistics-popup-helpers';
 import {
   Attributions,
   Criticality,
+  ExternalAttributionSources,
   FollowUp,
 } from '../../../../shared/shared-types';
 import { OpossumColors } from '../../../shared-styles';
 import { ProjectStatisticsPopupTitle } from '../../../enums/enums';
+import { PieChartData } from '../../PieChart/PieChart';
 
 const testAttributions_1: Attributions = {
   uuid1: {
@@ -111,123 +118,152 @@ const testAttributions_2: Attributions = {
   },
 };
 
-const testAttributions_3: Attributions = {
-  uuid1: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    criticality: Criticality.Medium,
-    licenseName: 'Apache License Version 2.0',
-    firstParty: true,
-  },
-  uuid2: {
-    source: {
-      name: 'reuser',
-      documentConfidence: 90,
-    },
-    criticality: Criticality.High,
-    licenseName: 'Apache License Version 2.0',
-  },
-  uuid3: {
-    source: {
-      name: 'reuser',
-      documentConfidence: 90,
-    },
-    licenseName: ' Apache license version-2.0 ',
-    followUp: FollowUp,
-  },
-  uuid4: {
-    source: {
-      name: 'reuser',
-      documentConfidence: 90,
-    },
-    licenseName: ' The-MIT-License (MIT) ',
-  },
-  uuid5: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    licenseName: 'The MIT License (MIT)',
-  },
-  uuid6: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    criticality: Criticality.Medium,
-    licenseName: 'Apache License Version 1.0',
-    firstParty: true,
-  },
-  uuid7: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    criticality: Criticality.Medium,
-    licenseName: 'Apache License Version 1.0.1',
-    firstParty: true,
-  },
-  uuid8: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    criticality: Criticality.Medium,
-    licenseName: 'Apache License Version 1.0.0.1',
-    firstParty: true,
-  },
-  uuid9: {
-    source: {
-      name: 'SC',
-      documentConfidence: 10,
-    },
-    criticality: Criticality.Medium,
-    licenseName: 'Apache License Version 1.0.0.0.1',
-    firstParty: true,
-  },
-};
-
-const attributionSources = {
+const attributionSources: ExternalAttributionSources = {
   SC: {
     name: 'ScanCode',
     priority: 2,
   },
 };
 
-describe('The ProjectStatisticsPopup helper', () => {
-  it('counts most frequent licenses - testAttributions_1', () => {
-    const expectedSortedMostFrequentLicenses = [
+describe('aggregateLicensesAndSourcesFromAttributions', () => {
+  it('counts sources for licenses, criticality', () => {
+    const expectedAttributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense =
       {
-        name: 'Apache License Version 2.0',
-        count: 3,
-      },
-      {
-        name: 'The MIT License (MIT)',
-        count: 3,
-      },
-    ];
+        'Apache License Version 2.0': { ScanCode: 1, reuser: 2, Total: 3 },
+        'The MIT License (MIT)': { ScanCode: 2, reuser: 1, Total: 3 },
+        Total: { ScanCode: 3, reuser: 3, Total: 6 },
+      };
+    const expectedLicenseNamesWithCriticality: LicenseNamesWithCriticality = {
+      'Apache License Version 2.0': Criticality.High,
+      'The MIT License (MIT)': undefined,
+    };
 
     const strippedLicenseNameToAttribution =
       getUniqueLicenseNameToAttribution(testAttributions_1);
-    const { attributionCountPerSourcePerLicense } =
+    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
       aggregateLicensesAndSourcesFromAttributions(
         testAttributions_1,
         strippedLicenseNameToAttribution,
         attributionSources
       );
-    const sortedMostFrequentLicenses = getMostFrequentLicenses(
-      attributionCountPerSourcePerLicense
-    );
 
-    expect(sortedMostFrequentLicenses).toEqual(
-      expectedSortedMostFrequentLicenses
+    expect(attributionCountPerSourcePerLicense).toEqual(
+      expectedAttributionCountPerSourcePerLicense
+    );
+    expect(licenseNamesWithCriticality).toEqual(
+      expectedLicenseNamesWithCriticality
     );
   });
+});
 
-  it('counts most frequent licenses - testAttributions_2', () => {
-    const expectedSortedMostFrequentLicenses = [
+describe('getLicenseCriticality', () => {
+  it('obtains undefined criticality', () => {
+    const expectedLicenseCriticality: Criticality | undefined = undefined;
+    const licenseCriticalityCounts = { high: 0, medium: 0, none: 5 };
+
+    const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
+
+    expect(licenseCriticality).toEqual(expectedLicenseCriticality);
+  });
+
+  it('obtains medium criticality', () => {
+    const expectedLicenseCriticality: Criticality | undefined =
+      Criticality.Medium;
+    const licenseCriticalityCounts = { high: 0, medium: 3, none: 2 };
+
+    const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
+
+    expect(licenseCriticality).toEqual(expectedLicenseCriticality);
+  });
+
+  it('obtains high criticality', () => {
+    const expectedLicenseCriticality: Criticality | undefined =
+      Criticality.High;
+    const licenseCriticalityCounts = { high: 1, medium: 3, none: 1 };
+
+    const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
+
+    expect(licenseCriticality).toEqual(expectedLicenseCriticality);
+  });
+});
+
+describe('aggregateAttributionPropertiesFromAttributions', () => {
+  it('counts attribution properties, ensures total attributions is the last element', () => {
+    const expectedAttributionPropertyCounts: {
+      [attributionPropertyOrTotal: string]: number;
+    } = {
+      followUp: 1,
+      firstParty: 2,
+      incomplete: 4,
+      [ATTRIBUTION_TOTAL]: 6,
+    };
+
+    const attributionPropertyCountsObject =
+      aggregateAttributionPropertiesFromAttributions(testAttributions_1);
+    const attributionPropertyCountsArray: Array<Array<string | number>> =
+      Object.entries(attributionPropertyCountsObject);
+
+    expect(attributionPropertyCountsObject).toEqual(
+      expectedAttributionPropertyCounts
+    );
+    expect(
+      attributionPropertyCountsArray[
+        attributionPropertyCountsArray.length - 1
+      ][0]
+    ).toEqual(ATTRIBUTION_TOTAL);
+  });
+
+  it('finds no follow up and first party attributions, ensures total attributions is the last element', () => {
+    const expectedAttributionPropertyCounts: {
+      [attributionPropertyOrTotal: string]: number;
+    } = {
+      followUp: 0,
+      firstParty: 0,
+      incomplete: 5,
+      [ATTRIBUTION_TOTAL]: 5,
+    };
+
+    const attributionPropertyCountsObject =
+      aggregateAttributionPropertiesFromAttributions(testAttributions_2);
+    const attributionPropertyCountsArray: Array<Array<string | number>> =
+      Object.entries(attributionPropertyCountsObject);
+
+    expect(attributionPropertyCountsObject).toEqual(
+      expectedAttributionPropertyCounts
+    );
+    expect(
+      attributionPropertyCountsArray[
+        attributionPropertyCountsArray.length - 1
+      ][0]
+    ).toEqual(ATTRIBUTION_TOTAL);
+  });
+});
+
+describe('getAttributionPropertyDisplayNameFromId', () => {
+  it('gets valid property display name from property id', () => {
+    const expectedDisplayName = 'First party';
+    const propertyID = 'firstParty';
+
+    const attributionPropertyDisplayName =
+      getAttributionPropertyDisplayNameFromId(propertyID);
+
+    expect(attributionPropertyDisplayName).toEqual(expectedDisplayName);
+  });
+
+  it('gets invalid display name as it is', () => {
+    const expectedDisplayName = 'random';
+    const propertyID = 'random';
+
+    const attributionPropertyDisplayName =
+      getAttributionPropertyDisplayNameFromId(propertyID);
+
+    expect(attributionPropertyDisplayName).toEqual(expectedDisplayName);
+  });
+});
+
+describe('getMostFrequentLicenses', () => {
+  it('obtains most frequent licenses without other accumulation', () => {
+    const expectedSortedMostFrequentLicenses: Array<PieChartData> = [
       {
         name: 'Apache License Version 2.0',
         count: 3,
@@ -237,15 +273,18 @@ describe('The ProjectStatisticsPopup helper', () => {
         count: 2,
       },
     ];
+    const attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense =
+      {
+        'Apache License Version 2.0': {
+          ScanCode: 1,
+          HC: 1,
+          reuser: 1,
+          Total: 3,
+        },
+        'The MIT License (MIT)': { reuser: 1, ScanCode: 1, Total: 2 },
+        Total: { ScanCode: 2, HC: 1, reuser: 2, Total: 5 },
+      };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_2);
-    const { attributionCountPerSourcePerLicense } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_2,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
     const sortedMostFrequentLicenses = getMostFrequentLicenses(
       attributionCountPerSourcePerLicense
     );
@@ -255,8 +294,8 @@ describe('The ProjectStatisticsPopup helper', () => {
     );
   });
 
-  it('counts most frequent licenses - testAttributions_3', () => {
-    const expectedSortedMostFrequentLicenses = [
+  it('obtains most frequent licenses with other accumulation', () => {
+    const expectedSortedMostFrequentLicenses: Array<PieChartData> = [
       {
         name: 'Apache License Version 2.0',
         count: 3,
@@ -282,15 +321,17 @@ describe('The ProjectStatisticsPopup helper', () => {
         count: 1,
       },
     ];
+    const attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense =
+      {
+        'Apache License Version 2.0': { ScanCode: 1, reuser: 2, Total: 3 },
+        'The MIT License (MIT)': { reuser: 1, ScanCode: 1, Total: 2 },
+        'Apache License Version 1.0': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.1': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.0.1': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.0.0.1': { ScanCode: 1, Total: 1 },
+        Total: { ScanCode: 6, reuser: 3, Total: 9 },
+      };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_3);
-    const { attributionCountPerSourcePerLicense } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_3,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
     const sortedMostFrequentLicenses = getMostFrequentLicenses(
       attributionCountPerSourcePerLicense
     );
@@ -299,149 +340,60 @@ describe('The ProjectStatisticsPopup helper', () => {
       expectedSortedMostFrequentLicenses
     );
   });
+});
 
-  it('aggregates attributions by stripped license names - testAttributions_1', () => {
-    const expectedStrippedLicenseNameToAttribution = {
-      'apachelicenseversion2.0': ['uuid1', 'uuid2', 'uuid3'],
-      'themitlicense(mit)': ['uuid4', 'uuid5', 'uuid6'],
-    };
-
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
-
-    expect(strippedLicenseNameToAttribution).toEqual(
-      expectedStrippedLicenseNameToAttribution
-    );
-  });
-
-  it('aggregates attributions by stripped license names - testAttributions_2', () => {
-    const expectedStrippedLicenseNameToAttribution = {
-      'apachelicenseversion2.0': ['uuid1', 'uuid3', 'uuid4'],
-      'themitlicense(mit)': ['uuid2', 'uuid5'],
-    };
-
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_2);
-
-    expect(strippedLicenseNameToAttribution).toEqual(
-      expectedStrippedLicenseNameToAttribution
-    );
-  });
-
-  it('counts sources for licenses, criticality - testAttributions_1', () => {
-    const expectedAttributionCountPerSourcePerLicense = {
-      'Apache License Version 2.0': { ScanCode: 1, reuser: 2, Total: 3 },
-      'The MIT License (MIT)': { ScanCode: 2, reuser: 1, Total: 3 },
-      Total: { ScanCode: 3, reuser: 3, Total: 6 },
-    };
-    const expectedLicenseNamesWithCriticality = {
+describe('getCriticalSignalsCount', () => {
+  it('counts number of critical signals across all licenses', () => {
+    const expectedCriticalSignalCount: Array<PieChartData> = [
+      {
+        name: 'High',
+        count: 3,
+      },
+      {
+        name: 'Medium',
+        count: 4,
+      },
+      {
+        name: 'Not critical',
+        count: 2,
+      },
+    ];
+    const attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense =
+      {
+        'Apache License Version 2.0': { ScanCode: 1, reuser: 2, Total: 3 },
+        'The MIT License (MIT)': { reuser: 1, ScanCode: 1, Total: 2 },
+        'Apache License Version 1.0': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.1': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.0.1': { ScanCode: 1, Total: 1 },
+        'Apache License Version 1.0.0.0.1': { ScanCode: 1, Total: 1 },
+        Total: { ScanCode: 6, reuser: 3, Total: 9 },
+      };
+    const licenseNamesWithCriticality: LicenseNamesWithCriticality = {
       'Apache License Version 2.0': Criticality.High,
       'The MIT License (MIT)': undefined,
+      'Apache License Version 1.0': Criticality.Medium,
+      'Apache License Version 1.0.1': Criticality.Medium,
+      'Apache License Version 1.0.0.1': Criticality.Medium,
+      'Apache License Version 1.0.0.0.1': Criticality.Medium,
     };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
-    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_1,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
+    const criticalSignalsCount = getCriticalSignalsCount(
+      attributionCountPerSourcePerLicense,
+      licenseNamesWithCriticality
+    );
 
-    expect(attributionCountPerSourcePerLicense).toEqual(
-      expectedAttributionCountPerSourcePerLicense
-    );
-    expect(licenseNamesWithCriticality).toEqual(
-      expectedLicenseNamesWithCriticality
-    );
+    expect(criticalSignalsCount).toEqual(expectedCriticalSignalCount);
   });
+});
 
-  it('counts sources for licenses, criticality - testAttributions_2', () => {
-    const expectedAttributionCountPerSourcePerLicense = {
-      'Apache License Version 2.0': { ScanCode: 1, reuser: 1, HC: 1, Total: 3 },
-      'The MIT License (MIT)': { ScanCode: 1, reuser: 1, Total: 2 },
-      Total: { ScanCode: 2, reuser: 2, HC: 1, Total: 5 },
-    };
-    const expectedLicenseNamesWithCriticality = {
-      'Apache License Version 2.0': Criticality.Medium,
-      'The MIT License (MIT)': undefined,
-    };
-
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_2);
-    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_2,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
-
-    expect(attributionCountPerSourcePerLicense).toEqual(
-      expectedAttributionCountPerSourcePerLicense
-    );
-    expect(licenseNamesWithCriticality).toEqual(
-      expectedLicenseNamesWithCriticality
-    );
-  });
-
-  it('counts sources for licenses, criticalities - testAttributions_1', () => {
-    const expectedSortedMostFrequentLicenses = [
-      {
-        name: 'Apache License Version 2.0',
-        count: 3,
-      },
-      {
-        name: 'The MIT License (MIT)',
-        count: 3,
-      },
+describe('getColorsForPieChart', () => {
+  it('obtains pie chart colors for critical signals pie chart', () => {
+    const expectedPieChartColors = [
+      OpossumColors.orange,
+      OpossumColors.mediumOrange,
+      OpossumColors.darkBlue,
     ];
-
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
-    const { attributionCountPerSourcePerLicense } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_1,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
-    const sortedMostFrequentLicenses = getMostFrequentLicenses(
-      attributionCountPerSourcePerLicense
-    );
-    expect(sortedMostFrequentLicenses).toEqual(
-      expectedSortedMostFrequentLicenses
-    );
-  });
-
-  it('counts sources for licenses, criticalities - testAttributions_1', () => {
-    const expectedSortedMostFrequentLicenses = [
-      {
-        name: 'Apache License Version 2.0',
-        count: 3,
-      },
-      {
-        name: 'The MIT License (MIT)',
-        count: 3,
-      },
-    ];
-
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
-    const { attributionCountPerSourcePerLicense } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_1,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
-    const sortedMostFrequentLicenses = getMostFrequentLicenses(
-      attributionCountPerSourcePerLicense
-    );
-    expect(sortedMostFrequentLicenses).toEqual(
-      expectedSortedMostFrequentLicenses
-    );
-  });
-
-  it('counts number of critical signals across all licenses - testAttributions_3', () => {
-    const expectedCriticalSignalCount = [
+    const criticalSignalsCount: Array<PieChartData> = [
       {
         name: 'High',
         count: 3,
@@ -456,23 +408,39 @@ describe('The ProjectStatisticsPopup helper', () => {
       },
     ];
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_3);
-    const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
-      aggregateLicensesAndSourcesFromAttributions(
-        testAttributions_3,
-        strippedLicenseNameToAttribution,
-        attributionSources
-      );
-    const criticalSignalsCount = getCriticalSignalsCount(
-      attributionCountPerSourcePerLicense,
-      licenseNamesWithCriticality
+    const pieChartColors = getColorsForPieChart(
+      criticalSignalsCount,
+      ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart
     );
-    expect(criticalSignalsCount).toEqual(expectedCriticalSignalCount);
+
+    expect(pieChartColors).toEqual(expectedPieChartColors);
   });
 
+  it('obtains undefined pie chart colors for default case', () => {
+    const expectedPieChartColors = undefined;
+    const sortedMostFrequentLicenses: Array<PieChartData> = [
+      {
+        name: 'Apache License Version 2.0',
+        count: 3,
+      },
+      {
+        name: 'The MIT License (MIT)',
+        count: 3,
+      },
+    ];
+
+    const pieChartColors = getColorsForPieChart(
+      sortedMostFrequentLicenses,
+      ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart
+    );
+
+    expect(pieChartColors).toEqual(expectedPieChartColors);
+  });
+});
+
+describe('getIncompleteAttributionsCount', () => {
   it('counts complete and incomplete attributions', () => {
-    const expectedIncompleteAttributionCount = [
+    const expectedIncompleteAttributionCount: Array<PieChartData> = [
       {
         name: 'Complete attributions',
         count: 2,
@@ -485,13 +453,14 @@ describe('The ProjectStatisticsPopup helper', () => {
 
     const incompleteAttributionCount =
       getIncompleteAttributionsCount(testAttributions_1);
+
     expect(incompleteAttributionCount).toEqual(
       expectedIncompleteAttributionCount
     );
   });
 
   it('counts only incomplete attributions', () => {
-    const expectedIncompleteAttributionCount = [
+    const expectedIncompleteAttributionCount: Array<PieChartData> = [
       {
         name: 'Incomplete attributions',
         count: 5,
@@ -500,90 +469,9 @@ describe('The ProjectStatisticsPopup helper', () => {
 
     const incompleteAttributionCount =
       getIncompleteAttributionsCount(testAttributions_2);
+
     expect(incompleteAttributionCount).toEqual(
       expectedIncompleteAttributionCount
     );
-  });
-
-  it('counts attribution properties - testAttributions_1', () => {
-    const expectedAttributionPropertyCounts = {
-      followUp: 1,
-      firstParty: 2,
-      incomplete: 4,
-      'Total Attributions': 6,
-    };
-
-    const attributionPropertyCounts =
-      aggregateAttributionPropertiesFromAttributions(testAttributions_1);
-
-    expect(attributionPropertyCounts).toEqual(
-      expectedAttributionPropertyCounts
-    );
-  });
-
-  it('finds no follow up and first party attributions - testAttributions_2', () => {
-    const expectedAttributionPropertyCounts = {
-      followUp: 0,
-      firstParty: 0,
-      incomplete: 5,
-      'Total Attributions': 5,
-    };
-
-    const attributionPropertyCounts =
-      aggregateAttributionPropertiesFromAttributions(testAttributions_2);
-
-    expect(attributionPropertyCounts).toEqual(
-      expectedAttributionPropertyCounts
-    );
-  });
-
-  it('obtains pie chart colors for critical signals pie chart', () => {
-    const criticalSignalsCount = [
-      {
-        name: 'High',
-        count: 3,
-      },
-      {
-        name: 'Medium',
-        count: 4,
-      },
-      {
-        name: 'Not critical',
-        count: 2,
-      },
-    ];
-
-    const expectedPieChartColors = [
-      OpossumColors.orange,
-      OpossumColors.mediumOrange,
-      OpossumColors.darkBlue,
-    ];
-
-    const pieChartColors = getColorsForPieChart(
-      criticalSignalsCount,
-      ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart
-    );
-    expect(pieChartColors).toEqual(expectedPieChartColors);
-  });
-
-  it('obtains undefined pie chart colors for default case', () => {
-    const sortedMostFrequentLicenses = [
-      {
-        name: 'Apache License Version 2.0',
-        count: 3,
-      },
-      {
-        name: 'The MIT License (MIT)',
-        count: 3,
-      },
-    ];
-
-    const expectedPieChartColors = undefined;
-
-    const pieChartColors = getColorsForPieChart(
-      sortedMostFrequentLicenses,
-      ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart
-    );
-    expect(pieChartColors).toEqual(expectedPieChartColors);
   });
 });

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -149,10 +149,13 @@ function getLicenseDataFromVariants(
 
       licenseCriticalityCounts[variantCriticality || 'none']++;
 
-      const sourceName = getSourceDisplayNameFromId(
-        attributions[attributionId].source?.name ?? UNKNOWN_SOURCE_PLACEHOLDER,
-        attributionSources
-      );
+      const sourceId =
+        attributions[attributionId].source?.name ?? UNKNOWN_SOURCE_PLACEHOLDER;
+      const sourceName =
+        Object.keys(attributionSources).includes(sourceId) &&
+        sourceId !== UNKNOWN_SOURCE_PLACEHOLDER
+          ? attributionSources[sourceId]['name']
+          : sourceId;
 
       sourcesCountForLicense[sourceName] =
         (sourcesCountForLicense[sourceName] || 0) + 1;
@@ -170,7 +173,8 @@ function getLicenseDataFromVariants(
   };
 }
 
-function getLicenseCriticality(licenseCriticalityCounts: {
+// right now getLicenseCriticality is being exported only to be tested
+export function getLicenseCriticality(licenseCriticalityCounts: {
   high: number;
   medium: number;
   none: number;
@@ -181,19 +185,6 @@ function getLicenseCriticality(licenseCriticalityCounts: {
       ? Criticality.High
       : Criticality.Medium
     : undefined;
-}
-
-function getSourceDisplayNameFromId(
-  sourceId: string,
-  externalAttributionSources: ExternalAttributionSources
-): string {
-  if (
-    Object.keys(externalAttributionSources).includes(sourceId) &&
-    sourceId !== UNKNOWN_SOURCE_PLACEHOLDER
-  ) {
-    return externalAttributionSources[sourceId]['name'];
-  }
-  return sourceId;
 }
 
 export function getUniqueLicenseNameToAttribution(
@@ -232,6 +223,7 @@ export function aggregateAttributionPropertiesFromAttributions(
   attributionPropertyCounts[ATTRIBUTION_PROPERTY_INCOMPLETE] = Object.keys(
     pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
   ).length;
+  // We expect Total Attributions to always be the last entry in the returned value
   attributionPropertyCounts[ATTRIBUTION_TOTAL] =
     Object.values(attributions).length;
 
@@ -245,19 +237,6 @@ export function getAttributionPropertyDisplayNameFromId(
     return ATTRIBUTION_PROPERTIES_ID_TO_DISPLAY_NAME[attributionProperty];
   }
   return attributionProperty;
-}
-
-export function sortAttributionPropertiesEntries(
-  attributionPropertiesOrTotalEntries: Array<Array<string | number>>
-): Array<Array<string | number>> {
-  // Move ATTRIBUTION_TOTAL to the end of the list
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  return attributionPropertiesOrTotalEntries
-    .slice()
-    .sort(([property1, _count1], [_property2, _count2]) =>
-      property1 === ATTRIBUTION_TOTAL ? 1 : 0
-    );
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 }
 
 export function getMostFrequentLicenses(


### PR DESCRIPTION
### Summary of changes

Refactor Tests for statistics popup helpers

### Context and reason for change

 - Have separate tests to check different behaviours of a function.
 - Refactor existing tests to have a more clear workflow.
 - Add dedicated tests for all functions that exist in the helper file. 

Fix: #1079

Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>