### PR TITLE
Remove improper selector returns

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -79,7 +79,8 @@ interface AttributionColumnProps {
 
 export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const dispatch = useAppDispatch();
-  const initialPackageInfo = useAppSelector(getPackageInfoOfSelected);
+  const initialPackageInfo: PackageInfo =
+    useAppSelector(getPackageInfoOfSelected) || {};
   const selectedPackage = useAppSelector(getDisplayedPackage);
   const resolvedExternalAttributions = useAppSelector(
     getResolvedExternalAttributions

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -10,7 +10,6 @@ import { PackageInfo } from '../../../shared/shared-types';
 import { getTemporaryPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 import { ResourcesList } from '../ResourcesList/ResourcesList';
-import { isEqual } from 'lodash';
 import {
   deleteAttributionGloballyAndSave,
   savePackageInfo,
@@ -53,10 +52,8 @@ const classes = {
 export function AttributionDetailsViewer(): ReactElement | null {
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
   const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
-  const resourceIdsOfSelectedAttributionId: Array<string> = useAppSelector(
-    getResourceIdsOfSelectedAttribution,
-    isEqual
-  );
+  const resourceIdsOfSelectedAttributionId: Array<string> =
+    useAppSelector(getResourceIdsOfSelectedAttribution) || [];
 
   const resourceListMaxHeight = useWindowHeight() - 112;
 

--- a/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
@@ -96,7 +96,7 @@ describe('The AttributionDetailsViewer', () => {
     expect(screen.getByDisplayValue('React'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }) as Element);
-    expect(getManualAttributions(store.getState()).uuid_1).toEqual(
+    expect(getManualAttributions(store.getState())?.uuid_1).toEqual(
       expectedPackageInfo
     );
   });

--- a/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
@@ -14,8 +14,8 @@ import {
   getResourcesToManualAttributions,
 } from '../../state/selectors/all-views-resource-selectors';
 import {
-  ProgressBarDataAndResourceId,
   ProgressBarData,
+  ProgressBarDataAndResourceId,
   ProgressBarWorkerArgs,
 } from '../../types/types';
 import { useAppSelector } from '../../state/hooks';

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -9,7 +9,7 @@ import MuiTab from '@mui/material/Tab';
 import { getManualData } from '../../state/selectors/all-views-resource-selectors';
 import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
 import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
-import { isEqual, remove } from 'lodash';
+import { remove } from 'lodash';
 import {
   getAttributionIdsOfSelectedResource,
   getDisplayedPackage,
@@ -80,10 +80,8 @@ export function ResourceDetailsTabs(
 
   const selectedPackage = useAppSelector(getDisplayedPackage);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
-  const attributionIdsOfSelectedResource: Array<string> = useAppSelector(
-    getAttributionIdsOfSelectedResource,
-    isEqual
-  );
+  const attributionIdsOfSelectedResource: Array<string> =
+    useAppSelector(getAttributionIdsOfSelectedResource) || [];
   const isAccordionSearchFieldDisplayed = useAppSelector(
     getIsAccordionSearchFieldDisplayed
   );

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -66,9 +66,8 @@ export function ResourceDetailsViewer(): ReactElement | null {
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const attributionIdsOfSelectedResourceClosestParent: Array<string> =
     useAppSelector(getAttributionIdsOfSelectedResourceClosestParent, isEqual);
-  const attributionIdsOfSelectedResource: Array<string> = useAppSelector(
-    getAttributionIdsOfSelectedResource,
-    isEqual
+  const attributionIdsOfSelectedResource: Array<string> | null = useAppSelector(
+    getAttributionIdsOfSelectedResource
   );
   const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
   const resourceIsAttributionBreakpoint = getAttributionBreakpointCheck(
@@ -84,7 +83,7 @@ export function ResourceDetailsViewer(): ReactElement | null {
     attributionIdsOfSelectedResourceClosestParent.length
   );
   const selectedResourceHasAttributions = Boolean(
-    attributionIdsOfSelectedResource.length
+    attributionIdsOfSelectedResource?.length
   );
 
   const showParentAttributions: boolean =

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -182,7 +182,9 @@ export function navigateToTargetResourceOrAttribution(): AppThunkAction {
     if (targetView) {
       dispatch(navigateToView(targetView));
     }
-    dispatch(setTemporaryPackageInfo(getPackageInfoOfSelected(getState())));
+    dispatch(
+      setTemporaryPackageInfo(getPackageInfoOfSelected(getState()) || {})
+    );
 
     dispatch(closePopup());
   };

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -333,7 +333,7 @@ describe('The savePackageInfo action', () => {
         emptyTestTemporaryPackageInfo
       )
     );
-    expect(getManualAttributions(testStore.getState())[testUuidA]).toBe(
+    expect(getManualAttributions(testStore.getState())?.[testUuidA]).toBe(
       undefined
     );
     expect(

--- a/src/Frontend/state/actions/resource-actions/navigation-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/navigation-actions.ts
@@ -44,14 +44,14 @@ export function resetTemporaryPackageInfo(): AppThunkAction {
       case View.Audit:
         dispatch(
           setTemporaryPackageInfo(
-            getAttributionOfDisplayedPackageInManualPanel(getState())
+            getAttributionOfDisplayedPackageInManualPanel(getState()) || {}
           )
         );
         break;
       case View.Attribution:
         dispatch(
           setTemporaryPackageInfo(
-            getPackageInfoOfSelectedAttribution(getState())
+            getPackageInfoOfSelectedAttribution(getState()) || {}
           )
         );
         break;

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -44,9 +44,9 @@ export function navigateToView(view: View): AppThunkAction {
     dispatch(setMultiSelectSelectedAttributionIds([]));
 
     const updatedTemporaryPackageInfo: PackageInfo =
-      view === View.Audit
+      (view === View.Audit
         ? getAttributionOfDisplayedPackageInManualPanel(getState())
-        : getPackageInfoOfSelectedAttribution(getState());
+        : getPackageInfoOfSelectedAttribution(getState())) || {};
     dispatch(setTemporaryPackageInfo(updatedTemporaryPackageInfo));
   };
 }

--- a/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
@@ -58,9 +58,9 @@ describe('getPackageInfoOfSelectedAttribution', () => {
       setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
 
-    expect(getPackageInfoOfSelectedAttribution(testStore.getState())).toEqual(
-      {}
-    );
+    expect(
+      getPackageInfoOfSelectedAttribution(testStore.getState())
+    ).toBeNull();
   });
 });
 

--- a/src/Frontend/state/selectors/__tests__/attribution-view-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/attribution-view-resource-selectors.test.ts
@@ -66,8 +66,8 @@ describe('The resource actions', () => {
     ]);
 
     testStore.dispatch(setSelectedAttributionId(testManualAttributionUuid_2));
-    expect(getResourceIdsOfSelectedAttribution(testStore.getState())).toEqual(
-      []
-    );
+    expect(
+      getResourceIdsOfSelectedAttribution(testStore.getState())
+    ).toBeNull();
   });
 });

--- a/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
@@ -58,7 +58,7 @@ describe('The audit view resource selectors', () => {
       packageName: 'test Package',
       licenseText: ' test License text',
     };
-    expect(getPackageInfoOfSelected(testStore.getState())).toMatchObject({});
+    expect(getPackageInfoOfSelected(testStore.getState())).toBeNull();
 
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -26,7 +26,7 @@ import {
   getAttributionOfDisplayedPackageInManualPanel,
 } from './audit-view-resource-selectors';
 import { getSelectedAttributionId } from './attribution-view-resource-selectors';
-import { getPopupAttributionId } from '../../state/selectors/view-selector';
+import { getPopupAttributionId } from './view-selector';
 
 export function getResources(state: State): Resources | null {
   return state.resourceState.allViews.resources;
@@ -37,7 +37,7 @@ export function getManualData(state: State): AttributionData {
 }
 
 export function getManualAttributions(state: State): Attributions {
-  return state.resourceState.allViews.manualData.attributions || {};
+  return state.resourceState.allViews.manualData.attributions;
 }
 
 export function getResourcesToManualAttributions(
@@ -121,18 +121,20 @@ export function getCurrentAttributionId(state: State): string | null {
   }
 }
 
-export function getPackageInfoOfSelectedAttribution(state: State): PackageInfo {
+export function getPackageInfoOfSelectedAttribution(
+  state: State
+): PackageInfo | null {
   const selectedAttributionId = getSelectedAttributionId(state);
 
   if (!selectedAttributionId) {
-    return {};
+    return null;
   }
   const attributions = getManualAttributions(state);
 
   return attributions[selectedAttributionId];
 }
 
-export function getPackageInfoOfSelected(state: State): PackageInfo {
+export function getPackageInfoOfSelected(state: State): PackageInfo | null {
   return getSelectedView(state) === View.Audit
     ? getAttributionOfDisplayedPackageInManualPanel(state)
     : getPackageInfoOfSelectedAttribution(state);
@@ -140,7 +142,8 @@ export function getPackageInfoOfSelected(state: State): PackageInfo {
 
 export function wereTemporaryPackageInfoModified(state: State): boolean {
   const temporaryPackageInfo: PackageInfo = getTemporaryPackageInfo(state);
-  const packageInfoOfSelected: PackageInfo = getPackageInfoOfSelected(state);
+  const packageInfoOfSelected: PackageInfo =
+    getPackageInfoOfSelected(state) || {};
 
   function hasPackageInfoChanged(): boolean {
     const temporaryPackageInfoWithoutConfidence = getStrippedPackageInfo(

--- a/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-view-resource-selectors.ts
@@ -16,14 +16,15 @@ export function getTargetSelectedAttributionId(state: State): string | null {
 
 export function getResourceIdsOfSelectedAttribution(
   state: State
-): Array<string> {
+): Array<string> | null {
   const attributionId = getSelectedAttributionId(state);
   const manualAttributionsToResources = getManualAttributionsToResources(state);
 
   if (attributionId in manualAttributionsToResources) {
     return manualAttributionsToResources[attributionId];
   }
-  return [];
+
+  return null;
 }
 
 export function getMultiSelectSelectedAttributionIds(

--- a/src/Frontend/state/selectors/audit-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/audit-view-resource-selectors.ts
@@ -66,19 +66,19 @@ function getAttributionsOfSelectedResourceClosestParent(
 
 export function getAttributionIdsOfSelectedResource(
   state: State
-): Array<string> {
+): Array<string> | null {
   const selectedResourceId = getSelectedResourceId(state);
   const resourcesToManualAttributions = getResourcesToManualAttributions(state);
   if (selectedResourceId in resourcesToManualAttributions) {
     return resourcesToManualAttributions[selectedResourceId];
   }
 
-  return [];
+  return null;
 }
 
 export function getAttributionsOfSelectedResource(state: State): Attributions {
   const attributionIdsOfSelectedResource: Array<string> =
-    getAttributionIdsOfSelectedResource(state);
+    getAttributionIdsOfSelectedResource(state) || [];
   const manualAttributions: Attributions = getManualAttributions(state);
 
   return getFilteredAttributionsById(
@@ -108,15 +108,15 @@ export function getAttributionIdOfDisplayedPackageInManualPanel(
 
 export function getAttributionOfDisplayedPackageInManualPanel(
   state: State
-): PackageInfo {
+): PackageInfo | null {
   const attributionId: string | null =
     getAttributionIdOfDisplayedPackageInManualPanel(state);
   if (attributionId) {
-    const manualAttributions: Attributions = getManualAttributions(state);
+    const manualAttributions: Attributions = getManualAttributions(state) || {};
     return manualAttributions[attributionId];
   }
 
-  return {};
+  return null;
 }
 
 export function getIsAccordionSearchFieldDisplayed(state: State): boolean {

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -29,6 +29,7 @@ export function getTargetView(state: State): View | null {
 
 export function getOpenPopup(state: State): null | PopupType {
   const popup = state.viewState.popupInfo.slice(-1);
+
   return popup.length === 1 ? popup[0].popup : null;
 }
 
@@ -38,7 +39,8 @@ export function getActiveFilters(state: State): Set<FilterType> {
 
 export function getPopupAttributionId(state: State): string | null {
   const popup = state.viewState.popupInfo.slice(-1);
-  return popup.length === 1 ? popup[0].attributionId ?? null : null;
+
+  return (popup.length === 1 && popup[0].attributionId) || null;
 }
 
 export function getIsLoading(state: State): boolean {


### PR DESCRIPTION
### Summary of changes

Selectors have been rewritten to return null instead of {} or [] created in the selector itself.

### Context and reason for change

Empty object or arrays created in the selector themselves should never be returned. They cause unnecessary re-renders and degraded performances. For examplle by navigation in the resource tree.
