### PR TITLE
Fixed shifted header by changing padding

### DIFF
--- a/src/Frontend/Components/ReportTableHeader/ReportTableHeader.tsx
+++ b/src/Frontend/Components/ReportTableHeader/ReportTableHeader.tsx
@@ -30,10 +30,6 @@ export const reportTableClasses = {
     padding: '10px',
     flex: '1 1 auto',
   },
-  emptyTableCell: {
-    paddingTop: '10px',
-    flex: '1 1 auto',
-  },
   emptyTableCellNoFlexGrow: {
     flex: '0 1 auto',
   },
@@ -85,9 +81,7 @@ export function ReportTableHeader(): ReactElement {
           {tableConfigs.map((config) => (
             <MuiBox
               sx={{
-                ...(config.attributionProperty === 'icons'
-                  ? reportTableClasses.emptyTableCell
-                  : reportTableClasses.tableCell),
+                ...reportTableClasses.tableCell,
                 ...(config.width === 'small'
                   ? reportTableClasses.smallTableCell
                   : config.width === 'wide'


### PR DESCRIPTION
### Summary of changes

The problem appeared when the table contained a vertical scrollbar, which shifted the table to the right, but not the header.
Now the first empty cell of the header has padding from all sides.

### Context and reason for change

Fix #1220

### How can the changes be tested
![image](https://user-images.githubusercontent.com/85183359/209824895-0882459c-8609-4d77-b367-e6a58f6218e5.png)

