### PR TITLE
Do not call the resource popup when it is not shown.

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -390,17 +390,17 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
 
   return (
     <MuiBox sx={!props.showCheckBox ? classes.multiSelectPackageCard : {}}>
-      {!Boolean(props.hideContextMenuAndMultiSelect) && (
-        <ResourcePathPopup
-          isOpen={showAssociatedResourcesPopup}
-          closePopup={(): void => setShowAssociatedResourcesPopup(false)}
-          attributionId={props.attributionId}
-          isExternalAttribution={Boolean(
-            props.cardConfig.isExternalAttribution
-          )}
-          displayedAttributionName={packageLabels[0] || ''}
-        />
-      )}
+      {showAssociatedResourcesPopup &&
+        !Boolean(props.hideContextMenuAndMultiSelect) && (
+          <ResourcePathPopup
+            closePopup={(): void => setShowAssociatedResourcesPopup(false)}
+            attributionId={props.attributionId}
+            isExternalAttribution={Boolean(
+              props.cardConfig.isExternalAttribution
+            )}
+            displayedAttributionName={packageLabels[0] || ''}
+          />
+        )}
       <ContextMenu
         menuItems={getContextMenuItems()}
         activation={'onRightClick'}

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -30,7 +30,6 @@ const classes = {
 };
 
 interface ResourcePathPopupProps {
-  isOpen: boolean;
   closePopup(): void;
   attributionId: string;
   isExternalAttribution: boolean;
@@ -90,7 +89,7 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
           />
         </MuiBox>
       }
-      isOpen={props.isOpen}
+      isOpen={true}
       fullWidth={true}
     />
   );

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -43,7 +43,6 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
   dispatch(setManualData(attributions, resourcesToManualAttributions));
   return (
     <ResourcePathPopup
-      isOpen={true}
       closePopup={doNothing}
       attributionId={'uuid_1'}
       isExternalAttribution={props.isExternalAttribution}


### PR DESCRIPTION
### Summary of changes
Do not call the resource popup when it is not shown.

### Context and reason for change
It just makes the app slow. Comparison: 
![OpossumUIvsResourcePopupLogsComparison](https://user-images.githubusercontent.com/62446606/204771977-6d440c88-0657-42e5-824e-a8cdd59aecca.png)


