### PR TITLE
Cache node_modules

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -39,16 +39,19 @@ jobs:
         with:
           node-version: 18
 
-      - name: Get path to yarn cache
-        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache
+      - name: Use yarn cache (linux, mac)
         uses: actions/cache@v3
         with:
-          path: ${{ env.cache_dir }}
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache (win)
+        uses: actions/cache@v3
+        with:
+          path: '**\node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
+        if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,16 +33,19 @@ jobs:
         with:
           node-version: 18
 
-      - name: Get path to yarn cache
-        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache
+      - name: Use yarn cache (linux, mac)
         uses: actions/cache@v3
         with:
-          path: $(yarn cache dir)
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache (win)
+        uses: actions/cache@v3
+        with:
+          path: '**\node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
+        if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 


### PR DESCRIPTION


### Summary of changes

The node_modules are cached in Github actions.

### Context and reason for change

The speed of the CI is imporoved.

### How can the changes be tested

<img width="1693" alt="Screenshot 2022-12-02 at 14 21 42" src="https://user-images.githubusercontent.com/46576389/205302314-d926991d-5121-4e01-9cae-95c3cb8538c4.png">

Also see for a test run: https://github.com/benedikt-richter/OpossumUI/actions/runs/3602046288/jobs/6068539426
