### PR TITLE
Decouple project statistics popup from its constituents

### DIFF
--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -5,11 +5,7 @@
 
 import React, { ReactElement } from 'react';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
-import {
-  AttributionCountPerSourcePerLicense,
-  LicenseNamesWithCriticality,
-} from '../../types/types';
-import { SOURCE_TOTAL, LICENSE_TOTAL } from '../../shared-constants';
+import { LicenseCounts, LicenseNamesWithCriticality } from '../../types/types';
 
 const classes = {
   container: {
@@ -20,9 +16,10 @@ const classes = {
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
 const FOOTER_TITLE = 'Total';
+const TOTAL_SOURCES_TITLE = 'Total';
 
 interface AttributionCountPerSourcePerLicenseTableProps {
-  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
+  licenseCounts: LicenseCounts;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
   title: string;
 }
@@ -30,33 +27,38 @@ interface AttributionCountPerSourcePerLicenseTableProps {
 export function AttributionCountPerSourcePerLicenseTable(
   props: AttributionCountPerSourcePerLicenseTableProps
 ): ReactElement {
-  const sourceNamesOrTotal = Object.keys(
-    props.attributionCountPerSourcePerLicense[LICENSE_TOTAL]
-  );
-  sourceNamesOrTotal.splice(sourceNamesOrTotal.indexOf(SOURCE_TOTAL), 1);
-  sourceNamesOrTotal.push(SOURCE_TOTAL);
-  const sourceNamesRow = [LICENSE_COLUMN_NAME_IN_TABLE].concat(
-    sourceNamesOrTotal
+  const sourceNames = Object.keys(
+    props.licenseCounts.totalAttributionsPerSource
   );
 
-  const valuesSourceTotals: Array<string> = sourceNamesOrTotal.map(
-    (sourceName) =>
-      props.attributionCountPerSourcePerLicense[LICENSE_TOTAL][
-        sourceName
-      ].toString()
+  const totalNumberOfAttributionsPerSource = sourceNames.map((sourceName) =>
+    props.licenseCounts.totalAttributionsPerSource[sourceName].toString()
   );
+  const totalNumberOfAttributions = Object.values(
+    props.licenseCounts.totalAttributionsPerSource
+  )
+    .reduce((partialSum, num) => partialSum + num, 0)
+    .toString();
+
+  const footerRow = [FOOTER_TITLE]
+    .concat(totalNumberOfAttributionsPerSource)
+    .concat(totalNumberOfAttributions);
+  const headerRow = [LICENSE_COLUMN_NAME_IN_TABLE]
+    .concat(sourceNames)
+    .concat(TOTAL_SOURCES_TITLE)
+    .map(
+      (sourceName) => sourceName.charAt(0).toUpperCase() + sourceName.slice(1)
+    );
 
   return (
     <ProjectLicensesTable
       title={props.title}
       containerStyle={classes.container}
-      columnHeaders={sourceNamesRow.map(
-        (sourceName) => sourceName.charAt(0).toUpperCase() + sourceName.slice(1)
-      )}
-      columnNames={sourceNamesRow}
+      columnHeaders={headerRow}
+      columnNames={headerRow}
       rowNames={Object.keys(props.licenseNamesWithCriticality).sort()}
-      tableContent={props.attributionCountPerSourcePerLicense}
-      tableFooter={[FOOTER_TITLE].concat(valuesSourceTotals)}
+      tableContent={props.licenseCounts.attributionCountPerSourcePerLicense}
+      tableFooter={footerRow}
       licenseNamesWithCriticality={props.licenseNamesWithCriticality}
     />
   );

--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -6,11 +6,7 @@
 import React, { ReactElement } from 'react';
 import { Criticality } from '../../../shared/shared-types';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
-import {
-  AttributionCountPerSourcePerLicense,
-  LicenseNamesWithCriticality,
-} from '../../types/types';
-import { SOURCE_TOTAL } from '../../shared-constants';
+import { LicenseNamesWithCriticality } from '../../types/types';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
 const AMOUNT_COLUMN_NAME_IN_TABLE = 'Amount';
@@ -29,7 +25,7 @@ const classes = {
 };
 
 interface CriticalLicensesTableProps {
-  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
+  totalAttributionsPerLicense: { [licenseName: string]: number };
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
   title: string;
 }
@@ -55,12 +51,12 @@ export function CriticalLicensesTable(
   );
   const highCriticalityLicensesTotalAttributions =
     getCriticalLicenseNamesWithTheirTotalAttributions(
-      props.attributionCountPerSourcePerLicense,
+      props.totalAttributionsPerLicense,
       highCriticalityLicenseNames
     );
   const mediumCriticalityLicensesTotalAttributions =
     getCriticalLicenseNamesWithTheirTotalAttributions(
-      props.attributionCountPerSourcePerLicense,
+      props.totalAttributionsPerLicense,
       mediumCriticalityLicenseNames
     );
   const criticalLicensesTotalAttributions =
@@ -112,7 +108,7 @@ function getLicenseNamesByCriticality(
 }
 
 function getCriticalLicenseNamesWithTheirTotalAttributions(
-  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense,
+  totalAttributionsPerLicense: { [licenseName: string]: number },
   criticalLicenseNames: Array<string>
 ): Array<{ licenseName: string; totalNumberOfAttributions: number }> {
   const licenseNamesAndTheirTotalAttributions = criticalLicenseNames.map(
@@ -120,9 +116,7 @@ function getCriticalLicenseNamesWithTheirTotalAttributions(
       return {
         licenseName: criticalLicenseName,
         totalNumberOfAttributions:
-          attributionCountPerSourcePerLicense[criticalLicenseName][
-            SOURCE_TOTAL
-          ],
+          totalAttributionsPerLicense[criticalLicenseName],
       };
     }
   );

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -43,7 +43,7 @@ export function ProjectStatisticsPopup(): ReactElement {
   const strippedLicenseNameToAttribution =
     getUniqueLicenseNameToAttribution(externalAttributions);
 
-  const { attributionCountPerSourcePerLicense, licenseNamesWithCriticality } =
+  const { licenseCounts, licenseNamesWithCriticality } =
     aggregateLicensesAndSourcesFromAttributions(
       externalAttributions,
       strippedLicenseNameToAttribution,
@@ -53,12 +53,10 @@ export function ProjectStatisticsPopup(): ReactElement {
   const manualAttributionPropertyCounts =
     aggregateAttributionPropertiesFromAttributions(manualAttributions);
 
-  const mostFrequentLicenseCountData = getMostFrequentLicenses(
-    attributionCountPerSourcePerLicense
-  );
+  const mostFrequentLicenseCountData = getMostFrequentLicenses(licenseCounts);
 
   const criticalSignalsCountData = getCriticalSignalsCount(
-    attributionCountPerSourcePerLicense,
+    licenseCounts,
     licenseNamesWithCriticality
   );
 
@@ -89,8 +87,8 @@ export function ProjectStatisticsPopup(): ReactElement {
                 }
               />
               <CriticalLicensesTable
-                attributionCountPerSourcePerLicense={
-                  attributionCountPerSourcePerLicense
+                totalAttributionsPerLicense={
+                  licenseCounts.totalAttributionsPerLicense
                 }
                 licenseNamesWithCriticality={licenseNamesWithCriticality}
                 title={ProjectStatisticsPopupTitle.CriticalLicensesTable}
@@ -119,13 +117,9 @@ export function ProjectStatisticsPopup(): ReactElement {
             </MuiBox>
           </MuiBox>
           <AttributionCountPerSourcePerLicenseTable
-            attributionCountPerSourcePerLicense={
-              attributionCountPerSourcePerLicense
-            }
+            licenseCounts={licenseCounts}
             licenseNamesWithCriticality={licenseNamesWithCriticality}
-            title={
-              ProjectStatisticsPopupTitle.AttributionCountPerSourcePerLicenseTable
-            }
+            title={ProjectStatisticsPopupTitle.LicenseCountsTable}
           />
         </>
       }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -77,7 +77,7 @@ export enum CheckboxLabel {
 }
 
 export enum ProjectStatisticsPopupTitle {
-  AttributionCountPerSourcePerLicenseTable = 'Signals per Sources',
+  LicenseCountsTable = 'Signals per Sources',
   AttributionPropertyCountTable = 'Attributions Overview',
   CriticalLicensesTable = 'Critical Licenses',
   PieChartsSectionHeader = 'Pie Charts',

--- a/src/Frontend/shared-constants.ts
+++ b/src/Frontend/shared-constants.ts
@@ -9,9 +9,6 @@ import {
   ProjectMetadata,
 } from '../shared/shared-types';
 
-export const SOURCE_TOTAL = 'Total';
-export const LICENSE_TOTAL = 'Total';
-
 export const EMPTY_ATTRIBUTION_DATA: AttributionData = {
   attributions: {},
   resourcesToAttributions: {},

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -119,8 +119,14 @@ export interface PieChartData {
   count: number;
 }
 
+export interface LicenseCounts {
+  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
+  totalAttributionsPerLicense: { [licenseName: string]: number };
+  totalAttributionsPerSource: { [sourceName: string]: number };
+}
+
 export interface AttributionCountPerSourcePerLicense {
-  [licenseNameOrTotal: string]: { [sourceNameOrTotal: string]: number };
+  [licenseName: string]: { [sourceName: string]: number };
 }
 
 export interface LicenseNamesWithCriticality {


### PR DESCRIPTION
### Summary of changes

Decouple project statistics popup from its constituents. The main change is to remove global constants 
```
export const SOURCE_TOTAL = 'Total';
export const LICENSE_TOTAL = 'Total';
```
and to replace the following interface:

```
export interface AttributionCountPerSourcePerLicense {
  [licenseName: string]: { [sourceName: string]: number };
}
```
by

```
export interface LicenseCounts {
  attributionCountPerSourcePerLicense: AttributionCountPerSourcePerLicense;
  totalAttributionsPerLicense: { [licenseName: string]: number };
  totalAttributionsPerSource: { [sourceName: string]: number };
}
```


### Context and reason for change

Fix: #1194

