### PR TITLE
Attribution Wizard: Add apply functionality.

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -34,7 +34,7 @@ const classes = {
 interface AttributionWizardPackageStepProps {
   attributedPackageNamespaces: Array<ListWithAttributesItem>;
   attributedPackageNames: Array<ListWithAttributesItem>;
-  temporaryPackageInfo: PackageInfo;
+  selectedPackageInfo: PackageInfo;
   selectedPackageNamespaceId: string;
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
@@ -44,9 +44,15 @@ interface AttributionWizardPackageStepProps {
 export function AttributionWizardPackageStep(
   props: AttributionWizardPackageStepProps
 ): ReactElement {
+  const selectedPackageInfoWithoutVersion = {
+    ...props.selectedPackageInfo,
+    packageVersion: undefined,
+  };
+
   const temporaryPackagePurl = generatePurlFromPackageInfo(
-    props.temporaryPackageInfo
+    selectedPackageInfoWithoutVersion
   );
+
   return (
     <MuiBox sx={classes.root}>
       <MuiTypography variant={'subtitle1'} sx={classes.purl}>

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -20,28 +20,38 @@ import {
 import {
   setExternalData,
   setManualData,
+  setTemporaryPackageInfo,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
+import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
 
 const selectedResourceId = '/samplepath/';
-const testExternalAttributions: Attributions = {
-  uuid_0: {
-    packageName: 'react',
-    packageNamespace: 'npm',
-  },
-};
 const testManualAttributions: Attributions = {
   uuid_0: {
+    packageType: 'generic',
     packageName: 'react',
     packageNamespace: 'npm',
+    packageVersion: '18.2.0',
+  },
+};
+const testManualResourcesToAttributions: ResourcesToAttributions = {
+  [selectedResourceId]: ['uuid_0'],
+};
+const testExternalAttributions: Attributions = {
+  uuid_1: {
+    packageType: 'generic',
+    packageName: 'numpy',
+    packageNamespace: 'pip',
+    packageVersion: '1.24.1',
   },
 };
 const testExternalResourcesToAttributions: ResourcesToAttributions = {
-  '/samplepath/subfolder': ['uuid_0'],
+  '/samplepath/file': ['uuid_1'],
 };
-const testManualResourcesToAttributions: ResourcesToAttributions = {
-  selectedResourceId: ['uuid_0'],
-};
+
+const namespaceListTitle = 'Package namespace';
+const nameListTitle = 'Package name';
+const versionListTitle = 'Package version';
 
 describe('AttributionWizardPopup', () => {
   it('renders with header, resource path, and buttons', () => {
@@ -63,8 +73,12 @@ describe('AttributionWizardPopup', () => {
 
     expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
     expect(screen.getByText(selectedResourceId)).toBeInTheDocument();
-    expect(screen.getByText(ButtonText.Cancel)).toBeInTheDocument();
-    expect(screen.getByText(ButtonText.Next)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: ButtonText.Cancel })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: ButtonText.Next })
+    ).toBeInTheDocument();
   });
 
   it('closes when clicking "cancel"', () => {
@@ -88,7 +102,7 @@ describe('AttributionWizardPopup', () => {
       PopupType.AttributionWizardPopup
     );
 
-    fireEvent.click(screen.getByText(ButtonText.Cancel));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Cancel }));
     expect(getOpenPopup(testStore.getState())).toBeNull();
   });
 
@@ -112,12 +126,6 @@ describe('AttributionWizardPopup', () => {
     expect(screen.getByText('package')).toBeInTheDocument();
     expect(screen.getByText('version')).toBeInTheDocument();
   });
-});
-
-describe('AttributionWizardPopup navigation', () => {
-  const namespaceListTitle = 'Package namespace';
-  const nameListTitle = 'Package name';
-  const versionListTitle = 'Package version';
 
   it('allows navigation via "next" and "back" buttons', () => {
     const testStore = createTestAppStore();
@@ -139,20 +147,27 @@ describe('AttributionWizardPopup navigation', () => {
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: ButtonText.Back })
+    ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('react'));
-    fireEvent.click(screen.getByText('npm'));
-    fireEvent.click(screen.getByText(ButtonText.Next));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
 
     expect(screen.queryByText(namespaceListTitle)).not.toBeInTheDocument();
     expect(screen.queryByText(nameListTitle)).not.toBeInTheDocument();
     expect(screen.getByText(versionListTitle)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: ButtonText.Next })
+    ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText(ButtonText.Back));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Back }));
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: ButtonText.Back })
+    ).not.toBeInTheDocument();
   });
 
   it('allows navigation via breadcrumbs (back only, so far)', () => {
@@ -176,9 +191,7 @@ describe('AttributionWizardPopup navigation', () => {
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('react'));
-    fireEvent.click(screen.getByText('npm'));
-    fireEvent.click(screen.getByText(ButtonText.Next));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
 
     expect(screen.queryByText(namespaceListTitle)).not.toBeInTheDocument();
     expect(screen.queryByText(nameListTitle)).not.toBeInTheDocument();
@@ -189,5 +202,65 @@ describe('AttributionWizardPopup navigation', () => {
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
     expect(screen.queryByText(versionListTitle)).not.toBeInTheDocument();
+  });
+
+  it('renders an apply button', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
+
+    expect(
+      screen.getByRole('button', { name: ButtonText.Apply })
+    ).toBeInTheDocument();
+  });
+
+  it('changes temporary package info', () => {
+    const initialTemporaryPackageInfo = testManualAttributions.uuid_0;
+    const expectedChangedTemporaryPackageInfo = testExternalAttributions.uuid_1;
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
+
+    testStore.dispatch(setTemporaryPackageInfo(initialTemporaryPackageInfo));
+
+    fireEvent.click(screen.getByText('pip'));
+    fireEvent.click(screen.getByText('numpy'));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
+    fireEvent.click(screen.getByText('1.24.1'));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Apply }));
+
+    const changedTemporaryPackageInfo = getTemporaryPackageInfo(
+      testStore.getState()
+    );
+    expect(changedTemporaryPackageInfo).toEqual(
+      expectedChangedTemporaryPackageInfo
+    );
   });
 });

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -33,7 +33,7 @@ const classes = {
 interface AttributionWizardVersionStepProps {
   attributedPackageVersions: Array<ListWithAttributesItem>;
   highlightedPackageNameIds: Array<string>;
-  temporaryPackageInfo: PackageInfo;
+  selectedPackageInfo: PackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
 }
@@ -42,7 +42,7 @@ export function AttributionWizardVersionStep(
   props: AttributionWizardVersionStepProps
 ): ReactElement {
   const temporaryPackagePurl = generatePurlFromPackageInfo(
-    props.temporaryPackageInfo
+    props.selectedPackageInfo
   );
 
   return (

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -78,6 +78,7 @@ interface ListWithAttributesProps {
   showAddNewInput: boolean; // TODO: required later
   title?: string;
   listItemSx?: SxProps;
+  emptyTextFallback?: string;
 }
 
 export function ListWithAttributes(
@@ -102,7 +103,7 @@ export function ListWithAttributes(
                 onClick={(): void => props.handleListItemClick(item.id)}
               >
                 <MuiListItemText
-                  primary={item.text}
+                  primary={item.text || (props.emptyTextFallback ?? '-')}
                   secondary={
                     <MuiBox sx={classes.listItemTextAttributesBox}>
                       {getAttributesWithHighlighting(

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -44,6 +44,7 @@ export enum PackagePanelTitle {
 }
 
 export enum ButtonText {
+  Apply = 'Apply',
   Back = 'Back',
   Close = 'Close',
   Cancel = 'Cancel',


### PR DESCRIPTION
### Summary of changes

Choosing package namespace, name, and version in the wizard and clicking 'apply' updates the temporary package info via a corresponding dispatch.

Fix: #1283