### PR TITLE
Attribution Wizard: Add package card context menu and wizard popup skeleton

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import MuiBox from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
+import { doNothing } from '../../util/do-nothing';
+import { OpossumColors } from '../../shared-styles';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { ButtonText } from '../../enums/enums';
+import { useAppDispatch } from '../../state/hooks';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { PathBar } from '../PathBar/PathBar';
+
+// TODO: const POPUP_CONTENT_PADDING = 48; monitored in upcoming tickets
+const attributionWizardPopupHeader = 'Attribution Wizard';
+
+const classes = {
+  dialogContent: {
+    // TODO: required later
+  },
+  dialogHeader: {
+    whiteSpace: 'nowrap',
+    // TODO: width: `calc(100% - ${POPUP_CONTENT_PADDING}px)`,  monitored in upcoming tickets
+  },
+
+  mainContent: {
+    borderRadius: 2,
+    paddingTop: '0px',
+    background: OpossumColors.white,
+  },
+  mainContentBox: {
+    padding: '4px',
+    borderRadius: 2,
+    marginTop: '8px',
+    background: OpossumColors.lightBlue,
+  },
+  pathBar: {
+    paddingLeft: '5px',
+    paddingRight: '5px',
+    paddingTop: '1px',
+    paddingBottom: '1px',
+  },
+  pathBarBox: {
+    padding: '4px',
+    background: OpossumColors.lightBlue,
+  },
+};
+
+export function AttributionWizardPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+
+  function closeAttributionWizardPopup(): void {
+    dispatch(closePopup());
+  }
+
+  // TODO: const selectedAttributionId = useAppSelector(getPopupAttributionId);  for later
+  // TODO: const selectedResourceId = useSelector(getSelectedResourceId);  for later
+  const nextButtonConfig = {
+    buttonText: ButtonText.Next,
+    onClick: doNothing,
+    isDisabled: true,
+  };
+  const closeButtonConfig = {
+    buttonText: ButtonText.Cancel,
+    onClick: closeAttributionWizardPopup,
+    isDisabled: false,
+  };
+
+  const testContent = (
+    <MuiBox style={classes.dialogContent}>
+      <MuiBox sx={classes.pathBarBox}>
+        <PathBar sx={classes.pathBar} />
+      </MuiBox>
+      <MuiBox sx={classes.mainContentBox}>
+        <MuiBox sx={classes.mainContent}>
+          <MuiTypography
+            sx={{
+              textAlign: 'center',
+              width: '300px',
+              height: '300px',
+            }}
+          >
+            Content dummy
+          </MuiTypography>
+        </MuiBox>
+      </MuiBox>
+    </MuiBox>
+  );
+  return (
+    <NotificationPopup
+      header={attributionWizardPopupHeader}
+      leftButtonConfig={nextButtonConfig}
+      rightButtonConfig={closeButtonConfig}
+      onBackdropClick={closeAttributionWizardPopup}
+      onEscapeKeyDown={closeAttributionWizardPopup}
+      isOpen={true}
+      fullWidth={false}
+      headerSx={classes.dialogHeader}
+      content={testContent}
+    />
+  );
+}

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { AttributionWizardPopup } from '../AttributionWizardPopup';
+import { fireEvent, screen } from '@testing-library/react';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { ButtonText, PopupType } from '../../../enums/enums';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
+import { openPopup } from '../../../state/actions/view-actions/view-actions';
+
+describe('Attribution Wizard Popup', () => {
+  it('renders with header, resource path, and buttons', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+
+    expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
+    expect(screen.getByText('/thirdParty')).toBeInTheDocument();
+    expect(screen.getByText(ButtonText.Cancel)).toBeInTheDocument();
+    expect(screen.getByText(ButtonText.Next)).toBeInTheDocument();
+  });
+
+  it('closes when clicking "cancel"', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+    testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_1'));
+
+    fireEvent.click(screen.getByText(ButtonText.Cancel));
+    expect(getOpenPopup(testStore.getState())).toBe(null);
+  });
+});

--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -24,6 +24,7 @@ import { OpossumColors } from '../../shared-styles';
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 
 const classes = {
   icon: {
@@ -54,6 +55,7 @@ const BUTTON_TITLE_TO_ICON_MAP: {
   [ButtonText.ShowResources]: <OpenInBrowserIcon fontSize="small" />,
   [ButtonText.Hide]: <VisibilityOffIcon fontSize="small" />,
   [ButtonText.Unhide]: <VisibilityIcon fontSize="small" />,
+  [ButtonText.OpenAttributionWizardPopup]: <AutoFixHighIcon fontSize="small" />,
 };
 
 export interface ContextMenuItem {

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -20,6 +20,7 @@ import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPo
 import { EditAttributionPopup } from '../EditAttributionPopup/EditAttributionPopup';
 import { PackageSearchPopup } from '../PackageSearchPopup/PackageSearchPopup';
 import { ChangedInputFilePopup } from '../ChangedInputFilePopup/ChangedInputFilePopup';
+import { AttributionWizardPopup } from '../AttributionWizardPopup/AttributionWizardPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -49,6 +50,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <PackageSearchPopup />;
     case PopupType.ChangedInputFilePopup:
       return <ChangedInputFilePopup />;
+    case PopupType.AttributionWizardPopup:
+      return <AttributionWizardPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -138,4 +138,14 @@ describe('The GlobalPopUp', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('opens the AttributionWizardPopup', () => {
+    const { store } = renderComponentWithStore(<GlobalPopup />);
+    act(() => {
+      store.dispatch(
+        openPopup(PopupType.AttributionWizardPopup, 'test_attribution_id')
+      );
+    });
+    expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
+  });
 });

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -316,6 +316,16 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             },
             hidden: mergeButtonDisplayState.hideReplaceMarkedByButton,
           },
