### PR TITLE
Fix icon for folder leaves

### DIFF
--- a/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
@@ -34,8 +34,9 @@ export function getTreeNodeProps(
   for (const nodeName of sortedNodeNames) {
     const node = nodes[nodeName];
     const nodeHeight = cardHeight - 1;
-    const isExpandable = canNodeHaveChildren(node);
-    const nodeId = getNodeId(nodeName, parentPath, isExpandable);
+    const isExpandable =
+      canNodeHaveChildren(node) && Object.keys(node).length !== 0;
+    const nodeId = getNodeId(nodeName, parentPath, canNodeHaveChildren(node));
     const isExpandedNode = isExpanded(nodeId, expandedNodes);
 
     const nodeIdsToExpand: Array<string> = getNodeIdsToExpand(nodeId, node);


### PR DESCRIPTION
### Summary of changes

Fix icon for folder leaves

### Context and reason for change

- If folder is a leaf, it won't have any more children to be found (no keys)

Fix: #1317

### How can the changes be tested

https://github.com/opossum-tool/OpossumUI/issues/1317#issuecomment-1411735374
