### PR TITLE
Replace resource popup list with a tree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 .idea
 /opossumUI.iml
 /notices
+
+/.vscode

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -13,6 +13,7 @@ import { Button } from '../Button/Button';
 import { doNothing } from '../../util/do-nothing';
 import { ButtonConfig } from '../../types/types';
 import { SxProps } from '@mui/material';
+import { POPUP_MAX_WIDTH_BREAKPOINT } from '../../shared-constants';
 
 interface NotificationPopupProps {
   header: string;
@@ -56,7 +57,7 @@ export function NotificationPopup(props: NotificationPopupProps): ReactElement {
   return (
     <MuiDialog
       fullWidth={props.fullWidth}
-      maxWidth={'xl'}
+      maxWidth={POPUP_MAX_WIDTH_BREAKPOINT}
       open={props.isOpen}
       disableEscapeKeyDown={true}
       onClose={handleOnClose}

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -31,48 +31,7 @@ import { Resources } from '../../../shared/shared-types';
 import { getTreeItemLabel } from './get-tree-item-label';
 import { useWindowHeight } from '../../util/use-window-height';
 import { topBarHeight } from '../TopBar/TopBar';
-import {
-  OpossumColors,
-  resourceBrowserWidthInPixels,
-} from '../../shared-styles';
-
-const classes = {
-  tree: {
-    width: resourceBrowserWidthInPixels,
-    padding: '4px 0',
-    background: OpossumColors.white,
-    height: '100%',
-  },
-  treeItemLabel: {
-    height: '19px',
-    whiteSpace: 'nowrap',
-    '&:hover': {
-      backgroundColor: `${OpossumColors.lightBlueOnHover}`,
-      cursor: 'pointer',
-    },
-  },
-  treeItemLabelChildrenOfSelected: {
-    backgroundColor: `${OpossumColors.lightestBlue}`,
-    borderBottom: `1px ${OpossumColors.lightestBlue} solid`,
-  },
-  treeItemLabelSelected: {
-    backgroundColor: `${OpossumColors.lightestBlue} !important`,
-    borderBottom: `1px ${OpossumColors.lightestBlue} solid`,
-    '&:hover': {
-      backgroundColor: `${OpossumColors.lightBlueOnHover} !important`,
-    },
-  },
-  treeExpandIcon: {
-    width: '16px',
-    height: '20px',
-    padding: '0px',
-    margin: '0px',
-    color: OpossumColors.darkBlue,
-    '&:hover': {
-      background: OpossumColors.middleBlue,
-    },
-  },
-};
+import { treeClasses } from '../../shared-styles';
 
 const TREE_ROW_HEIGHT = 20;
 const ROOT_FOLDER_LABEL = '';
@@ -161,13 +120,13 @@ export function ResourceBrowser(): ReactElement | null {
       breakpoints={attributionBreakpoints}
       cardHeight={TREE_ROW_HEIGHT}
       maxHeight={maxTreeHeight}
-      sx={classes.tree}
+      sx={treeClasses.tree('browser')}
       alwaysShowHorizontalScrollBar={true}
       treeNodeStyle={{
-        root: classes.treeItemLabel,
-        childrenOfSelected: classes.treeItemLabelChildrenOfSelected,
-        selected: classes.treeItemLabelSelected,
-        treeExpandIcon: classes.treeExpandIcon,
+        root: treeClasses.treeItemLabel,
+        childrenOfSelected: treeClasses.treeItemLabelChildrenOfSelected,
+        selected: treeClasses.treeItemLabelSelected,
+        treeExpandIcon: treeClasses.treeExpandIcon,
       }}
     />
   ) : null;

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -3,31 +3,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { ResourcesList } from '../ResourcesList/ResourcesList';
 import {
   getExternalAttributionsToResources,
   getManualAttributionsToResources,
 } from '../../state/selectors/all-views-resource-selectors';
 import { useWindowHeight } from '../../util/use-window-height';
-import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
-import { splitResourceIdsToCurrentAndOtherFolder } from './resource-path-popup-helpers';
-import { ResourcesListBatch } from '../../types/types';
-import { useAppSelector } from '../../state/hooks';
+import {
+  getInitialExpandedIds,
+  getResourcesFromResourcePaths,
+} from './resource-path-popup-helpers';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { ButtonText } from '../../enums/enums';
 import MuiBox from '@mui/material/Box';
+import { VirtualizedTree } from '../../extracted/VirtualisedTree/VirtualizedTree';
+import { treeClasses } from '../../shared-styles';
+import {
+  getAttributionBreakpoints,
+  getFilesWithChildren,
+} from '../../state/selectors/all-views-resource-selectors';
+import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
+import { getTreeItemLabel } from '../ResourceBrowser/get-tree-item-label';
+import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
+import { Resources } from '../../../shared/shared-types';
+import { navigateToSelectedPathOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
+import { remove } from 'lodash';
+import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
+import { EMPTY_ATTRIBUTION_DATA } from '../../shared-constants';
 
-const heightOffset = 300;
-
-const classes = {
-  header: {
-    whiteSpace: 'nowrap',
-  },
-  resourceListContainer: {
-    overflowY: 'hidden',
-  },
-};
+const ROOT_FOLDER_LABEL = '';
+const TREE_ROW_HEIGHT = 20;
+const VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 236;
+const HORIZONTAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 112;
+const POPUP_CONTENT_PADDING = 48;
 
 interface ResourcePathPopupProps {
   closePopup(): void;
@@ -37,44 +46,78 @@ interface ResourcePathPopupProps {
 }
 
 export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
-  const folderPath = useAppSelector(getSelectedResourceId);
-
   const externalAttributionsToResources = useAppSelector(
     getExternalAttributionsToResources
   );
   const manualAttributionsToResources = useAppSelector(
     getManualAttributionsToResources
   );
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+
+  function getTreeItemLabelGetter() {
+    return (
+      resourceName: string,
+      resource: Resources | 1,
+      nodeId: string
+    ): ReactElement =>
+      getTreeItemLabel(
+        resourceName,
+        resource,
+        nodeId,
+        {},
+        {},
+        {},
+        {},
+        {},
+        new Set<string>(),
+        getAttributionBreakpointCheck(attributionBreakpoints),
+        getFileWithChildrenCheck(filesWithChildren),
+        EMPTY_ATTRIBUTION_DATA
+      );
+  }
+
   const allResourceIds = props.isExternalAttribution
     ? externalAttributionsToResources[props.attributionId]
     : manualAttributionsToResources[props.attributionId];
 
+  const initialExpandedIds = getInitialExpandedIds(allResourceIds);
+
+  const [expandedIds, setExpandedIds] = useState<string[]>(initialExpandedIds);
+
+  function handleToggle(nodeIdsToExpand: Array<string>): void {
+    let newExpandedNodeIds = [...expandedIds];
+    if (expandedIds.includes(nodeIdsToExpand[0])) {
+      remove(newExpandedNodeIds, (nodeId: string): boolean =>
+        nodeId.startsWith(nodeIdsToExpand[0])
+      );
+    } else {
+      newExpandedNodeIds = newExpandedNodeIds.concat(nodeIdsToExpand);
+    }
+    setExpandedIds(newExpandedNodeIds);
+  }
+
+  const dispatch = useAppDispatch();
+
+  function handleSelect(
+    event: React.ChangeEvent<unknown>,
+    nodeId: string
+  ): void {
+    dispatch(navigateToSelectedPathOrOpenUnsavedPopup(nodeId));
+  }
+
+  const maxTreeHeight: number =
+    useWindowHeight() - VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES;
   const header = `Resources for selected ${
     props.isExternalAttribution ? 'signal' : 'attribution'
   }`;
-
-  function getResourcesListBatches(): Array<ResourcesListBatch> {
-    const resourcesListBatches: Array<ResourcesListBatch> = [];
-
-    const { currentFolderResourceIds, otherFolderResourceIds } =
-      splitResourceIdsToCurrentAndOtherFolder(allResourceIds, folderPath);
-
-    resourcesListBatches.push({ resourceIds: currentFolderResourceIds });
-    if (otherFolderResourceIds.length > 0) {
-      resourcesListBatches.push({
-        header: 'Resources in Other Folders',
-        resourceIds: otherFolderResourceIds,
-      });
-    }
-    return resourcesListBatches;
-  }
-
-  const resourcesListBatches = getResourcesListBatches();
+  const resources = getResourcesFromResourcePaths(allResourceIds);
 
   return (
     <NotificationPopup
       header={header}
-      headerSx={classes.header}
+      headerSx={treeClasses.header(POPUP_CONTENT_PADDING)}
       rightButtonConfig={{
         onClick: props.closePopup,
         buttonText: ButtonText.Close,
@@ -82,15 +125,41 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
       onBackdropClick={props.closePopup}
       onEscapeKeyDown={props.closePopup}
       content={
-        <MuiBox sx={classes.resourceListContainer}>
-          <ResourcesList
-            resourcesListBatches={resourcesListBatches}
-            maxHeight={useWindowHeight() - heightOffset}
+        <MuiBox
+          sx={treeClasses.treeContainer(
+            VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES
+          )}
+        >
+          <VirtualizedTree
+            expandedIds={expandedIds}
+            isFakeNonExpandableNode={getFileWithChildrenCheck(
+              filesWithChildren
+            )}
+            onSelect={handleSelect}
+            onToggle={handleToggle}
+            nodes={{ [ROOT_FOLDER_LABEL]: resources }}
+            selectedNodeId={selectedResourceId}
+            ariaLabel={'resource browser'}
+            getTreeNodeLabel={getTreeItemLabelGetter()}
+            cardHeight={TREE_ROW_HEIGHT}
+            maxHeight={maxTreeHeight}
+            sx={treeClasses.tree(
+              'popup',
+              HORIZONTAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES,
+              POPUP_CONTENT_PADDING
+            )}
+            alwaysShowHorizontalScrollBar={true}
+            treeNodeStyle={{
+              root: treeClasses.treeItemLabel,
+              childrenOfSelected: treeClasses.treeItemLabelChildrenOfSelected,
+              selected: treeClasses.treeItemLabelSelected,
+              treeExpandIcon: treeClasses.treeExpandIcon,
+            }}
           />
         </MuiBox>
       }
       isOpen={true}
-      fullWidth={true}
+      fullWidth={false}
     />
   );
 }

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -4,10 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import {
-  createTestAppStore,
-  renderComponentWithStore,
-} from '../../../test-helpers/render-component-with-store';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { doNothing } from '../../../util/do-nothing';
 import { ResourcePathPopup } from '../ResourcePathPopup';
 import {
@@ -18,7 +15,6 @@ import {
   setExternalData,
   setManualData,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { screen } from '@testing-library/react';
 import { useAppDispatch } from '../../../state/hooks';
 
@@ -52,15 +48,13 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
 }
 
 describe('ResourcePathPopup', () => {
-  const resourcesInOtherFoldersHeader = 'Resources in Other Folders';
-
   it('renders resources for manual Attributions', () => {
     renderComponentWithStore(<HelperComponent isExternalAttribution={false} />);
 
     expect(
       screen.getByText('Resources for selected attribution')
     ).toBeInTheDocument();
-    expect(screen.getByText('/thirdParty')).toBeInTheDocument();
+    expect(screen.getByText('thirdParty')).toBeInTheDocument();
   });
 
   it('renders resources for external Attributions', () => {
@@ -69,31 +63,6 @@ describe('ResourcePathPopup', () => {
     expect(
       screen.getByText('Resources for selected signal')
     ).toBeInTheDocument();
-    expect(screen.getByText('/firstParty')).toBeInTheDocument();
-  });
-
-  it('renders subheader, if resources in other folders exist', () => {
-    const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId('/folder/anotherFirstParty'));
-    renderComponentWithStore(<HelperComponent isExternalAttribution={true} />, {
-      store: testStore,
-    });
-
-    expect(screen.getByText(resourcesInOtherFoldersHeader)).toBeInTheDocument();
-    expect(screen.getByText('/firstParty')).toBeInTheDocument();
-    expect(screen.getByText('/folder/anotherFirstParty')).toBeInTheDocument();
-  });
-
-  it('renders no subheader, if no resources in other folders exist', () => {
-    const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId('/thirdParty'));
-    renderComponentWithStore(
-      <HelperComponent isExternalAttribution={false} />,
-      { store: testStore }
-    );
-    expect(
-      screen.queryByText(resourcesInOtherFoldersHeader)
-    ).not.toBeInTheDocument();
-    expect(screen.getByText('/thirdParty')).toBeInTheDocument();
+    expect(screen.getByText('firstParty')).toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -3,7 +3,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { splitResourceIdsToCurrentAndOtherFolder } from '../resource-path-popup-helpers';
+import { Resources } from '../../../../shared/shared-types';
+import {
+  getResourcesFromResourcePaths,
+  splitResourceIdsToCurrentAndOtherFolder,
+} from '../resource-path-popup-helpers';
 
 describe('splitResourceItToCurrentAndOtherFolder', () => {
   it('splits resource ids correctly', () => {
@@ -28,6 +32,36 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
     );
     expect(otherFolderResourceIds).toStrictEqual(
       expectedOtherFolderResourceIds
+    );
+  });
+
+  const testResourcesList: string[] = [
+    '/OpossumUI/DCO.md',
+    '/OpossumUI/src/Frontend/test.txt',
+    '/OpossumUI/src/Frontend/Components/file.tsx',
+    '/OpossumUI/src/abc.test.tsx',
+    '/OpossumUI/.idea/',
+  ];
+
+  const expectedResources: Resources = {
+    OpossumUI: {
+      ['.idea']: {},
+      src: {
+        Frontend: {
+          ['test.txt']: 1,
+          Components: {
+            ['file.tsx']: 1,
+          },
+        },
+        ['abc.test.tsx']: 1,
+      },
+      ['DCO.md']: 1,
+    },
+  };
+
+  it('correctly converts a list of resource ids (paths) into a Resources object', () => {
+    expect(getResourcesFromResourcePaths(testResourcesList)).toEqual(
+      expectedResources
     );
   });
 });

--- a/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
+++ b/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { Resources } from '../../../shared/shared-types';
+
 export function splitResourceIdsToCurrentAndOtherFolder(
   allResourceIds: Array<string>,
   folderPath: string
@@ -22,4 +24,49 @@ export function splitResourceIdsToCurrentAndOtherFolder(
     currentFolderResourceIds,
     otherFolderResourceIds,
   };
+}
+
+export function getResourcesFromResourcePaths(
+  resourcePaths: Array<string>
+): Resources {
+  const resources: Resources = {};
+  for (const resourcePath of resourcePaths) {
+    addPathToResources(resourcePath, resources);
+  }
+
+  return resources;
+}
+
+function addPathToResources(resourcePath: string, resources: Resources): void {
+  const isFolder = resourcePath.endsWith('/');
+  const resourcePathSplit = isFolder
+    ? resourcePath.split('/').slice(1, -1)
+    : resourcePath.split('/').slice(1);
+  resourcePathSplit.reduce(
+    (parent: Resources, childName: string, index: number) => {
+      if (index === resourcePathSplit.length - 1) {
+        parent[childName] = isFolder ? {} : 1;
+      } else {
+        parent[childName] = parent[childName] || {};
+      }
+      const returnValue = parent[childName];
+      return returnValue !== 1 ? returnValue : {};
+    },
+    resources
+  );
+}
+
+export function getInitialExpandedIds(allResourceIds: string[]): string[] {
+  const initialExpandedIdsSet = new Set<string>().add('/');
+  for (const resourceId of allResourceIds) {
+    const resourceIdParents = resourceId.split('/').slice(1, -1);
+    for (let i = 0; i < resourceIdParents.length; i++) {
+      initialExpandedIdsSet.add(
+        '/' + resourceIdParents.slice(0, i + 1).join('/') + '/'
+      );
+    }
+  }
+  const initialExpandedIds = Array.from(initialExpandedIdsSet);
+
+  return initialExpandedIds;
 }

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -44,7 +44,7 @@ import {
   expectResourceBrowserIsNotShown,
 } from '../../../test-helpers/resource-browser-test-helpers';
 import {
-  clickOnPathInPopupWithResources,
+  clickOnNodeInPopupWithResources,
   expectConfirmDeletionPopupNotVisible,
   expectConfirmDeletionPopupVisible,
   expectShowResourcesPopupVisible,
@@ -280,7 +280,7 @@ describe('The ContextMenu', () => {
     });
   });
 
-  it('show resource button opens working popup with file list when clicking on show resources icon', () => {
+  it('show resource button opens working popup with resources tree when clicking on show resources icon', () => {
     const testResources: Resources = {
       folder1: { 'firstResource.js': 1 },
       'secondResource.js': 1,
@@ -353,7 +353,8 @@ describe('The ContextMenu', () => {
       ButtonText.ShowResources
     );
     expectShowResourcesPopupVisible(screen);
-    clickOnPathInPopupWithResources(screen, '/folder1/');
+    clickOnNodeInPopupWithResources(screen, 'folder1');
+
     expectPackageInPackagePanel(screen, 'JQuery, 16.5.0', 'Signals');
 
     expectContextMenuForNotPreSelectedAttributionMultipleResources(
@@ -366,7 +367,8 @@ describe('The ContextMenu', () => {
       ButtonText.ShowResources
     );
     expectShowResourcesPopupVisible(screen);
-    clickOnPathInPopupWithResources(screen, '/thirdResource.js');
+    clickOnNodeInPopupWithResources(screen, 'thirdResource.js');
+
     expectValueInTextBox(screen, 'Name', 'React');
 
     clickOnTab(screen, 'Global Tab');
@@ -380,7 +382,8 @@ describe('The ContextMenu', () => {
       ButtonText.ShowResources
     );
     expectShowResourcesPopupVisible(screen);
-    clickOnPathInPopupWithResources(screen, '/secondResource.js');
+    clickOnNodeInPopupWithResources(screen, 'secondResource.js');
+
     expectValueInTextBox(screen, 'Name', 'Vue');
 
     goToView(screen, View.Attribution);
@@ -396,7 +399,8 @@ describe('The ContextMenu', () => {
       ButtonText.ShowResources
     );
     expectShowResourcesPopupVisible(screen);
-    clickOnPathInPopupWithResources(screen, '/secondResource.js');
+    clickOnNodeInPopupWithResources(screen, 'secondResource.js');
+
     expectValueInTextBox(screen, 'Name', 'Vue');
   });
 });

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -33,7 +33,7 @@ import {
 } from '../../../test-helpers/attribution-column-test-helpers';
 import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-browser-test-helpers';
 import {
-  clickOnPathInPopupWithResources,
+  clickOnNodeInPopupWithResources,
   expectErrorPopupIsNotShown,
   expectErrorPopupIsShown,
   expectUnsavedChangesPopupIsNotShown,
@@ -275,7 +275,7 @@ describe('Other popups of the app', () => {
     expectPackageInPackagePanel(screen, 'JQuery', 'Signals in Folder Content');
 
     fireEvent.click(getOpenResourcesButtonForPackagePanel(screen, 'JQuery'));
-    clickOnPathInPopupWithResources(screen, '/root/src/');
+    clickOnNodeInPopupWithResources(screen, 'src');
     expectPackageInPackagePanel(screen, 'JQuery', 'High Compute');
   });
 

--- a/src/Frontend/shared-constants.ts
+++ b/src/Frontend/shared-constants.ts
@@ -25,3 +25,13 @@ export const EMPTY_PROJECT_METADATA: ProjectMetadata = {
   projectId: '',
   fileCreationDate: '',
 };
+
+export const POPUP_MAX_WIDTH_BREAKPOINT = 'xl';
+
+export const MUI_BREAKPOINTS_TO_PIXELS_MAPPING = {
+  xs: 0,
+  sm: 600,
+  md: 900,
+  lg: 1200,
+  xl: 1536,
+};

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -3,6 +3,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { SxProps } from '@mui/material';
+import {
+  MUI_BREAKPOINTS_TO_PIXELS_MAPPING,
+  POPUP_MAX_WIDTH_BREAKPOINT,
+} from './shared-constants';
+
 export const OpossumColors = {
   white: 'hsl(0, 0%, 100%)',
   whiteOnHover: 'hsl(220, 41%, 65%)',
@@ -91,5 +97,93 @@ export const tableClasses = {
     position: 'sticky',
     bottom: 0,
     color: OpossumColors.black,
+  },
+};
+
+export const treeClasses = {
+  header: (popupContentPadding: number): SxProps => {
+    return {
+      whiteSpace: 'nowrap',
+      width: `calc(100% - ${popupContentPadding}px)`,
+    };
+  },
+  treeContainer: (
+    verticalSpaceBetweenTreeAndViewportEdges: number
+  ): SxProps => {
+    return {
+      overflow: 'hidden',
+      height: `calc(100vh - ${verticalSpaceBetweenTreeAndViewportEdges}px)`,
+    };
+  },
+  tree: (
+    treeLocation: 'popup' | 'browser',
+    horizontalSpaceBetweenTreeAndViewportEdges?: number,
+    popupContentPadding?: number
+  ): SxProps => {
+    function shouldNotBeCalled(treeLocation: never): never {
+      throw Error(
+        `Unknown treeLocation: ${treeLocation}. Possible values are 'browser' and 'popup'.`
+      );
+    }
+    switch (treeLocation) {
+      case 'browser': {
+        return {
+          width: resourceBrowserWidthInPixels,
+          padding: '4px 0',
+          background: OpossumColors.white,
+          height: '100%',
+        };
+      }
+      case 'popup': {
+        const popupMaxWidth =
+          MUI_BREAKPOINTS_TO_PIXELS_MAPPING[POPUP_MAX_WIDTH_BREAKPOINT];
+        if (
+          horizontalSpaceBetweenTreeAndViewportEdges !== undefined &&
+          popupContentPadding !== undefined
+        ) {
+          return {
+            width: `calc(100vw - ${horizontalSpaceBetweenTreeAndViewportEdges}px)`,
+            maxWidth: `calc(${popupMaxWidth}px - ${popupContentPadding}px)`,
+            background: OpossumColors.white,
+          };
+        } else {
+          throw Error(
+            "horizontalSpaceBetweenTreeAndViewportEdges and popupContentPadding have to be provided if treeLocation='popup'"
+          );
+        }
+      }
+      default: {
+        shouldNotBeCalled(treeLocation);
+      }
+    }
+  },
+  treeItemLabel: {
+    height: '19px',
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      backgroundColor: `${OpossumColors.lightBlueOnHover}`,
+      cursor: 'pointer',
+    },
+  },
+  treeItemLabelChildrenOfSelected: {
+    backgroundColor: `${OpossumColors.lightestBlue}`,
+    borderBottom: `1px ${OpossumColors.lightestBlue} solid`,
+  },
+  treeItemLabelSelected: {
+    backgroundColor: `${OpossumColors.lightestBlue} !important`,
+    borderBottom: `1px ${OpossumColors.lightestBlue} solid`,
+    '&:hover': {
+      backgroundColor: `${OpossumColors.lightBlueOnHover} !important`,
+    },
+  },
+  treeExpandIcon: {
+    width: '16px',
+    height: '20px',
+    padding: '0px',
+    margin: '0px',
+    color: OpossumColors.darkBlue,
+    '&:hover': {
+      background: OpossumColors.middleBlue,
+    },
   },
 };

--- a/src/Frontend/test-helpers/popup-test-helpers.ts
+++ b/src/Frontend/test-helpers/popup-test-helpers.ts
@@ -9,13 +9,13 @@ export function expectShowResourcesPopupVisible(screen: Screen): void {
   expect(getPopupWithResources(screen)).toBeTruthy();
 }
 
-export function clickOnPathInPopupWithResources(
+export function clickOnNodeInPopupWithResources(
   screen: Screen,
-  path: string
+  nodeLabel: string
 ): void {
   const popupWithResources = getPopupWithResources(screen);
   // eslint-disable-next-line testing-library/prefer-screen-queries
-  fireEvent.click(getByText(popupWithResources, path));
+  fireEvent.click(getByText(popupWithResources, nodeLabel));
 }
 
 function getPopupWithResources(screen: Screen): HTMLElement {


### PR DESCRIPTION
### Summary of changes
The resource popup list was replaced with a tree. 

### Context and reason for change
The list shown when opening the resource popup looked quite unappealing. The new tree view provides improved navigation. By default, the tree opens with all affected nodes expanded.

### Further comments
The icon design is still rather sparse and could be improved in another ticket, if necessary.

By default, all nodes in the tree are expanded when the popup is opened. This strategy has been chosen to minimize clicking work. Therefore, the tree can become very large if many resources are affected by the underlying signal/attribution. However, the whole tree can be contracted by clicking the arrow of the root node. Afterwards, the tree can be expanded manually.

Before:
![0_opossumui_resources_popup_list](https://user-images.githubusercontent.com/83081698/205599770-e24a9d90-8ac3-4afd-b71d-f970068a1bc8.png)

After:
![0_opossumui_resources_popup_tree_final](https://user-images.githubusercontent.com/83081698/205599822-40b2b4fe-af3e-4ff6-8fca-4e8ccd0dca85.png)

Sorry for the large number of changed lines. However, some stuff was just copied from ResourceBrowser.tsx to create the VistualizedTree.

Fix: #993