### PR TITLE
Improve performance of package panel

### DIFF
--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -63,16 +63,19 @@ export function PackagePanel(
   const dispatch = useAppDispatch();
 
   function getPreSelectedExternalAttributionIdsForSelectedResource(): Array<string> {
-    const externalAttributionsForSelectedResource =
+    const externalAttributionIdsForSelectedResource =
       resourcesToExternalAttributions[selectedResourceId] || [];
 
-    return Object.entries(externalAttributions)
-      .filter(
-        ([attributionId, attribution]) =>
-          externalAttributionsForSelectedResource.includes(attributionId) &&
-          attribution?.preSelected
-      )
-      .map(([attributionId]) => attributionId);
+    const externalPreselectedAttributionIds: Array<string> = [];
+    externalAttributionIdsForSelectedResource.forEach((attributionId) => {
+      const externalAttribution = externalAttributions[attributionId];
+
+      if (externalAttribution?.preSelected) {
+        externalPreselectedAttributionIds.push(attributionId);
+      }
+    });
+
+    return externalPreselectedAttributionIds;
   }
 
   function onCardClick(attributionId: string): void {


### PR DESCRIPTION
### Summary of changes

Before all external attributions where filtered after converting the object into an array. In cases where there are several 100k of attributions, this takes a long time and affects performance.

### Context and reason for change

The performance of the PackagePanel is improved for large numbers of external attributions. In test some cases, the performance was improved by a factor of 5 for the action of clicking on a file in OpossumUI. 
The time for adding an attribution to a root folder for a huge example went down from approx 4.6s to approx 3.1s.

This work is in the context of [#1110](https://github.com/opossum-tool/OpossumUI/issues/1110).
