### PR TITLE
Sort license dropdown

### DIFF
--- a/src/Frontend/Components/AttributionColumn/LicenseField.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseField.tsx
@@ -44,7 +44,9 @@ export function LicenseField(props: LicenseFieldProps): ReactElement {
     getFormattedLicenseNamesToShortNameMapping(props.frequentLicenseNames);
   const sortedLicenses = Object.keys(
     formattedLicenseNamesToShortNameMapping
-  ).sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
+  ).sort((license, otherLicense) =>
+    license.toLowerCase() < otherLicense.toLowerCase() ? -1 : 1
+  );
 
   function formatOptionForDisplay(option: string): string {
     return formattedLicenseNamesToShortNameMapping[option]

--- a/src/Frontend/Components/AttributionColumn/LicenseField.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseField.tsx
@@ -17,18 +17,18 @@ function isPresentInOptions(
   return frequentLicenseNames.some(matchesValue);
 }
 
-function combineLicenseNames(licenseName: FrequentLicenseName): string {
-  return licenseName.shortName + ' - ' + licenseName.fullName;
-}
-
 function getFormattedLicenseNamesToShortNameMapping(
   frequentLicenseNames: Array<FrequentLicenseName>
 ): {
   [key: string]: string;
 } {
+  function formatLicenseName(licenseName: FrequentLicenseName): string {
+    return licenseName.shortName + ' - ' + licenseName.fullName;
+  }
+
   return Object.fromEntries(
     frequentLicenseNames.map((option: FrequentLicenseName) => [
-      combineLicenseNames(option),
+      formatLicenseName(option),
       option.shortName,
     ])
   );
@@ -42,6 +42,9 @@ interface LicenseFieldProps extends InputElementProps {
 export function LicenseField(props: LicenseFieldProps): ReactElement {
   const formattedLicenseNamesToShortNameMapping =
     getFormattedLicenseNamesToShortNameMapping(props.frequentLicenseNames);
+  const sortedLicenses = Object.keys(
+    formattedLicenseNamesToShortNameMapping
+  ).sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
 
   function formatOptionForDisplay(option: string): string {
     return formattedLicenseNamesToShortNameMapping[option]
@@ -62,7 +65,7 @@ export function LicenseField(props: LicenseFieldProps): ReactElement {
       title={props.title}
       handleChange={props.handleChange}
       isHighlighted={props.isHighlighted}
-      options={Object.keys(formattedLicenseNamesToShortNameMapping)}
+      options={sortedLicenses}
       endAdornmentText={props.endAdornmentText}
       inputValue={inputValue}
       showTextBold={inputValueIsInOptions}

--- a/src/Frontend/Components/AttributionColumn/__tests__/LicenseField.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/LicenseField.test.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ChangeEvent } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
 import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
 import { LicenseField } from '../LicenseField';
@@ -57,5 +57,37 @@ describe('The LicenseField', () => {
     expectElementsInAutoCompleteAndSelectFirst(screen, [
       'GPL - General Public License',
     ]);
+  });
+
+  it('sorts entries', () => {
+    const testLicenseNames: Array<FrequentLicenseName> = [
+      { shortName: 'MIT', fullName: 'MIT license' },
+      { shortName: 'GPL', fullName: 'General Public License' },
+    ];
+    render(
+      <LicenseField
+        title={'Test Title'}
+        frequentLicenseNames={testLicenseNames}
+        text={''}
+        endAdornmentText={'Test Adornment Text'}
+        handleChange={
+          doNothing as unknown as (
+            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+          ) => void
+        }
+      />
+    );
+
+    const autoComplete = screen.getByRole('combobox');
+    autoComplete.focus();
+    fireEvent.keyDown(autoComplete, { key: 'ArrowDown' });
+
+    const licenseDropdownList = screen.getByRole('listbox');
+    expect(licenseDropdownList.children[0]).toHaveTextContent(
+      'GPL - General Public License'
+    );
+    expect(licenseDropdownList.children[1]).toHaveTextContent(
+      'MIT - MIT license'
+    );
   });
 });

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -218,11 +218,17 @@ function sortPackageAttributesAndCounts(packageAttributesAndCounts: {
     .sort(compareTextAndCount);
 }
 
-function compareTextAndCount(a: TextAndCount, b: TextAndCount): number {
-  if (a.count !== b.count) {
-    return b.count - a.count;
+function compareTextAndCount(
+  textAndCount: TextAndCount,
+  otherTextAndCount: TextAndCount
+): number {
+  if (textAndCount.count !== otherTextAndCount.count) {
+    return otherTextAndCount.count - textAndCount.count;
   } else {
-    return a.text.toLowerCase() < b.text.toLowerCase() ? -1 : 1;
+    return textAndCount.text.toLowerCase() <
+      otherTextAndCount.text.toLowerCase()
+      ? -1
+      : 1;
   }
 }
 

--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -145,7 +145,7 @@ export function ContextMenu(props: ContextMenuProps): ReactElement | null {
           }
         }}
       >
-        {props.children}{' '}
+        {props.children}
       </div>
       <MuiMenu
         open={isContextMenuOpen}

--- a/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
+++ b/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
@@ -61,9 +61,10 @@ function sortSources(
         attributionSources[sourceA]?.priority -
         attributionSources[sourceB]?.priority
       ) ||
-      attributionSources[sourceA]?.name.localeCompare(
-        attributionSources[sourceB]?.name
-      )
+      (attributionSources[sourceA]?.name.toLowerCase() <
+      attributionSources[sourceB]?.name.toLowerCase()
+        ? -1
+        : 1)
     );
   });
 

--- a/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
@@ -200,7 +200,7 @@ function getSortFunction(
     } else if (!leftNodeIsFolder && rightNodeIsFolder) {
       return 1;
     }
-    return left.toLowerCase().localeCompare(right.toLowerCase());
+    return left.toLowerCase() < right.toLowerCase() ? -1 : 1;
   };
 }
 

