### PR TITLE
Make URLs in ReportView clickable

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -16,6 +16,7 @@ import { FetchLicenseInformationButton } from '../FetchLicenseInformationButton/
 import { SearchPackagesIcon } from '../Icons/Icons';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
+import { openUrl } from '../../util/open-url';
 
 const iconClasses = { clickableIcon, disabledIcon };
 
@@ -34,19 +35,6 @@ interface PackageSubPanelProps {
 }
 
 export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
-  function openUrl(): void {
-    let urlString = props.displayPackageInfo.url;
-    if (urlString) {
-      if (
-        !urlString.startsWith('https://') &&
-        !urlString.startsWith('http://')
-      ) {
-        urlString = 'https://' + urlString;
-      }
-      window.electronAPI.openLink(urlString);
-    }
-  }
-
   const openLinkButtonTooltip = props.displayPackageInfo.url
     ? 'Open link in browser'
     : 'No link to open. Please enter a URL.';
@@ -140,7 +128,10 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
             <IconButton
               tooltipTitle={openLinkButtonTooltip}
               tooltipPlacement="right"
-              onClick={openUrl}
+              onClick={(): void => {
+                props.displayPackageInfo.url &&
+                  openUrl(props.displayPackageInfo.url);
+              }}
               disabled={!props.displayPackageInfo.url}
               icon={
                 <OpenInNewIcon

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement, ReactText } from 'react';
+import React, { ReactElement } from 'react';
 import { getFormattedCellData } from './report-table-item-helpers';
 import MuiTypography from '@mui/material/Typography';
 import {
@@ -27,6 +27,8 @@ import {
 import { getFrequentLicensesTexts } from '../../state/selectors/all-views-resource-selectors';
 import { useAppSelector } from '../../state/hooks';
 import MuiBox from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
+import { openUrl } from '../../util/open-url';
 
 export const reportTableRowHeight = 190;
 const padding = 10;
@@ -238,7 +240,7 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
   }
 
   function getCellData(
-    cellData: ReactText,
+    cellData: string | number,
     attributionProperty: keyof AttributionInfo
   ): ReactElement {
     if (attributionProperty === 'resources' && typeof cellData === 'string') {
@@ -257,7 +259,12 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
     } else if (attributionProperty === 'url') {
       return (
         <MuiBox sx={reportTableItemClasses.containerWithoutLineBreak}>
-          {cellData}
+          <MuiLink
+            component="button"
+            onClick={(): void => openUrl(cellData.toString())}
+          >
+            {cellData}
+          </MuiLink>
         </MuiBox>
       );
     }

--- a/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
+++ b/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
@@ -7,14 +7,13 @@ import { AttributionInfo } from '../../../shared/shared-types';
 import { TableConfig } from '../Table/Table';
 import { PathPredicate } from '../../types/types';
 import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
-import { ReactText } from 'react';
 
 export function getFormattedCellData(
   config: TableConfig,
   attributionInfo: AttributionInfo,
   isFileWithChildren: PathPredicate
-): ReactText {
-  let cellData: ReactText;
+): string | number {
+  let cellData: string | number;
   switch (config.attributionProperty) {
     case 'resources':
       cellData = attributionInfo[config.attributionProperty]

--- a/src/Frontend/util/__tests__/open-url.test.ts
+++ b/src/Frontend/util/__tests__/open-url.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { openUrl } from '../open-url';
+
+describe('openUrl', () => {
+  it('checks protocol is getting added if originally missing', () => {
+    const urlString = 'www.google.com';
+    openUrl(urlString);
+    expect(window.electronAPI.openLink).toHaveBeenCalledWith(
+      'https://' + urlString
+    );
+  });
+
+  it('does not add protocol if originally present', () => {
+    const urlString = 'https://www.google.com';
+    openUrl(urlString);
+    expect(window.electronAPI.openLink).toHaveBeenCalledWith(urlString);
+  });
+});

--- a/src/Frontend/util/open-url.ts
+++ b/src/Frontend/util/open-url.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function openUrl(urlString: string): void {
+  if (!urlString.startsWith('https://') && !urlString.startsWith('http://')) {
+    urlString = 'https://' + urlString;
+  }
+  window.electronAPI.openLink(urlString);
+}


### PR DESCRIPTION
### Summary of changes

Make URLs in ReportView clickable

### Context and reason for change

Fix: #1222

### How can the changes be tested

If no URLs are present in the ReportView, click on button to edit the table row and add a URL, and then click on it to test it.

