### PR TITLE
Support full names of frequent licenses in license field

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -138,9 +138,10 @@ const expectedFileContent: ParsedFileContent = {
     },
   },
   frequentLicenses: {
-    nameOrder: ['MIT'],
+    nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
     texts: {
       MIT: 'MIT license text',
+      'MIT license': 'MIT license text',
     },
   },
   resolvedExternalAttributions: new Set(),
@@ -327,7 +328,7 @@ describe('Test of loading function', () => {
             },
             {
               shortName: 'GPL',
-              fullName: 'GPL license',
+              fullName: 'General Public License',
               defaultText: 'GPL license text',
             },
           ],
@@ -396,10 +397,18 @@ describe('Test of loading function', () => {
           },
         },
         frequentLicenses: {
-          nameOrder: ['MIT', 'GPL'],
+          nameOrder: [
+            { shortName: 'MIT', fullName: 'MIT license' },
+            {
+              shortName: 'GPL',
+              fullName: 'General Public License',
+            },
+          ],
           texts: {
             MIT: 'MIT license text',
+            'MIT license': 'MIT license text',
             GPL: 'GPL license text',
+            'General Public License': 'GPL license text',
           },
         },
         resolvedExternalAttributions: new Set(),

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -245,15 +245,23 @@ describe('parseFrequentLicenses', () => {
       },
       {
         shortName: 'GPL',
-        fullName: 'GPL license',
+        fullName: 'General Public License',
         defaultText: 'GPL license text',
       },
     ];
     const expectedFrequentLicenses: FrequentLicenses = {
-      nameOrder: ['MIT', 'GPL'],
+      nameOrder: [
+        { shortName: 'MIT', fullName: 'MIT license' },
+        {
+          shortName: 'GPL',
+          fullName: 'General Public License',
+        },
+      ],
       texts: {
         MIT: 'MIT license text',
+        'MIT license': 'MIT license text',
         GPL: 'GPL license text',
+        'General Public License': 'GPL license text',
       },
     };
 

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -163,8 +163,13 @@ export function parseFrequentLicenses(
   }
 
   rawFrequentLicenses.forEach((rawFrequentLicense) => {
-    parsedFrequentLicenses.nameOrder.push(rawFrequentLicense.shortName);
+    parsedFrequentLicenses.nameOrder.push({
+      shortName: rawFrequentLicense.shortName,
+      fullName: rawFrequentLicense.fullName,
+    });
     parsedFrequentLicenses.texts[rawFrequentLicense.shortName] =
+      rawFrequentLicense.defaultText;
+    parsedFrequentLicenses.texts[rawFrequentLicense.fullName] =
       rawFrequentLicense.defaultText;
   });
 

--- a/src/Frontend/Components/AttributionColumn/LicenseField.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseField.tsx
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { InputElementProps } from '../InputElements/shared';
+import { FrequentLicenseName } from '../../../shared/shared-types';
+import { AutoComplete } from '../InputElements/AutoComplete';
+
+function isPresentInOptions(
+  inputValue: string,
+  frequentLicenseNames: Array<FrequentLicenseName>
+): boolean {
+  const matchesValue = (licenseName: FrequentLicenseName): boolean =>
+    licenseName.shortName === inputValue || licenseName.fullName === inputValue;
+  return frequentLicenseNames.some(matchesValue);
+}
+
+function combineLicenseNames(licenseName: FrequentLicenseName): string {
+  return licenseName.shortName + ' - ' + licenseName.fullName;
+}
+
+function getFormattedLicenseNamesToShortNameMapping(
+  frequentLicenseNames: Array<FrequentLicenseName>
+): {
+  [key: string]: string;
+} {
+  return Object.fromEntries(
+    frequentLicenseNames.map((option: FrequentLicenseName) => [
+      combineLicenseNames(option),
+      option.shortName,
+    ])
+  );
+}
+
+interface LicenseFieldProps extends InputElementProps {
+  frequentLicenseNames: Array<FrequentLicenseName>;
+  endAdornmentText?: string;
+}
+
+export function LicenseField(props: LicenseFieldProps): ReactElement {
+  const formattedLicenseNamesToShortNameMapping =
+    getFormattedLicenseNamesToShortNameMapping(props.frequentLicenseNames);
+
+  function formatOptionForDisplay(option: string): string {
+    return formattedLicenseNamesToShortNameMapping[option]
+      ? formattedLicenseNamesToShortNameMapping[option]
+      : option;
+  }
+
+  const inputValue = props.text || '';
+  const inputValueIsInOptions = isPresentInOptions(
+    inputValue,
+    props.frequentLicenseNames
+  );
+
+  return (
+    <AutoComplete
+      isEditable={props.isEditable}
+      sx={props.sx}
+      title={props.title}
+      handleChange={props.handleChange}
+      isHighlighted={props.isHighlighted}
+      options={Object.keys(formattedLicenseNamesToShortNameMapping)}
+      endAdornmentText={props.endAdornmentText}
+      inputValue={inputValue}
+      showTextBold={inputValueIsInOptions}
+      formatOptionForDisplay={formatOptionForDisplay}
+    />
+  );
+}

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -10,7 +10,6 @@ import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-re
 import { doNothing } from '../../util/do-nothing';
 import { TextBox } from '../InputElements/TextBox';
 import { OpossumColors } from '../../shared-styles';
