### PR TITLE
Reset the progress bar cache when opening a new file

### DIFF
--- a/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
+++ b/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
@@ -74,8 +74,16 @@ export const ProgressBarWorkersContextProvider: FC<{
 
   useMemo(() => {
     try {
+      progressBarWorkers.TopProgressBarWorker.postMessage({
+        isCacheInitializationMessage: true,
+        resources: null,
+        resourcesToExternalAttributions: null,
+        attributionBreakpoints: null,
+        filesWithChildren: null,
+      });
       Object.values(progressBarWorkers).forEach((worker) => {
         worker.postMessage({
+          isCacheInitializationMessage: true,
           resources,
           resourcesToExternalAttributions,
           attributionBreakpoints,

--- a/src/Frontend/web-workers/progress-bar-worker.ts
+++ b/src/Frontend/web-workers/progress-bar-worker.ts
@@ -14,6 +14,7 @@ let cachedFilesWithChildren: Set<string> | null = null;
 
 self.onmessage = ({
   data: {
+    isCacheInitializationMessage,
     resources,
     resourceId,
     manualAttributions,
@@ -24,7 +25,12 @@ self.onmessage = ({
     filesWithChildren,
   },
 }): void => {
-  if (
+  if (isCacheInitializationMessage) {
+    cachedResources = resources;
+    cachedResourcesToExternalAttributions = resourcesToExternalAttributions;
+    cachedAttributionBreakpoints = attributionBreakpoints;
+    cachedFilesWithChildren = filesWithChildren;
+  } else if (
     cachedResources &&
     cachedResourcesToExternalAttributions &&
     cachedAttributionBreakpoints &&
@@ -49,12 +55,5 @@ self.onmessage = ({
     self.postMessage({
       output,
     });
-  } else {
-    if (resources) cachedResources = resources;
-    if (resourcesToExternalAttributions)
-      cachedResourcesToExternalAttributions = resourcesToExternalAttributions;
-    if (attributionBreakpoints)
-      cachedAttributionBreakpoints = attributionBreakpoints;
-    if (filesWithChildren) cachedFilesWithChildren = filesWithChildren;
   }
 };


### PR DESCRIPTION
Signed-off-by: Markus Obendrauf <markus.obendrauf@tngtech.com>

### Summary of changes

Make explicit which messages sent to the progress bar worker are used for cache initialisation, and correct the behaviour on opening a new file.

### Context and reason for change

[Another PR](https://github.com/opossum-tool/OpossumUI/commit/2dfff7b80cd5a5b59a20d75e2582a7fb1ee74ec6) introduced a bug where the progress bar would not update if you open two different input files. This PR fixes the bug.

### How can the changes be tested

Open two different input files and hover over the progress bar to check that it is correct.