### PR TITLE
[BugFix] Do not show tooltip for hidden button

### DIFF
--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -20,13 +20,6 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { PopupType } from '../../enums/enums';
 
-const classes = {
-  hidden: {
-    visibility: 'hidden',
-  },
-  clickableIcon,
-};
-
 export function GoToLinkButton(): ReactElement {
   const path = useAppSelector(getSelectedResourceId);
   const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
@@ -95,10 +88,8 @@ export function GoToLinkButton(): ReactElement {
       }
       tooltipPlacement="right"
       onClick={onClick}
-      sx={!openLinkArgs.link ? classes.hidden : {}}
-      icon={
-        <OpenInNewIcon sx={classes.clickableIcon} aria-label={'link to open'} />
-      }
+      hidden={!openLinkArgs.link}
+      icon={<OpenInNewIcon sx={clickableIcon} aria-label={'link to open'} />}
     />
   );
 }

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -8,6 +8,13 @@ import MuiButtonBase from '@mui/material/ButtonBase';
 import MuiTooltip from '@mui/material/Tooltip';
 import { tooltipStyle } from '../../shared-styles';
 import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
+
+const classes = {
+  hidden: {
+    visibility: 'hidden',
+  },
+};
 
 interface IconButtonProps {
   tooltipTitle: string;
@@ -16,6 +23,7 @@ interface IconButtonProps {
   onClick(): void;
   icon: ReactElement;
   disabled?: boolean;
+  hidden?: boolean;
 }
 
 export function IconButton(props: IconButtonProps): ReactElement {
@@ -23,7 +31,7 @@ export function IconButton(props: IconButtonProps): ReactElement {
     <MuiTooltip
       describeChild={true}
       sx={tooltipStyle}
-      title={props.tooltipTitle}
+      title={props.hidden ? '' : props.tooltipTitle}
       placement={props.tooltipPlacement}
     >
       <span>
@@ -32,7 +40,14 @@ export function IconButton(props: IconButtonProps): ReactElement {
         }
         <MuiButtonBase
           aria-label={props.tooltipTitle}
-          sx={props.sx}
+          sx={
+            props.hidden
+              ? getSxFromPropsAndClasses({
+                  styleClass: classes.hidden,
+                  sxProps: props.sx,
+                })
+              : props.sx
+          }
           onClick={(event): void => {
             event.stopPropagation();
             props.onClick();

--- a/src/Frontend/Components/IconButton/__tests__/IconButton.test.tsx
+++ b/src/Frontend/Components/IconButton/__tests__/IconButton.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 
-describe('Button', () => {
+describe('IconButton', () => {
   it('renders a button', () => {
     render(
       <IconButton
@@ -22,5 +22,50 @@ describe('Button', () => {
 
     expect(screen.getByLabelText('Test'));
     expect(screen.getByText('Test Icon'));
+  });
+
+  it('renders tooltip when hidden flag is inactive', () => {
+    render(
+      <IconButton
+        tooltipTitle={'Test'}
+        tooltipPlacement="left"
+        disabled={false}
+        onClick={doNothing}
+        icon={<div>Test Icon</div>}
+        hidden={false}
+      />
+    );
+
+    expect(screen.getByTitle('Test')).toBeInTheDocument();
+  });
+
+  it('does not render tooltip when hidden flag is active', () => {
+    render(
+      <IconButton
+        tooltipTitle={'Test'}
+        tooltipPlacement="left"
+        disabled={false}
+        onClick={doNothing}
+        icon={<div>Test Icon</div>}
+        hidden={true}
+      />
+    );
+
+    expect(screen.queryByTitle('Test')).not.toBeInTheDocument();
+  });
+
+  it('checks for successful application of hidden visibility style', () => {
+    render(
+      <IconButton
+        tooltipTitle={'Test'}
+        tooltipPlacement="left"
+        disabled={false}
+        onClick={doNothing}
+        icon={<div>Test Icon</div>}
+        hidden={true}
+      />
+    );
+
+    expect(screen.getByLabelText('Test')).toHaveStyle('visibility: hidden');
   });
 });


### PR DESCRIPTION
### Summary of changes

[BugFix] Do not show tooltip for hidden button

### Context and reason for change

- We keep the text shown in tooltip as empty to not let the tooltip render, when IconButton has the hidden prop set to true.

Fix: #1290

### How can the changes be tested

- Load the large_opossum_input.json.gz file in the application
- In the right corner of PathBar of AuditView, the tooltip is no longer visible since the button is hidden. 


Signed-off-by: someshkhandelia <someshkhandelia@gmail.com>