### PR TITLE
Fix icon for folder leaves

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -246,10 +246,10 @@ describe('ResourceBrowser', () => {
     expect(screen.queryByText('doesntExist')).not.toBeInTheDocument();
 
     const expectedSequence: Array<string> = [
-      'c_package_folder',
-      'd_package_folder',
       'a_package.exe',
       'b_package.exe',
+      'c_package_folder',
+      'd_package_folder',
     ];
 
     const allPackages = screen.queryAllByText(/package/);
@@ -281,11 +281,11 @@ describe('ResourceBrowser', () => {
     expect(screen.queryByText('doesntExist')).not.toBeInTheDocument();
 
     const expectedSequence: Array<string> = [
-      'a_package_folder',
-      'z_package_folder',
       'a_package.exe',
+      'a_package_folder',
       'package.json',
       'z_package.exe',
+      'z_package_folder',
     ];
 
     const allPackages = screen.queryAllByText(/package/);

--- a/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
@@ -205,7 +205,7 @@ function getSortFunction(
 }
 
 function canNodeHaveChildren(node: NodesForTree | 1): node is NodesForTree {
-  return node !== 1;
+  return node !== 1 && Object.keys(node).length !== 0;
 }
 
 function isIdOfNodeWithChildren(nodeId: string): boolean {


### PR DESCRIPTION
### Summary of changes

Fix icon for folder leaves

### Context and reason for change

- If folder is a leaf, it won't have any more children to be found (no keys)
- isEmpty() function from lodash doesn't work for this use-case. (because of recursion and we need to check next level)
- The tests needed to be fixed because now both files and empty folders are treated as proper leaves, and an empty folder has no importance over a file.

Fix: #1317

### How can the changes be tested

https://github.com/opossum-tool/OpossumUI/issues/1317#issuecomment-1411735374
