### PR TITLE
Adjust buttons of URL field in attribution column.

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -47,6 +47,10 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
     }
   }
 
+  const openLinkButtonTooltip = props.displayPackageInfo.url
+    ? 'Open link in browser'
+    : 'No link to open. Please enter a URL.';
+
   return (
     <MuiPaper sx={attributionColumnClasses.panel} elevation={0} square={true}>
       <MuiBox sx={attributionColumnClasses.displayRow}>
@@ -134,7 +138,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
               isDisabled={!props.isEditable}
             />
             <IconButton
-              tooltipTitle="open link in browser"
+              tooltipTitle={openLinkButtonTooltip}
               tooltipPlacement="right"
               onClick={openUrl}
               disabled={!props.displayPackageInfo.url}

--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -52,7 +52,9 @@ const classes = {
   },
 };
 
-const FETCH_DATA_TOOLTIP = 'Fetch data';
+export const FETCH_DATA_TOOLTIP = 'Fetch data';
+export const FETCH_DATA_BUTTON_DISABLED_TOOLTIP =
+  'Fetching data is not possible. Please enter a URL with one of the following domains: pypi.org, npmjs.com, github.com.';
 
 export enum FetchStatus {
   Idle = 'Idle',
@@ -125,16 +127,16 @@ export function useFetchPackageInfo(props: LicenseFetchingInformation): {
 function DisabledFetchLicenseInformationButton(): ReactElement {
   return (
     <IconButton
-      tooltipTitle={FETCH_DATA_TOOLTIP}
+      tooltipTitle={FETCH_DATA_BUTTON_DISABLED_TOOLTIP}
       tooltipPlacement="right"
-      disabled={false}
+      disabled={true}
       onClick={doNothing}
       icon={<CachedIcon sx={classes.disabledIcon} />}
     />
   );
 }
 
-function EnabledFetchLicenseInformationButton(
+export function EnabledFetchLicenseInformationButton(
   props: LicenseFetchingInformation
 ): ReactElement {
   const { fetchStatus, errorMessage, fetchData } = useFetchPackageInfo(props);

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -19,29 +19,29 @@ interface IconButtonProps {
 }
 
 export function IconButton(props: IconButtonProps): ReactElement {
-  function wrapInTooltip(children: ReactElement): ReactElement {
-    return props.disabled ? (
-      <span>{children}</span>
-    ) : (
-      <MuiTooltip
-        sx={tooltipStyle}
-        title={props.tooltipTitle}
-        placement={props.tooltipPlacement}
-      >
-        {children}
-      </MuiTooltip>
-    );
-  }
-  return wrapInTooltip(
-    <MuiButtonBase
-      sx={props.sx}
-      onClick={(event): void => {
-        event.stopPropagation();
-        props.onClick();
-      }}
-      disabled={props.disabled}
+  return (
+    <MuiTooltip
+      describeChild={true}
+      sx={tooltipStyle}
+      title={props.tooltipTitle}
+      placement={props.tooltipPlacement}
     >
-      {props.icon}
-    </MuiButtonBase>
+      <span>
+        {
+          // span is needed to enable tooltips for disabled buttons
+        }
+        <MuiButtonBase
+          aria-label={props.tooltipTitle}
+          sx={props.sx}
+          onClick={(event): void => {
+            event.stopPropagation();
+            props.onClick();
+          }}
+          disabled={props.disabled}
+        >
+          {props.icon}
+        </MuiButtonBase>
+      </span>
+    </MuiTooltip>
   );
 }


### PR DESCRIPTION
### Summary of changes
If disabled, the fetch button is not clickable. The fetch button and the open button do show a tooltip if they are disabled. The tooltips indicate that fetching or opening is not possible because the URL is missing or unsuitable.

### Context and reason for change
Previously, the fetch button was clickable, although disabled. Furthermore, disabled buttons did not show a tooltip. However, a tooltip with information on why the buttons are disabled is helpful for unexperienced users of the app.

Tooltip of the enabled fetch button:
![url_tooltip_fetch_enabled](https://user-images.githubusercontent.com/83081698/206160458-dacd7a5a-c382-4220-8e03-205f74b5c75f.png)

Tooltip of the enabled open button:
![url_tooltip_open_enabled](https://user-images.githubusercontent.com/83081698/206160637-69204f92-4412-449d-8457-e61850a34715.png)

Tooltip of the disabled fetch button:
![fetch](https://user-images.githubusercontent.com/83081698/208462033-4cdee2ab-deff-4a12-a9f5-551b3041eebe.png)

Tooltip of the disabled open button:
![open](https://user-images.githubusercontent.com/83081698/208462091-fe45a145-077e-4fbe-a180-9f6d5101bdf8.png)

Fix: #1217