### PR TITLE
Attribution Wizard: Implement "add new" functionality.

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -32,6 +32,10 @@ interface AttributionWizardPackageStepProps {
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
   handlePackageNameListItemClick: (id: string) => void;
+  manuallyAddedNamespaces: Array<string>;
+  setManuallyAddedNamespaces(items: Array<string>): void;
+  manuallyAddedNames: Array<string>;
+  setManuallyAddedNames(items: Array<string>): void;
   listBoxSx?: SxProps;
   listSx?: SxProps;
 }
@@ -64,7 +68,9 @@ export function AttributionWizardPackageStep(
           selectedListItemId={props.selectedPackageNamespaceId}
           handleListItemClick={props.handlePackageNamespaceListItemClick}
           showChipsForAttributes={false}
-          showAddNewInput={false}
+          showAddNewListItem={true}
+          manuallyAddedListItems={props.manuallyAddedNamespaces}
+          setManuallyAddedListItems={props.setManuallyAddedNamespaces}
           title={'Package namespace'}
           listSx={props.listSx}
         />
@@ -73,7 +79,9 @@ export function AttributionWizardPackageStep(
           selectedListItemId={props.selectedPackageNameId}
           handleListItemClick={props.handlePackageNameListItemClick}
           showChipsForAttributes={false}
-          showAddNewInput={false}
+          showAddNewListItem={true}
+          manuallyAddedListItems={props.manuallyAddedNames}
+          setManuallyAddedListItems={props.setManuallyAddedNames}
           title={'Package name'}
           listSx={props.listSx}
         />

--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -86,6 +86,16 @@ export function AttributionWizardPopup(): ReactElement {
   const popupAttributionId = useAppSelector(getPopupAttributionId);
   const manualAttributions = useAppSelector(getManualAttributions);
 
+  const [manuallyAddedNamespaces, setManuallyAddedNamespaces] = useState<
+    Array<string>
+  >([]);
+  const [manuallyAddedNames, setManuallyAddedNames] = useState<Array<string>>(
+    []
+  );
+  const [manuallyAddedVersions, setManuallyAddedVersions] = useState<
+    Array<string>
+  >([]);
+
   const dispatch = useAppDispatch();
   function closeAttributionWizardPopup(): void {
     dispatch(closePopup());
@@ -139,7 +149,9 @@ export function AttributionWizardPopup(): ReactElement {
     {
       ...externalData.attributions,
       ...manualData.attributions,
-    }
+    },
+    manuallyAddedNamespaces,
+    manuallyAddedNames
   );
 
   const selectedPackageNamespace = filterForPackageAttributeId(
@@ -156,7 +168,8 @@ export function AttributionWizardPopup(): ReactElement {
     selectedPackageName !== ''
       ? getAttributionWizardPackageVersionListItems(
           selectedPackageName,
-          packageNamesToVersions
+          packageNamesToVersions,
+          manuallyAddedVersions
         )
       : [];
 
@@ -198,7 +211,6 @@ export function AttributionWizardPopup(): ReactElement {
   const handleBreadcrumbsClick = function (wizardStepId: string): void {
     setSelectedWizardStepId(wizardStepId);
   };
-
   function handleNextClick(): void {
     if (selectedWizardStepId !== wizardStepIds[wizardStepIds.length - 1]) {
       setSelectedWizardStepId(
@@ -213,7 +225,6 @@ export function AttributionWizardPopup(): ReactElement {
       );
     }
   }
-
   function handlePackageNamespaceListItemClick(id: string): void {
     setSelectedPackageNamespaceId(id);
   }
@@ -223,7 +234,6 @@ export function AttributionWizardPopup(): ReactElement {
   function handlePackageVersionListItemClick(id: string): void {
     setSelectedPackageVersionId(id);
   }
-
   function handleApplyClick(): void {
     dispatch(
       setTemporaryPackageInfo({
@@ -305,6 +315,10 @@ export function AttributionWizardPopup(): ReactElement {
                   handlePackageNamespaceListItemClick
                 }
                 handlePackageNameListItemClick={handlePackageNameListItemClick}
+                manuallyAddedNamespaces={manuallyAddedNamespaces}
+                setManuallyAddedNamespaces={setManuallyAddedNamespaces}
+                manuallyAddedNames={manuallyAddedNames}
+                setManuallyAddedNames={setManuallyAddedNames}
                 listBoxSx={classes.listBox}
                 listSx={classes.list}
               />
@@ -317,6 +331,8 @@ export function AttributionWizardPopup(): ReactElement {
                 handlePackageVersionListItemClick={
                   handlePackageVersionListItemClick
                 }
+                manuallyAddedVersions={manuallyAddedVersions}
+                setManuallyAddedVersions={setManuallyAddedVersions}
                 listSx={classes.list}
               />
             ) : null}

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -8,7 +8,7 @@ import {
   createTestAppStore,
   renderComponentWithStore,
 } from '../../../test-helpers/render-component-with-store';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, within } from '@testing-library/react';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { ButtonText, PopupType } from '../../../enums/enums';
 import { getOpenPopup } from '../../../state/selectors/view-selector';
@@ -262,5 +262,67 @@ describe('AttributionWizardPopup', () => {
     expect(changedTemporaryPackageInfo).toEqual(
       expectedChangedTemporaryPackageInfo
     );
+  });
+
+  it('displays manually added list entries', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+    });
+
+    const namespaceTable = screen.getByText('Package namespace')
+      .parentElement as HTMLElement;
+    const namespaceTextBox = within(namespaceTable).getByRole('textbox');
+    const namespaceIconButton = within(namespaceTable).getByRole('button', {
+      name: 'Enter text to add a new item to the list',
+    });
+    expect(namespaceIconButton).toBeDisabled();
+    fireEvent.change(namespaceTextBox, { target: { value: 'new_namespace' } });
+    expect(namespaceIconButton).toBeEnabled();
+    fireEvent.click(namespaceIconButton);
+    expect(namespaceTextBox).toHaveValue('');
+    expect(namespaceIconButton).toBeDisabled();
+    expect(screen.getByText('new_namespace')).toBeInTheDocument();
+
+    const nameTable = screen.getByText('Package name')
+      .parentElement as HTMLElement;
+    const nameTextBox = within(nameTable).getByRole('textbox');
+    const nameIconButton = within(nameTable).getByRole('button', {
+      name: 'Enter text to add a new item to the list',
+    });
+    expect(nameIconButton).toBeDisabled();
+    fireEvent.change(nameTextBox, { target: { value: 'new_name' } });
+    expect(nameIconButton).toBeEnabled();
+    fireEvent.click(nameIconButton);
+    expect(nameTextBox).toHaveValue('');
+    expect(nameIconButton).toBeDisabled();
+    expect(screen.getByText('new_name')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
+
+    const versionTable = screen.getByText('Package version')
+      .parentElement as HTMLElement;
+    const versionTextBox = within(versionTable).getByRole('textbox');
+    const versionIconButton = within(versionTable).getByRole('button', {
+      name: 'Enter text to add a new item to the list',
+    });
+    expect(versionIconButton).toBeDisabled();
+    fireEvent.change(versionTextBox, { target: { value: 'new_version' } });
+    expect(versionIconButton).toBeEnabled();
+    fireEvent.click(versionIconButton);
+    expect(versionTextBox).toHaveValue('');
+    expect(versionIconButton).toBeDisabled();
+    expect(screen.getByText('new_version')).toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -17,6 +17,8 @@ import {
   getAllAttributionIdsWithCountsFromResourceAndChildren,
   getHighlightedPackageNameIds,
   getPreSelectedPackageAttributeIds,
+  convertManuallyAddedListEntriesToListItems,
+  getManuallyAddedPackageNamesToVersions,
 } from '../attribution-wizard-popup-helpers';
 
 describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', () => {
@@ -149,6 +151,8 @@ describe('getAttributionWizardPackageListsItems', () => {
         packageVersion: '6.0',
       },
     };
+    const testManuallyAddedNamespaces: Array<string> = [];
+    const testManuallyAddedNames: Array<string> = [];
     const expectedAttributedPackageNamespaces: Array<ListWithAttributesItem> = [
       {
         text: 'pip',
@@ -208,7 +212,9 @@ describe('getAttributionWizardPackageListsItems', () => {
       packageNamesToVersions,
     } = getAttributionWizardPackageListsItems(
       testContainedExternalPackages,
-      testExternalAttributions
+      testExternalAttributions,
+      testManuallyAddedNamespaces,
+      testManuallyAddedNames
     );
 
     expect(attributedPackageNamespaces).toEqual(
@@ -228,6 +234,7 @@ describe('getAttributionWizardPackageVersionListItems', () => {
       [testPackageName2]: new Set<string>(['6.0.3']),
       numpy: new Set<string>(['1.24.0']),
     };
+    const testManuallyAddedVersions: Array<string> = [];
 
     const expectedPackageVersionListItems = [
       {
@@ -259,7 +266,8 @@ describe('getAttributionWizardPackageVersionListItems', () => {
     const testPackageVersionListItems =
       getAttributionWizardPackageVersionListItems(
         testPackageName,
-        testPackageNamesToVersions
+        testPackageNamesToVersions,
+        testManuallyAddedVersions
       );
 
     expect(testPackageVersionListItems).toEqual(
@@ -287,6 +295,48 @@ describe('getHighlightedPackeNameIds', () => {
 
     expect(testHighlightedPackageNameIds).toEqual(
       expectedHighlightedPackeNameIds
+    );
+  });
+});
+
+describe('convertManuallyAddedListEntriesToListItems', () => {
+  it('yields correct output', () => {
+    const testManuallyAddedListEntries = ['new_package_0', 'new_package_1'];
+    const testPackageAttributeId = 'name';
+    const expectedNewListItems: Array<ListWithAttributesItem> = [
+      {
+        text: 'new_package_0',
+        manuallyAdded: true,
+        id: 'name-new_package_0',
+      },
+      {
+        text: 'new_package_1',
+        manuallyAdded: true,
+        id: 'name-new_package_1',
+      },
+    ];
+
+    const testNewListItems = convertManuallyAddedListEntriesToListItems(
+      testManuallyAddedListEntries,
+      testPackageAttributeId
+    );
+
+    expect(testNewListItems).toEqual(expectedNewListItems);
+  });
+});
+
+describe('getManuallyAddedPackageNamesToVersions', () => {
+  it('yields correct output', () => {
+    const testManuallyAddedPackageNames = ['new_package_0', 'new_package_1'];
+    const expectedNewPackageNamesToVersions = {
+      ['new_package_0']: new Set<string>([emptyAttribute]),
+      ['new_package_1']: new Set<string>([emptyAttribute]),
+    };
+    const testNewPackageNamesToVersions =
+      getManuallyAddedPackageNamesToVersions(testManuallyAddedPackageNames);
+
+    expect(testNewPackageNamesToVersions).toEqual(
+      expectedNewPackageNamesToVersions
     );
   });
 });

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -27,6 +27,8 @@ interface AttributionWizardVersionStepProps {
   selectedPackageInfo: PackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
+  manuallyAddedVersions: Array<string>;
+  setManuallyAddedVersions(items: Array<string>): void;
   listSx?: SxProps;
 }
 
@@ -53,7 +55,9 @@ export function AttributionWizardVersionStep(
           highlightedAttributeIds={props.highlightedPackageNameIds}
           handleListItemClick={props.handlePackageVersionListItemClick}
           showChipsForAttributes={true}
-          showAddNewInput={false}
+          showAddNewListItem={true}
+          manuallyAddedListItems={props.manuallyAddedVersions}
+          setManuallyAddedListItems={props.setManuallyAddedVersions}
           title={'Package version'}
           listSx={props.listSx}
         />

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -15,6 +15,7 @@ import IndeterminateCheckBoxIcon from '@mui/icons-material/IndeterminateCheckBox
 import ReplayIcon from '@mui/icons-material/Replay';
 import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import SearchIcon from '@mui/icons-material/Search';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import React, { ReactElement } from 'react';
 import {
   baseIcon,
@@ -237,4 +238,8 @@ export function IncompletePackagesIcon(props: IconProps): ReactElement {
       />
     </MuiTooltip>
   );
+}
+
+export function ManuallyAddedListItemIcon(props: IconProps): ReactElement {
+  return <AutoAwesomeIcon sx={props.sx} />;
 }

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -3,20 +3,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement, useState } from 'react';
 import MuiBox from '@mui/material/Box';
 import MuiList from '@mui/material/List';
 import MuiListItem from '@mui/material/ListItem';
 import MuiListItemText from '@mui/material/ListItemText';
 import MuiListItemButton from '@mui/material/ListItemButton';
 import MuiTypography from '@mui/material/Typography';
-import { OpossumColors } from '../../shared-styles';
+import AddBoxIcon from '@mui/icons-material/AddBox';
+import {
+  baseIcon,
+  clickableIcon,
+  disabledIcon,
+  OpossumColors,
+} from '../../shared-styles';
 import { getAttributesWithHighlighting } from './list-with-attributes-helpers';
 import { ListWithAttributesItem } from '../../types/types';
 import { SxProps } from '@mui/system';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
+import { TextBox } from '../InputElements/TextBox';
+import { ManuallyAddedListItemIcon } from '../Icons/Icons';
+import { IconButton } from '../IconButton/IconButton';
 
 const LIST_TITLE_HEIGHT = 36;
+const ITEM_TEXT_FALLBACK = '-';
 
 const classes = {
   titleAndListBox: {
@@ -72,11 +82,25 @@ const classes = {
     marginBottom: '8px',
     borderWidth: '2px',
   },
-  listItemTextAttributesBox: {
+  listItemTextPrimaryBox: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  manuallyAddedListItemIcon: {
+    ...baseIcon,
+    color: OpossumColors.darkBlue,
+  },
+  listItemTextSecondaryBox: {
     display: 'flex',
     flexWrap: 'wrap',
     marginLeft: '24px',
     paddingTop: '1px',
+  },
+  primaryTypography: {
+    margin: '13px 5px 13px 0px',
+  },
+  secondaryTypography: {
+    component: 'span',
   },
 };
 
@@ -86,7 +110,9 @@ interface ListWithAttributesProps {
   highlightedAttributeIds?: Array<string>;
   handleListItemClick: (id: string) => void;
   showChipsForAttributes: boolean;
-  showAddNewInput: boolean;
+  showAddNewListItem?: boolean;
+  manuallyAddedListItems?: Array<string>;
+  setManuallyAddedListItems?(items: Array<string>): void;
   title?: string;
   listSx?: SxProps;
   emptyTextFallback?: string;
@@ -95,6 +121,28 @@ interface ListWithAttributesProps {
 export function ListWithAttributes(
   props: ListWithAttributesProps
 ): ReactElement {
+  const [textBoxInput, setTextBoxInput] = useState<string>('');
+
+  function handleTextBoxInputChange(
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ): void {
+    setTextBoxInput(event.target.value);
+  }
+
+  function handleAddNewInputClick(): void {
+    if (
+      !props.manuallyAddedListItems?.includes(textBoxInput) &&
+      props.setManuallyAddedListItems &&
+      props.manuallyAddedListItems
+    ) {
+      props.setManuallyAddedListItems([
+        textBoxInput,
+        ...props.manuallyAddedListItems,
+      ]);
+    }
+    setTextBoxInput('');
+  }
+
   return (
     <MuiBox sx={classes.titleAndListBox}>
       <MuiTypography sx={classes.title} variant={'subtitle1'}>
@@ -128,22 +176,67 @@ export function ListWithAttributes(
               onClick={(): void => props.handleListItemClick(item.id)}
             >
               <MuiListItemText
-                primary={item.text || (props.emptyTextFallback ?? '-')}
-                secondary={
-                  <MuiBox sx={classes.listItemTextAttributesBox}>
-                    {getAttributesWithHighlighting(
-                      item.attributes,
-                      props.showChipsForAttributes,
-                      props.highlightedAttributeIds
-                    )}
-                  </MuiBox>
+                primary={
+                  Boolean(item.manuallyAdded) ? (
+                    <MuiBox sx={classes.listItemTextPrimaryBox}>
+                      {item.text ||
+                        (props.emptyTextFallback ?? ITEM_TEXT_FALLBACK)}
+                      <ManuallyAddedListItemIcon
+                        sx={classes.manuallyAddedListItemIcon}
+                      />
+                    </MuiBox>
+                  ) : (
+                    item.text || (props.emptyTextFallback ?? ITEM_TEXT_FALLBACK)
+                  )
                 }
+                secondary={
+                  Boolean(item.manuallyAdded) ||
+                  item.attributes === undefined ? undefined : (
+                    <MuiBox sx={classes.listItemTextSecondaryBox}>
+                      {getAttributesWithHighlighting(
+                        item.attributes,
+                        props.showChipsForAttributes,
+                        props.highlightedAttributeIds
+                      )}
+                    </MuiBox>
+                  )
+                }
+                primaryTypographyProps={{
+                  sx: Boolean(item.manuallyAdded)
+                    ? classes.primaryTypography
+                    : undefined,
+                }}
                 secondaryTypographyProps={{ component: 'span' }}
               />
             </MuiListItemButton>
           </MuiListItem>
         ))}
       </MuiList>
+      {props.showAddNewListItem && (
+        <TextBox
+          title={'Add new item'}
+          isEditable={true}
+          handleChange={handleTextBoxInputChange}
+          text={textBoxInput}
+          endIcon={
+            <IconButton
+              icon={
+                <AddBoxIcon
+                  sx={!Boolean(textBoxInput) ? disabledIcon : clickableIcon}
+                />
+              }
+              onClick={handleAddNewInputClick}
+              disabled={!Boolean(textBoxInput)}
+              tooltipTitle={
+                !Boolean(textBoxInput)
+                  ? 'Enter text to add a new item to the list'
+                  : 'Click to add a new item to the list'
+              }
+              tooltipPlacement={'right'}
+            />
+          }
+        />
+      )}
     </MuiBox>
   );
 }

--- a/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
+++ b/src/Frontend/Components/ListWithAttributes/__tests__/ListWithAttributes.test.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, within } from '@testing-library/react';
+import { fireEvent, render, within } from '@testing-library/react';
 import { ListWithAttributes } from '../ListWithAttributes';
 import { screen } from '@testing-library/react';
 import { ListWithAttributesItem } from '../../../types/types';
@@ -40,7 +40,7 @@ describe('ListWithAttributes', () => {
         highlightedAttributeIds={testHighlightedAttributeIds}
         handleListItemClick={doNothing}
         showChipsForAttributes={true}
-        showAddNewInput={false}
+        showAddNewListItem={false}
         title={testListTitle}
       />
     );
@@ -56,5 +56,39 @@ describe('ListWithAttributes', () => {
     expect(listItemElement2.getByText('package_1')).toBeInTheDocument();
     expect(listItemElement2.getByText('attrib_10')).toBeInTheDocument();
     expect(listItemElement2.getByText('attrib_11')).toBeInTheDocument();
+  });
+
+  it('renders a text field for adding new list items', () => {
+    const testItems: Array<ListWithAttributesItem> = [
+      {
+        text: '',
+        id: '',
+        attributes: [{ text: '', id: '' }],
+      },
+    ];
+    const testSelectedItemId = '';
+    const testHighlightedAttributeIds = [''];
+    const testListTitle = '';
+
+    render(
+      <ListWithAttributes
+        listItems={testItems}
+        selectedListItemId={testSelectedItemId}
+        highlightedAttributeIds={testHighlightedAttributeIds}
+        handleListItemClick={doNothing}
+        showChipsForAttributes={false}
+        showAddNewListItem={true}
+        title={testListTitle}
+      />
+    );
+
+    expect(screen.queryAllByText('Add new item')).toHaveLength(2);
+    const textBox = screen.getByRole('textbox');
+    const iconButton = screen.getByRole('button', {
+      name: 'Enter text to add a new item to the list',
+    });
+    expect(iconButton).toBeDisabled();
+    fireEvent.change(textBox, { target: { value: 'abc' } });
+    expect(iconButton).toBeEnabled();
   });
 });

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -150,5 +150,6 @@ export interface ListWithAttributesItemAttribute {
 export interface ListWithAttributesItem {
   text: string;
   id: string;
-  attributes: Array<ListWithAttributesItemAttribute>;
+  manuallyAdded?: boolean;
+  attributes?: Array<ListWithAttributesItemAttribute>;
 }


### PR DESCRIPTION
### Summary of changes

A textbox is placed below each list for adding items manually. After having entered a string, the item can be added by clicking the icon button on the right.

### Context and reason for change

Flexibility for the user.

### Further comments

Inserting the textbox below the list was done for better visual separation.

First wizard step:
<img src="https://user-images.githubusercontent.com/83081698/215442895-06e5c523-a765-4140-8cd0-281d05a859ca.PNG" width="550"/>

Fix: #1280 