--- a/src/Frontend/util/__tests__/get-contained-packages.ts
+++ b/src/Frontend/util/__tests__/get-contained-packages.ts
@@ -120,7 +120,7 @@ describe('sortByCountAndPackageName', () => {
         packageName: 'e',
       },
       uuid5: {
-        packageName: 'Ä',
+        packageName: 'z',
       },
       uuid6: {
         packageName: 'd',
@@ -132,11 +132,11 @@ describe('sortByCountAndPackageName', () => {
         count: 11,
       },
       {
-        attributionId: 'uuid5',
+        attributionId: 'uuid3',
         count: 10,
       },
       {
-        attributionId: 'uuid3',
+        attributionId: 'uuid5',
         count: 10,
       },
       {

--- a/src/Frontend/util/get-alphabetical-comparer.ts
+++ b/src/Frontend/util/get-alphabetical-comparer.ts
@@ -41,9 +41,9 @@ export function getAlphabeticalComparer(attributions: Attributions) {
     if (elementTitleIsAlphabetical && !otherElementTitleIsAlphabetical)
       return -1;
 
-    return elementTitle.localeCompare(otherElementTitle, undefined, {
-      sensitivity: 'base',
-    });
+    return elementTitle.toLowerCase() < otherElementTitle.toLowerCase()
+      ? -1
+      : 1;
   };
 }
 
@@ -58,5 +58,5 @@ function isElementTitleAlphabetical(
   elementTitle: string,
   defaultName: string
 ): boolean {
-  return elementTitle.localeCompare('a') >= 0 && elementTitle !== defaultName;
+  return elementTitle.toLowerCase() > 'a' && elementTitle !== defaultName;
 }

--- a/src/Frontend/util/get-contained-packages.ts
+++ b/src/Frontend/util/get-contained-packages.ts
@@ -100,9 +100,9 @@ export function sortByCountAndPackageName(
     const p1: PackageInfo = attributions[a1.attributionId];
     const p2: PackageInfo = attributions[a2.attributionId];
     if (p1?.packageName && p2?.packageName) {
-      return p1.packageName.localeCompare(p2.packageName, undefined, {
-        sensitivity: 'base',
-      });
+      return p1.packageName.toLowerCase() < p2.packageName.toLowerCase()
+        ? -1
+        : 1;
     } else if (p1?.packageName) {
       return -1;
     } else if (p2?.packageName) {


### PR DESCRIPTION
### Summary of changes

* Sort licenses in license dropdown alphabetically.
* For performance reasons `localCompare` is replaced everywhere.

### Context and reason for change

Licenses in license dropdown were not sorted alphabetically.

### How can the changes be tested

Check that in UI packages etc are still sorted correctly.
