### PR TITLE
Improve statistics popup

### DIFF
--- a/src/Frontend/Components/AccordionWithPieChart/AccordionWithPieChart.tsx
+++ b/src/Frontend/Components/AccordionWithPieChart/AccordionWithPieChart.tsx
@@ -37,6 +37,7 @@ const classes = {
 interface AccordionProps {
   data: Array<PieChartData>;
   title: string;
+  defaultExpanded?: boolean;
 }
 
 export function getColorsForPieChart(
@@ -75,7 +76,11 @@ export function AccordionWithPieChart(
   }
 
   return (
-    <MuiAccordion sx={classes.accordion} disableGutters>
+    <MuiAccordion
+      sx={classes.accordion}
+      disableGutters
+      defaultExpanded={props.defaultExpanded}
+    >
       <MuiAccordionSummary
         sx={classes.accordionSummary}
         expandIcon={<ExpandMoreIcon sx={classes.accordionTitle} />}

--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -9,11 +9,11 @@ import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTab
 import { LicenseNamesWithCriticality } from '../../types/types';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
-const AMOUNT_COLUMN_NAME_IN_TABLE = 'Amount';
+const COUNT_COLUMN_NAME_IN_TABLE = 'Count';
 const FOOTER_TITLE = 'Total';
 const TABLE_COLUMN_NAMES = [
   LICENSE_COLUMN_NAME_IN_TABLE,
-  AMOUNT_COLUMN_NAME_IN_TABLE,
+  COUNT_COLUMN_NAME_IN_TABLE,
 ];
 
 const classes = {
@@ -77,7 +77,7 @@ export function CriticalLicensesTable(
         criticalLicensesTotalAttributions.map(
           ({ licenseName, totalNumberOfAttributions }) => [
             licenseName,
-            { [AMOUNT_COLUMN_NAME_IN_TABLE]: totalNumberOfAttributions },
+            { [COUNT_COLUMN_NAME_IN_TABLE]: totalNumberOfAttributions },
           ]
         )
       )}

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -105,6 +105,7 @@ export function ProjectStatisticsPopup(): ReactElement {
                 title={
                   ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart
                 }
+                defaultExpanded={true}
               />
               <AccordionWithPieChart
                 data={criticalSignalsCountData}


### PR DESCRIPTION

### Summary of changes

Open first pie chart by default and rename "amount" to "count".

### Context and reason for change

It is nice to show a pie chart initially.

### How can the changes be tested


After:
![Screenshot 2022-12-22 at 08 17 20](https://user-images.githubusercontent.com/46576389/209079637-e9a1793b-1f3b-4910-a31f-6ca96029eb68.png)

Before:
![Screenshot 2022-12-22 at 08 22 15](https://user-images.githubusercontent.com/46576389/209079779-a1f0360c-25af-41cf-b048-8295094e31f7.png)
