### PR TITLE
Fixing jumping resource browser width

### DIFF
--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -35,7 +35,7 @@ const classes = {
     background: OpossumColors.lightestBlue,
     flex: 1,
     padding: '8px',
-    width: `calc(100% - ${resourceBrowserWidthInPixels}px)`,
+    width: `calc(95% - ${resourceBrowserWidthInPixels}px)`,
   },
   columnDiv: {
     display: 'flex',


### PR DESCRIPTION
### Summary of changes
Resource browser width was jumping probably due to changing path field length and some uncounted paddings.
Fix #1197

### How can the changes be tested

Visually test