### PR TITLE
Attribution Wizard: Finalize Step 2

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -4,12 +4,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
+import MuiBox from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
+import { PackageInfo } from '../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../types/types';
+import { generatePurlFromPackageInfo } from '../../util/handle-purl';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
 
+const PURL_HEIGHT = 45;
+
+const classes = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'start',
+  },
+  purl: {
+    border: 1,
+    padding: '0px 3px',
+    marginTop: '5px',
+    marginBottom: '10px',
+  },
+  listBox: {
+    display: 'flex',
+    gap: '30px',
+    maxHeight: `calc(100% - ${PURL_HEIGHT}px)`,
+  },
+};
 interface AttributionWizardPackageStepProps {
   attributedPackageNamespaces: Array<ListWithAttributesItem>;
   attributedPackageNames: Array<ListWithAttributesItem>;
+  temporaryPackageInfo: PackageInfo;
   selectedPackageNamespaceId: string;
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
@@ -19,22 +44,30 @@ interface AttributionWizardPackageStepProps {
 export function AttributionWizardPackageStep(
   props: AttributionWizardPackageStepProps
 ): ReactElement {
+  const temporaryPackagePurl = generatePurlFromPackageInfo(
+    props.temporaryPackageInfo
+  );
   return (
-    <>
-      <ListWithAttributes
-        listItems={props.attributedPackageNamespaces}
-        selectedListItemId={props.selectedPackageNamespaceId}
-        handleListItemClick={props.handlePackageNamespaceListItemClick}
-        showAddNewInput={false}
-        title={'Package namespace'}
-      />
-      <ListWithAttributes
-        listItems={props.attributedPackageNames}
-        selectedListItemId={props.selectedPackageNameId}
-        handleListItemClick={props.handlePackageNameListItemClick}
-        showAddNewInput={false}
-        title={'Package name'}
-      />
-    </>
+    <MuiBox sx={classes.root}>
+      <MuiTypography variant={'subtitle1'} sx={classes.purl}>
+        {temporaryPackagePurl}
+      </MuiTypography>
+      <MuiBox sx={classes.listBox}>
+        <ListWithAttributes
+          listItems={props.attributedPackageNamespaces}
+          selectedListItemId={props.selectedPackageNamespaceId}
+          handleListItemClick={props.handlePackageNamespaceListItemClick}
+          showAddNewInput={false}
+          title={'Package namespace'}
+        />
+        <ListWithAttributes
+          listItems={props.attributedPackageNames}
+          selectedListItemId={props.selectedPackageNameId}
+          handleListItemClick={props.handlePackageNameListItemClick}
+          showAddNewInput={false}
+          title={'Package name'}
+        />
+      </MuiBox>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -8,8 +8,7 @@ import {
   createTestAppStore,
   renderComponentWithStore,
 } from '../../../test-helpers/render-component-with-store';
-import { AttributionWizardPopup } from '../AttributionWizardPopup';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { ButtonText, PopupType } from '../../../enums/enums';
 import { getOpenPopup } from '../../../state/selectors/view-selector';
@@ -18,27 +17,73 @@ import {
   Attributions,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
-import { setExternalData } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  setExternalData,
+  setManualData,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
+
+const selectedResourceId = '/samplepath/';
+const testExternalAttributions: Attributions = {
+  uuid_0: {
+    packageName: 'react',
+    packageNamespace: 'npm',
+  },
+};
+const testManualAttributions: Attributions = {
+  uuid_0: {
+    packageName: 'react',
+    packageNamespace: 'npm',
+  },
+};
+const testExternalResourcesToAttributions: ResourcesToAttributions = {
+  '/samplepath/subfolder': ['uuid_0'],
+};
+const testManualResourcesToAttributions: ResourcesToAttributions = {
+  selectedResourceId: ['uuid_0'],
+};
 
 describe('AttributionWizardPopup', () => {
   it('renders with header, resource path, and buttons', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId('/thirdParty'));
-
-    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
 
     expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
-    expect(screen.getByText('/thirdParty')).toBeInTheDocument();
+    expect(screen.getByText(selectedResourceId)).toBeInTheDocument();
     expect(screen.getByText(ButtonText.Cancel)).toBeInTheDocument();
     expect(screen.getByText(ButtonText.Next)).toBeInTheDocument();
   });
 
   it('closes when clicking "cancel"', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId('/thirdParty'));
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
 
-    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
-    testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_1'));
     expect(getOpenPopup(testStore.getState())).toBe(
       PopupType.AttributionWizardPopup
     );
@@ -49,63 +94,54 @@ describe('AttributionWizardPopup', () => {
 
   it('renders breadcrumbs', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId('/thirdParty'));
-
-    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
 
     expect(screen.getByText('package')).toBeInTheDocument();
     expect(screen.getByText('version')).toBeInTheDocument();
   });
 });
 
-describe('AttributionWizardPoup navigation', () => {
+describe('AttributionWizardPopup navigation', () => {
   const namespaceListTitle = 'Package namespace';
   const nameListTitle = 'Package name';
   const versionListTitle = 'Package version';
 
   it('allows navigation via "next" and "back" buttons', () => {
     const testStore = createTestAppStore();
-    const selectedResourceId = '/samplepath/';
-
-    const testAttributions: Attributions = {
-      uuid_0: {
-        packageName: 'boost',
-        packageNamespace: 'pkg:npm',
-      },
-      uuid_1: {
-        packageName: 'buffer',
-        packageNamespace: 'pkg:npm',
-      },
-      uuid_2: {
-        packageName: 'numpy',
-        packageNamespace: 'pkg:pip',
-      },
-      uuid_3: {
-        packageName: 'pandas',
-        packageNamespace: 'pkg:pip',
-      },
-    };
-
-    const testResourcesToAttributions: ResourcesToAttributions = {
-      '/samplepath/subfolder1': ['uuid_0', 'uuid_1'],
-      '/samplepath/subfolder2/subsubfolder1': ['uuid_2', 'uuid_1'],
-      '/samplepath/subfolder2/subsubfolder2': ['uuid_3'],
-    };
-
     testStore.dispatch(setSelectedResourceId(selectedResourceId));
     testStore.dispatch(
-      setExternalData(testAttributions, testResourcesToAttributions)
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
     );
-    renderComponentWithStore(<AttributionWizardPopup />, {
-      store: testStore,
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
     });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('buffer'));
-    fireEvent.click(screen.getByText('pkg:npm'));
+    fireEvent.click(screen.getByText('react'));
+    fireEvent.click(screen.getByText('npm'));
     fireEvent.click(screen.getByText(ButtonText.Next));
 
     expect(screen.queryByText(namespaceListTitle)).not.toBeInTheDocument();
@@ -121,45 +157,27 @@ describe('AttributionWizardPoup navigation', () => {
 
   it('allows navigation via breadcrumbs (back only, so far)', () => {
     const testStore = createTestAppStore();
-    const selectedResourceId = '/samplepath/';
-
-    const testAttributions: Attributions = {
-      uuid_0: {
-        packageName: 'boost',
-        packageNamespace: 'pkg:npm',
-      },
-      uuid_1: {
-        packageName: 'buffer',
-        packageNamespace: 'pkg:npm',
-      },
-      uuid_2: {
-        packageName: 'numpy',
-        packageNamespace: 'pkg:pip',
-      },
-      uuid_3: {
-        packageName: 'pandas',
-        packageNamespace: 'pkg:pip',
-      },
-    };
-
-    const testResourcesToAttributions: ResourcesToAttributions = {
-      '/samplepath/subfolder1': ['uuid_0', 'uuid_1'],
-      '/samplepath/subfolder2/subsubfolder1': ['uuid_2', 'uuid_1'],
-      '/samplepath/subfolder2/subsubfolder2': ['uuid_3'],
-    };
-
     testStore.dispatch(setSelectedResourceId(selectedResourceId));
     testStore.dispatch(
-      setExternalData(testAttributions, testResourcesToAttributions)
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
     );
-    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('buffer'));
-    fireEvent.click(screen.getByText('pkg:npm'));
+    fireEvent.click(screen.getByText('react'));
+    fireEvent.click(screen.getByText('npm'));
     fireEvent.click(screen.getByText(ButtonText.Next));
 
     expect(screen.queryByText(namespaceListTitle)).not.toBeInTheDocument();

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -4,70 +4,174 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  AttributionData,
   AttributionIdWithCount,
   Attributions,
+  PackageInfo,
 } from '../../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../../types/types';
-import { getAttributionWizardPackageListsItems } from '../attribution-wizard-popup-helpers';
+import {
+  emptyAttribute,
+  getAttributionWizardPackageListsItems,
+  getAttributionWizardPackageVersionListItems,
+  getAllAttributionIdsWithCountsFromResourceAndChildren,
+  getHighlightedPackageNameIds,
+  getPreSelectedPackageAttributeIds,
+} from '../attribution-wizard-popup-helpers';
+
+describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', () => {
+  it('yields correct output', () => {
+    const testSelectedResourceId = '/samplepath/';
+    const testExternalData: AttributionData = {
+      attributionsToResources: {},
+      resourcesWithAttributedChildren: {
+        '/samplepath/': new Set<string>([
+          '/samplepath/file_0',
+          '/samplepath/subfolder/file_1',
+          '/samplepath/subfolder/file_2',
+        ]),
+      },
+      resourcesToAttributions: {
+        '/samplepath/file_0': ['uuid_0'],
+        '/samplepath/subfolder/file_1': ['uuid_1'],
+        '/samplepath/subfolder/file_2': ['uuid_0'],
+      },
+      attributions: {},
+    };
+    const testManualData: AttributionData = {
+      attributionsToResources: {},
+      resourcesWithAttributedChildren: {
+        '/samplepath/': new Set<string>([
+          '/samplepath/subfolder/file_0',
+          '/samplepath/subfolder_2/file_3',
+          '/samplepath/subfolder_2/file_4',
+        ]),
+      },
+      resourcesToAttributions: {
+        '/samplepath/subfolder/file_0': ['uuid_2'],
+        '/samplepath/subfolder_2/file_3': ['uuid_3'],
+        '/samplepath/subfolder_2/file_4': ['uuid_4'],
+      },
+      attributions: {},
+    };
+    const testResolvedExternalAttributions: Set<string> = new Set<string>();
+
+    const expectedTestAttributionsWithCounts: Array<AttributionIdWithCount> = [
+      { attributionId: 'uuid_0', count: 2 },
+      { attributionId: 'uuid_1', count: 1 },
+      { attributionId: 'uuid_2', count: 1 },
+      { attributionId: 'uuid_3', count: 1 },
+      { attributionId: 'uuid_4', count: 1 },
+    ];
+
+    const testAttributionsWithCounts =
+      getAllAttributionIdsWithCountsFromResourceAndChildren(
+        testSelectedResourceId,
+        testExternalData,
+        testManualData,
+        testResolvedExternalAttributions
+      );
+
+    expect(testAttributionsWithCounts).toEqual(
+      expectedTestAttributionsWithCounts
+    );
+  });
+});
+
+describe('getPreSelectedPackageAttributeIds', () => {
+  it('yields correct output', () => {
+    const testPackageInfo: PackageInfo = {
+      packageVersion: '6.0.3',
+      packageNamespace: 'npm',
+      packageName: 'buffer',
+    };
+    const expectedPreSelectedPackageNamespaceId = 'namespace-npm';
+    const expectedPreSelectedPackageNameId = 'name-buffer';
+    const expectedPreSelectedPackageVersionId = 'version-6.0.3';
+
+    const {
+      preSelectedPackageNamespaceId: testPreSelectedPackageNamespaceId,
+      preSelectedPackageNameId: testPreSelectedPackageNameId,
+      preSelectedPackageVersionId: testPreSelectedPackageVersionId,
+    } = getPreSelectedPackageAttributeIds(testPackageInfo);
+
+    expect(testPreSelectedPackageNamespaceId).toEqual(
+      expectedPreSelectedPackageNamespaceId
+    );
+    expect(testPreSelectedPackageNameId).toEqual(
+      expectedPreSelectedPackageNameId
+    );
+    expect(testPreSelectedPackageVersionId).toEqual(
+      expectedPreSelectedPackageVersionId
+    );
+  });
+});
 
 describe('getAttributionWizardPackageListsItems', () => {
   it('yields correct output', () => {
     const testContainedExternalPackages: Array<AttributionIdWithCount> = [
-      { attributionId: 'uuid_0', childrenWithAttributionCount: 2 },
-      { attributionId: 'uuid_1', childrenWithAttributionCount: 5 },
-      { attributionId: 'uuid_2', childrenWithAttributionCount: 1 },
-      { attributionId: 'uuid_3', childrenWithAttributionCount: 1 },
-      { attributionId: 'uuid_4', childrenWithAttributionCount: 1 },
+      { attributionId: 'uuid_0', count: 1 },
+      { attributionId: 'uuid_1', count: 5 },
+      { attributionId: 'uuid_2', count: 1 },
+      { attributionId: 'uuid_3', count: 1 },
+      { attributionId: 'uuid_4', count: 1 },
+      { attributionId: 'uuid_5', count: 1 },
     ];
     const testExternalAttributions: Attributions = {
       uuid_0: {
-        packageName: 'boost',
-        packageNamespace: 'pkg:npm',
+        packageName: 'buffer',
+        packageNamespace: 'npm',
+        packageVersion: '6.0.3',
       },
       uuid_1: {
         packageName: 'numpy',
-        packageNamespace: 'pkg:pip',
+        packageNamespace: 'pip',
+        packageVersion: '1.24.0',
       },
       uuid_2: {
         packageName: undefined,
         packageNamespace: undefined,
+        packageVersion: undefined,
       },
       uuid_3: {
         packageName: '',
         packageNamespace: '',
+        packageVersion: '',
       },
       uuid_4: {
         packageName: 'pandas',
-        packageNamespace: 'pkg:pip',
+        packageNamespace: 'pip',
+        packageVersion: '1.5.2',
+      },
+      uuid_5: {
+        packageName: 'buffer',
+        packageNamespace: 'npm',
+        packageVersion: '6.0',
       },
     };
     const expectedAttributedPackageNamespaces: Array<ListWithAttributesItem> = [
       {
-        text: 'pkg:pip',
-        id: 'namespace-pkg:pip',
+        text: 'pip',
+        id: 'namespace-pip',
         attributes: [
-          { text: 'count: 6 (60.0%)', id: 'namespace-attribute-pkg:pip' },
+          { text: 'count: 6 (60.0%)', id: 'namespace-attribute-pip' },
         ],
       },
       {
-        text: 'pkg:npm',
-        id: 'namespace-pkg:npm',
+        text: emptyAttribute,
+        id: `namespace-${emptyAttribute}`,
         attributes: [
-          { text: 'count: 2 (20.0%)', id: 'namespace-attribute-pkg:npm' },
+          {
+            text: 'count: 2 (20.0%)',
+            id: `namespace-attribute-${emptyAttribute}`,
+          },
         ],
       },
       {
-        text: 'empty',
-        id: 'namespace-empty',
+        text: 'npm',
+        id: 'namespace-npm',
         attributes: [
-          { text: 'count: 1 (10.0%)', id: 'namespace-attribute-empty' },
-        ],
-      },
-      {
-        text: 'none',
-        id: 'namespace-none',
-        attributes: [
-          { text: 'count: 1 (10.0%)', id: 'namespace-attribute-none' },
+          { text: 'count: 2 (20.0%)', id: 'namespace-attribute-npm' },
         ],
       },
     ];
@@ -78,19 +182,16 @@ describe('getAttributionWizardPackageListsItems', () => {
         attributes: [{ text: 'count: 5 (50.0%)', id: 'name-attribute-numpy' }],
       },
       {
-        text: 'boost',
-        id: 'name-boost',
-        attributes: [{ text: 'count: 2 (20.0%)', id: 'name-attribute-boost' }],
+        text: emptyAttribute,
+        id: `name-${emptyAttribute}`,
+        attributes: [
+          { text: 'count: 2 (20.0%)', id: `name-attribute-${emptyAttribute}` },
+        ],
       },
       {
-        text: 'empty',
-        id: 'name-empty',
-        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-empty' }],
-      },
-      {
-        text: 'none',
-        id: 'name-none',
-        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-none' }],
+        text: 'buffer',
+        id: 'name-buffer',
+        attributes: [{ text: 'count: 2 (20.0%)', id: 'name-attribute-buffer' }],
       },
       {
         text: 'pandas',
@@ -98,16 +199,98 @@ describe('getAttributionWizardPackageListsItems', () => {
         attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-pandas' }],
       },
     ];
+    const expectedPackageNamesToVersions = {
+      buffer: new Set<string>(['6.0.3', '6.0']),
+      numpy: new Set<string>(['1.24.0']),
+      pandas: new Set<string>(['1.5.2']),
+      [emptyAttribute]: new Set<string>([emptyAttribute]),
+    };
 
-    const { attributedPackageNamespaces, attributedPackageNames } =
-      getAttributionWizardPackageListsItems(
-        testContainedExternalPackages,
-        testExternalAttributions
-      );
+    const {
+      attributedPackageNamespaces,
+      attributedPackageNames,
+      packageNamesToVersions,
+    } = getAttributionWizardPackageListsItems(
+      testContainedExternalPackages,
+      testExternalAttributions
+    );
 
     expect(attributedPackageNamespaces).toEqual(
       expectedAttributedPackageNamespaces
     );
     expect(attributedPackageNames).toEqual(expectedAttributedPackageNames);
+    expect(packageNamesToVersions).toEqual(expectedPackageNamesToVersions);
+  });
+});
+
+describe('getAttributionWizardPackageVersionListItems', () => {
+  it('yields correct output', () => {
+    const testPackageName = 'buffer';
+    const testPackageName2 = 'buffer2';
+    const testPackageNamesToVersions = {
+      [testPackageName]: new Set<string>(['6.0.3', '6.0']),
+      [testPackageName2]: new Set<string>(['6.0.3']),
+      numpy: new Set<string>(['1.24.0']),
+    };
+
+    const expectedPackageVersionListItems = [
+      {
+        text: '6.0',
+        id: 'version-6.0',
+        attributes: [
+          {
+            text: testPackageName,
+            id: `version-6.0-name-${testPackageName}`,
+          },
+        ],
+      },
+      {
+        text: '6.0.3',
+        id: 'version-6.0.3',
+        attributes: [
+          {
+            text: testPackageName,
+            id: `version-6.0.3-name-${testPackageName}`,
+          },
+          {
+            text: testPackageName2,
+            id: `version-6.0.3-name-${testPackageName2}`,
+          },
+        ],
+      },
+    ];
+
+    const testPackageVersionListItems =
+      getAttributionWizardPackageVersionListItems(
+        testPackageName,
+        testPackageNamesToVersions
+      );
+
+    expect(testPackageVersionListItems).toEqual(
+      expectedPackageVersionListItems
+    );
+  });
+});
+
+describe('getHighlightedPackeNameIds', () => {
+  it('yields correct output', () => {
+    const testSelectedPackageName = 'buffer';
+    const testPackageNamesToVersions = {
+      buffer: new Set<string>(['6.0.3', '6.0']),
+      numpy: new Set<string>(['1.24.0']),
+    };
+    const expectedHighlightedPackeNameIds = [
+      'version-6.0.3-name-buffer',
+      'version-6.0-name-buffer',
+    ];
+
+    const testHighlightedPackageNameIds = getHighlightedPackageNameIds(
+      testSelectedPackageName,
+      testPackageNamesToVersions
+    );
+
+    expect(testHighlightedPackageNameIds).toEqual(
+      expectedHighlightedPackeNameIds
+    );
   });
 });

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -4,10 +4,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  AttributionData,
   AttributionIdWithCount,
   Attributions,
+  PackageInfo,
+  ResourcesToAttributions,
 } from '../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../types/types';
+import { getAttributedChildren } from '../../util/get-attributed-children';
 import { shouldNotBeCalled } from '../../util/should-not-be-called';
 
 interface TextAndCount {
@@ -19,32 +23,116 @@ interface NamesWithCounts {
   [name: string]: number;
 }
 
+export const emptyAttribute = '-';
+
+export function getAllAttributionIdsWithCountsFromResourceAndChildren(
+  selectedResourceId: string,
+  externalData: AttributionData,
+  manualData: AttributionData,
+  resolvedExternalAttributions: Set<string>
+): Array<AttributionIdWithCount> {
+  const externalAttributedChildren = getAttributedChildren(
+    externalData.resourcesWithAttributedChildren,
+    selectedResourceId
+  );
+  if (selectedResourceId in externalData.resourcesToAttributions) {
+    externalAttributedChildren.add(selectedResourceId);
+  }
+
+  const manualAttributedChildren = getAttributedChildren(
+    manualData.resourcesWithAttributedChildren,
+    selectedResourceId
+  );
+  if (selectedResourceId in manualData.resourcesToAttributions) {
+    manualAttributedChildren.add(selectedResourceId);
+  }
+
+  const externalAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
+    externalData.resourcesToAttributions,
+    externalAttributedChildren,
+    resolvedExternalAttributions
+  );
+  const manualAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
+    manualData.resourcesToAttributions,
+    manualAttributedChildren
+  );
+
+  return externalAttributionsWithCounts.concat(manualAttributionsWithCounts);
+}
+
+function getAggregatedAttributionIdsAndCounts(
+  resourcesToAttributions: ResourcesToAttributions,
+  attributedChildren: Set<string>,
+  resolvedExternalAttributions?: Set<string>
+): Array<AttributionIdWithCount> {
+  const attributionCount: { [attributionId: string]: number } = {};
+  attributedChildren.forEach((child: string) => {
+    resourcesToAttributions[child].forEach((attributionId: string) => {
+      if (
+        !resolvedExternalAttributions ||
+        !resolvedExternalAttributions.has(attributionId)
+      ) {
+        attributionCount[attributionId] =
+          (attributionCount[attributionId] || 0) + 1;
+      }
+    });
+  });
+
+  return Object.entries(attributionCount).map(([attributionId, count]) => ({
+    attributionId,
+    count,
+  }));
+}
+
+export function getPreSelectedPackageAttributeIds(popupPackage: PackageInfo): {
+  preSelectedPackageNamespaceId: string;
+  preSelectedPackageNameId: string;
+  preSelectedPackageVersionId: string;
+} {
+  const namespace = popupPackage.packageNamespace || emptyAttribute;
+  const name = popupPackage.packageName || emptyAttribute;
+  const version = popupPackage.packageVersion || emptyAttribute;
+
+  const preSelectedPackageNamespaceId = `namespace-${namespace}`;
+  const preSelectedPackageNameId = `name-${name}`;
+  const preSelectedPackageVersionId = `version-${version}`;
+
+  return {
+    preSelectedPackageNamespaceId,
+    preSelectedPackageNameId,
+    preSelectedPackageVersionId,
+  };
+}
+
 export function getAttributionWizardPackageListsItems(
-  containedExternalPackages: Array<AttributionIdWithCount>,
-  externalAttributions: Attributions
+  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
+  externalAndManualAttributions: Attributions
 ): {
   attributedPackageNamespaces: Array<ListWithAttributesItem>;
   attributedPackageNames: Array<ListWithAttributesItem>;
+  packageNamesToVersions: { [packageName: string]: Set<string> };
 } {
-  const totalAttributionCount = containedExternalPackages
-    .map(
-      (containedExternalPackage) =>
-        containedExternalPackage.childrenWithAttributionCount ?? 0
-    )
+  const totalAttributionCount = externalAndManualAttributionIdsWithCounts
+    .map((attributionIdWithCount) => attributionIdWithCount.count ?? 0)
     .reduce(
       (accumulatedCounts, currentCount) => accumulatedCounts + currentCount,
       0
     );
 
   const packageNamespacesAndCounts = getPackageAttributesAndCounts(
-    containedExternalPackages,
-    externalAttributions,
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions,
     'namespace'
   );
   const packageNamesAndCounts = getPackageAttributesAndCounts(
-    containedExternalPackages,
-    externalAttributions,
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions,
     'name'
+  );
+
+  const packageNamesToVersions = getPackageNamesToVersions(
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions
   );
 
   const packageNamespacesWithCounts = sortPackageAttributesAndCounts(
@@ -68,32 +156,26 @@ export function getAttributionWizardPackageListsItems(
   return {
     attributedPackageNamespaces,
     attributedPackageNames,
+    packageNamesToVersions,
   };
 }
 
 function getPackageAttributesAndCounts(
-  containedExternalPackages: Array<AttributionIdWithCount>,
-  externalAttributions: Attributions,
+  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
+  externalAndManualAttributions: Attributions,
   packageAttributeId: 'namespace' | 'name'
 ): NamesWithCounts {
   const packageAttributesAndCounts: NamesWithCounts = {};
-  for (const containedExternalPackage of containedExternalPackages) {
+  for (const attributionIdWithCount of externalAndManualAttributionIdsWithCounts) {
     const packageInfo =
-      externalAttributions[containedExternalPackage.attributionId];
-    const packageCount =
-      containedExternalPackage.childrenWithAttributionCount ?? 0;
+      externalAndManualAttributions[attributionIdWithCount.attributionId];
+    const packageCount = attributionIdWithCount.count ?? 0;
 
     let packageAttribute: string;
     if (packageAttributeId === 'namespace') {
-      packageAttribute =
-        packageInfo.packageNamespace !== ''
-          ? packageInfo.packageNamespace ?? 'none'
-          : 'empty';
+      packageAttribute = packageInfo.packageNamespace || emptyAttribute;
     } else if (packageAttributeId === 'name') {
-      packageAttribute =
-        packageInfo.packageName !== ''
-          ? packageInfo.packageName ?? 'none'
-          : 'empty';
+      packageAttribute = packageInfo.packageName || emptyAttribute;
     } else {
       shouldNotBeCalled(packageAttributeId);
     }
@@ -103,6 +185,26 @@ function getPackageAttributesAndCounts(
   }
 
   return packageAttributesAndCounts;
+}
+
+function getPackageNamesToVersions(
+  containedExternalPackages: Array<AttributionIdWithCount>,
+  externalAttributions: Attributions
+): { [packageName: string]: Set<string> } {
+  const packageNamesToVersions: { [packageName: string]: Set<string> } = {};
+  for (const containedExternalPackage of containedExternalPackages) {
+    const packageInfo =
+      externalAttributions[containedExternalPackage.attributionId];
+
+    const packageName = packageInfo.packageName || emptyAttribute;
+    const packageVersion = packageInfo.packageVersion || emptyAttribute;
+
+    packageNamesToVersions[packageName] ??
+      (packageNamesToVersions[packageName] = new Set<string>());
+    packageNamesToVersions[packageName].add(packageVersion);
+  }
+
+  return packageNamesToVersions;
 }
 
 function sortPackageAttributesAndCounts(packageAttributesAndCounts: {
@@ -153,4 +255,53 @@ function getWizardListItem(
       },
     ],
   };
+}
+export function getAttributionWizardPackageVersionListItems(
+  packageName: string,
+  packageNamesToVersions: { [name: string]: Set<string> }
+): Array<ListWithAttributesItem> {
+  const packageVersionsToNames: { [version: string]: Set<string> } = {};
+  for (const [name, versions] of Object.entries(packageNamesToVersions)) {
+    for (const version of versions) {
+      packageVersionsToNames[version] ??
+        (packageVersionsToNames[version] = new Set<string>());
+      packageVersionsToNames[version].add(name);
+    }
+  }
+
+  const versions = Array.from(packageNamesToVersions[packageName]).sort();
+  const packageVersionListItems: Array<ListWithAttributesItem> = [];
+  for (const version of versions) {
+    packageVersionListItems.push({
+      text: version,
+      id: `version-${version}`,
+      attributes: Array.from(packageVersionsToNames[version])
+        .sort()
+        .map((packageName) => ({
+          text: `${packageName}`,
+          id: `version-${version}-name-${packageName}`,
+        })),
+    });
+  }
+  return packageVersionListItems;
+}
+
+export function getHighlightedPackageNameIds(
+  selectedPackageName: string,
+  packageNamesToVersions: { [packageName: string]: Set<string> }
+): Array<string> {
+  return Array.from(packageNamesToVersions[selectedPackageName]).map(
+    (version) => `version-${version}-name-${selectedPackageName}`
+  );
+}
+
+export function filterForPackageAttributeId(
+  selectedPackageAttributeId: string,
+  packageAttributes: Array<ListWithAttributesItem>
+): string {
+  return selectedPackageAttributeId !== ''
+    ? packageAttributes.filter(
+        (item) => item.id === selectedPackageAttributeId
+      )[0].text
+    : '';
 }

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -4,32 +4,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
+import MuiBox from '@mui/material/Box';
+import MuiTypography from '@mui/material/Typography';
 import { ListWithAttributesItem } from '../../types/types';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
+import { PackageInfo } from '../../../shared/shared-types';
+import { generatePurlFromPackageInfo } from '../../util/handle-purl';
 
+const PURL_HEIGHT = 45;
+
+const classes = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'start',
+  },
+  purl: {
+    border: 1,
+    padding: '0px 3px',
+    marginTop: '5px',
+    marginBottom: '10px',
+  },
+  listBox: {
+    display: 'flex',
+    maxHeight: `calc(100% - ${PURL_HEIGHT}px)`,
+  },
+};
 interface AttributionWizardVersionStepProps {
-  packageVersionListItems: Array<ListWithAttributesItem>;
+  attributedPackageVersions: Array<ListWithAttributesItem>;
   highlightedPackageNameIds: Array<string>;
-  selectedPackageNamespaceId: string;
-  selectedPackageNameId: string;
+  temporaryPackageInfo: PackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
 }
 
-// TODO: selectedPackageNamespaceId and selectedPackageNameId already in props for upcoming ticket
-
 export function AttributionWizardVersionStep(
   props: AttributionWizardVersionStepProps
 ): ReactElement {
+  const temporaryPackagePurl = generatePurlFromPackageInfo(
+    props.temporaryPackageInfo
+  );
+
   return (
-    <ListWithAttributes
-      listItems={props.packageVersionListItems}
-      selectedListItemId={props.selectedPackageVersionId}
-      highlightedAttributeIds={props.highlightedPackageNameIds}
-      handleListItemClick={props.handlePackageVersionListItemClick}
-      showAddNewInput={false}
-      title={'Package version'}
-      listItemSx={{ maxWidth: '400px' }}
-    />
+    <MuiBox sx={classes.root}>
+      <MuiTypography variant={'subtitle1'} sx={classes.purl}>
+        {temporaryPackagePurl}
+      </MuiTypography>
+      <MuiBox sx={classes.listBox}>
+        <ListWithAttributes
+          listItems={props.attributedPackageVersions}
+          selectedListItemId={props.selectedPackageVersionId}
+          highlightedAttributeIds={props.highlightedPackageNameIds}
+          handleListItemClick={props.handlePackageVersionListItemClick}
+          showAddNewInput={false}
+          title={'Package version'}
+          listItemSx={{ maxWidth: '400px' }}
+        />
+      </MuiBox>
+    </MuiBox>
   );
 }

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -12,11 +12,19 @@ import {
 import { GlobalPopup } from '../GlobalPopup';
 import { PopupType } from '../../../enums/enums';
 import { screen } from '@testing-library/react';
-import { Attributions } from '../../../../shared/shared-types';
+import {
+  Attributions,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { act } from 'react-dom/test-utils';
+import {
+  setManualData,
+  setExternalData,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
 describe('The GlobalPopUp', () => {
   it('does not open by default', () => {
@@ -140,11 +148,42 @@ describe('The GlobalPopUp', () => {
   });
 
   it('opens the AttributionWizardPopup', () => {
-    const { store } = renderComponentWithStore(<GlobalPopup />);
+    const store = createTestAppStore();
+    const selectedResourceId = '/samplepath/';
+    const testExternalAttributions: Attributions = {
+      uuid_0: {
+        packageName: 'react',
+        packageNamespace: 'npm',
+      },
+    };
+    const testManualAttributions: Attributions = {
+      uuid_0: {
+        packageName: 'react',
+        packageNamespace: 'npm',
+      },
+    };
+    const testExternalResourcesToAttributions: ResourcesToAttributions = {
+      '/samplepath/subfolder': ['uuid_0'],
+    };
+    const testManualResourcesToAttributions: ResourcesToAttributions = {
+      selectedResourceId: ['uuid_0'],
+    };
+
+    store.dispatch(setSelectedResourceId(selectedResourceId));
+    store.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    store.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+
+    renderComponentWithStore(<GlobalPopup />, { store });
+
     act(() => {
-      store.dispatch(
-        openPopup(PopupType.AttributionWizardPopup, 'test_attribution_id')
-      );
+      store.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
     });
     expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
   });

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -64,6 +64,7 @@ const classes = {
   },
   listItemTextAttributesBox: {
     display: 'flex',
+    flexWrap: 'wrap',
     marginLeft: '20px',
     paddingTop: '1px',
   },

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -19,6 +19,7 @@ interface ManualAttributionListProps {
   selectedAttributionId: string | null;
   onCardClick(attributionId: string, isButton?: boolean): void;
   isAddNewAttributionItemShown?: boolean;
+  attributionsFromParent?: boolean;
 }
 
 export function ManualAttributionList(
@@ -66,6 +67,7 @@ export function ManualAttributionList(
         cardId={`manual-${props.selectedResourceId}-${attributionId}`}
         packageInfo={packageInfo}
         showOpenResourcesIcon={!isButton}
+        hideAttributionWizardContextMenuItem={props.attributionsFromParent}
       />
     );
   }

--- a/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
+++ b/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
@@ -93,6 +93,7 @@ export function ManualPackagePanel(
         selectedAttributionId={selectedAttributionId}
         isAddNewAttributionItemShown={props.showAddNewAttributionButton}
         onCardClick={onCardClick}
+        attributionsFromParent={showParentAttributions}
       />
       <MuiBox sx={classes.buttonDiv}>
         {showParentAttributions && (

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -83,6 +83,7 @@ interface PackageCardProps {
   hideContextMenuAndMultiSelect?: boolean;
   hideResourceSpecificButtons?: boolean;
   showCheckBox?: boolean;
+  hideAttributionWizardContextMenuItem?: boolean;
 }
 
 export function PackageCard(props: PackageCardProps): ReactElement | null {
@@ -319,7 +320,10 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           {
             buttonText: ButtonText.OpenAttributionWizardPopup,
             disabled: false,
-            hidden: true, // isExternalAttribution || hideResourceSpecificButtons,
+            hidden: true,
+            // isExternalAttribution ||
+            // hideResourceSpecificButtons ||
+            // props.hideAttributionWizardContextMenuItem,
             onClick: (): void => {
               dispatch(
                 openPopup(PopupType.AttributionWizardPopup, attributionId)

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -104,7 +104,7 @@ export function PackagePanel(
     const packageCount = props.attributionIdsWithCount.filter(
       (attributionIdWithCount) =>
         attributionIdWithCount.attributionId === attributionId
-    )[0].childrenWithAttributionCount;
+    )[0].count;
 
     const isExternalAttribution =
       props.title === PackagePanelTitle.ExternalPackages ||

--- a/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
@@ -30,12 +30,12 @@ const testAttributionSources: ExternalAttributionSources = {
 describe('PackagePanel helpers', () => {
   const testAttributionIds: Array<AttributionIdWithCount> = [
     { attributionId: 'jquery' },
-    { attributionId: 'b_unknown', childrenWithAttributionCount: 5 },
-    { attributionId: 'react', childrenWithAttributionCount: 5 },
-    { attributionId: 'vue', childrenWithAttributionCount: 500 },
-    { attributionId: 'a_unknown', childrenWithAttributionCount: 3 },
-    { attributionId: 'reuser', childrenWithAttributionCount: 3 },
-    { attributionId: 'blub', childrenWithAttributionCount: 1 },
+    { attributionId: 'b_unknown', count: 5 },
+    { attributionId: 'react', count: 5 },
+    { attributionId: 'vue', count: 500 },
+    { attributionId: 'a_unknown', count: 3 },
+    { attributionId: 'reuser', count: 3 },
+    { attributionId: 'blub', count: 1 },
   ];
   const testAttributions: Attributions = {
     react: {
@@ -93,7 +93,7 @@ describe('PackagePanel helpers', () => {
       [
         {
           attributionId: 'react',
-          childrenWithAttributionCount: 5,
+          count: 5,
         },
       ];
     expect(

--- a/src/Frontend/util/__tests__/get-contained-packages.ts
+++ b/src/Frontend/util/__tests__/get-contained-packages.ts
@@ -32,15 +32,15 @@ describe('computeAggregatedAttributionsFromChildren', () => {
   it('selects aggregated children and sorts correctly', () => {
     const expectedResult: Array<AttributionIdWithCount> = [
       {
-        childrenWithAttributionCount: 2,
+        count: 2,
         attributionId: 'uuid_2',
       },
       {
-        childrenWithAttributionCount: 1,
+        count: 1,
         attributionId: 'uuid_1',
       },
       {
-        childrenWithAttributionCount: 1,
+        count: 1,
         attributionId: 'uuid_3',
       },
     ];
@@ -57,11 +57,11 @@ describe('computeAggregatedAttributionsFromChildren', () => {
   it('filters resolved attributions correctly', () => {
     const expectedResult: Array<AttributionIdWithCount> = [
       {
-        childrenWithAttributionCount: 2,
+        count: 2,
         attributionId: 'uuid_2',
       },
       {
-        childrenWithAttributionCount: 1,
+        count: 1,
         attributionId: 'uuid_3',
       },
     ];
@@ -85,27 +85,27 @@ describe('sortByCountAndPackageName', () => {
     const initialAttributionIdsWithCount: Array<AttributionIdWithCount> = [
       {
         attributionId: 'uuid1',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid2',
-        childrenWithAttributionCount: 11,
+        count: 11,
       },
       {
         attributionId: 'uuid3',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid4',
-        childrenWithAttributionCount: 1,
+        count: 1,
       },
       {
         attributionId: 'uuid5',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid6',
-        childrenWithAttributionCount: 1,
+        count: 1,
       },
     ];
     const testAttributions: Attributions = {
@@ -129,27 +129,27 @@ describe('sortByCountAndPackageName', () => {
     const expectedAttributionIdsWithCount: Array<AttributionIdWithCount> = [
       {
         attributionId: 'uuid2',
-        childrenWithAttributionCount: 11,
+        count: 11,
       },
       {
         attributionId: 'uuid5',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid3',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid1',
-        childrenWithAttributionCount: 10,
+        count: 10,
       },
       {
         attributionId: 'uuid6',
-        childrenWithAttributionCount: 1,
+        count: 1,
       },
       {
         attributionId: 'uuid4',
-        childrenWithAttributionCount: 1,
+        count: 1,
       },
     ];
 

--- a/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
+++ b/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
@@ -57,7 +57,7 @@ describe('The getStrippedPackageInfo function', () => {
   it('strips excess values', () => {
     const testPackageInfo = {
       packageName: 'React',
-      childrenWithAttributionCount: 0,
+      count: 0,
     };
 
     expect(getStrippedPackageInfo(testPackageInfo)).toEqual({

--- a/src/Frontend/util/get-contained-packages.ts
+++ b/src/Frontend/util/get-contained-packages.ts
@@ -81,7 +81,7 @@ export function computeAggregatedAttributionsFromChildren(
   return Object.keys(attributionCount)
     .map((attributionId: string) => ({
       attributionId,
-      childrenWithAttributionCount: attributionCount[attributionId],
+      count: attributionCount[attributionId],
     }))
     .sort(sortByCountAndPackageName(attributions));
 }
@@ -93,12 +93,8 @@ export function sortByCountAndPackageName(
     a1: AttributionIdWithCount,
     a2: AttributionIdWithCount
   ): number {
-    if (
-      a1.childrenWithAttributionCount &&
-      a2.childrenWithAttributionCount &&
-      a1.childrenWithAttributionCount !== a2.childrenWithAttributionCount
-    ) {
-      return a2.childrenWithAttributionCount - a1.childrenWithAttributionCount;
+    if (a1.count && a2.count && a1.count !== a2.count) {
+      return a2.count - a1.count;
     }
 
     const p1: PackageInfo = attributions[a1.attributionId];

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -53,7 +53,7 @@ export interface Source {
 
 export interface AttributionIdWithCount {
   attributionId: string;
-  childrenWithAttributionCount?: number;
+  count?: number;
 }
 
 export interface Attributions {


### PR DESCRIPTION
### Summary of changes

In step 2 of the wizard, a package version is selected based on the previously selected package namespace and name in step 1.  The changes include mostly business logic that provides possible versions given the package name. This PR does not include an "apply" functionality. 

Screenshot of the second wizard step with large ort file.
![Unbenannt](https://user-images.githubusercontent.com/83081698/212885959-d8b67b41-a6e5-4c35-98c6-897e79db7189.png)

Fix: #1282