### PR TITLE
Replace deprecated keypress event

### DIFF
--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -23,7 +23,7 @@ const classes = {
 };
 
 function enterWasPressed(event: KeyboardEvent): boolean {
-  return event.which == 13 || event.keyCode == 13;
+  return event.key === 'Enter';
 }
 
 export function AutoComplete(props: AutoCompleteProps): ReactElement {


### PR DESCRIPTION
### Summary of changes

The keypress event is replaced.

### Context and reason for change

The keypress event is deprecated.

### How can the changes be tested

Select license from dropdown using "Enter" key.
