### PR TITLE
Docu update: Replace the link to the REUSE website by the actual deep link to the installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ The following software is required for working on the repository:
 - [git](https://git-scm.com/),
 - [node.js](https://nodejs.org/) 18,
 - [yarn](https://yarnpkg.com/en/),
-- [reuse.software](https://reuse.software/) (to check that copyright information is provided),
+- [reuse/tool](https://git.fsfe.org/reuse/tool#install) (to check that copyright information is provided, for more context see https://reuse.software/),
 - [wine](https://www.winehq.org/) (only to build the Windows version).
 
 ### Building the app


### PR DESCRIPTION
### Summary of changes
Replace the link to the REUSE website by the actual deep link to the installation instructions of the REUSE tool.

### Context and reason for change

For new users that just want to get started developing, the website https://reuse.software/ is confusing as there is no clear instruction what to install. You actually have to click on "Developers" and then go to the subsection "Helper Tool" and click the link there. So I decided to add the deep link to the docu.
I did prefer https://git.fsfe.org/reuse/tool#install over https://reuse.readthedocs.io/en/stable/readme.html#install as it seems to be more up-to-date (7 vs 8 operating systems listed).

### How can the changes be tested

Click the link and check that you get to the right install instructions.
