### PR TITLE
Attribution Wizard: Implement navigation

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -123,7 +123,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
             <FetchLicenseInformationButton
               url={props.displayPackageInfo.url}
               version={props.displayPackageInfo.packageVersion}
-              isDisabled={!props.isEditable}
+              disabled={!props.isEditable}
             />
             <IconButton
               tooltipTitle={openLinkButtonTooltip}

--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
+
+interface AttributionWizardPackageStepProps {
+  selectedPackageNamespaceId: string;
+  selectedPackageNameId: string;
+  handlePackageNamespaceListItemClick: (id: string) => void;
+  handlePackageNameListItemClick: (id: string) => void;
+}
+
+export function AttributionWizardPackageStep(
+  props: AttributionWizardPackageStepProps
+): ReactElement {
+  // create dummy data
+  const N = 15;
+  const items = [];
+  const highlightedAttributeIds = [];
+  for (let i = 0; i < N; i++) {
+    items.push({
+      text: `package${i}`,
+      id: `testItemId${i}`,
+      attributes: [
+        {
+          text: `attrib${4 * i}`,
+          id: `testAttributeId${4 * i}`,
+        },
+        {
+          text: `attrib${4 * i + 1}`,
+          id: `testAttributeId${4 * i + 1}`,
+        },
+        {
+          text: `attrib${4 * i + 2}`,
+          id: `testAttributeId${4 * i + 2}`,
+        },
+        {
+          text: `attrib${4 * i + 3}`,
+          id: `testAttributeId${4 * i + 3}`,
+        },
+      ],
+    });
+    highlightedAttributeIds.push(`testAttributeId${4 * i + (i % 4)}`);
+  }
+
+  return (
+    <>
+      <ListWithAttributes
+        listItems={items}
+        selectedListItemId={props.selectedPackageNamespaceId}
+        highlightedAttributeIds={highlightedAttributeIds}
+        handleListItemClick={props.handlePackageNamespaceListItemClick}
+        showAddNewInput={false}
+        title={'Package namespace'}
+      />
+      <ListWithAttributes
+        listItems={items}
+        selectedListItemId={props.selectedPackageNameId}
+        highlightedAttributeIds={highlightedAttributeIds}
+        handleListItemClick={props.handlePackageNameListItemClick}
+        showAddNewInput={false}
+        title={'Package name'}
+      />
+    </>
+  );
+}

--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -5,45 +5,43 @@
 
 import React, { ReactElement, useState } from 'react';
 import MuiBox from '@mui/material/Box';
-import { doNothing } from '../../util/do-nothing';
-import { OpossumColors } from '../../shared-styles';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { ButtonText } from '../../enums/enums';
+import { Breadcrumbs } from '../Breadcrumbs/Breadcrumbs';
 import { useAppDispatch } from '../../state/hooks';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { OpossumColors } from '../../shared-styles';
 import { PathBar } from '../PathBar/PathBar';
