### PR TITLE
Run tests only on ubuntu

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -39,16 +39,19 @@ jobs:
         with:
           node-version: 18
 
-      - name: Get path to yarn cache
-        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache
+      - name: Use yarn cache (linux, mac)
         uses: actions/cache@v3
         with:
-          path: ${{ env.cache_dir }}
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache (win)
+        uses: actions/cache@v3
+        with:
+          path: '**\node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
+        if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 

--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -43,14 +43,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
 
       - name: Use yarn cache (win)
         uses: actions/cache@v3
         with:
           path: '**\node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**\yarn.lock') }}
         if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -14,16 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-          - os: macos-latest
-          - os: windows-latest
-
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
@@ -33,25 +24,16 @@ jobs:
         with:
           node-version: 18
 
-      - name: Use yarn cache (linux, mac)
+      - name: Use yarn cache
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache (win)
-        uses: actions/cache@v3
-        with:
-          path: '**\node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
-        if: matrix.os == 'windows-latest'
+          key: ${{ 'ubuntu-latest' }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-        if: matrix.os == 'ubuntu-latest'
 
       - run: yarn lint-check
       - run: yarn compile-all

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,16 +33,19 @@ jobs:
         with:
           node-version: 18
 
-      - name: Get path to yarn cache
-        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache
+      - name: Use yarn cache (linux, mac)
         uses: actions/cache@v3
         with:
-          path: $(yarn cache dir)
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
+
+      - name: Use yarn cache (win)
+        uses: actions/cache@v3
+        with:
+          path: '**\node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**\yarn.lock') }}
+        if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 


### PR DESCRIPTION
### Summary of changes

Run tests only on ubuntu in Github actions.

### Context and reason for change

The unit and integration tests run in our Github actions on mac, ubuntu, and windows. However, we do not expect a lot of differences there. For this reason and to use less resources, the Ci is changed.
