### PR TITLE
Attribution Wizard: Improve Styling

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -5,30 +5,23 @@
 
 import React, { ReactElement } from 'react';
 import MuiBox from '@mui/material/Box';
-import MuiTypography from '@mui/material/Typography';
 import { PackageInfo } from '../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../types/types';
 import { generatePurlFromPackageInfo } from '../../util/handle-purl';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
-
-const PURL_HEIGHT = 45;
+import { TextBox } from '../InputElements/TextBox';
+import { doNothing } from '../../util/do-nothing';
+import {
+  attributionWizardStepClasses,
+  ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT,
+} from '../../shared-styles';
+import { SxProps } from '@mui/system';
 
 const classes = {
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'start',
-  },
-  purl: {
-    border: 1,
-    padding: '0px 3px',
-    marginTop: '5px',
-    marginBottom: '10px',
-  },
   listBox: {
     display: 'flex',
-    gap: '30px',
-    maxHeight: `calc(100% - ${PURL_HEIGHT}px)`,
+    gap: '25px',
+    maxHeight: `calc(100% - ${ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT}px)`,
   },
 };
 interface AttributionWizardPackageStepProps {
@@ -39,6 +32,8 @@ interface AttributionWizardPackageStepProps {
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
   handlePackageNameListItemClick: (id: string) => void;
+  listBoxSx?: SxProps;
+  listSx?: SxProps;
 }
 
 export function AttributionWizardPackageStep(
@@ -48,30 +43,39 @@ export function AttributionWizardPackageStep(
     ...props.selectedPackageInfo,
     packageVersion: undefined,
   };
-
-  const temporaryPackagePurl = generatePurlFromPackageInfo(
+  const temporaryPurl = generatePurlFromPackageInfo(
     selectedPackageInfoWithoutVersion
   );
 
   return (
-    <MuiBox sx={classes.root}>
-      <MuiTypography variant={'subtitle1'} sx={classes.purl}>
-        {temporaryPackagePurl}
-      </MuiTypography>
-      <MuiBox sx={classes.listBox}>
+    <MuiBox sx={attributionWizardStepClasses.root}>
+      <TextBox
+        title={'PURL'}
+        isEditable={false}
+        text={temporaryPurl}
+        isHighlighted={false}
+        handleChange={doNothing}
+        sx={attributionWizardStepClasses.purlRoot}
+        textFieldInputSx={attributionWizardStepClasses.purlText}
+      />
+      <MuiBox sx={{ ...classes.listBox, ...props.listBoxSx }}>
         <ListWithAttributes
           listItems={props.attributedPackageNamespaces}
           selectedListItemId={props.selectedPackageNamespaceId}
           handleListItemClick={props.handlePackageNamespaceListItemClick}
+          showChipsForAttributes={false}
           showAddNewInput={false}
           title={'Package namespace'}
+          listSx={props.listSx}
         />
         <ListWithAttributes
           listItems={props.attributedPackageNames}
           selectedListItemId={props.selectedPackageNameId}
           handleListItemClick={props.handlePackageNameListItemClick}
+          showChipsForAttributes={false}
           showAddNewInput={false}
           title={'Package name'}
+          listSx={props.listSx}
         />
       </MuiBox>
     </MuiBox>

--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -37,35 +37,41 @@ import { getPopupAttributionId } from '../../state/selectors/view-selector';
 import { PackageInfo } from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 
+const MAXIMUM_NUMBER_OF_TABLES_IN_SINGLE_STEP = 2;
+const TABLE_WIDTH = 250;
+const GAP_BETWEEN_TABLES = 20;
+const PATH_BAR_TOTAL_HEIGHT = 62;
+const BREADCRUMBS_TOTAL_HEIGHT = 42;
 const attributionWizardPopupHeader = 'Attribution Wizard';
 
+const MAIN_CONTENT_WIDTH =
+  MAXIMUM_NUMBER_OF_TABLES_IN_SINGLE_STEP * TABLE_WIDTH +
+  (MAXIMUM_NUMBER_OF_TABLES_IN_SINGLE_STEP - 1) * GAP_BETWEEN_TABLES;
+
 const classes = {
-  dialogHeader: {
-    whiteSpace: 'nowrap',
-  },
-  pathFieldAndBreadcrumbsBox: {
-    display: 'flex',
-    gap: '30px',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+  dialogContent: {
+    backgroundColor: OpossumColors.lightestBlue,
+    height: '75vh',
+    margin: '0px 24px 12px 24px',
   },
   mainContentBox: {
-    key: 'mainContent',
-    display: 'flex',
-    gap: '30px',
-    width: 'fit-content',
-    heigth: 'fit-content',
-    marginTop: '12px',
-    maxHeight: '70vh',
-    minHeight: '50vh',
-    minWidth: '60vw',
+    width: `${MAIN_CONTENT_WIDTH}px`,
+    marginTop: '15px',
+    height: `calc(100% - ${PATH_BAR_TOTAL_HEIGHT}px - ${BREADCRUMBS_TOTAL_HEIGHT}px)`,
   },
   pathBar: {
-    padding: '1px 5px',
+    margin: '24px 0px 12px 0px',
+    padding: '1px 0px 1px 5px',
   },
-  pathBarBox: {
-    padding: '4px',
-    background: OpossumColors.lightBlue,
+  breadcrumbs: {
+    height: `calc(${BREADCRUMBS_TOTAL_HEIGHT}px - 20px)`,
+    marginBottom: '20px',
+  },
+  listBox: {
+    gap: `${GAP_BETWEEN_TABLES}px`,
+  },
+  list: {
+    width: `${TABLE_WIDTH}px`,
   },
 };
 
@@ -236,7 +242,7 @@ export function AttributionWizardPopup(): ReactElement {
     tooltipText: isPackageNamespaceAndNameSelected
       ? ''
       : 'Please select package namespace and name to continue',
-    tooltipPlacement: 'left',
+    tooltipPlacement: 'top',
   };
   const backButtonConfig: ButtonConfig = {
     buttonText: ButtonText.Back,
@@ -258,7 +264,7 @@ export function AttributionWizardPopup(): ReactElement {
     tooltipText: !isPackageVersionSelected
       ? 'Please select package version to apply changes'
       : '',
-    tooltipPlacement: 'left',
+    tooltipPlacement: 'top',
   };
 
   return (
@@ -277,19 +283,16 @@ export function AttributionWizardPopup(): ReactElement {
       onEscapeKeyDown={closeAttributionWizardPopup}
       isOpen={true}
       fullWidth={false}
-      headerSx={classes.dialogHeader}
+      contentSx={classes.dialogContent}
       content={
         <>
-          <MuiBox sx={classes.pathFieldAndBreadcrumbsBox}>
-            <MuiBox sx={classes.pathBarBox}>
-              <PathBar sx={classes.pathBar} />
-            </MuiBox>
-            <Breadcrumbs
-              selectedId={selectedWizardStepId}
-              onClick={handleBreadcrumbsClick}
-              idsToDisplayValues={wizardStepIdsToDisplayValues}
-            />
-          </MuiBox>
+          <PathBar sx={classes.pathBar} />
+          <Breadcrumbs
+            selectedId={selectedWizardStepId}
+            onClick={handleBreadcrumbsClick}
+            idsToDisplayValues={wizardStepIdsToDisplayValues}
+            sx={classes.breadcrumbs}
+          />
           <MuiBox sx={classes.mainContentBox}>
             {selectedWizardStepId === wizardStepIds[0] ? (
               <AttributionWizardPackageStep
@@ -302,6 +305,8 @@ export function AttributionWizardPopup(): ReactElement {
                   handlePackageNamespaceListItemClick
                 }
                 handlePackageNameListItemClick={handlePackageNameListItemClick}
+                listBoxSx={classes.listBox}
+                listSx={classes.list}
               />
             ) : selectedWizardStepId === wizardStepIds[1] ? (
               <AttributionWizardVersionStep
@@ -312,6 +317,7 @@ export function AttributionWizardPopup(): ReactElement {
                 handlePackageVersionListItemClick={
                   handlePackageVersionListItemClick
                 }
+                listSx={classes.list}
               />
             ) : null}
           </MuiBox>

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -153,16 +153,14 @@ describe('getAttributionWizardPackageListsItems', () => {
       {
         text: 'pip',
         id: 'namespace-pip',
-        attributes: [
-          { text: 'count: 6 (60.0%)', id: 'namespace-attribute-pip' },
-        ],
+        attributes: [{ text: '6 (60%)', id: 'namespace-attribute-pip' }],
       },
       {
         text: emptyAttribute,
         id: `namespace-${emptyAttribute}`,
         attributes: [
           {
-            text: 'count: 2 (20.0%)',
+            text: '2 (20%)',
             id: `namespace-attribute-${emptyAttribute}`,
           },
         ],
@@ -170,33 +168,31 @@ describe('getAttributionWizardPackageListsItems', () => {
       {
         text: 'npm',
         id: 'namespace-npm',
-        attributes: [
-          { text: 'count: 2 (20.0%)', id: 'namespace-attribute-npm' },
-        ],
+        attributes: [{ text: '2 (20%)', id: 'namespace-attribute-npm' }],
       },
     ];
     const expectedAttributedPackageNames: Array<ListWithAttributesItem> = [
       {
         text: 'numpy',
         id: 'name-numpy',
-        attributes: [{ text: 'count: 5 (50.0%)', id: 'name-attribute-numpy' }],
+        attributes: [{ text: '5 (50%)', id: 'name-attribute-numpy' }],
       },
       {
         text: emptyAttribute,
         id: `name-${emptyAttribute}`,
         attributes: [
-          { text: 'count: 2 (20.0%)', id: `name-attribute-${emptyAttribute}` },
+          { text: '2 (20%)', id: `name-attribute-${emptyAttribute}` },
         ],
       },
       {
         text: 'buffer',
         id: 'name-buffer',
-        attributes: [{ text: 'count: 2 (20.0%)', id: 'name-attribute-buffer' }],
+        attributes: [{ text: '2 (20%)', id: 'name-attribute-buffer' }],
       },
       {
         text: 'pandas',
         id: 'name-pandas',
-        attributes: [{ text: 'count: 1 (10.0%)', id: 'name-attribute-pandas' }],
+        attributes: [{ text: '1 (10%)', id: 'name-attribute-pandas' }],
       },
     ];
     const expectedPackageNamesToVersions = {

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -254,14 +254,20 @@ function getWizardListItem(
     id: `${idPrefix}-${packageAttribute}`,
     attributes: [
       {
-        text: `count: ${count} (${((count / totalAttributeCount) * 100).toFixed(
-          1
-        )}%)`,
+        text: getCountText(count, totalAttributeCount),
         id: `${idPrefix}-attribute-${packageAttribute}`,
       },
     ],
   };
 }
+
+function getCountText(count: number, totalAttributeCount: number): string {
+  const percentage = (count / totalAttributeCount) * 100;
+  return percentage < 1
+    ? `${count} (< 1%)`
+    : `${count} (${percentage.toFixed(0)}%)`;
+}
+
 export function getAttributionWizardPackageVersionListItems(
   packageName: string,
   packageNamesToVersions: { [name: string]: Set<string> }

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -5,29 +5,20 @@
 
 import React, { ReactElement } from 'react';
 import MuiBox from '@mui/material/Box';
-import MuiTypography from '@mui/material/Typography';
 import { ListWithAttributesItem } from '../../types/types';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
 import { PackageInfo } from '../../../shared/shared-types';
 import { generatePurlFromPackageInfo } from '../../util/handle-purl';
-
-const PURL_HEIGHT = 45;
+import { doNothing } from '../../util/do-nothing';
+import { TextBox } from '../InputElements/TextBox';
+import { attributionWizardStepClasses } from '../../shared-styles';
+import { ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT } from '../../shared-styles';
+import { SxProps } from '@mui/system';
 
 const classes = {
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'start',
-  },
-  purl: {
-    border: 1,
-    padding: '0px 3px',
-    marginTop: '5px',
-    marginBottom: '10px',
-  },
   listBox: {
     display: 'flex',
-    maxHeight: `calc(100% - ${PURL_HEIGHT}px)`,
+    maxHeight: `calc(100% - ${ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT}px)`,
   },
 };
 interface AttributionWizardVersionStepProps {
@@ -36,29 +27,35 @@ interface AttributionWizardVersionStepProps {
   selectedPackageInfo: PackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
+  listSx?: SxProps;
 }
 
 export function AttributionWizardVersionStep(
   props: AttributionWizardVersionStepProps
 ): ReactElement {
-  const temporaryPackagePurl = generatePurlFromPackageInfo(
-    props.selectedPackageInfo
-  );
+  const temporaryPurl = generatePurlFromPackageInfo(props.selectedPackageInfo);
 
   return (
-    <MuiBox sx={classes.root}>
-      <MuiTypography variant={'subtitle1'} sx={classes.purl}>
-        {temporaryPackagePurl}
-      </MuiTypography>
+    <MuiBox sx={attributionWizardStepClasses.root}>
+      <TextBox
+        title={'PURL'}
+        isEditable={false}
+        text={temporaryPurl}
+        isHighlighted={false}
+        handleChange={doNothing}
+        sx={attributionWizardStepClasses.purlRoot}
+        textFieldInputSx={attributionWizardStepClasses.purlText}
+      />
       <MuiBox sx={classes.listBox}>
         <ListWithAttributes
           listItems={props.attributedPackageVersions}
           selectedListItemId={props.selectedPackageVersionId}
           highlightedAttributeIds={props.highlightedPackageNameIds}
           handleListItemClick={props.handlePackageVersionListItemClick}
+          showChipsForAttributes={true}
           showAddNewInput={false}
           title={'Package version'}
-          listItemSx={{ maxWidth: '400px' }}
+          listSx={props.listSx}
         />
       </MuiBox>
     </MuiBox>

--- a/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,6 +9,7 @@ import MuiListItemButton from '@mui/material/ListItemButton';
 import MuiTypography from '@mui/material/Typography';
 import MuiNavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { OpossumColors } from '../../shared-styles';
+import { SxProps } from '@mui/system';
 
 const classes = {
   breadcrumbs: {
@@ -19,18 +20,18 @@ const classes = {
   },
   breadcrumbsButton: {
     padding: '1px 4px',
-    backgroundColor: OpossumColors.white,
+    backgroundColor: OpossumColors.lightestBlue,
     '&:hover': {
-      backgroundColor: OpossumColors.white,
+      backgroundColor: OpossumColors.lightestBlue,
     },
     '&:loading': {
-      backgroundColor: OpossumColors.white,
+      backgroundColor: OpossumColors.lightestBlue,
     },
     '&.Mui-selected': {
       '&:hover': {
-        backgroundColor: OpossumColors.white,
+        backgroundColor: OpossumColors.lightestBlue,
       },
-      backgroundColor: OpossumColors.white,
+      backgroundColor: OpossumColors.lightestBlue,
     },
     '&.Mui-disabled': {
       opacity: 1,
@@ -45,6 +46,7 @@ interface BreadcrumbsProps {
   selectedId: string;
   onClick: (id: string) => void;
   idsToDisplayValues: Array<[string, string]>;
+  sx?: SxProps;
 }
 
 export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
@@ -54,7 +56,7 @@ export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
 
   return (
     <MuiBreadcrumbs
-      sx={classes.breadcrumbs}
+      sx={{ ...classes.breadcrumbs, ...props.sx }}
       separator={<MuiNavigateNextIcon fontSize="inherit" />}
     >
       {ids.map((id, index) => (

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -12,6 +12,7 @@ import { SxProps } from '@mui/material';
 
 interface TextProps extends InputElementProps {
   textFieldSx?: SxProps;
+  textFieldInputSx?: SxProps;
   minRows?: number;
   maxRows?: number;
   endIcon?: ReactElement;
@@ -34,6 +35,7 @@ export function TextBox(props: TextProps): ReactElement {
         InputProps={{
           inputProps: {
             'aria-label': props.title,
+            sx: props.textFieldInputSx,
           },
           endAdornment: props.endIcon && (
             <MuiInputAdornment position="end">

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -16,56 +16,66 @@ import { ListWithAttributesItem } from '../../types/types';
 import { SxProps } from '@mui/system';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
-const LIST_WITH_ATTRIBUTES_VERTICAL_BORDER_AND_MARGIN = 10; // 10px = margin + border
-const LIST_TITLE_HEIGHT = 28;
+const LIST_TITLE_HEIGHT = 36;
 
 const classes = {
   titleAndListBox: {
     display: 'flex',
     flexDirection: 'column',
+    marginTop: '15px',
   },
-  listBox: {
-    width: 'fit-content',
-    maxHeight: `calc(100% - ${LIST_TITLE_HEIGHT}px)`,
-    background: OpossumColors.lightBlue,
+  title: {
+    backgroundColor: OpossumColors.white,
+    paddingLeft: '9px',
+    paddingBottom: '8px',
+    height: `${LIST_TITLE_HEIGHT}px - 8px`,
   },
   list: {
     padding: '0px',
-    width: 'fit-content',
+    width: '250px',
     backgroundColor: OpossumColors.white,
-    border: `1px ${OpossumColors.grey} solid`,
-    maxHeight: `calc(100% - ${LIST_WITH_ATTRIBUTES_VERTICAL_BORDER_AND_MARGIN}px)`,
+    maxHeight: `calc(100% - ${LIST_TITLE_HEIGHT}px)`,
     overflowY: 'auto',
-    margin: '4px',
   },
   listItem: {
     padding: '0px',
-    borderBottom: 2,
-    borderColor: OpossumColors.lightBlue,
-    // TODO: Now: Single scroll bar for each list item.
-    // Remove 'overflowX' property to get single scroll bar
-    // for the whole list (also if only a single
-    // list item exceeds maxWidth)
-    overflowX: 'auto',
-    maxWidth: '300px',
-    minWidth: '200px',
+    backgroundColor: OpossumColors.white,
   },
   listItemButton: {
+    overflowX: 'auto',
+    margin: '0px 8px',
+    border: 'solid',
+    borderWidth: '1px 2px 1px 2px',
+    borderColor: OpossumColors.lightestBlue,
     padding: '0px 0px 0px 4px',
     '&:hover': {
       backgroundColor: OpossumColors.lightestBlueOnHover,
+      borderColor: OpossumColors.lightestBlueOnHover,
     },
     '&.Mui-selected': {
+      backgroundColor: OpossumColors.middleBlue,
+      borderColor: OpossumColors.middleBlue,
       '&:hover': {
         backgroundColor: OpossumColors.middleBlueOnHover,
+        borderColor: OpossumColors.middleBlueOnHover,
       },
-      backgroundColor: OpossumColors.middleBlue,
     },
+  },
+  firstListItemButton: {
+    borderWidth: '2px 2px 1px 2px',
+  },
+  lastListItemButton: {
+    marginBottom: '8px',
+    borderWidth: '1px 2px 2px 2px',
+  },
+  onlySingleListItemButton: {
+    marginBottom: '8px',
+    borderWidth: '2px',
   },
   listItemTextAttributesBox: {
     display: 'flex',
     flexWrap: 'wrap',
-    marginLeft: '20px',
+    marginLeft: '24px',
     paddingTop: '1px',
   },
 };
@@ -75,9 +85,10 @@ interface ListWithAttributesProps {
   selectedListItemId: string;
   highlightedAttributeIds?: Array<string>;
   handleListItemClick: (id: string) => void;
-  showAddNewInput: boolean; // TODO: required later
+  showChipsForAttributes: boolean;
+  showAddNewInput: boolean;
   title?: string;
-  listItemSx?: SxProps;
+  listSx?: SxProps;
   emptyTextFallback?: string;
 }
 
@@ -86,39 +97,53 @@ export function ListWithAttributes(
 ): ReactElement {
   return (
     <MuiBox sx={classes.titleAndListBox}>
-      <MuiTypography variant={'subtitle1'}>{props.title}</MuiTypography>
-      <MuiBox sx={classes.listBox}>
-        <MuiList sx={classes.list}>
-          {props.listItems.map((item) => (
-            <MuiListItem
-              key={`itemId-${item.id}`}
-              sx={getSxFromPropsAndClasses({
-                styleClass: classes.listItem,
-                sxProps: props.listItemSx,
-              })}
+      <MuiTypography sx={classes.title} variant={'subtitle1'}>
+        {props.title}
+      </MuiTypography>
+      <MuiList
+        sx={getSxFromPropsAndClasses({
+          sxProps: props.listSx,
+          styleClass: classes.list,
+        })}
+      >
+        {props.listItems.map((item, index) => (
+          <MuiListItem key={`itemId-${item.id}`} sx={classes.listItem}>
+            <MuiListItemButton
+              sx={
+                props.listItems.length === 1
+                  ? {
+                      ...classes.listItemButton,
+                      ...classes.onlySingleListItemButton,
+                    }
+                  : index === 0
+                  ? {
+                      ...classes.listItemButton,
+                      ...classes.firstListItemButton,
+                    }
+                  : index === props.listItems.length - 1
+                  ? { ...classes.listItemButton, ...classes.lastListItemButton }
+                  : classes.listItemButton
+              }
+              selected={item.id === props.selectedListItemId}
+              onClick={(): void => props.handleListItemClick(item.id)}
             >
-              <MuiListItemButton
-                sx={classes.listItemButton}
-                selected={item.id === props.selectedListItemId}
-                onClick={(): void => props.handleListItemClick(item.id)}
-              >
-                <MuiListItemText
-                  primary={item.text || (props.emptyTextFallback ?? '-')}
-                  secondary={
-                    <MuiBox sx={classes.listItemTextAttributesBox}>
-                      {getAttributesWithHighlighting(
-                        item.attributes,
-                        props.highlightedAttributeIds
-                      )}
-                    </MuiBox>
-                  }
-                  secondaryTypographyProps={{ component: 'span' }}
-                />
-              </MuiListItemButton>
-            </MuiListItem>
-          ))}
-        </MuiList>
-      </MuiBox>
+              <MuiListItemText
+                primary={item.text || (props.emptyTextFallback ?? '-')}
+                secondary={
+                  <MuiBox sx={classes.listItemTextAttributesBox}>
+                    {getAttributesWithHighlighting(
+                      item.attributes,
+                      props.showChipsForAttributes,
+                      props.highlightedAttributeIds
+                    )}
+                  </MuiBox>
+                }
+                secondaryTypographyProps={{ component: 'span' }}
+              />
+            </MuiListItemButton>
+          </MuiListItem>
+        ))}
+      </MuiList>
     </MuiBox>
   );
 }

--- a/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
+++ b/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
@@ -39,6 +39,7 @@ describe('ListWithAttributes', () => {
         selectedListItemId={testSelectedItemId}
         highlightedAttributeIds={testHighlightedAttributeIds}
         handleListItemClick={doNothing}
+        showChipsForAttributes={true}
         showAddNewInput={false}
         title={testListTitle}
       />
@@ -55,7 +56,5 @@ describe('ListWithAttributes', () => {
     expect(listItemElement2.getByText('package_1')).toBeInTheDocument();
     expect(listItemElement2.getByText('attrib_10')).toBeInTheDocument();
     expect(listItemElement2.getByText('attrib_11')).toBeInTheDocument();
-
-    // TODO: test for item highlighting/selecting later via redux state
   });
 });

--- a/src/Frontend/Components/ListWithAttributes/__tests__/list-with-attributes-helpers.test.tsx
+++ b/src/Frontend/Components/ListWithAttributes/__tests__/list-with-attributes-helpers.test.tsx
@@ -14,9 +14,11 @@ describe('getAttributesWithHighlighting', () => {
       { text: 'attrib_01', id: 'test_id_1' },
     ];
     const testHighlightedAttributeIds = ['test_id_1'];
+    const testShowChipsForAttributes = true;
 
     const resultingComponents = getAttributesWithHighlighting(
       testAttributes,
+      testShowChipsForAttributes,
       testHighlightedAttributeIds
     );
 

--- a/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
+++ b/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
@@ -4,34 +4,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement } from 'react';
-import MuiBox from '@mui/material/Box';
+import MuiChip from '@mui/material/Chip';
 import { ListWithAttributesItemAttribute } from '../../types/types';
+import { OpossumColors } from '../../shared-styles';
 
 export function getAttributesWithHighlighting(
   attributes: Array<ListWithAttributesItemAttribute>,
-  highlightedAttributeIds: Array<string> = ['']
+  showChipsForAttributes: boolean,
+  highlightedAttributeIds?: Array<string>
 ): Array<ReactElement> {
-  const styleBasic = {
-    padding: '0px 1px 0px 2px',
-    marginLeft: '5px',
+  const styleChips = {
+    cursor: 'pointer',
+    backgroundColor: OpossumColors.lightGrey,
+    padding: '0px 8px',
+    margin: '5px 5px 0px 0px',
+    height: '22px',
+    '.MuiChip-label': {
+      padding: '0px',
+      color: OpossumColors.black,
+    },
   };
-  const styleHighlighted = {
-    border: 1,
+  const styleChipsHighlighted = {
+    backgroundColor: OpossumColors.mediumGrey,
   };
 
-  return attributes.map((attribute, attributeIndex) => (
+  return attributes.map((attribute) => (
     <React.Fragment key={`attributeId-${attribute.id}`}>
-      {attributeIndex === 0 ? '' : ','}
-      <MuiBox
-        sx={{
-          ...styleBasic,
-          ...(highlightedAttributeIds.includes(attribute.id)
-            ? styleHighlighted
-            : {}),
-        }}
-      >
-        {attribute.text}
-      </MuiBox>
+      {showChipsForAttributes ? (
+        <MuiChip
+          clickable={false}
+          label={attribute.text}
+          variant={'filled'}
+          size={'small'}
+          sx={{
+            ...styleChips,
+            ...(highlightedAttributeIds?.includes(attribute.id)
+              ? styleChipsHighlighted
+              : {}),
+          }}
+        />
+      ) : (
+        attribute.text
+      )}
     </React.Fragment>
   ));
 }

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -14,7 +14,13 @@ import { doNothing } from '../../util/do-nothing';
 import { ButtonConfig } from '../../types/types';
 import { SxProps } from '@mui/material';
 import { POPUP_MAX_WIDTH_BREAKPOINT } from '../../shared-styles';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
+const classes = {
+  dialogContent: {
+    paddingTop: '5px',
+  },
+};
 interface NotificationPopupProps {
   header: string;
   content: ReactElement | string;
@@ -27,6 +33,7 @@ interface NotificationPopupProps {
   isOpen: boolean;
   fullWidth?: boolean;
   headerSx?: SxProps;
+  contentSx?: SxProps;
 }
 
 export function NotificationPopup(props: NotificationPopupProps): ReactElement {
@@ -67,7 +74,12 @@ export function NotificationPopup(props: NotificationPopupProps): ReactElement {
       >
         {props.header}
       </MuiDialogTitle>
-      <MuiDialogContent style={{ paddingTop: '5px' }}>
+      <MuiDialogContent
+        sx={getSxFromPropsAndClasses({
+          sxProps: props.contentSx,
+          styleClass: classes.dialogContent,
+        })}
+      >
         {typeof props.content === 'string' ? (
           <MuiDialogContentText>{props.content}</MuiDialogContentText>
         ) : (

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -320,10 +320,10 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           {
             buttonText: ButtonText.OpenAttributionWizardPopup,
             disabled: false,
-            hidden: true,
-            // isExternalAttribution ||
-            // hideResourceSpecificButtons ||
-            // props.hideAttributionWizardContextMenuItem,
+            hidden:
+              isExternalAttribution ||
+              hideResourceSpecificButtons ||
+              props.hideAttributionWizardContextMenuItem,
             onClick: (): void => {
               dispatch(
                 openPopup(PopupType.AttributionWizardPopup, attributionId)

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -22,6 +22,9 @@ export const OpossumColors = {
   disabledButtonGrey: 'hsla(0, 0%, 0%, 0.13)',
   disabledGrey: 'hsla(0, 0%, 0%, 0.26)',
   grey: 'hsla(0, 0%, 0%, 0.52)',
+  lightGrey: 'hsla(0, 0%, 0%, 0.09)',
+  mediumGrey: 'hsla(0, 0%, 0%, 0.36)',
+  darkGrey: 'hsla(0, 0%, 0%, 0.7)',
   black: 'hsl(0, 0%, 0%)',
   pastelLightGreen: 'hsl(146, 50%, 80%)',
   pastelMiddleGreen: 'hsl(146, 50%, 68%)',
@@ -258,3 +261,22 @@ export const treeItemClasses = {
   },
   tooltip: tooltipStyle,
 };
+
+export const attributionWizardStepClasses = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'start',
+    height: '100%',
+  },
+  purlRoot: {
+    width: '100%',
+  },
+  purlText: {
+    '&.Mui-disabled': {
+      WebkitTextFillColor: OpossumColors.darkGrey,
+    },
+  },
+};
+
+export const ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT = 45;


### PR DESCRIPTION
### Summary of changes

Adapt the wizard styling such that it looks cohesive to the rest of the app.

### Test changes

Open the attribution wizard via the context menu of a manual attribution in audit view. Make sure that you select a folder which contains a reasonable amount of signals.

First wizard step:
<img src=https://user-images.githubusercontent.com/83081698/214889038-022f4cfd-6a3c-4c48-9e90-7beb795b9f70.PNG width=500/>

Second wizard step:
<img src=https://user-images.githubusercontent.com/83081698/214889110-11065088-1583-4c8b-894f-12736d07ae4d.PNG width=500/>


Fix: #1322
