### PR TITLE
Decouple copyright attribution package sub panel

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ChangeEvent, ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement, useMemo } from 'react';
 
 import { PackageInfo } from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -246,6 +246,27 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     !props.displayPackageInfo.firstParty &&
     !props.displayPackageInfo.excludeFromNotice;
 
+  const copyrightSubPanel = useMemo(
+    () => (
+      <CopyrightSubPanel
+        setUpdateTemporaryPackageInfoFor={
+          props.setUpdateTemporaryPackageInfoFor
+        }
+        isEditable={props.isEditable}
+        copyright={props.displayPackageInfo.copyright}
+        copyrightRows={copyrightRows}
+        showHighlight={showHighlight}
+      />
+    ),
+    [
+      props.setUpdateTemporaryPackageInfoFor,
+      props.isEditable,
+      props.displayPackageInfo.copyright,
+      copyrightRows,
+      showHighlight,
+    ]
+  );
+
   return (
     <MuiBox sx={classes.root}>
       <PackageSubPanel
@@ -263,15 +284,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         }}
         showHighlight={showHighlight}
       />
-      <CopyrightSubPanel
-        setUpdateTemporaryPackageInfoFor={
-          props.setUpdateTemporaryPackageInfoFor
-        }
-        isEditable={props.isEditable}
-        displayPackageInfo={props.displayPackageInfo}
-        copyrightRows={copyrightRows}
-        showHighlight={showHighlight}
-      />
+      {copyrightSubPanel}
       <LicenseSubPanel
         isLicenseTextShown={isLicenseTextShown}
         displayPackageInfo={props.displayPackageInfo}

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -5,7 +5,6 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { PackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
@@ -13,7 +12,7 @@ import MuiBox from '@mui/material/Box';
 
 interface CopyrightSubPanelProps {
   isEditable: boolean;
-  displayPackageInfo: PackageInfo;
+  copyright?: string;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
@@ -29,17 +28,16 @@ export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
           isEditable={props.isEditable}
           sx={attributionColumnClasses.textBox}
           title={'Copyright'}
-          text={props.displayPackageInfo.copyright}
+          text={props.copyright}
           minRows={props.copyrightRows}
           maxRows={props.copyrightRows}
           multiline={true}
           handleChange={props.setUpdateTemporaryPackageInfoFor('copyright')}
           isHighlighted={
             props.showHighlight &&
-            isImportantAttributionInformationMissing(
-              'copyright',
-              props.displayPackageInfo
-            )
+            isImportantAttributionInformationMissing('copyright', {
+              copyright: props.copyright,
+            })
           }
         />
       </MuiBox>

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -79,7 +79,7 @@ export function AttributionDetailsViewer(): ReactElement | null {
   }, [dispatch, selectedAttributionId, temporaryPackageInfo]);
 
   const setUpdateTemporaryPackageInfoFor =
-    setUpdateTemporaryPackageInfoForCreator(dispatch, temporaryPackageInfo);
+    setUpdateTemporaryPackageInfoForCreator(dispatch);
 
   function deleteAttribution(): void {
     if (temporaryPackageInfo.preSelected) {

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -28,7 +28,7 @@ export function EditAttributionPopup(): ReactElement {
   const popupAttributionId = useAppSelector(getPopupAttributionId);
   const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
   const setUpdateTemporaryPackageInfoFor =
-    setUpdateTemporaryPackageInfoForCreator(dispatch, temporaryPackageInfo);
+    setUpdateTemporaryPackageInfoForCreator(dispatch);
 
   const saveFileRequestListener = useCallback(() => {
     dispatch(

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
@@ -162,6 +162,11 @@ export function ResourceDetailsAttributionColumn(
     displayedPackage?.panel === PackagePanelTitle.ManualPackages &&
     selectedResourceIsAttributionBreakpoint;
 
+  const setUpdateTemporaryPackageInfoFor = useMemo(
+    () => setUpdateTemporaryPackageInfoForCreator(dispatch),
+    [dispatch]
+  );
+
   return selectedResourceId &&
     displayedPackage &&
     !manualAttributionsOfBreakpointSelected ? (
@@ -176,10 +181,7 @@ export function ResourceDetailsAttributionColumn(
       showParentAttributions={props.showParentAttributions}
       showSaveGloballyButton={showSaveGloballyButton}
       hideDeleteButtons={hideDeleteButtons}
-      setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoForCreator(
-        dispatch,
-        temporaryPackageInfo
-      )}
+      setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoFor}
       onSaveButtonClick={
         showSaveGloballyButton
           ? dispatchUnlinkAttributionAndSavePackageInfo

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -57,6 +57,7 @@ import {
   savePackageInfoIfSavingIsNotDisabled,
   setIsSavingDisabled,
   unlinkAttributionAndSavePackageInfo,
+  updateTemporaryPackageInfo,
 } from '../save-actions';
 import { getOpenPopup } from '../../../selectors/view-selector';
 
@@ -100,6 +101,33 @@ const testResourcesToExternalAttributions: ResourcesToAttributions = {
   '/root/src/something.js': ['uuid_1'],
   '/root/readme.md': ['uuid_1'],
 };
+
+describe('The updateTemporaryPackageInfo action', () => {
+  it('updates the existing package infos', () => {
+    const startingTemporaryPackageInfo: PackageInfo = {
+      packageVersion: '1.1',
+      packageName: 'test Package',
+    };
+    const newPackageName = 'New Package Name';
+    const expectedFinalTemporaryPackageInfo: PackageInfo = {
+      ...startingTemporaryPackageInfo,
+      packageName: newPackageName,
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(setTemporaryPackageInfo(startingTemporaryPackageInfo));
+    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(
+      startingTemporaryPackageInfo
+    );
+
+    testStore.dispatch(
+      updateTemporaryPackageInfo({ packageName: newPackageName })
+    );
+    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(
+      expectedFinalTemporaryPackageInfo
+    );
+  });
+});
 
 describe('The savePackageInfo action', () => {
   it('does not save if saving is disabled', () => {

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -20,6 +20,7 @@ import {
   getManualAttributions,
   getManualAttributionsToResources,
   getResourcesToManualAttributions,
+  getTemporaryPackageInfo,
   wereTemporaryPackageInfoModified,
 } from '../../selectors/all-views-resource-selectors';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
@@ -56,6 +57,7 @@ import { getAttributionBreakpointCheckForState } from '../../../util/is-attribut
 import { openPopup } from '../view-actions/view-actions';
 import { getMultiSelectSelectedAttributionIds } from '../../selectors/attribution-view-resource-selectors';
 import { setMultiSelectSelectedAttributionIds } from './attribution-view-simple-actions';
+import { setTemporaryPackageInfo } from './all-views-simple-actions';
 
 export function setIsSavingDisabled(
   isSavingDisabled: boolean
@@ -63,6 +65,19 @@ export function setIsSavingDisabled(
   return {
     type: ACTION_SET_IS_SAVING_DISABLED,
     payload: isSavingDisabled,
+  };
+}
+
+export function updateTemporaryPackageInfo(
+  packageInfo: PackageInfo
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    dispatch(
+      setTemporaryPackageInfo({
+        ...getTemporaryPackageInfo(getState()),
+        ...packageInfo,
+      })
+    );
   };
 }
 

--- a/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
+++ b/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
@@ -4,13 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChangeEvent } from 'react';
-import { PackageInfo } from '../../shared/shared-types';
 import { AppThunkDispatch } from '../state/types';
-import { setTemporaryPackageInfo } from '../state/actions/resource-actions/all-views-simple-actions';
+import { updateTemporaryPackageInfo } from '../state/actions/resource-actions/save-actions';
 
 export function setUpdateTemporaryPackageInfoForCreator(
-  dispatch: AppThunkDispatch,
-  temporaryPackageInfo: PackageInfo
+  dispatch: AppThunkDispatch
 ) {
   return (propertyToUpdate: string) => {
     return (
@@ -21,8 +19,7 @@ export function setUpdateTemporaryPackageInfoForCreator(
           ? parseInt(event.target.value)
           : event.target.value;
       dispatch(
-        setTemporaryPackageInfo({
-          ...temporaryPackageInfo,
+        updateTemporaryPackageInfo({
           [propertyToUpdate]: newValue,
         })
       );


### PR DESCRIPTION
### Summary of changes

The copyright sub panel will re-render only when the copyright field gets modified.

### Context and reason for change

The app can lag if typing is really fast in the comment field. This would be the first of several similar changes to just re-render the modified subpanel, instead of all of them + the button below them.

### How can the changes be tested

WIP