### PR TITLE
Attribution Wizard: Show all versions in second step and sort by relevance

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -26,11 +26,8 @@ import {
 } from '../../state/selectors/audit-view-resource-selectors';
 import {
   getAttributionWizardPackageListsItems,
-  getAttributionWizardPackageVersionListItems,
   getAllAttributionIdsWithCountsFromResourceAndChildren,
-  getHighlightedPackageNameIds,
   getPreSelectedPackageAttributeIds,
-  filterForPackageAttributeId,
   emptyAttribute,
 } from './attribution-wizard-popup-helpers';
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
@@ -141,9 +138,12 @@ export function AttributionWizardPopup(): ReactElement {
     );
 
   const {
-    attributedPackageNamespaces,
-    attributedPackageNames,
-    packageNamesToVersions,
+    sortedAttributedPackageNamespacesWithManuallyAddedOnes,
+    sortedAttributedPackageNamesWithManuallyAddedOnes,
+    sortedAttributedPackageVersionsWithManuallyAddedOnes,
+    selectedPackageNamespace,
+    selectedPackageName,
+    highlightedPackageNameIds,
   } = getAttributionWizardPackageListsItems(
     allAttributionIdsOfResourceAndChildrenWithCounts,
     {
@@ -151,33 +151,18 @@ export function AttributionWizardPopup(): ReactElement {
       ...manualData.attributions,
     },
     manuallyAddedNamespaces,
-    manuallyAddedNames
-  );
-
-  const selectedPackageNamespace = filterForPackageAttributeId(
+    manuallyAddedNames,
+    manuallyAddedVersions,
     selectedPackageNamespaceId,
-    attributedPackageNamespaces
+    selectedPackageNameId
   );
-
-  const selectedPackageName = filterForPackageAttributeId(
-    selectedPackageNameId,
-    attributedPackageNames
-  );
-
-  const attributedPackageVersions =
-    selectedPackageName !== ''
-      ? getAttributionWizardPackageVersionListItems(
-          selectedPackageName,
-          packageNamesToVersions,
-          manuallyAddedVersions
-        )
-      : [];
 
   let selectedPackageVersion = '';
   if (selectedPackageVersionId !== '') {
-    const attributedPackageVersion = attributedPackageVersions.filter(
-      (item) => item.id === selectedPackageVersionId
-    )[0];
+    const attributedPackageVersion =
+      sortedAttributedPackageVersionsWithManuallyAddedOnes.filter(
+        (item) => item.id === selectedPackageVersionId
+      )[0];
 
     if (attributedPackageVersion === undefined) {
       setSelectedPackageVersionId('');
@@ -185,14 +170,6 @@ export function AttributionWizardPopup(): ReactElement {
       selectedPackageVersion = attributedPackageVersion.text;
     }
   }
-
-  const highlightedPackageNameIds =
-    selectedPackageName !== ''
-      ? getHighlightedPackageNameIds(
-          selectedPackageName,
-          packageNamesToVersions
-        )
-      : [''];
 
   const selectedPackageInfo: PackageInfo = {
     packageType: popupAttribution.packageType ?? 'generic',
@@ -306,8 +283,12 @@ export function AttributionWizardPopup(): ReactElement {
           <MuiBox sx={classes.mainContentBox}>
             {selectedWizardStepId === wizardStepIds[0] ? (
               <AttributionWizardPackageStep
-                attributedPackageNamespaces={attributedPackageNamespaces}
-                attributedPackageNames={attributedPackageNames}
+                attributedPackageNamespaces={
+                  sortedAttributedPackageNamespacesWithManuallyAddedOnes
+                }
+                attributedPackageNames={
+                  sortedAttributedPackageNamesWithManuallyAddedOnes
+                }
                 selectedPackageInfo={selectedPackageInfo}
                 selectedPackageNamespaceId={selectedPackageNamespaceId}
                 selectedPackageNameId={selectedPackageNameId}
@@ -324,7 +305,9 @@ export function AttributionWizardPopup(): ReactElement {
               />
             ) : selectedWizardStepId === wizardStepIds[1] ? (
               <AttributionWizardVersionStep
-                attributedPackageVersions={attributedPackageVersions}
+                attributedPackageVersions={
+                  sortedAttributedPackageVersionsWithManuallyAddedOnes
+                }
                 selectedPackageInfo={selectedPackageInfo}
                 highlightedPackageNameIds={highlightedPackageNameIds}
                 selectedPackageVersionId={selectedPackageVersionId}

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -241,5 +241,14 @@ export function IncompletePackagesIcon(props: IconProps): ReactElement {
 }
 
 export function ManuallyAddedListItemIcon(props: IconProps): ReactElement {
-  return <AutoAwesomeIcon sx={props.sx} />;
+  return (
+    <MuiTooltip
+      describeChild={true}
+      sx={classes.tooltip}
+      title={'entry was added manually'}
+      placement={'left'}
+    >
+      <AutoAwesomeIcon sx={props.sx} />
+    </MuiTooltip>
+  );
 }


### PR DESCRIPTION
### Summary of changes

The second step of the wizard shows all versions instead of only the versions
that correspond to the selected package name. Versions that correspond
to the selected package name are displayed at the top.


Second wizard step:
<img src="https://user-images.githubusercontent.com/83081698/216002477-50c714ed-3bbc-4f55-bc67-667dd758c840.PNG" width="550" />

Fix: #1352