-import { AutoComplete } from '../InputElements/AutoComplete';
 import { getLicenseTextLabelText } from './attribution-column-helpers';
 import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
@@ -20,6 +19,7 @@ import { attributionColumnClasses } from './shared-attribution-column-styles';
 import { useAppSelector } from '../../state/hooks';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
+import { LicenseField } from './LicenseField';
 
 const classes = {
   expansionPanel: {
@@ -59,13 +59,13 @@ const classes = {
 interface LicenseSubPanelProps {
   isEditable: boolean;
   displayPackageInfo: PackageInfo;
+  isLicenseTextShown: boolean;
+  licenseTextRows: number;
+  showHighlight?: boolean;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  isLicenseTextShown: boolean;
-  licenseTextRows: number;
   setIsLicenseTextShown(isLicenseTextShown: boolean): void;
-  showHighlight?: boolean;
 }
 
 export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
@@ -104,12 +104,12 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
             </MuiBox>
           }
         >
-          <AutoComplete
+          <LicenseField
             isEditable={props.isEditable}
             sx={licenseSubPanelClasses.licenseTextBox}
             title={'License Name'}
             text={props.displayPackageInfo.licenseName}
-            options={frequentLicensesNameOrder}
+            frequentLicenseNames={frequentLicensesNameOrder}
             handleChange={props.setUpdateTemporaryPackageInfoFor('licenseName')}
             endAdornmentText={
               props.displayPackageInfo.licenseText

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -465,7 +465,7 @@ describe('The AttributionColumn', () => {
         />
       );
       const testFrequentLicenses: FrequentLicenses = {
-        nameOrder: ['MIT'],
+        nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
         texts: { MIT: 'text' },
       };
       act(() => {
@@ -495,7 +495,7 @@ describe('The AttributionColumn', () => {
         />
       );
       const testFrequentLicenses: FrequentLicenses = {
-        nameOrder: ['MIT'],
+        nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
         texts: { MIT: 'text' },
       };
       act(() => {

--- a/src/Frontend/Components/AttributionColumn/__tests__/LicenseField.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/LicenseField.test.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ChangeEvent } from 'react';
+import { render, screen } from '@testing-library/react';
+import { doNothing } from '../../../util/do-nothing';
+import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
+import { LicenseField } from '../LicenseField';
+import { FrequentLicenseName } from '../../../../shared/shared-types';
+
+describe('The LicenseField', () => {
+  it('renders text and label', () => {
+    const testLicenseNames: Array<FrequentLicenseName> = [
+      { shortName: 'MIT', fullName: 'MIT license' },
+      { shortName: 'GPL', fullName: 'General Public License' },
+    ];
+    render(
+      <LicenseField
+        title={'Test Title'}
+        frequentLicenseNames={testLicenseNames}
+        text={'MIT License'}
+        endAdornmentText={'Test Adornment Text'}
+        handleChange={
+          doNothing as unknown as (
+            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+          ) => void
+        }
+      />
+    );
+
+    expect(screen.queryAllByText('Test Title')).toHaveLength(2);
+    screen.getByText('Test Adornment Text');
+    expect(screen.getByDisplayValue('MIT License'));
+    expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT - MIT license']);
+  });
+
+  it('shows options with substring matching', () => {
+    const testLicenseNames: Array<FrequentLicenseName> = [
+      { shortName: 'MIT', fullName: 'MIT license' },
+      { shortName: 'GPL', fullName: 'General Public License' },
+    ];
+    render(
+      <LicenseField
+        title={'Test Title'}
+        frequentLicenseNames={testLicenseNames}
+        text={'Public Lic'}
+        handleChange={
+          doNothing as unknown as (
+            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+          ) => void
+        }
+      />
+    );
+
+    expectElementsInAutoCompleteAndSelectFirst(screen, [
+      'GPL - General Public License',
+    ]);
+  });
+});

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -6,7 +6,11 @@
 
 import { View } from '../../enums/enums';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { FollowUp, PackageInfo } from '../../../shared/shared-types';
+import {
+  FollowUp,
+  FrequentLicenseName,
+  PackageInfo,
+} from '../../../shared/shared-types';
 import { AppThunkDispatch } from '../../state/types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
@@ -139,11 +143,15 @@ export function selectedPackageIsResolved(
 export function getLicenseTextLabelText(
   licenseName: string | undefined,
   isEditable: boolean,
-  frequentLicensesNameOrder: Array<string>
+  frequentLicensesNameOrder: Array<FrequentLicenseName>
 ): string {
   return licenseName &&
     frequentLicensesNameOrder
-      .map((name) => name.toLowerCase())
+      .map((licenseNames) => [
+        licenseNames.shortName.toLowerCase(),
+        licenseNames.fullName.toLowerCase(),
+      ])
+      .flat()
       .includes(licenseName.toLowerCase())
     ? `Standard license text implied. ${
         isEditable ? 'Insert notice text if necessary.' : ''

--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -13,6 +13,9 @@ import MuiBox from '@mui/material/Box';
 interface AutoCompleteProps extends InputElementProps {
   options: Array<string>;
   endAdornmentText?: string;
+  inputValue: string;
+  showTextBold?: boolean;
+  formatOptionForDisplay?(value: string): string;
 }
 
 const classes = {
@@ -36,15 +39,15 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
       event &&
       (event.type === 'click' || enterWasPressed(event as KeyboardEvent))
     ) {
-      props.handleChange({ target: { value } } as unknown as ChangeEvent<
-        HTMLInputElement | HTMLTextAreaElement
-      >);
+      props.handleChange({
+        target: {
+          value: props.formatOptionForDisplay
+            ? props.formatOptionForDisplay(value)
+            : value,
+        },
+      } as unknown as ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
     }
   }
-
-  const inputValue = props.text || '';
-  const inputValueIndexInOptions: number = props.options.indexOf(inputValue);
-  const isInputValueInOptions: boolean = inputValueIndexInOptions > -1;
 
   return (
     <MuiBox sx={props.sx}>
@@ -59,7 +62,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
         options={props.options}
         disableClearable={true}
         disabled={!props.isEditable}
-        inputValue={inputValue}
+        inputValue={props.inputValue}
         onInputChange={onInputChange}
         renderInput={(params): ReactElement => {
           const paramsWithAdornment = props.endAdornmentText
@@ -82,7 +85,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
               label={props.title}
               sx={{
                 ...classes.textField,
-                ...(isInputValueInOptions ? classes.textFieldBoldText : {}),
+                ...(props.showTextBold ? classes.textFieldBoldText : {}),
               }}
               variant="outlined"
               size="small"

--- a/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/AutoComplete.test.tsx
@@ -16,6 +16,8 @@ describe('The AutoComplete', () => {
       <AutoComplete
         title={'Test Title'}
         options={testLicenseNames}
+        inputValue={''}
+        showTextBold={false}
         handleChange={
           doNothing as unknown as (
             event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -35,12 +37,14 @@ describe('The AutoComplete', () => {
       <AutoComplete
         title={'Test Title'}
         options={testLicenseNames}
-        endAdornmentText={'Adornment Text'}
+        inputValue={''}
+        showTextBold={false}
         handleChange={
           doNothing as unknown as (
             event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
           ) => void
         }
+        endAdornmentText={'Adornment Text'}
       />
     );
 

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -55,7 +55,13 @@ describe('The ReportView', () => {
 
   it('renders', () => {
     const testFrequentLicenses: FrequentLicenses = {
-      nameOrder: ['MIT', 'GPL'],
+      nameOrder: [
+        { shortName: 'MIT', fullName: 'MIT license' },
+        {
+          shortName: 'GPL',
+          fullName: 'General Public License',
+        },
+      ],
       texts: { MIT: 'MIT text', GPL: 'GPL text' },
     };
     const { store } = renderComponentWithStore(<ReportView />);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -43,7 +43,13 @@ import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-
 describe('The App in Audit View', () => {
   it('saves new attributions to file in AuditView', () => {
     const testPackageName = 'React';
-    const testLicenseNames = ['MIT', 'MIT License'];
+    const testLicenseNames = [
+      { shortName: 'MIT', fullName: 'MIT License' },
+      {
+        shortName: 'HaskellReport',
+        fullName: 'Haskell Language Report License',
+      },
+    ];
     const mockChannelReturn: ParsedFileContent = {
       ...EMPTY_PARSED_FILE_CONTENT,
       resources: { 'something.js': 1 },
@@ -62,7 +68,10 @@ describe('The App in Audit View', () => {
 
       frequentLicenses: {
         nameOrder: testLicenseNames,
-        texts: { MIT: 'MIT License Text', 'MIT License': 'MIT License Text' },
+        texts: {
+          MIT: 'MIT License Text',
+          HaskellReport: 'Haskell License Text',
+        },
       },
     };
 
@@ -91,7 +100,10 @@ describe('The App in Audit View', () => {
     expect(screen.queryAllByText(`Low (${DiscreteConfidence.Low})`).length);
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
-    expectElementsInAutoCompleteAndSelectFirst(screen, testLicenseNames);
+    expectElementsInAutoCompleteAndSelectFirst(screen, [
+      'MIT - MIT License',
+      'HaskellReport - Haskell Language Report License',
+    ]);
 
     clickOnButton(screen, ButtonText.Save);
 

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -98,10 +98,16 @@ describe('The report view', () => {
         },
       },
       frequentLicenses: {
-        nameOrder: ['GPL-2.0', 'Apache'],
+        nameOrder: [
+          { shortName: 'GPL-2.0', fullName: 'General Public License 2.0' },
+          {
+            shortName: 'Apache',
+            fullName: 'Apache license',
+          },
+        ],
         texts: {
           'GPL-2.0': 'frequent license',
-          Apache: 'Apache license',
+          Apache: 'Apache license text',
         },
       },
     };
@@ -127,10 +133,10 @@ describe('The report view', () => {
 
     goToView(screen, View.Audit);
     insertValueIntoTextBox(screen, 'License Name', 'Apac');
-    fireEvent.click(screen.getByText('Apache'));
+    fireEvent.click(screen.getByText('Apache - Apache license'));
     clickOnButton(screen, ButtonText.Save);
     goToView(screen, View.Report);
     screen.getByText('Apache');
-    screen.getByText('Apache license');
+    screen.getByText('Apache license text');
   });
 });

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -200,7 +200,13 @@ describe('The load and navigation simple actions', () => {
 
   it('sets and gets frequentLicenses', () => {
     const testFrequentLicenses: FrequentLicenses = {
-      nameOrder: ['MIT', 'GPL'],
+      nameOrder: [
+        { shortName: 'MIT', fullName: 'MIT license' },
+        {
+          shortName: 'GPL',
+          fullName: 'General Public License',
+        },
+      ],
       texts: { MIT: 'MIT text', GPL: 'GPL text' },
     };
     const testStore = createTestAppStore();

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -83,7 +83,7 @@ describe('loadFromFile', () => {
       '/thirdParty/package_1.tr.gz': ['test_id'],
     };
     const testFrequentLicenses: FrequentLicenses = {
-      nameOrder: ['MIT', 'MIT license'],
+      nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
       texts: {
         MIT: 'MIT license text',
         'MIT license': 'MIT license text',

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -10,6 +10,7 @@ import {
   AttributionsToResources,
   BaseUrlsForSources,
   ExternalAttributionSources,
+  FrequentLicenseName,
   LicenseTexts,
   PackageInfo,
   ProjectMetadata,
@@ -86,7 +87,9 @@ export function getResourcesWithExternalAttributedChildren(
     .resourcesWithAttributedChildren;
 }
 
-export function getFrequentLicensesNameOrder(state: State): Array<string> {
+export function getFrequentLicensesNameOrder(
+  state: State
+): Array<FrequentLicenseName> {
   return state.resourceState.allViews.frequentLicenses.nameOrder;
 }
 

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -90,8 +90,13 @@ export interface AttributionsWithResources {
   [uuid: string]: AttributionInfo;
 }
 
+export interface FrequentLicenseName {
+  shortName: string;
+  fullName: string;
+}
+
 export interface FrequentLicenses {
-  nameOrder: Array<string>;
+  nameOrder: Array<FrequentLicenseName>;
   texts: LicenseTexts;
 }
 
@@ -209,6 +214,7 @@ export interface IElectronAPI {
   on: (channel: AllowedFrontendChannels, listener: Listener) => void;
   removeListener: (channel: AllowedFrontendChannels) => void;
 }
+
 declare global {
   interface Window {
     electronAPI: IElectronAPI;


### PR DESCRIPTION
Add features for frequent licenses to the license field

### Summary of changes

- Show both, the short- and full name in the dropdown for frequent licenses
- Show full license names of frequent licenses in bold
- For full license names of frequent licenses use implied license text
- When selecting a license from the dropdown, use the short name

### Context and reason for change

When typing the full name of a frequent license, the component should behave accordingly.

### How can the changes be tested

Run the test for LicenseField

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
