### PR TITLE
Remove shared constant

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -21,14 +21,13 @@ import {
   getManualData,
 } from '../../state/selectors/all-views-resource-selectors';
 import {
-  getSelectedResourceId,
   getResolvedExternalAttributions,
+  getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import {
-  getAttributionWizardPackageListsItems,
   getAllAttributionIdsWithCountsFromResourceAndChildren,
+  getAttributionWizardPackageListsItems,
   getPreSelectedPackageAttributeIds,
-  emptyAttribute,
 } from './attribution-wizard-popup-helpers';
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
 import { PackageInfo } from '../../../shared/shared-types';
@@ -173,16 +172,11 @@ export function AttributionWizardPopup(): ReactElement {
 
   const selectedPackageInfo: PackageInfo = {
     packageType: popupAttribution.packageType ?? 'generic',
-    packageName:
-      selectedPackageName !== emptyAttribute ? selectedPackageName : undefined,
-    packageNamespace:
-      selectedPackageNamespace !== emptyAttribute
-        ? selectedPackageNamespace
-        : undefined,
-    packageVersion:
-      selectedPackageVersion !== emptyAttribute
-        ? selectedPackageVersion
-        : undefined,
+    packageName: selectedPackageName ? selectedPackageName : undefined,
+    packageNamespace: selectedPackageNamespace
+      ? selectedPackageNamespace
+      : undefined,
+    packageVersion: selectedPackageVersion ? selectedPackageVersion : undefined,
   };
 
   const handleBreadcrumbsClick = function (wizardStepId: string): void {

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -11,13 +11,12 @@ import {
 } from '../../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../../types/types';
 import {
-  emptyAttribute,
+  convertManuallyAddedListEntriesToListItems,
+  getAllAttributionIdsWithCountsFromResourceAndChildren,
   getAttributionWizardPackageListsItems,
   getAttributionWizardPackageVersionListItems,
-  getAllAttributionIdsWithCountsFromResourceAndChildren,
   getHighlightedPackageNameIds,
   getPreSelectedPackageAttributeIds,
-  convertManuallyAddedListEntriesToListItems,
   sortAttributedPackageVersions,
 } from '../attribution-wizard-popup-helpers';
 
@@ -171,12 +170,12 @@ describe('getAttributionWizardPackageListsItems', () => {
           attributes: [{ text: '6 (60%)', id: 'namespace-attribute-pip' }],
         },
         {
-          text: emptyAttribute,
-          id: `namespace-${emptyAttribute}`,
+          text: '',
+          id: 'namespace-',
           attributes: [
             {
               text: '2 (20%)',
-              id: `namespace-attribute-${emptyAttribute}`,
+              id: 'namespace-attribute-',
             },
           ],
         },
@@ -204,11 +203,9 @@ describe('getAttributionWizardPackageListsItems', () => {
           attributes: [{ text: '5 (50%)', id: 'name-attribute-numpy' }],
         },
         {
-          text: emptyAttribute,
-          id: `name-${emptyAttribute}`,
-          attributes: [
-            { text: '2 (20%)', id: `name-attribute-${emptyAttribute}` },
-          ],
+          text: '',
+          id: 'name-',
+          attributes: [{ text: '2 (20%)', id: 'name-attribute-' }],
         },
         {
           text: 'buffer',
@@ -234,9 +231,9 @@ describe('getAttributionWizardPackageListsItems', () => {
           attributes: [{ text: 'numpy', id: 'version-1.24.0-name-numpy' }],
         },
         {
-          text: '-',
-          id: 'version--',
-          attributes: [{ text: '-', id: 'version---name--' }],
+          text: '',
+          id: 'version-',
+          attributes: [{ text: '', id: 'version--name-' }],
         },
         {
           text: '1.5.2',

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -24,8 +24,6 @@ interface NamesWithCounts {
   [name: string]: number;
 }
 
-export const emptyAttribute = '-';
-
 export function getAllAttributionIdsWithCountsFromResourceAndChildren(
   selectedResourceId: string,
   externalData: AttributionData,
@@ -90,9 +88,9 @@ export function getPreSelectedPackageAttributeIds(popupPackage: PackageInfo): {
   preSelectedPackageNameId: string;
   preSelectedPackageVersionId: string;
 } {
-  const namespace = popupPackage.packageNamespace || emptyAttribute;
-  const name = popupPackage.packageName || emptyAttribute;
-  const version = popupPackage.packageVersion || emptyAttribute;
+  const namespace = popupPackage.packageNamespace || '';
+  const name = popupPackage.packageName || '';
+  const version = popupPackage.packageVersion || '';
 
   const preSelectedPackageNamespaceId = `namespace-${namespace}`;
   const preSelectedPackageNameId = `name-${name}`;
@@ -225,9 +223,9 @@ function getPackageAttributesAndCounts(
 
     let packageAttribute: string;
     if (packageAttributeId === 'namespace') {
-      packageAttribute = packageInfo.packageNamespace || emptyAttribute;
+      packageAttribute = packageInfo.packageNamespace || '';
     } else if (packageAttributeId === 'name') {
-      packageAttribute = packageInfo.packageName || emptyAttribute;
+      packageAttribute = packageInfo.packageName || '';
     } else {
       shouldNotBeCalled(packageAttributeId);
     }
@@ -248,8 +246,8 @@ function getPackageNamesToVersions(
     const packageInfo =
       externalAttributions[containedExternalPackage.attributionId];
 
-    const packageName = packageInfo.packageName || emptyAttribute;
-    const packageVersion = packageInfo.packageVersion || emptyAttribute;
+    const packageName = packageInfo.packageName || '';
+    const packageVersion = packageInfo.packageVersion || '';
 
     packageNamesToVersions[packageName] ??
       (packageNamesToVersions[packageName] = new Set<string>());

--- a/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
+++ b/src/Frontend/Components/ListWithAttributes/list-with-attributes-helpers.tsx
@@ -33,7 +33,7 @@ export function getAttributesWithHighlighting(
       {showChipsForAttributes ? (
         <MuiChip
           clickable={false}
-          label={attribute.text}
+          label={attribute.text || '-'}
           variant={'filled'}
           size={'small'}
           sx={{
@@ -44,7 +44,7 @@ export function getAttributesWithHighlighting(
           }}
         />
       ) : (
-        attribute.text
+        attribute.text || '-'
       )}
     </React.Fragment>
   ));


### PR DESCRIPTION

### Summary of changes

The constant emptyAttribute is removed and a fallback for the display value is introduced.

### Context and reason for change

Related to #1345

### How can the changes be tested

Check that the attribution wizard still shows "-" as fallback for empty attributes.