### PR TITLE
Cache yarn cache

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -35,15 +34,30 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Get path to yarn cache
+        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
+        if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.cache_dir }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+        if: matrix.os != 'windows-latest'
+
+      - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
+
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'
 
-      - run: yarn install --network-timeout 560000
       - name: Run end2end tests
         run: ${{ matrix.E2E }}
-      - run: yarn ${{ matrix.SHIP }}
+
+      - name: Build app
+        run: yarn ${{ matrix.SHIP }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -29,15 +28,28 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Get path to yarn cache
+        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
+        if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache
+        uses: actions/cache@v3
+        with:
+          path: $(yarn cache dir)
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+        if: matrix.os != 'windows-latest'
+
+      - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
+
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'
 
-      - run: yarn install --network-timeout 560000
       - run: yarn lint-check
       - run: yarn compile-all
       - run: yarn test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   publish_artifact:
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +30,25 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: yarn install --network-timeout 560000
+
+      - name: Get yarn cache
+        id: get-yarn-cache
+        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
+        if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.cache_dir }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+        if: matrix.os != 'windows-latest'
+
+      - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
+
       - run: yarn ${{ matrix.SHIP }}
       - name: Upload release asset
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION


### Summary of changes

The cache of yarn is cached to be reused between Github actions. This speeds up the action and reduces downloads from npm.
Note: so far it is implemented for Ubuntu and Mac only.

### Context and reason for change

Fix: #1148

### How can the changes be tested

![Screenshot 2022-11-18 at 14 43 09](https://user-images.githubusercontent.com/46576389/202718809-289d8e05-ca55-4165-a70a-7af8c57a469a.png)

