### PR TITLE
Refactor sx props usage

### DIFF
--- a/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
+++ b/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
@@ -11,6 +11,7 @@ import MuiBox from '@mui/material/Box';
 
 import { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const classes = {
   root: {
@@ -36,7 +37,12 @@ interface ButtonGroupProps {
 
 export function ButtonGroup(props: ButtonGroupProps): ReactElement | null {
   return props.isHidden ? null : (
-    <MuiBox sx={{ ...classes.root, ...props.sx }}>
+    <MuiBox
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.root,
+        sxProps: props.sx,
+      })}
+    >
       <MuiButtonGroup disableElevation variant="contained">
         {props.mainButtonConfigs
           .filter((buttonConfig) => !buttonConfig.hidden)

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -26,6 +26,7 @@ import {
 import { SxProps } from '@mui/material';
 import RectangleIcon from '@mui/icons-material/Rectangle';
 import { Criticality } from '../../../shared/shared-types';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const classes = {
   clickableIcon,
@@ -75,7 +76,10 @@ export function FirstPartyIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="is first party">
       <Filter1Icon
         aria-label={'First party icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );
@@ -86,7 +90,10 @@ export function CommentIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="has comment">
       <InsertCommentIcon
         aria-label={'Comment icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );
@@ -97,7 +104,10 @@ export function ExcludeFromNoticeIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="excluded from notice">
       <IndeterminateCheckBoxIcon
         aria-label={'Exclude from notice icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );
@@ -108,7 +118,10 @@ export function FollowUpIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="has follow-up">
       <ReplayIcon
         aria-label={'Follow-up icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );
@@ -135,15 +148,22 @@ export function DirectoryIcon({
   sx,
   labelDetail,
 }: LabelDetailIconProps): ReactElement {
+  const sxProps = sx
+    ? getSxFromPropsAndClasses({
+        styleClass: classes.resourceIcon,
+        sxProps: sx,
+      })
+    : {
+        ...classes.resourceIcon,
+        ...classes.resourceDefaultColor,
+      };
+
   return (
     <FolderOutlinedIcon
       aria-label={
         labelDetail ? `Directory icon ${labelDetail}` : 'Directory icon'
       }
-      sx={{
-        ...classes.resourceIcon,
-        ...(sx ?? classes.resourceDefaultColor),
-      }}
+      sx={sxProps}
     />
   );
 }
@@ -161,13 +181,20 @@ export function FileIcon({
   sx,
   labelDetail,
 }: LabelDetailIconProps): ReactElement {
+  const sxProps = sx
+    ? getSxFromPropsAndClasses({
+        styleClass: classes.resourceIcon,
+        sxProps: sx,
+      })
+    : {
+        ...classes.resourceIcon,
+        ...classes.resourceDefaultColor,
+      };
+
   return (
     <DescriptionIcon
       aria-label={labelDetail ? `File icon ${labelDetail}` : 'File icon'}
-      sx={{
-        ...classes.resourceIcon,
-        ...(sx ?? classes.resourceDefaultColor),
-      }}
+      sx={sxProps}
     />
   );
 }
@@ -177,7 +204,10 @@ export function PreSelectedIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="was pre-selected">
       <LocalParkingIcon
         aria-label={'Pre-selected icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );
@@ -186,7 +216,10 @@ export function PreSelectedIcon(props: IconProps): ReactElement {
 export function SearchPackagesIcon(props: IconProps): ReactElement {
   return (
     <SearchIcon
-      sx={{ ...classes.nonClickableIcon, ...props.sx }}
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.nonClickableIcon,
+        sxProps: props.sx,
+      })}
       aria-label={'Search packages icon'}
     />
   );
@@ -197,7 +230,10 @@ export function IncompletePackagesIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="contains incomplete information">
       <RectangleIcon
         aria-label={'Incomplete icon'}
-        sx={{ ...classes.nonClickableIcon, ...props.sx }}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
       />
     </MuiTooltip>
   );

--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -15,6 +15,7 @@ import { getFilesWithChildren } from '../../state/selectors/all-views-resource-s
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/system';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const classes = {
   root: {
@@ -43,7 +44,12 @@ export function PathBar(props: PathBarProps): ReactElement | null {
   const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
 
   return path ? (
-    <MuiBox sx={{ ...classes.root, ...props.sx }}>
+    <MuiBox
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.root,
+        sxProps: props.sx,
+      })}
+    >
       <MuiTooltip sx={classes.tooltip} title={path}>
         <MuiTypography sx={classes.leftEllipsis} variant={'subtitle1'}>
           <bdi>

--- a/src/Frontend/Components/Spinner/Spinner.tsx
+++ b/src/Frontend/Components/Spinner/Spinner.tsx
@@ -6,6 +6,7 @@ import React, { ReactElement } from 'react';
 import MuiSpinner from '@mui/material/CircularProgress';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const classes = {
   root: {
@@ -21,7 +22,12 @@ interface SpinnerProps {
 
 export function Spinner(props: SpinnerProps): ReactElement {
   return (
-    <MuiBox sx={{ ...classes.root, ...props.sx }}>
+    <MuiBox
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.root,
+        sxProps: props.sx,
+      })}
+    >
       <MuiSpinner />
     </MuiBox>
   );

--- a/src/Frontend/Components/ToggleButton/ToggleButton.tsx
+++ b/src/Frontend/Components/ToggleButton/ToggleButton.tsx
@@ -8,6 +8,7 @@ import MuiToggleButton from '@mui/material/ToggleButton';
 import React, { ReactElement } from 'react';
 import { OpossumColors } from '../../shared-styles';
 import { SxProps } from '@mui/material';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const classes = {
   button: {
@@ -39,7 +40,10 @@ export function ToggleButton(props: ToggleButtonProps): ReactElement {
       value="check"
       selected={props.selected}
       onChange={props.handleChange}
-      sx={{ ...classes.button, ...props.sx }}
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.button,
+        sxProps: props.sx,
+      })}
       aria-label={props.ariaLabel}
     >
       {props.buttonText}


### PR DESCRIPTION

### Summary of changes

The helper `getSxFromPropsAndClasses` that merges style classes and sx props is used though out the code.

### Context and reason for change

We did not handle applying style classes and sx props to components consistently. This, in particular, caused some confusions: https://github.com/opossum-tool/OpossumUI/pull/1318#discussion_r1068128769 