-import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
+import { AttributionWizardPackageStep } from '../AttributionWizardPackageStep/AttributionWizardPackageStep';
+import { AttributionWizardVersionStep } from '../AttributionWizardVersionStep/AttributionWizardVersionStep';
+import { ButtonConfig } from '../../types/types';
 
 // const POPUP_CONTENT_PADDING = 48; // TODO: monitored in upcoming tickets
 const attributionWizardPopupHeader = 'Attribution Wizard';
 
 const classes = {
-  dialogContent: {
-    // TODO: required later
-  },
   dialogHeader: {
     whiteSpace: 'nowrap',
     // width: `calc(100% - ${POPUP_CONTENT_PADDING}px)`, // TODO: monitored in upcoming tickets
   },
-  mainContent: {
-    borderRadius: 2,
-    paddingTop: '0px',
-    background: OpossumColors.white,
+  pathFieldAndBreadcrumbsBox: {
+    display: 'flex',
+    gap: '30px',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   mainContentBox: {
     key: 'mainContent',
     display: 'flex',
     gap: '30px',
     width: 'fit-content',
-    marginTop: '8px',
+    heigth: 'fit-content',
+    marginTop: '12px',
     maxHeight: '70vh',
-    minWidth: '60vh',
+    minWidth: '60vw',
   },
   pathBar: {
-    paddingLeft: '5px',
-    paddingRight: '5px',
-    paddingTop: '1px',
-    paddingBottom: '1px',
+    padding: '1px 5px',
   },
   pathBarBox: {
     padding: '4px',
@@ -52,70 +50,97 @@ const classes = {
 };
 
 export function AttributionWizardPopup(): ReactElement {
-  const dispatch = useAppDispatch();
+  const wizardStepIdsToDisplayValues: Array<[string, string]> = [
+    ['packageNamespaceAndName', 'package'],
+    ['packageVersion', 'version'],
+  ];
+  const wizardStepIds = wizardStepIdsToDisplayValues.map(
+    (idAndDisplayValue) => idAndDisplayValue[0]
+  );
 
+  // TODO: streamline and integrate this logic later
+  const [selectedPackageNamespaceId, setSelectedPackageNamespaceId] =
+    useState<string>('');
+  const [selectedPackageNameId, setSelectedPackageNameId] =
+    useState<string>('');
+  const [selectedPackageVersionId, setSelectedPackageVersionId] =
+    useState<string>('');
+  const [selectedWizardStepId, setSelectedWizardStepId] = useState<string>(
+    wizardStepIds[0]
+  );
+
+  const packageNamespaceAndNameSelected: boolean =
+    selectedPackageNamespaceId !== '' && selectedPackageNameId !== '';
+
+  const dispatch = useAppDispatch();
   function closeAttributionWizardPopup(): void {
     dispatch(closePopup());
   }
 
-  // TODO: const selectedAttributionId = useAppSelector(getPopupAttributionId);  for later
-  // TODO: const selectedResourceId = useSelector(getSelectedResourceId);  for later
-  const nextButtonConfig = {
-    buttonText: ButtonText.Next,
-    onClick: doNothing,
-    isDisabled: true,
+  const handleBreadcrumbsClick = function (wizardStepId: string): void {
+    setSelectedWizardStepId(wizardStepId);
   };
-  const closeButtonConfig = {
+
+  function handleNextClick(): void {
+    if (selectedWizardStepId !== wizardStepIds[wizardStepIds.length - 1]) {
+      setSelectedWizardStepId(
+        wizardStepIds[wizardStepIds.indexOf(selectedWizardStepId) + 1]
+      );
+    }
+  }
+  function handleBackClick(): void {
+    if (selectedWizardStepId !== wizardStepIds[0]) {
+      setSelectedWizardStepId(
+        wizardStepIds[wizardStepIds.indexOf(selectedWizardStepId) - 1]
+      );
+    }
+  }
+
+  function handlePackageNamespaceListItemClick(id: string): void {
+    setSelectedPackageNamespaceId(id);
+  }
+  function handlePackageNameListItemClick(id: string): void {
+    setSelectedPackageNameId(id);
+  }
+  function handlePackageVersionListItemClick(id: string): void {
+    setSelectedPackageVersionId(id);
+  }
+
+  const nextButtonConfig: ButtonConfig = {
+    buttonText: ButtonText.Next,
+    onClick: handleNextClick,
+    disabled: !packageNamespaceAndNameSelected,
+    isDark: true,
+    tooltipText: !packageNamespaceAndNameSelected
+      ? 'Please select package namespace and name to continue'
+      : '',
+    tooltipPlacement: 'left',
+  };
+  const backButtonConfig: ButtonConfig = {
+    buttonText: ButtonText.Back,
+    onClick: handleBackClick,
+    disabled: false,
+    isDark: false,
+  };
+  const cancelButtonConfig: ButtonConfig = {
     buttonText: ButtonText.Cancel,
     onClick: closeAttributionWizardPopup,
-    isDisabled: false,
+    disabled: false,
+    isDark: false,
   };
-
-  // TODO: streamline and integrate this logic later
-  const [selectedIdList1, setSelectedIdList1] = useState<string>('');
-  const [selectedIdList2, setSelectedIdList2] = useState<string>('');
-  const handleListItemClickList1 = (id: string): void => {
-    setSelectedIdList1(id);
-  };
-  const handleListItemClickList2 = (id: string): void => {
-    setSelectedIdList2(id);
-  };
-
-  // create dummy data
-  const N = 15;
-  const items = [];
-  const highlightedAttributeIds = [];
-  for (let i = 0; i < N; i++) {
-    items.push({
-      text: `package${i}`,
-      id: `testItemId${i}`,
-      attributes: [
-        {
-          text: `attrib${4 * i}`,
-          id: `testAttributeId${4 * i}`,
-        },
-        {
-          text: `attrib${4 * i + 1}`,
-          id: `testAttributeId${4 * i + 1}`,
-        },
-        {
-          text: `attrib${4 * i + 2}`,
-          id: `testAttributeId${4 * i + 2}`,
-        },
-        {
-          text: `attrib${4 * i + 3}`,
-          id: `testAttributeId${4 * i + 3}`,
-        },
-      ],
-    });
-    highlightedAttributeIds.push(`testAttributeId${4 * i + (i % 4)}`);
-  }
 
   return (
     <NotificationPopup
       header={attributionWizardPopupHeader}
-      leftButtonConfig={nextButtonConfig}
-      rightButtonConfig={closeButtonConfig}
+      centerLeftButtonConfig={
+        selectedWizardStepId !== wizardStepIds[0] ? backButtonConfig : undefined
+      }
+      centerRightButtonConfig={
+        selectedWizardStepId !== wizardStepIds[wizardStepIds.length - 1]
+          ? nextButtonConfig
+          : undefined
+      }
+      rightButtonConfig={cancelButtonConfig}
       onBackdropClick={closeAttributionWizardPopup}
       onEscapeKeyDown={closeAttributionWizardPopup}
       isOpen={true}
@@ -123,24 +148,34 @@ export function AttributionWizardPopup(): ReactElement {
       headerSx={classes.dialogHeader}
       content={
         <>
-          <MuiBox sx={classes.pathBarBox}>
-            <PathBar sx={classes.pathBar} />
+          <MuiBox sx={classes.pathFieldAndBreadcrumbsBox}>
+            <MuiBox sx={classes.pathBarBox}>
+              <PathBar sx={classes.pathBar} />
+            </MuiBox>
+            <Breadcrumbs
+              selectedId={selectedWizardStepId}
+              onClick={handleBreadcrumbsClick}
+              idsToDisplayValues={wizardStepIdsToDisplayValues}
+            />
           </MuiBox>
           <MuiBox sx={classes.mainContentBox}>
-            <ListWithAttributes
-              listItems={items}
-              selectedListItemId={selectedIdList1}
-              highlightedAttributeIds={highlightedAttributeIds}
-              handleListItemClick={handleListItemClickList1}
-              showAddNewInput={false}
-            />
-            <ListWithAttributes
-              listItems={items}
-              selectedListItemId={selectedIdList2}
-              highlightedAttributeIds={highlightedAttributeIds}
-              handleListItemClick={handleListItemClickList2}
-              showAddNewInput={false}
-            />
+            {selectedWizardStepId === wizardStepIds[0] ? (
+              <AttributionWizardPackageStep
+                selectedPackageNamespaceId={selectedPackageNamespaceId}
+                selectedPackageNameId={selectedPackageNameId}
+                handlePackageNamespaceListItemClick={
+                  handlePackageNamespaceListItemClick
+                }
+                handlePackageNameListItemClick={handlePackageNameListItemClick}
+              />
+            ) : selectedWizardStepId === wizardStepIds[1] ? (
+              <AttributionWizardVersionStep
+                selectedPackageVersionId={selectedPackageVersionId}
+                handlePackageVersionListItemClick={
+                  handlePackageVersionListItemClick
+                }
+              />
+            ) : null}
           </MuiBox>
         </>
       }

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -34,8 +34,22 @@ describe('Attribution Wizard Popup', () => {
 
     renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
     testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_1'));
+    expect(getOpenPopup(testStore.getState())).toBe(
+      PopupType.AttributionWizardPopup
+    );
 
     fireEvent.click(screen.getByText(ButtonText.Cancel));
     expect(getOpenPopup(testStore.getState())).toBe(null);
   });
+
+  it('renders breadcrumbs in first wizard step', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+
+    expect(screen.getByText('package')).toBeInTheDocument();
+    expect(screen.getByText('version')).toBeInTheDocument();
+  });
+  // TODO: More logic required to test for navigation as it requires item selection of dispatched data
 });

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
+
+interface AttributionWizardVersionStepProps {
+  selectedPackageVersionId: string;
+  handlePackageVersionListItemClick: (id: string) => void;
+}
+
+// TODO: Add Text with selected package namespace and name to the second step
+// TODO: Provide selected Ids (or names) from both lists of the first step to the second step
+
+export function AttributionWizardVersionStep(
+  props: AttributionWizardVersionStepProps
+): ReactElement {
+  // create dummy data
+  const N = 15;
+  const items = [];
+  const highlightedAttributeIds = [];
+  for (let i = 0; i < N; i++) {
+    items.push({
+      text: `package${i}`,
+      id: `testItemId${i}`,
+      attributes: [
+        {
+          text: `attrib${4 * i}`,
+          id: `testAttributeId${4 * i}`,
+        },
+        {
+          text: `attrib${4 * i + 1}`,
+          id: `testAttributeId${4 * i + 1}`,
+        },
+        {
+          text: `attrib${4 * i + 2}`,
+          id: `testAttributeId${4 * i + 2}`,
+        },
+        {
+          text: `attrib${4 * i + 3}`,
+          id: `testAttributeId${4 * i + 3}`,
+        },
+      ],
+    });
+    highlightedAttributeIds.push(`testAttributeId${4 * i + (i % 4)}`);
+  }
+
+  return (
+    <ListWithAttributes
+      listItems={items}
+      selectedListItemId={props.selectedPackageVersionId}
+      highlightedAttributeIds={highlightedAttributeIds}
+      handleListItemClick={props.handlePackageVersionListItemClick}
+      showAddNewInput={false}
+      title={'Package version'}
+    />
+  );
+}

--- a/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import MuiBreadcrumbs from '@mui/material/Breadcrumbs';
+import MuiListItemButton from '@mui/material/ListItemButton';
+import MuiTypography from '@mui/material/Typography';
+import MuiNavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { OpossumColors } from '../../shared-styles';
+
+const classes = {
+  breadcrumbs: {
+    color: OpossumColors.black,
+    '.MuiBreadcrumbs-separator': {
+      margin: '0px',
+    },
+  },
+  breadcrumbsButton: {
+    padding: '1px 4px',
+    backgroundColor: OpossumColors.white,
+    '&:hover': {
+      backgroundColor: OpossumColors.white,
+    },
+    '&:loading': {
+      backgroundColor: OpossumColors.white,
+    },
+    '&.Mui-selected': {
+      '&:hover': {
+        backgroundColor: OpossumColors.white,
+      },
+      backgroundColor: OpossumColors.white,
+    },
+    '&.Mui-disabled': {
+      opacity: 1,
+    },
+  },
+  breadcrumbsSelected: {
+    fontWeight: 'bold',
+  },
+};
+
+interface BreadcrumbsProps {
+  selectedId: string;
+  onClick: (id: string) => void;
+  idsToDisplayValues: Array<[string, string]>;
+}
+
+export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
+  const ids: Array<string> = props.idsToDisplayValues.map(
+    (idToDisplayValue) => idToDisplayValue[0]
+  );
+
+  return (
+    <MuiBreadcrumbs
+      sx={classes.breadcrumbs}
+      separator={<MuiNavigateNextIcon fontSize="inherit" />}
+    >
+      {ids.map((id, index) => (
+        <MuiListItemButton
+          key={`breadcrumbs-${id}`}
+          sx={classes.breadcrumbsButton}
+          selected={props.selectedId === id}
+          onClick={(): void => props.onClick(id)}
+          disableRipple={true}
+          disabled={index >= ids.indexOf(props.selectedId)}
+        >
+          <MuiTypography
+            sx={props.selectedId === id ? classes.breadcrumbsSelected : null}
+          >
+            {props.idsToDisplayValues[index][1]}
+          </MuiTypography>
+        </MuiListItemButton>
+      ))}
+    </MuiBreadcrumbs>
+  );
+}

--- a/src/Frontend/Components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/src/Frontend/Components/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import { doNothing } from '../../../util/do-nothing';
+import { Breadcrumbs } from '../Breadcrumbs';
+import React from 'react';
+
+describe('Breadcrumbs', () => {
+  it('renders breadcrumbs', () => {
+    const testIdToSelectedValue: Array<[string, string]> = [
+      ['package_id', 'package'],
+      ['version_id', 'version'],
+    ];
+    render(
+      <Breadcrumbs
+        selectedId={'package_id'}
+        onClick={doNothing}
+        idsToDisplayValues={testIdToSelectedValue}
+      />
+    );
+
+    expect(screen.getByText('package')).toBeInTheDocument();
+    expect(screen.getByText('version')).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/Components/Button/Button.tsx
+++ b/src/Frontend/Components/Button/Button.tsx
@@ -4,25 +4,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import MuiButton from '@mui/material/Button';
+import MuiTooltip from '@mui/material/Tooltip';
 import React, { ReactElement } from 'react';
+import { tooltipStyle } from '../../shared-styles';
+import { ButtonConfig } from '../../types/types';
 import { buttonStyles } from './button-styles';
 
-interface ButtonProps {
-  buttonText: string;
-  disabled?: boolean;
-  isDark: boolean;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-}
+type ButtonProps = ButtonConfig;
 
 export function Button(props: ButtonProps): ReactElement {
   return (
-    <MuiButton
-      sx={props.isDark ? buttonStyles.dark : buttonStyles.light}
-      variant="contained"
-      disabled={props.disabled}
-      onClick={props.onClick}
+    <MuiTooltip
+      sx={tooltipStyle}
+      title={props.tooltipText}
+      placement={props.tooltipPlacement}
+      describeChild={true}
     >
-      {props.buttonText}
-    </MuiButton>
+      <span>
+        <MuiButton
+          sx={props.isDark ? buttonStyles.dark : buttonStyles.light}
+          variant="contained"
+          disabled={props.disabled}
+          onClick={props.onClick}
+        >
+          {props.buttonText}
+        </MuiButton>
+      </span>
+    </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/Button/__tests__/Button.test.tsx
+++ b/src/Frontend/Components/Button/__tests__/Button.test.tsx
@@ -5,7 +5,7 @@
 
 import { Button } from '../Button';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('Button', () => {
@@ -15,12 +15,53 @@ describe('Button', () => {
         buttonText={'Test'}
         disabled={false}
         isDark={false}
-        onClick={(): void => {
-          doNothing();
-        }}
+        onClick={doNothing}
       />
     );
 
     screen.getByText('Test');
+  });
+
+  it('renders a tooltip for enabled button', () => {
+    const testTooltipText = 'This button can be clicked';
+    render(
+      <Button
+        buttonText={'Test'}
+        disabled={false}
+        isDark={false}
+        onClick={doNothing}
+        tooltipText={testTooltipText}
+        tooltipPlacement={'left'}
+      />
+    );
+
+    fireEvent.mouseOver(screen.getByRole('button'));
+
+    expect(
+      waitFor(() => {
+        screen.getByLabelText(testTooltipText);
+      })
+    ).resolves.toBeInTheDocument();
+  });
+
+  it('renders a tooltip for disabled button', () => {
+    const testTooltipText = 'This button cannot be clicked';
+    render(
+      <Button
+        buttonText={'Test'}
+        disabled={true}
+        isDark={false}
+        onClick={doNothing}
+        tooltipText={testTooltipText}
+        tooltipPlacement={'left'}
+      />
+    );
+    fireEvent.mouseOver(screen.getByRole('button'));
+
+    expect(
+      waitFor(() => {
+        screen.getByLabelText(testTooltipText);
+      })
+    ).resolves.toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/ChangedInputFilePopup/ChangedInputFilePopup.tsx
+++ b/src/Frontend/Components/ChangedInputFilePopup/ChangedInputFilePopup.tsx
@@ -33,6 +33,7 @@ export function ChangedInputFilePopup(): ReactElement {
       leftButtonConfig={{
         onClick: handleKeepClick,
         buttonText: ButtonText.Keep,
+        isDark: true,
       }}
       centerRightButtonConfig={{
         onClick: handleOverwriteClick,

--- a/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
+++ b/src/Frontend/Components/ConfirmationPopup/ConfirmationPopup.tsx
@@ -34,6 +34,7 @@ export function ConfirmationPopup(props: ConfirmationPopupProps): ReactElement {
       leftButtonConfig={{
         onClick: handleDeletionClick,
         buttonText: ButtonText.Confirm,
+        isDark: true,
       }}
       rightButtonConfig={{
         onClick: handleCancelClick,

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -76,7 +76,8 @@ export function EditAttributionPopup(): ReactElement {
       leftButtonConfig={{
         onClick: savePackageInfoBeforeClosing,
         buttonText: ButtonText.Save,
-        isDisabled: isSavingDisabled,
+        disabled: isSavingDisabled,
+        isDark: true,
       }}
       rightButtonConfig={{
         onClick: checkForModifiedPackageInfoBeforeClosing,

--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -186,13 +186,13 @@ export function EnabledFetchLicenseInformationButton(
 export function FetchLicenseInformationButton(props: {
   url?: string;
   version?: string;
-  isDisabled: boolean;
+  disabled: boolean;
 }): ReactElement {
   const licenseFetchingInformation = getLicenseFetchingInformation(
     props.url,
     props.version
   );
-  return !props.isDisabled && licenseFetchingInformation ? (
+  return !props.disabled && licenseFetchingInformation ? (
     <EnabledFetchLicenseInformationButton
       url={licenseFetchingInformation.url}
       convertPayload={licenseFetchingInformation.convertPayload}

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -29,7 +29,7 @@ const axiosMock = new MockAdapter(axios);
 
 describe('FetchLicenseInformationButton', () => {
   it('renders disabled button', () => {
-    render(<FetchLicenseInformationButton isDisabled={true} url={''} />);
+    render(<FetchLicenseInformationButton disabled={true} url={''} />);
     expect(
       screen.getByLabelText(FETCH_DATA_BUTTON_DISABLED_TOOLTIP)
     ).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('FetchLicenseInformationButton', () => {
     renderComponentWithStore(
       <FetchLicenseInformationButton
         url={'https://pypi.org/pypi/pip'}
-        isDisabled={false}
+        disabled={false}
       />
     );
     expect(screen.getByRole('button')).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe('FetchLicenseInformationButton', () => {
       axiosMock.onGet(MOCK_URL).networkErrorOnce();
 
       renderComponentWithStore(
-        <FetchLicenseInformationButton url={MOCK_URL} isDisabled={false} />
+        <FetchLicenseInformationButton url={MOCK_URL} disabled={false} />
       );
 
       fireEvent.click(screen.getByRole('button'));
@@ -70,7 +70,7 @@ describe('FetchLicenseInformationButton', () => {
       axiosMock.onGet(MOCK_URL).replyOnce(404, {});
 
       renderComponentWithStore(
-        <FetchLicenseInformationButton url={MOCK_URL} isDisabled={false} />
+        <FetchLicenseInformationButton url={MOCK_URL} disabled={false} />
       );
 
       fireEvent.click(screen.getByRole('button'));
@@ -92,7 +92,7 @@ describe('FetchLicenseInformationButton', () => {
       });
 
       renderComponentWithStore(
-        <FetchLicenseInformationButton url={MOCK_URL} isDisabled={false} />
+        <FetchLicenseInformationButton url={MOCK_URL} disabled={false} />
       );
 
       fireEvent.click(screen.getByRole('button'));

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -9,16 +9,22 @@ import MuiList from '@mui/material/List';
 import MuiListItem from '@mui/material/ListItem';
 import MuiListItemText from '@mui/material/ListItemText';
 import MuiListItemButton from '@mui/material/ListItemButton';
+import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
 import { getAttributesWithHighlighting } from './list-with-attributes-helpers';
 import { ListWithAttributesItem } from '../../types/types';
 
 const LIST_WITH_ATTRIBUTES_VERTICAL_BORDER_AND_MARGIN = 10; // 10px = margin + border
+const LIST_TITLE_HEIGHT = 28;
 
 const classes = {
+  titleAndListBox: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
   listBox: {
     width: 'fit-content',
-    maxHeight: '100%',
+    maxHeight: `calc(100% - ${LIST_TITLE_HEIGHT}px)`,
     background: OpossumColors.lightBlue,
   },
   list: {
@@ -66,37 +72,41 @@ interface ListWithAttributesProps {
   highlightedAttributeIds: Array<string>;
   handleListItemClick: (id: string) => void;
   showAddNewInput: boolean; // TODO: required later
+  title?: string;
 }
 
 export function ListWithAttributes(
   props: ListWithAttributesProps
 ): ReactElement {
   return (
-    <MuiBox sx={classes.listBox}>
-      <MuiList sx={classes.list}>
-        {props.listItems.map((item) => (
-          <MuiListItem key={`itemId-${item.id}`} sx={classes.listItem}>
-            <MuiListItemButton
-              sx={classes.listItemButton}
-              selected={item.id === props.selectedListItemId}
-              onClick={(): void => props.handleListItemClick(item.id)}
-            >
-              <MuiListItemText
-                primary={item.text}
-                secondary={
-                  <MuiBox sx={classes.listItemTextAttributesBox}>
-                    {getAttributesWithHighlighting(
-                      item.attributes,
-                      props.highlightedAttributeIds
-                    )}
-                  </MuiBox>
-                }
-                secondaryTypographyProps={{ component: 'span' }}
-              />
-            </MuiListItemButton>
-          </MuiListItem>
-        ))}
-      </MuiList>
+    <MuiBox sx={classes.titleAndListBox}>
+      <MuiTypography variant={'subtitle1'}>{props.title}</MuiTypography>
+      <MuiBox sx={classes.listBox}>
+        <MuiList sx={classes.list}>
+          {props.listItems.map((item) => (
+            <MuiListItem key={`itemId-${item.id}`} sx={classes.listItem}>
+              <MuiListItemButton
+                sx={classes.listItemButton}
+                selected={item.id === props.selectedListItemId}
+                onClick={(): void => props.handleListItemClick(item.id)}
+              >
+                <MuiListItemText
+                  primary={item.text}
+                  secondary={
+                    <MuiBox sx={classes.listItemTextAttributesBox}>
+                      {getAttributesWithHighlighting(
+                        item.attributes,
+                        props.highlightedAttributeIds
+                      )}
+                    </MuiBox>
+                  }
+                  secondaryTypographyProps={{ component: 'span' }}
+                />
+              </MuiListItemButton>
+            </MuiListItem>
+          ))}
+        </MuiList>
+      </MuiBox>
     </MuiBox>
   );
 }

--- a/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
+++ b/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
@@ -11,7 +11,7 @@ import { ListWithAttributesItem } from '../../../types/types';
 import { doNothing } from '../../../util/do-nothing';
 
 describe('ListWithAttributes', () => {
-  it('renders with items containing name and attributes', () => {
+  it('renders with title and items containing name and attributes', () => {
     const testItems: Array<ListWithAttributesItem> = [
       {
         text: 'package_0',
@@ -32,6 +32,7 @@ describe('ListWithAttributes', () => {
     ];
     const testSelectedItemId = '';
     const testHighlightedAttributeIds = [''];
+    const testListTitle = 'Packages';
     render(
       <ListWithAttributes
         listItems={testItems}
@@ -39,8 +40,11 @@ describe('ListWithAttributes', () => {
         highlightedAttributeIds={testHighlightedAttributeIds}
         handleListItemClick={doNothing}
         showAddNewInput={false}
+        title={testListTitle}
       />
     );
+
+    expect(screen.getByText(testListTitle)).toBeInTheDocument();
 
     const listItemElement1 = within(screen.getAllByRole('listitem')[0]);
     expect(listItemElement1.getByText('package_0')).toBeInTheDocument();

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -81,14 +81,15 @@ export function NotSavedPopup(): ReactElement {
           ? handleSaveClick
           : handleSaveGloballyClick,
         buttonText: ButtonText.Save,
-        isDisabled: isSavingDisabled,
+        disabled: isSavingDisabled,
+        isDark: true,
       }}
       centerLeftButtonConfig={
         showSaveGloballyButton
           ? {
               onClick: handleSaveGloballyClick,
               buttonText: ButtonText.SaveGlobally,
-              isDisabled: isSavingDisabled,
+              disabled: isSavingDisabled,
             }
           : undefined
       }

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -79,32 +79,40 @@ export function NotificationPopup(props: NotificationPopupProps): ReactElement {
           <Button
             buttonText={props.leftButtonConfig.buttonText}
             onClick={props.leftButtonConfig.onClick}
-            isDark={true}
-            disabled={props.leftButtonConfig.isDisabled}
+            isDark={Boolean(props.leftButtonConfig?.isDark)}
+            disabled={props.leftButtonConfig.disabled}
+            tooltipText={props.leftButtonConfig?.tooltipText ?? ''}
+            tooltipPlacement={props.leftButtonConfig?.tooltipPlacement}
           />
         ) : null}
         {props.centerLeftButtonConfig ? (
           <Button
             buttonText={props.centerLeftButtonConfig.buttonText}
             onClick={props.centerLeftButtonConfig.onClick}
-            isDark={false}
-            disabled={props.centerLeftButtonConfig.isDisabled}
+            isDark={Boolean(props.centerLeftButtonConfig?.isDark)}
+            disabled={props.centerLeftButtonConfig.disabled}
+            tooltipText={props.centerLeftButtonConfig?.tooltipText ?? ''}
+            tooltipPlacement={props.centerLeftButtonConfig?.tooltipPlacement}
           />
         ) : null}
         {props.centerRightButtonConfig ? (
           <Button
             buttonText={props.centerRightButtonConfig.buttonText}
             onClick={props.centerRightButtonConfig.onClick}
-            isDark={false}
-            disabled={props.centerRightButtonConfig.isDisabled}
+            isDark={Boolean(props.centerRightButtonConfig?.isDark)}
+            disabled={props.centerRightButtonConfig.disabled}
+            tooltipText={props.centerRightButtonConfig?.tooltipText ?? ''}
+            tooltipPlacement={props.centerRightButtonConfig?.tooltipPlacement}
           />
         ) : null}
         {props.rightButtonConfig ? (
           <Button
             buttonText={props.rightButtonConfig.buttonText}
             onClick={props.rightButtonConfig.onClick}
-            isDark={false}
-            disabled={props.rightButtonConfig.isDisabled}
+            isDark={Boolean(props.rightButtonConfig?.isDark)}
+            disabled={props.rightButtonConfig.disabled}
+            tooltipText={props.rightButtonConfig?.tooltipText ?? ''}
+            tooltipPlacement={props.rightButtonConfig?.tooltipPlacement}
           />
         ) : null}
       </MuiDialogActions>

--- a/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
+++ b/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
@@ -5,8 +5,8 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { NotificationPopup } from '../NotificationPopup';
 import { ButtonConfig } from '../../../types/types';
+import { NotificationPopup } from '../NotificationPopup';
 
 describe('NotificationPopup', () => {
   it('renders open popup with text', () => {

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -93,6 +93,7 @@ export function ReplaceAttributionPopup(): ReactElement {
       leftButtonConfig={{
         onClick: handleReplaceClick,
         buttonText: ButtonText.Replace,
+        isDark: true,
       }}
       rightButtonConfig={{
         onClick: handleCancelClick,

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -44,6 +44,7 @@ export enum PackagePanelTitle {
 }
 
 export enum ButtonText {
+  Back = 'Back',
   Close = 'Close',
   Cancel = 'Cancel',
   Confirm = 'Confirm',

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -86,9 +86,12 @@ export interface PopupInfo {
 }
 
 export interface ButtonConfig {
-  onClick(): void;
+  onClick(event: React.MouseEvent<HTMLButtonElement>): void;
   buttonText: string;
-  isDisabled?: boolean;
+  disabled?: boolean;
+  isDark?: boolean;
+  tooltipText?: string;
+  tooltipPlacement?: 'left' | 'right' | 'top' | 'bottom';
 }
 
 export interface PanelData {


### PR DESCRIPTION
### Summary of changes

Breadcrumbs as well as next and back buttons are implemented to switch between the two steps of the wizard. Additional components for the individual wizard steps are added. Switching to the second step is only possible if both lists of the first step have an item selected. Breadcrumbs are only displayed up to the current step. Alternatively, all breadcrumbs could be displayed but disabled if the corresponding steps are not already reached.

### Additional Comments

Testing the navigation is hardly possible without a working business logic that gets redux state data. Testing the navigation will therefore be done in an upcoming ticket.

### Pictures
First step (no items selected, next button disabled):
<img src="https://user-images.githubusercontent.com/83081698/210790629-e7b3983a-032e-4210-8cd9-236704af15d5.png" width="600">

First step (items selected, next button enabled):
<img src="https://user-images.githubusercontent.com/83081698/210790738-14821b61-6f37-4024-b190-3dcf43a359e3.png" width="600">

Second step:
<img src="https://user-images.githubusercontent.com/83081698/210790782-85a671ef-8df7-4d58-b768-5907396b5b59.png" width="600">

Fix: #1278 