+          {
+            buttonText: ButtonText.OpenAttributionWizardPopup,
+            disabled: true,
+            hidden: isExternalAttribution || hideResourceSpecificButtons,
+            onClick: (): void => {
+              dispatch(
+                openPopup(PopupType.AttributionWizardPopup, attributionId)
+              );
+            },
+          },
         ];
   }
 
@@ -389,7 +399,6 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             isExternalAttribution={Boolean(
               props.cardConfig.isExternalAttribution
             )}
-            displayedAttributionName={packageLabels[0] || ''}
           />
         )}
       <ContextMenu

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -19,10 +19,13 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
-import { ButtonText } from '../../../enums/enums';
+import { ButtonText, PopupType } from '../../../enums/enums';
 import { clickOnButtonInPackageContextMenu } from '../../../test-helpers/context-menu-test-helpers';
 import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { getMultiSelectSelectedAttributionIds } from '../../../state/selectors/attribution-view-resource-selectors';
+import { setManualData } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
 
 const testResources: Resources = {
   thirdParty: {
@@ -258,5 +261,43 @@ describe('The PackageCard', () => {
       testStore.getState().resourceState.allViews.manualData.attributions;
     expect(updatedAttributions[testAttributionId].preSelected).toBeFalsy();
     expect(updatedAttributions[anotherAttributionId].preSelected).toBeFalsy();
+  });
+
+  it('opens AttributionWizardPopup via context menu', () => {
+    const testStore = createTestAppStore();
+
+    const attributions: Attributions = {
+      uuid_1: { packageName: 'testPackage' },
+    };
+    const resourcesToManualAttributions: ResourcesToAttributions = {
+      '/thirdParty': ['uuid_1'],
+    };
+    testStore.dispatch(
+      setManualData(attributions, resourcesToManualAttributions)
+    );
+    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+
+    renderComponentWithStore(
+      <PackageCard
+        cardId={'testCardId'}
+        packageInfo={{ packageName: 'testPackage' }}
+        attributionId={'uuid_1'}
+        cardConfig={{ isExternalAttribution: false, isSelected: true }}
+        onClick={doNothing}
+        hideContextMenuAndMultiSelect={false}
+        showCheckBox={false}
+      />,
+      { store: testStore }
+    );
+
+    clickOnButtonInPackageContextMenu(
+      screen,
+      'testPackage',
+      ButtonText.OpenAttributionWizardPopup
+    );
+
+    expect(getOpenPopup(testStore.getState())).toBe(
+      PopupType.AttributionWizardPopup
+    );
   });
 });

--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -14,6 +14,7 @@ import { useAppSelector } from '../../state/hooks';
 import { getFilesWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import MuiBox from '@mui/material/Box';
+import { SxProps } from '@mui/system';
 
 const classes = {
   root: {
@@ -33,13 +34,16 @@ const classes = {
   tooltip: tooltipStyle,
 };
 
-export function PathBar(): ReactElement | null {
+interface PathBarProps {
+  sx?: SxProps;
+}
+export function PathBar(props: PathBarProps): ReactElement | null {
   const path = useAppSelector(getSelectedResourceId);
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
 
   return path ? (
-    <MuiBox sx={classes.root}>
+    <MuiBox sx={{ ...classes.root, ...props.sx }}>
       <MuiTooltip sx={classes.tooltip} title={path}>
         <MuiTypography sx={classes.leftEllipsis} variant={'subtitle1'}>
           <bdi>

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -24,7 +24,6 @@ interface ResourcePathPopupProps {
   closePopup(): void;
   attributionId: string;
   isExternalAttribution: boolean;
-  displayedAttributionName: string;
 }
 
 export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -42,7 +42,6 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
       closePopup={doNothing}
       attributionId={'uuid_1'}
       isExternalAttribution={props.isExternalAttribution}
-      displayedAttributionName={'test name'}
     />
   );
 }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -24,6 +24,7 @@ export enum PopupType {
   EditAttributionPopup = 'EditAttributionPopup',
   PackageSearchPopup = 'PackageSearchPopup',
   ChangedInputFilePopup = 'ChangedInputFilePopup',
+  AttributionWizardPopup = 'AttributionWizardPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -54,6 +55,8 @@ export enum ButtonText {
   Hide = 'Hide',
   Keep = 'Keep',
   MarkForReplacement = 'Mark for replacement',
+  Next = 'Next',
+  OpenAttributionWizardPopup = 'Open attribution wizard',
   Replace = 'Replace',
   ReplaceMarked = 'Replace marked',
   Save = 'Save',


### PR DESCRIPTION
This PR is part of the story [Attribution wizard - proof of concept](https://github.com/opossum-tool/OpossumUI/issues/1275).

### Summary of changes

Rightclicking a package card (manual attributions only) and clicking 'Open attribution wizard' opens the popup. The skeleton comprises a header, the ID (path) of the current resource, and buttons to cancel and switch to the next view (only a dummy so far).

### Context and reason for change

The Attribution Wizard is meant to streamline the editing of attributions. 
Fix #1276, #1277

### Images

Package card context menu:
![att_wiz_context_menu](https://user-images.githubusercontent.com/83081698/209799019-227021cb-1e0a-403a-b0dd-510652db02ae.png)

Wizard skeleton:
![att_wiz_skeleton](https://user-images.githubusercontent.com/83081698/209799061-3950f156-fc7d-4255-b708-a54801d42f6a.png)

### Comments
I think it makes sense to not focus on stylistic details at this stage of development since the style will certainly change when adding more components to the wizard later. 