### PR TITLE
Fix bugs that prevent package data to be fetched from github and npmjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^4.20.4",
     "@types/recharts": "^1.8.24",
     "axios": "^1.2.1",
+    "buffer": "^6.0.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-is-dev": "^2.0.0",
     "electron-log": "^4.4.8",

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -11,24 +11,6 @@ import upath from 'upath';
 import { createMenu } from './menu';
 import { getIconPath } from './iconHelpers';
 
-const filter = {
-  urls: ['https://registry.npmjs.org/*'],
-};
-
-function allowCORS(mainWindow: Electron.BrowserWindow): void {
-  mainWindow.webContents.session.webRequest.onHeadersReceived(
-    filter,
-    (details, callback) => {
-      callback({
-        responseHeaders: {
-          'Access-Control-Allow-Origin': ['http://localhost:3000'],
-          ...details.responseHeaders,
-        },
-      });
-    }
-  );
-}
-
 export async function createWindow(): Promise<BrowserWindow> {
   const mainWindow: BrowserWindow = new BrowserWindow({
     width: 1920,
@@ -44,9 +26,6 @@ export async function createWindow(): Promise<BrowserWindow> {
 
   Menu.setApplicationMenu(createMenu(mainWindow));
   await loadApplication(mainWindow, '', '../../index.html', true);
-
-  // Electron is running on localhost, CORS needs to allow requests from there
-  allowCORS(mainWindow);
 
   return mainWindow;
 }

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -64,24 +64,6 @@ describe('FetchLicenseInformationButton', () => {
       ).resolves.toBeInTheDocument();
     });
 
-    it("shows fetching error 'Buffer is not defined'", () => {
-      const MOCK_URL = 'https://github.com/opossum-tool/OpossumUI/';
-
-      axiosMock.onGet(MOCK_URL).replyOnce(200, {});
-
-      renderComponentWithStore(
-        <FetchLicenseInformationButton url={MOCK_URL} isDisabled={false} />
-      );
-
-      fireEvent.click(screen.getByRole('button'));
-
-      expect(
-        waitFor(() => {
-          screen.getByLabelText('Buffer is not defined');
-        })
-      ).resolves.toBeInTheDocument();
-    });
-
     it("shows fetching error 'Request failed with status code 404'", () => {
       const MOCK_URL = 'https://github.com/opossum-tool/Oposs';
 

--- a/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
+++ b/src/Frontend/Components/FetchLicenseInformationButton/github-fetching-helpers.ts
@@ -5,6 +5,7 @@
 
 import { PackageInfo } from '../../../shared/shared-types';
 import { Schema, Validator } from 'jsonschema';
+import { Buffer } from 'buffer';
 
 const jsonSchemaValidator = new Validator();
 
@@ -59,9 +60,11 @@ export function convertGithubPayload(payload: unknown): PackageInfo {
 
   const { namespace, packageName } =
     getPackageNamespaceAndPackageNameFromGithubURL(validatedPayload.html_url);
+
   const licenseText = validatedPayload.content
     ? Buffer.from(validatedPayload.content, 'base64').toString()
     : undefined;
+
   return {
     licenseName: validatedPayload.license.spdx_id,
     licenseText,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,6 +3600,14 @@ buffer@^5.1.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 builder-util-runtime@9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.1.1.tgz#2da7b34e78a64ad14ccd070d6eed4662d893bd60"
@@ -6285,7 +6293,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
### Summary of changes

Github: the `buffer` package was installed and imported to facilitate conversion from base64 to utf-8.
Npmjs: a backend function was removed that manually extended the http response header to allow cross-origin resource sharing. This manual extension of the header is not required anymore.

### Context and reason for change

When trying to fetch package data from github, a 'Buffer is not defined' error is thrown. Fetching data from npmjs results in a 'Network error'.

Fix: #1260