### PR TITLE
Use new cache for releases

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -39,14 +39,14 @@ jobs:
         with:
           node-version: 18
 
-      - name: Use yarn cache (linux, mac)
+      - name: Use cached node modules (linux, mac)
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
 
-      - name: Use yarn cache (win)
+      - name: Use cached node modules (win)
         uses: actions/cache@v3
         with:
           path: '**\node_modules'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 18
 
-      - name: Use yarn cache
+      - name: Use cached node modules
         uses: actions/cache@v3
         with:
           path: '**/node_modules'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,19 @@ jobs:
         with:
           node-version: 18
 
-      - name: Get yarn cache
-        id: get-yarn-cache
-        run: echo "cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
-        if: matrix.os != 'windows-latest'
-
-      - name: Use yarn cache
+      - name: Use cached node modules (linux, mac)
         uses: actions/cache@v3
         with:
-          path: ${{ env.cache_dir }}
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
         if: matrix.os != 'windows-latest'
+
+      - name: Use cached node modules (win)
+        uses: actions/cache@v3
+        with:
+          path: '**\node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**\yarn.lock') }}
+        if: matrix.os == 'windows-latest'
 
       - run: yarn install --frozen-lockfile --prefer-offline --network-timeout 560000
 


### PR DESCRIPTION
### Summary of changes

With this change cached node modules are also used in the release pipeline.

### Context and reason for change

We only cached the yar cache before. The update of the release pipeline to the new cache was forgotten.


