### PR TITLE
Attribution Wizard: Finalize first wizard step

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -4,9 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
+import { ListWithAttributesItem } from '../../types/types';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
 
 interface AttributionWizardPackageStepProps {
+  attributedPackageNamespaces: Array<ListWithAttributesItem>;
+  attributedPackageNames: Array<ListWithAttributesItem>;
   selectedPackageNamespaceId: string;
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
@@ -16,50 +19,18 @@ interface AttributionWizardPackageStepProps {
 export function AttributionWizardPackageStep(
   props: AttributionWizardPackageStepProps
 ): ReactElement {
-  // create dummy data
-  const N = 15;
-  const items = [];
-  const highlightedAttributeIds = [];
-  for (let i = 0; i < N; i++) {
-    items.push({
-      text: `package${i}`,
-      id: `testItemId${i}`,
-      attributes: [
-        {
-          text: `attrib${4 * i}`,
-          id: `testAttributeId${4 * i}`,
-        },
-        {
-          text: `attrib${4 * i + 1}`,
-          id: `testAttributeId${4 * i + 1}`,
-        },
-        {
-          text: `attrib${4 * i + 2}`,
-          id: `testAttributeId${4 * i + 2}`,
-        },
-        {
-          text: `attrib${4 * i + 3}`,
-          id: `testAttributeId${4 * i + 3}`,
-        },
-      ],
-    });
-    highlightedAttributeIds.push(`testAttributeId${4 * i + (i % 4)}`);
-  }
-
   return (
     <>
       <ListWithAttributes
-        listItems={items}
+        listItems={props.attributedPackageNamespaces}
         selectedListItemId={props.selectedPackageNamespaceId}
-        highlightedAttributeIds={highlightedAttributeIds}
         handleListItemClick={props.handlePackageNamespaceListItemClick}
         showAddNewInput={false}
         title={'Package namespace'}
       />
       <ListWithAttributes
-        listItems={items}
+        listItems={props.attributedPackageNames}
         selectedListItemId={props.selectedPackageNameId}
-        highlightedAttributeIds={highlightedAttributeIds}
         handleListItemClick={props.handlePackageNameListItemClick}
         showAddNewInput={false}
         title={'Package name'}

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AttributionIdWithCount,
+  Attributions,
+} from '../../../../shared/shared-types';
+import { ListWithAttributesItem } from '../../../types/types';
+import { getAttributionWizardPackageListsItems } from '../attribution-wizard-popup-helpers';
+
+describe('getAttributionWizardPackageListsItems', () => {
+  it('yields correct output', () => {
+    const testContainedExternalPackages: Array<AttributionIdWithCount> = [
+      { attributionId: 'uuid_0', childrenWithAttributionCount: 2 },
+      { attributionId: 'uuid_1', childrenWithAttributionCount: 5 },
+      { attributionId: 'uuid_2', childrenWithAttributionCount: 1 },
+      { attributionId: 'uuid_3', childrenWithAttributionCount: 1 },
+      { attributionId: 'uuid_4', childrenWithAttributionCount: 1 },
+    ];
+    const testExternalAttributions: Attributions = {
+      uuid_0: {
+        packageName: 'boost',
+        packageNamespace: 'pkg:npm',
+      },
+      uuid_1: {
+        packageName: 'numpy',
+        packageNamespace: 'pkg:pip',
+      },
+      uuid_2: {
+        packageName: undefined,
+        packageNamespace: undefined,
+      },
+      uuid_3: {
+        packageName: '',
+        packageNamespace: '',
+      },
+      uuid_4: {
+        packageName: 'pandas',
+        packageNamespace: 'pkg:pip',
+      },
+    };
+    const expectedAttributedPackageNamespaces: Array<ListWithAttributesItem> = [
+      {
+        text: 'pkg:pip',
+        id: 'namespace-pkg:pip',
+        attributes: [
+          { text: 'count: 6 (60.0%)', id: 'namespace-attribute-pkg:pip' },
+        ],
+      },
+      {
+        text: 'pkg:npm',
+        id: 'namespace-pkg:npm',
+        attributes: [
+          { text: 'count: 2 (20.0%)', id: 'namespace-attribute-pkg:npm' },
+        ],
+      },
+      {
+        text: 'empty',
+        id: 'namespace-empty',
+        attributes: [
+          { text: 'count: 1 (10.0%)', id: 'namespace-attribute-empty' },
+        ],
+      },
+      {
+        text: 'none',
+        id: 'namespace-none',
+        attributes: [
+          { text: 'count: 1 (10.0%)', id: 'namespace-attribute-none' },
+        ],
+      },
+    ];
+    const expectedAttributedPackageNames: Array<ListWithAttributesItem> = [
+      {
+        text: 'numpy',
+        id: 'name-numpy',
+        attributes: [{ text: 'count: 5 (50.0%)', id: 'name-attribute-numpy' }],
+      },
+      {
+        text: 'boost',
+        id: 'name-boost',
+        attributes: [{ text: 'count: 2 (20.0%)', id: 'name-attribute-boost' }],
+      },
+      {
+        text: 'empty',
+        id: 'name-empty',
+        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-empty' }],
+      },
+      {
+        text: 'none',
+        id: 'name-none',
+        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-none' }],
+      },
+      {
+        text: 'pandas',
+        id: 'name-pandas',
+        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-pandas' }],
+      },
+    ];
+
+    const { attributedPackageNamespaces, attributedPackageNames } =
+      getAttributionWizardPackageListsItems(
+        testContainedExternalPackages,
+        testExternalAttributions
+      );
+
+    expect(attributedPackageNamespaces).toEqual(
+      expectedAttributedPackageNamespaces
+    );
+    expect(attributedPackageNames).toEqual(expectedAttributedPackageNames);
+  });
+});

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AttributionIdWithCount,
+  Attributions,
+} from '../../../shared/shared-types';
+import { ListWithAttributesItem } from '../../types/types';
+import { shouldNotBeCalled } from '../../util/should-not-be-called';
+
+interface TextAndCount {
+  text: string;
+  count: number;
+}
+
+interface NamesWithCounts {
+  [name: string]: number;
+}
+
+export function getAttributionWizardPackageListsItems(
+  containedExternalPackages: Array<AttributionIdWithCount>,
+  externalAttributions: Attributions
+): {
+  attributedPackageNamespaces: Array<ListWithAttributesItem>;
+  attributedPackageNames: Array<ListWithAttributesItem>;
+} {
+  const totalAttributionCount = containedExternalPackages
+    .map(
+      (containedExternalPackage) =>
+        containedExternalPackage.childrenWithAttributionCount ?? 0
+    )
+    .reduce(
+      (accumulatedCounts, currentCount) => accumulatedCounts + currentCount,
+      0
+    );
+
+  const packageNamespacesAndCounts = getPackageAttributesAndCounts(
+    containedExternalPackages,
+    externalAttributions,
+    'namespace'
+  );
+  const packageNamesAndCounts = getPackageAttributesAndCounts(
+    containedExternalPackages,
+    externalAttributions,
+    'name'
+  );
+
+  const packageNamespacesWithCounts = sortPackageAttributesAndCounts(
+    packageNamespacesAndCounts
+  );
+  const packageNamesWithCounts = sortPackageAttributesAndCounts(
+    packageNamesAndCounts
+  );
+
+  const attributedPackageNamespaces = getWizardListItems(
+    packageNamespacesWithCounts,
+    totalAttributionCount,
+    'namespace'
+  );
+  const attributedPackageNames = getWizardListItems(
+    packageNamesWithCounts,
+    totalAttributionCount,
+    'name'
+  );
+
+  return {
+    attributedPackageNamespaces,
+    attributedPackageNames,
+  };
+}
+
+function getPackageAttributesAndCounts(
+  containedExternalPackages: Array<AttributionIdWithCount>,
+  externalAttributions: Attributions,
+  packageAttributeId: 'namespace' | 'name'
+): NamesWithCounts {
+  const packageAttributesAndCounts: NamesWithCounts = {};
+  for (const containedExternalPackage of containedExternalPackages) {
+    const packageInfo =
+      externalAttributions[containedExternalPackage.attributionId];
+    const packageCount =
+      containedExternalPackage.childrenWithAttributionCount ?? 0;
+
+    let packageAttribute: string;
+    if (packageAttributeId === 'namespace') {
+      packageAttribute =
+        packageInfo.packageNamespace !== ''
+          ? packageInfo.packageNamespace ?? 'none'
+          : 'empty';
+    } else if (packageAttributeId === 'name') {
+      packageAttribute =
+        packageInfo.packageName !== ''
+          ? packageInfo.packageName ?? 'none'
+          : 'empty';
+    } else {
+      shouldNotBeCalled(packageAttributeId);
+    }
+
+    packageAttributesAndCounts[packageAttribute] =
+      (packageAttributesAndCounts[packageAttribute] ?? 0) + packageCount;
+  }
+
+  return packageAttributesAndCounts;
+}
+
+function sortPackageAttributesAndCounts(packageAttributesAndCounts: {
+  [text: string]: number;
+}): Array<TextAndCount> {
+  return Object.entries(packageAttributesAndCounts)
+    .map(([attributeName, count]) => ({
+      text: attributeName,
+      count,
+    }))
+    .sort(compareTextAndCount);
+}
+
+function compareTextAndCount(a: TextAndCount, b: TextAndCount): number {
+  if (a.count !== b.count) {
+    return b.count - a.count;
+  } else {
+    return a.text.toLowerCase() < b.text.toLowerCase() ? -1 : 1;
+  }
+}
+
+function getWizardListItems(
+  packageAttributesWithCounts: Array<TextAndCount>,
+  totalAttributeCount: number,
+  idPrefix: string
+): Array<ListWithAttributesItem> {
+  return packageAttributesWithCounts.map((packageAttributeAndCount) =>
+    getWizardListItem(packageAttributeAndCount, totalAttributeCount, idPrefix)
+  );
+}
+
+function getWizardListItem(
+  packageAttributeAndCount: TextAndCount,
+  totalAttributeCount: number,
+  idPrefix: string
+): ListWithAttributesItem {
+  const count = packageAttributeAndCount.count;
+  const packageAttribute = packageAttributeAndCount.text;
+  return {
+    text: packageAttribute,
+    id: `${idPrefix}-${packageAttribute}`,
+    attributes: [
+      {
+        text: `count: ${count} (${((count / totalAttributeCount) * 100).toFixed(
+          1
+        )}%)`,
+        id: `${idPrefix}-attribute-${packageAttribute}`,
+      },
+    ],
+  };
+}

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -4,57 +4,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
+import { ListWithAttributesItem } from '../../types/types';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
 
 interface AttributionWizardVersionStepProps {
+  packageVersionListItems: Array<ListWithAttributesItem>;
+  highlightedPackageNameIds: Array<string>;
+  selectedPackageNamespaceId: string;
+  selectedPackageNameId: string;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
 }
 
-// TODO: Add Text with selected package namespace and name to the second step
-// TODO: Provide selected Ids (or names) from both lists of the first step to the second step
+// TODO: selectedPackageNamespaceId and selectedPackageNameId already in props for upcoming ticket
 
 export function AttributionWizardVersionStep(
   props: AttributionWizardVersionStepProps
 ): ReactElement {
-  // create dummy data
-  const N = 15;
-  const items = [];
-  const highlightedAttributeIds = [];
-  for (let i = 0; i < N; i++) {
-    items.push({
-      text: `package${i}`,
-      id: `testItemId${i}`,
-      attributes: [
-        {
-          text: `attrib${4 * i}`,
-          id: `testAttributeId${4 * i}`,
-        },
-        {
-          text: `attrib${4 * i + 1}`,
-          id: `testAttributeId${4 * i + 1}`,
-        },
-        {
-          text: `attrib${4 * i + 2}`,
-          id: `testAttributeId${4 * i + 2}`,
-        },
-        {
-          text: `attrib${4 * i + 3}`,
-          id: `testAttributeId${4 * i + 3}`,
-        },
-      ],
-    });
-    highlightedAttributeIds.push(`testAttributeId${4 * i + (i % 4)}`);
-  }
-
   return (
     <ListWithAttributes
-      listItems={items}
+      listItems={props.packageVersionListItems}
       selectedListItemId={props.selectedPackageVersionId}
-      highlightedAttributeIds={highlightedAttributeIds}
+      highlightedAttributeIds={props.highlightedPackageNameIds}
       handleListItemClick={props.handlePackageVersionListItemClick}
       showAddNewInput={false}
       title={'Package version'}
+      listItemSx={{ maxWidth: '400px' }}
     />
   );
 }

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -13,6 +13,8 @@ import MuiTypography from '@mui/material/Typography';
 import { OpossumColors } from '../../shared-styles';
 import { getAttributesWithHighlighting } from './list-with-attributes-helpers';
 import { ListWithAttributesItem } from '../../types/types';
+import { SxProps } from '@mui/system';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const LIST_WITH_ATTRIBUTES_VERTICAL_BORDER_AND_MARGIN = 10; // 10px = margin + border
 const LIST_TITLE_HEIGHT = 28;
@@ -40,6 +42,13 @@ const classes = {
     padding: '0px',
     borderBottom: 2,
     borderColor: OpossumColors.lightBlue,
+    // TODO: Now: Single scroll bar for each list item.
+    // Remove 'overflowX' property to get single scroll bar
+    // for the whole list (also if only a single
+    // list item exceeds maxWidth)
+    overflowX: 'auto',
+    maxWidth: '300px',
+    minWidth: '200px',
   },
   listItemButton: {
     padding: '0px 0px 0px 4px',
@@ -55,12 +64,6 @@ const classes = {
   },
   listItemTextAttributesBox: {
     display: 'flex',
-    // TODO: Now: Single scroll bar for each list item.
-    // Remove 'overflowX' property to get single scroll bar
-    // for the whole list (also if only a single
-    // list item exceeds maxWidth)
-    overflowX: 'auto',
-    maxWidth: '50vw',
     marginLeft: '20px',
     paddingTop: '1px',
   },
@@ -69,10 +72,11 @@ const classes = {
 interface ListWithAttributesProps {
   listItems: Array<ListWithAttributesItem>;
   selectedListItemId: string;
-  highlightedAttributeIds: Array<string>;
+  highlightedAttributeIds?: Array<string>;
   handleListItemClick: (id: string) => void;
   showAddNewInput: boolean; // TODO: required later
   title?: string;
+  listItemSx?: SxProps;
 }
 
 export function ListWithAttributes(
@@ -84,7 +88,13 @@ export function ListWithAttributes(
       <MuiBox sx={classes.listBox}>
         <MuiList sx={classes.list}>
           {props.listItems.map((item) => (
-            <MuiListItem key={`itemId-${item.id}`} sx={classes.listItem}>
+            <MuiListItem
+              key={`itemId-${item.id}`}
+              sx={getSxFromPropsAndClasses({
+                styleClass: classes.listItem,
+                sxProps: props.listItemSx,
+              })}
+            >
               <MuiListItemButton
                 sx={classes.listItemButton}
                 selected={item.id === props.selectedListItemId}

--- a/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
+++ b/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
@@ -9,7 +9,7 @@ import { ListWithAttributesItemAttribute } from '../../types/types';
 
 export function getAttributesWithHighlighting(
   attributes: Array<ListWithAttributesItemAttribute>,
-  highlightedAttributeIds: Array<string>
+  highlightedAttributeIds: Array<string> = ['']
 ): Array<ReactElement> {
   const styleBasic = {
     padding: '0px 1px 0px 2px',

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SxProps } from '@mui/material';
+import { shouldNotBeCalled } from './util/should-not-be-called';
 
 export const OpossumColors = {
   white: 'hsl(0, 0%, 100%)',
@@ -133,11 +134,6 @@ export const treeClasses = {
     horizontalSpaceBetweenTreeAndViewportEdges?: number,
     popupContentPadding?: number
   ): SxProps => {
-    function shouldNotBeCalled(treeLocation: never): never {
-      throw Error(
-        `Unknown treeLocation: ${treeLocation}. Possible values are 'attributionView', 'browser' and 'popup'.`
-      );
-    }
     switch (treeLocation) {
       case 'attributionView': {
         return {

--- a/src/Frontend/util/should-not-be-called.ts
+++ b/src/Frontend/util/should-not-be-called.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function shouldNotBeCalled(variableOfInterest: never): never {
+  throw Error(
+    `There is a typing problem with respect to ${variableOfInterest}.`
+  );
+}


### PR DESCRIPTION
### Summary of changes

Relevant data is taken from the redux state and processed in order to fill the lists of the first wizard step (package namespace and version). The second wizard step isn't touched. 

### Further comments
Only the large `input_from_ort.json.gz` provides reasonable data for the wizard but the performance is poor. Maybe we should create a new more appropriate file.

Example image captured with `input_from_ort.json.gz` and resource `package.json`
![Unbenannt](https://user-images.githubusercontent.com/83081698/212072797-c960e134-e6f2-441d-a934-8a13c0b2f460.PNG)


Fix: #1281
