### PR TITLE
Attribution Wizard: Clean business logic

### DIFF
--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -16,6 +16,7 @@ import {
   ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT,
 } from '../../shared-styles';
 import { SxProps } from '@mui/system';
+import { sortAttributedPackageItems } from '../AttributionWizardPopup/attribution-wizard-popup-helpers';
 
 const classes = {
   listBox: {
@@ -32,10 +33,8 @@ interface AttributionWizardPackageStepProps {
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
   handlePackageNameListItemClick: (id: string) => void;
-  manuallyAddedNamespaces: Array<string>;
-  setManuallyAddedNamespaces(items: Array<string>): void;
-  manuallyAddedNames: Array<string>;
-  setManuallyAddedNames(items: Array<string>): void;
+  addPackageNamespace(namespace: string): void;
+  addPackageName(name: string): void;
   listBoxSx?: SxProps;
   listSx?: SxProps;
 }
@@ -69,10 +68,10 @@ export function AttributionWizardPackageStep(
           handleListItemClick={props.handlePackageNamespaceListItemClick}
           showChipsForAttributes={false}
           showAddNewListItem={true}
-          manuallyAddedListItems={props.manuallyAddedNamespaces}
-          setManuallyAddedListItems={props.setManuallyAddedNamespaces}
+          setManuallyAddedListItems={props.addPackageNamespace}
           title={'Package namespace'}
           listSx={props.listSx}
+          sortList={sortAttributedPackageItems}
         />
         <ListWithAttributes
           listItems={props.attributedPackageNames}
@@ -80,10 +79,10 @@ export function AttributionWizardPackageStep(
           handleListItemClick={props.handlePackageNameListItemClick}
           showChipsForAttributes={false}
           showAddNewListItem={true}
-          manuallyAddedListItems={props.manuallyAddedNames}
-          setManuallyAddedListItems={props.setManuallyAddedNames}
+          setManuallyAddedListItems={props.addPackageName}
           title={'Package name'}
           listSx={props.listSx}
+          sortList={sortAttributedPackageItems}
         />
       </MuiBox>
     </MuiBox>

--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -16,7 +16,7 @@ import {
   ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT,
 } from '../../shared-styles';
 import { SxProps } from '@mui/system';
-import { sortAttributedPackageItems } from '../AttributionWizardPopup/attribution-wizard-popup-helpers';
+import { sortAttributedPackageItems } from './attribution-wizard-package-step-helpers';
 
 const classes = {
   listBox: {

--- a/src/Frontend/Components/AttributionWizardPackageStep/__tests__/attribution-wizard-package-step-helpers.test.ts
+++ b/src/Frontend/Components/AttributionWizardPackageStep/__tests__/attribution-wizard-package-step-helpers.test.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ListWithAttributesItem } from '../../../types/types';
+import { sortAttributedPackageItems } from '../attribution-wizard-package-step-helpers';
+
+describe('sortAttributedPackageItems', () => {
+  it('yields correct output', () => {
+    const testAttributedPackageItems: Array<ListWithAttributesItem> = [
+      { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
+      { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
+      { text: 'numpy', id: '33333', manuallyAdded: true },
+    ];
+    const expectedSortedAttributedPackageItems: Array<ListWithAttributesItem> =
+      [
+        { text: 'numpy', id: '33333', manuallyAdded: true },
+        { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
+        { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
+      ];
+
+    const testSortedAttributedPackageItems = sortAttributedPackageItems(
+      testAttributedPackageItems,
+      ['']
+    );
+
+    expect(testSortedAttributedPackageItems).toEqual(
+      expectedSortedAttributedPackageItems
+    );
+  });
+});

--- a/src/Frontend/Components/AttributionWizardPackageStep/attribution-wizard-package-step-helpers.ts
+++ b/src/Frontend/Components/AttributionWizardPackageStep/attribution-wizard-package-step-helpers.ts
@@ -7,7 +7,9 @@ import { ListWithAttributesItem } from '../../types/types';
 
 export function sortAttributedPackageItems(
   attributedPackageItems: Array<ListWithAttributesItem>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+  // required for easy invoking of sortList in ListWithAttributes
+  // no logic to handle different numbers of input args necessary
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   highlightedPackageNameIds: Array<string>
 ): Array<ListWithAttributesItem> {
   return attributedPackageItems.sort(compareAttributedPackageItems);
@@ -21,7 +23,8 @@ function compareAttributedPackageItems(
 
   if (manuallyAddedA !== manuallyAddedB) {
     return manuallyAddedA ? -1 : 1;
-  } else if (manuallyAddedA && manuallyAddedB) {
+  }
+  if (manuallyAddedA && manuallyAddedB) {
     const textA = attributedPackageItemA.text;
     const textB = attributedPackageItemB.text;
     return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
@@ -38,9 +41,8 @@ function compareAttributedPackageItems(
 
   if (countA !== countB) {
     return countB - countA;
-  } else {
-    const textA = attributedPackageItemA.text;
-    const textB = attributedPackageItemB.text;
-    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
   }
+  const textA = attributedPackageItemA.text;
+  const textB = attributedPackageItemB.text;
+  return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
 }

--- a/src/Frontend/Components/AttributionWizardPackageStep/attribution-wizard-package-step-helpers.ts
+++ b/src/Frontend/Components/AttributionWizardPackageStep/attribution-wizard-package-step-helpers.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ListWithAttributesItem } from '../../types/types';
+
+export function sortAttributedPackageItems(
+  attributedPackageItems: Array<ListWithAttributesItem>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+  highlightedPackageNameIds: Array<string>
+): Array<ListWithAttributesItem> {
+  return attributedPackageItems.sort(compareAttributedPackageItems);
+}
+function compareAttributedPackageItems(
+  attributedPackageItemA: ListWithAttributesItem,
+  attributedPackageItemB: ListWithAttributesItem
+): number {
+  const manuallyAddedA = Boolean(attributedPackageItemA.manuallyAdded);
+  const manuallyAddedB = Boolean(attributedPackageItemB.manuallyAdded);
+
+  if (manuallyAddedA !== manuallyAddedB) {
+    return manuallyAddedA ? -1 : 1;
+  } else if (manuallyAddedA && manuallyAddedB) {
+    const textA = attributedPackageItemA.text;
+    const textB = attributedPackageItemB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
+  }
+
+  const countA =
+    attributedPackageItemA.attributes !== undefined
+      ? parseInt(attributedPackageItemA.attributes[0].text.split(' ')[0])
+      : 0;
+  const countB =
+    attributedPackageItemB.attributes !== undefined
+      ? parseInt(attributedPackageItemB.attributes[0].text.split(' ')[0])
+      : 0;
+
+  if (countA !== countB) {
+    return countB - countA;
+  } else {
+    const textA = attributedPackageItemA.text;
+    const textB = attributedPackageItemB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
+  }
+}

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -10,8 +10,7 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 import { act, fireEvent, screen, within } from '@testing-library/react';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
-import { ButtonText, PopupType } from '../../../enums/enums';
-import { getOpenPopup } from '../../../state/selectors/view-selector';
+import { ButtonText } from '../../../enums/enums';
 import {
   Attributions,
   ResourcesToAttributions,
@@ -19,12 +18,9 @@ import {
 import {
   setExternalData,
   setManualData,
-  setTemporaryPackageInfo,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
 import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
 import { AttributionWizardPopup } from '../AttributionWizardPopup';
-import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
 
 const selectedResourceId = '/samplepath/';
 const testManualAttributions: Attributions = {
@@ -80,35 +76,6 @@ describe('AttributionWizardPopup', () => {
     expect(
       screen.getByRole('button', { name: ButtonText.Next })
     ).toBeInTheDocument();
-  });
-
-  it('closes when clicking "cancel"', () => {
-    const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId(selectedResourceId));
-    testStore.dispatch(
-      setExternalData(
-        testExternalAttributions,
-        testExternalResourcesToAttributions
-      )
-    );
-    testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
-    );
-
-    // GlobalPopup has to be rendered, otherwise closing is not possible and triggers re-render
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
-
-    act(() => {
-      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
-    });
-
-    expect(getOpenPopup(testStore.getState())).toBe(
-      PopupType.AttributionWizardPopup
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: ButtonText.Cancel }));
-
-    expect(getOpenPopup(testStore.getState())).toBeNull();
   });
 
   it('renders breadcrumbs', () => {
@@ -231,44 +198,6 @@ describe('AttributionWizardPopup', () => {
     expect(
       screen.getByRole('button', { name: ButtonText.Apply })
     ).toBeInTheDocument();
-  });
-
-  it('changes temporary package info', () => {
-    const initialTemporaryPackageInfo = testManualAttributions.uuid_0;
-    const expectedChangedTemporaryPackageInfo = testExternalAttributions.uuid_1;
-
-    const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId(selectedResourceId));
-    testStore.dispatch(
-      setExternalData(
-        testExternalAttributions,
-        testExternalResourcesToAttributions
-      )
-    );
-    testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
-    );
-
-    // GlobalPopup has to be rendered, otherwise closing is not possible and triggers re-render
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
-    act(() => {
-      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
-    });
-
-    testStore.dispatch(setTemporaryPackageInfo(initialTemporaryPackageInfo));
-
-    fireEvent.click(screen.getByText('pip'));
-    fireEvent.click(screen.getByText('numpy'));
-    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
-    fireEvent.click(screen.getByText('1.24.1'));
-    fireEvent.click(screen.getByRole('button', { name: ButtonText.Apply }));
-
-    const changedTemporaryPackageInfo = getTemporaryPackageInfo(
-      testStore.getState()
-    );
-    expect(changedTemporaryPackageInfo).toEqual(
-      expectedChangedTemporaryPackageInfo
-    );
   });
 
   it('displays manually added list entries', () => {

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -12,7 +12,6 @@ import { act, fireEvent, screen, within } from '@testing-library/react';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { ButtonText, PopupType } from '../../../enums/enums';
 import { getOpenPopup } from '../../../state/selectors/view-selector';
-import { openPopup } from '../../../state/actions/view-actions/view-actions';
 import {
   Attributions,
   ResourcesToAttributions,
@@ -24,6 +23,7 @@ import {
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
 import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
+import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
 
 const selectedResourceId = '/samplepath/';
 const testManualAttributions: Attributions = {
@@ -68,7 +68,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     expect(getOpenPopup(testStore.getState())).toBe(
@@ -120,7 +120,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     expect(screen.getByText('package')).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
@@ -184,7 +184,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
@@ -245,7 +245,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     testStore.dispatch(setTemporaryPackageInfo(initialTemporaryPackageInfo));
@@ -278,7 +278,7 @@ describe('AttributionWizardPopup', () => {
     );
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
-      testStore.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
 
     const namespaceTable = screen.getByText('Package namespace')

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -21,9 +21,10 @@ import {
   setManualData,
   setTemporaryPackageInfo,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
 import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
 import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
+import { AttributionWizardPopup } from '../AttributionWizardPopup';
+import { GlobalPopup } from '../../GlobalPopup/GlobalPopup';
 
 const selectedResourceId = '/samplepath/';
 const testManualAttributions: Attributions = {
@@ -66,10 +67,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
     expect(screen.getByText(selectedResourceId)).toBeInTheDocument();
@@ -93,7 +94,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
+
+    // GlobalPopup has to be rendered, otherwise closing is not possible and triggers re-render
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
+
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
@@ -103,6 +107,7 @@ describe('AttributionWizardPopup', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: ButtonText.Cancel }));
+
     expect(getOpenPopup(testStore.getState())).toBeNull();
   });
 
@@ -118,10 +123,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     expect(screen.getByText('package')).toBeInTheDocument();
     expect(screen.getByText('version')).toBeInTheDocument();
@@ -139,10 +144,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
@@ -182,10 +187,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     expect(screen.getByText(namespaceListTitle)).toBeInTheDocument();
     expect(screen.getByText(nameListTitle)).toBeInTheDocument();
@@ -216,10 +221,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
 
@@ -243,6 +248,8 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
+
+    // GlobalPopup has to be rendered, otherwise closing is not possible and triggers re-render
     renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -276,10 +283,10 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setManualData(testManualAttributions, testManualResourcesToAttributions)
     );
-    renderComponentWithStore(<GlobalPopup />, { store: testStore });
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
 
     const namespaceTable = screen.getByText('Package namespace')
       .parentElement as HTMLElement;

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -4,396 +4,128 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  AttributionData,
-  AttributionIdWithCount,
-  Attributions,
-  PackageInfo,
-} from '../../../../shared/shared-types';
-import { ListWithAttributesItem } from '../../../types/types';
+  ListWithAttributesItem,
+  PackageAttributes,
+} from '../../../types/types';
 import {
-  convertManuallyAddedListEntriesToListItems,
-  getAllAttributionIdsWithCountsFromResourceAndChildren,
-  getAttributionWizardPackageListsItems,
-  getAttributionWizardPackageVersionListItems,
-  getHighlightedPackageNameIds,
-  getPreSelectedPackageAttributeIds,
+  getAttributionWizardListItems,
+  sortAttributedPackageItems,
   sortAttributedPackageVersions,
 } from '../attribution-wizard-popup-helpers';
 
-describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', () => {
+describe('getAttributionWizardListItems', () => {
   it('yields correct output', () => {
-    const testSelectedResourceId = '/samplepath/';
-    const testExternalData: AttributionData = {
-      attributionsToResources: {},
-      resourcesWithAttributedChildren: {
-        '/samplepath/': new Set<string>([
-          '/samplepath/file_0',
-          '/samplepath/subfolder/file_1',
-          '/samplepath/subfolder/file_2',
-        ]),
-      },
-      resourcesToAttributions: {
-        '/samplepath/file_0': ['uuid_0'],
-        '/samplepath/subfolder/file_1': ['uuid_1'],
-        '/samplepath/subfolder/file_2': ['uuid_0'],
-      },
-      attributions: {},
+    const testPackageNamespaces: PackageAttributes = {
+      uuid_0: { text: 'npm', count: 6 },
+      uuid_1: { text: 'pip', count: 4 },
+      uuid_2: { text: 'new_namespace', manuallyAdded: true },
     };
-    const testManualData: AttributionData = {
-      attributionsToResources: {},
-      resourcesWithAttributedChildren: {
-        '/samplepath/': new Set<string>([
-          '/samplepath/subfolder/file_0',
-          '/samplepath/subfolder_2/file_3',
-          '/samplepath/subfolder_2/file_4',
-        ]),
-      },
-      resourcesToAttributions: {
-        '/samplepath/subfolder/file_0': ['uuid_2'],
-        '/samplepath/subfolder_2/file_3': ['uuid_3'],
-        '/samplepath/subfolder_2/file_4': ['uuid_4'],
-      },
-      attributions: {},
+    const testPackageNames: PackageAttributes = {
+      uuid_3: { text: 'buffer', count: 6 },
+      uuid_4: { text: 'numpy', count: 4 },
+      uuid_5: { text: 'new_name', manuallyAdded: true },
     };
-    const testResolvedExternalAttributions: Set<string> = new Set<string>();
-
-    const expectedTestAttributionsWithCounts: Array<AttributionIdWithCount> = [
-      { attributionId: 'uuid_0', count: 2 },
-      { attributionId: 'uuid_1', count: 1 },
-      { attributionId: 'uuid_2', count: 1 },
-      { attributionId: 'uuid_3', count: 1 },
-      { attributionId: 'uuid_4', count: 1 },
-    ];
-
-    const testAttributionsWithCounts =
-      getAllAttributionIdsWithCountsFromResourceAndChildren(
-        testSelectedResourceId,
-        testExternalData,
-        testManualData,
-        testResolvedExternalAttributions
-      );
-
-    expect(testAttributionsWithCounts).toEqual(
-      expectedTestAttributionsWithCounts
-    );
-  });
-});
-
-describe('getPreSelectedPackageAttributeIds', () => {
-  it('yields correct output', () => {
-    const testPackageInfo: PackageInfo = {
-      packageVersion: '6.0.3',
-      packageNamespace: 'npm',
-      packageName: 'buffer',
+    const testPackageVersions: PackageAttributes = {
+      uuid_6: { text: '6.0.2', relatedIds: new Set<string>(['uuid_3']) },
+      uuid_7: { text: '1.24.0', relatedIds: new Set<string>(['uuid_4']) },
+      uuid_8: { text: '6.0', relatedIds: new Set<string>(['uuid_3']) },
+      uuid_9: { text: 'new_version', manuallyAdded: true },
     };
-    const expectedPreSelectedPackageNamespaceId = 'namespace-npm';
-    const expectedPreSelectedPackageNameId = 'name-buffer';
-    const expectedPreSelectedPackageVersionId = 'version-6.0.3';
-
-    const {
-      preSelectedPackageNamespaceId: testPreSelectedPackageNamespaceId,
-      preSelectedPackageNameId: testPreSelectedPackageNameId,
-      preSelectedPackageVersionId: testPreSelectedPackageVersionId,
-    } = getPreSelectedPackageAttributeIds(testPackageInfo);
-
-    expect(testPreSelectedPackageNamespaceId).toEqual(
-      expectedPreSelectedPackageNamespaceId
-    );
-    expect(testPreSelectedPackageNameId).toEqual(
-      expectedPreSelectedPackageNameId
-    );
-    expect(testPreSelectedPackageVersionId).toEqual(
-      expectedPreSelectedPackageVersionId
-    );
-  });
-});
-
-describe('getAttributionWizardPackageListsItems', () => {
-  it('yields correct output', () => {
-    const testExternalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount> =
-      [
-        { attributionId: 'uuid_0', count: 1 },
-        { attributionId: 'uuid_1', count: 5 },
-        { attributionId: 'uuid_2', count: 1 },
-        { attributionId: 'uuid_3', count: 1 },
-        { attributionId: 'uuid_4', count: 1 },
-        { attributionId: 'uuid_5', count: 1 },
-      ];
-    const testExternalAndManualAttributions: Attributions = {
-      uuid_0: {
-        packageName: 'buffer',
-        packageNamespace: 'npm',
-        packageVersion: '6.0.3',
-      },
-      uuid_1: {
-        packageName: 'numpy',
-        packageNamespace: 'pip',
-        packageVersion: '1.24.0',
-      },
-      uuid_2: {
-        packageName: undefined,
-        packageNamespace: undefined,
-        packageVersion: undefined,
-      },
-      uuid_3: {
-        packageName: '',
-        packageNamespace: '',
-        packageVersion: '',
-      },
-      uuid_4: {
-        packageName: 'pandas',
-        packageNamespace: 'pip',
-        packageVersion: '1.5.2',
-      },
-      uuid_5: {
-        packageName: 'buffer',
-        packageNamespace: 'npm',
-        packageVersion: '6.0',
-      },
-    };
-    const testManuallyAddedNamespaces: Array<string> = ['new_namespace'];
-    const testManuallyAddedNames: Array<string> = ['new_name_1', 'new_name_2'];
-    const testManuallyAddedVersions: Array<string> = ['new_version'];
-    const testSelectedPackageNamespaceId = 'namespace-npm';
-    const testSelectedPackageNameId = 'name-numpy';
-
-    const expectedSortedAttributedPackageNamespacesWithManuallyAddedOnes: Array<ListWithAttributesItem> =
+    const testTotalAttributionCount = 10;
+    const expectedAttributedPackageNamespacesWithManuallyAddedOnes: Array<ListWithAttributesItem> =
       [
         {
-          text: 'new_namespace',
-          manuallyAdded: true,
-          id: 'namespace-new_namespace',
+          text: 'npm',
+          id: 'uuid_0',
+          attributes: [{ text: '6 (60%)' }],
         },
         {
           text: 'pip',
-          id: 'namespace-pip',
-          attributes: [{ text: '6 (60%)', id: 'namespace-attribute-pip' }],
+          id: 'uuid_1',
+          attributes: [{ text: '4 (40%)' }],
         },
-        {
-          text: '',
-          id: 'namespace-',
-          attributes: [
-            {
-              text: '2 (20%)',
-              id: 'namespace-attribute-',
-            },
-          ],
-        },
-        {
-          text: 'npm',
-          id: 'namespace-npm',
-          attributes: [{ text: '2 (20%)', id: 'namespace-attribute-npm' }],
-        },
+        { text: 'new_namespace', id: 'uuid_2', manuallyAdded: true },
       ];
-    const expectedSortedAttributedPackageNamesWithManuallyAddedOnes: Array<ListWithAttributesItem> =
+    const expectedAttributedPackageNamesWithManuallyAddedOnes: Array<ListWithAttributesItem> =
       [
         {
-          text: 'new_name_1',
-          manuallyAdded: true,
-          id: 'name-new_name_1',
-        },
-        {
-          text: 'new_name_2',
-          manuallyAdded: true,
-          id: 'name-new_name_2',
+          text: 'buffer',
+          id: 'uuid_3',
+          attributes: [{ text: '6 (60%)' }],
         },
         {
           text: 'numpy',
-          id: 'name-numpy',
-          attributes: [{ text: '5 (50%)', id: 'name-attribute-numpy' }],
+          id: 'uuid_4',
+          attributes: [{ text: '4 (40%)' }],
         },
-        {
-          text: '',
-          id: 'name-',
-          attributes: [{ text: '2 (20%)', id: 'name-attribute-' }],
-        },
-        {
-          text: 'buffer',
-          id: 'name-buffer',
-          attributes: [{ text: '2 (20%)', id: 'name-attribute-buffer' }],
-        },
-        {
-          text: 'pandas',
-          id: 'name-pandas',
-          attributes: [{ text: '1 (10%)', id: 'name-attribute-pandas' }],
-        },
+        { text: 'new_name', id: 'uuid_5', manuallyAdded: true },
       ];
-    const expectedSortedAttributedPackageVersionsWithManuallyAddedOnes: Array<ListWithAttributesItem> =
+    const expectedAttributedPackageVersionsWithManuallyAddedOnes: Array<ListWithAttributesItem> =
       [
         {
-          text: 'new_version',
-          manuallyAdded: true,
-          id: 'version-new_version',
+          text: '6.0.2',
+          id: 'uuid_6',
+          attributes: [{ text: 'buffer', id: 'uuid_3' }],
         },
         {
           text: '1.24.0',
-          id: 'version-1.24.0',
-          attributes: [{ text: 'numpy', id: 'version-1.24.0-name-numpy' }],
-        },
-        {
-          text: '',
-          id: 'version-',
-          attributes: [{ text: '', id: 'version--name-' }],
-        },
-        {
-          text: '1.5.2',
-          id: 'version-1.5.2',
-          attributes: [{ text: 'pandas', id: 'version-1.5.2-name-pandas' }],
+          id: 'uuid_7',
+          attributes: [{ text: 'numpy', id: 'uuid_4' }],
         },
         {
           text: '6.0',
-          id: 'version-6.0',
-          attributes: [{ text: 'buffer', id: 'version-6.0-name-buffer' }],
+          id: 'uuid_8',
+          attributes: [{ text: 'buffer', id: 'uuid_3' }],
         },
-        {
-          text: '6.0.3',
-          id: 'version-6.0.3',
-          attributes: [{ text: 'buffer', id: 'version-6.0.3-name-buffer' }],
-        },
+        { text: 'new_version', id: 'uuid_9', manuallyAdded: true },
       ];
-    const expectedSelectedPackageNamespace = 'npm';
-    const expectedSelectedPackageName = 'numpy';
-    const expectedHighlightedPackageNameIds: Array<string> = [
-      'version-1.24.0-name-numpy',
-    ];
-
     const {
-      sortedAttributedPackageNamespacesWithManuallyAddedOnes,
-      sortedAttributedPackageNamesWithManuallyAddedOnes,
-      sortedAttributedPackageVersionsWithManuallyAddedOnes,
-      selectedPackageNamespace,
-      selectedPackageName,
-      highlightedPackageNameIds,
-    } = getAttributionWizardPackageListsItems(
-      testExternalAndManualAttributionIdsWithCounts,
-      testExternalAndManualAttributions,
-      testManuallyAddedNamespaces,
-      testManuallyAddedNames,
-      testManuallyAddedVersions,
-      testSelectedPackageNamespaceId,
-      testSelectedPackageNameId
+      attributedPackageNamespacesWithManuallyAddedOnes:
+        testAttributedPackageNamespacesWithManuallyAddedOnes,
+      attributedPackageNamesWithManuallyAddedOnes:
+        testAttributedPackageNamesWithManuallyAddedOnes,
+      attributedPackageVersionsWithManuallyAddedOnes:
+        testAttributedPackageVersionsWithManuallyAddedOnes,
+    } = getAttributionWizardListItems(
+      testPackageNamespaces,
+      testPackageNames,
+      testPackageVersions,
+      testTotalAttributionCount
     );
 
-    expect(sortedAttributedPackageNamespacesWithManuallyAddedOnes).toEqual(
-      expectedSortedAttributedPackageNamespacesWithManuallyAddedOnes
+    expect(testAttributedPackageNamespacesWithManuallyAddedOnes).toEqual(
+      expectedAttributedPackageNamespacesWithManuallyAddedOnes
     );
-    expect(sortedAttributedPackageNamesWithManuallyAddedOnes).toEqual(
-      expectedSortedAttributedPackageNamesWithManuallyAddedOnes
+    expect(testAttributedPackageNamesWithManuallyAddedOnes).toEqual(
+      expectedAttributedPackageNamesWithManuallyAddedOnes
     );
-    expect(sortedAttributedPackageVersionsWithManuallyAddedOnes).toEqual(
-      expectedSortedAttributedPackageVersionsWithManuallyAddedOnes
-    );
-    expect(selectedPackageNamespace).toEqual(expectedSelectedPackageNamespace);
-    expect(selectedPackageName).toEqual(expectedSelectedPackageName);
-    expect(highlightedPackageNameIds).toEqual(
-      expectedHighlightedPackageNameIds
+    expect(testAttributedPackageVersionsWithManuallyAddedOnes).toEqual(
+      expectedAttributedPackageVersionsWithManuallyAddedOnes
     );
   });
 });
 
-describe('getAttributionWizardPackageVersionListItems', () => {
+describe('sortAttributedPackageItems', () => {
   it('yields correct output', () => {
-    const testPackageName = 'buffer';
-    const testPackageName2 = 'buffer2';
-    const testPackageName3 = 'numpy';
-    const testPackageNamesToVersions = {
-      [testPackageName]: new Set<string>(['6.0.3', '6.0']),
-      [testPackageName2]: new Set<string>(['6.0.3']),
-      [testPackageName3]: new Set<string>(['1.24.0']),
-    };
-
-    const expectedAttributedPackageVersions = [
-      {
-        text: '1.24.0',
-        id: 'version-1.24.0',
-        attributes: [
-          {
-            text: testPackageName3,
-            id: `version-1.24.0-name-${testPackageName3}`,
-          },
-        ],
-      },
-      {
-        text: '6.0',
-        id: 'version-6.0',
-        attributes: [
-          {
-            text: testPackageName,
-            id: `version-6.0-name-${testPackageName}`,
-          },
-        ],
-      },
-      {
-        text: '6.0.3',
-        id: 'version-6.0.3',
-        attributes: [
-          {
-            text: testPackageName,
-            id: `version-6.0.3-name-${testPackageName}`,
-          },
-          {
-            text: testPackageName2,
-            id: `version-6.0.3-name-${testPackageName2}`,
-          },
-        ],
-      },
+    const testAttributedPackageItems: Array<ListWithAttributesItem> = [
+      { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
+      { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
+      { text: 'numpy', id: '33333', manuallyAdded: true },
     ];
+    const expectedSortedAttributedPackageItems: Array<ListWithAttributesItem> =
+      [
+        { text: 'numpy', id: '33333', manuallyAdded: true },
+        { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
+        { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
+      ];
 
-    const testAttributedPackageVersions =
-      getAttributionWizardPackageVersionListItems(testPackageNamesToVersions);
-
-    expect(testAttributedPackageVersions).toEqual(
-      expectedAttributedPackageVersions
-    );
-  });
-});
-
-describe('getHighlightedPackeNameIds', () => {
-  it('yields correct output', () => {
-    const testSelectedPackageName = 'buffer';
-    const testPackageNamesToVersions = {
-      buffer: new Set<string>(['6.0.3', '6.0']),
-      numpy: new Set<string>(['1.24.0']),
-    };
-    const expectedHighlightedPackeNameIds = [
-      'version-6.0.3-name-buffer',
-      'version-6.0-name-buffer',
-    ];
-
-    const testHighlightedPackageNameIds = getHighlightedPackageNameIds(
-      testSelectedPackageName,
-      testPackageNamesToVersions
+    const testSortedAttributedPackageItems = sortAttributedPackageItems(
+      testAttributedPackageItems
     );
 
-    expect(testHighlightedPackageNameIds).toEqual(
-      expectedHighlightedPackeNameIds
+    expect(testSortedAttributedPackageItems).toEqual(
+      expectedSortedAttributedPackageItems
     );
-  });
-});
-
-describe('convertManuallyAddedListEntriesToListItems', () => {
-  it('yields correct output', () => {
-    const testManuallyAddedListEntries = ['new_package_0', 'new_package_1'];
-    const testPackageAttributeId = 'name';
-    const expectedNewListItems: Array<ListWithAttributesItem> = [
-      {
-        text: 'new_package_0',
-        manuallyAdded: true,
-        id: 'name-new_package_0',
-      },
-      {
-        text: 'new_package_1',
-        manuallyAdded: true,
-        id: 'name-new_package_1',
-      },
-    ];
-
-    const testNewListItems = convertManuallyAddedListEntriesToListItems(
-      testManuallyAddedListEntries,
-      testPackageAttributeId
-    );
-
-    expect(testNewListItems).toEqual(expectedNewListItems);
   });
 });
 
@@ -402,51 +134,53 @@ describe('sortAttributedPackageVersions', () => {
     const testAttributedPackageVersions: Array<ListWithAttributesItem> = [
       {
         text: '6.0',
-        id: 'version-6.0',
-        attributes: [{ text: 'Buffer', id: 'version-6.0-name-Buffer' }],
+        id: '1111',
+        attributes: [{ text: 'buffer', id: '2222' }],
       },
       {
         text: '1.24.0',
-        id: 'version-1.24.0',
-        attributes: [{ text: 'numpy', id: 'version-1.24.0-name-numpy' }],
+        id: '3333',
+        attributes: [{ text: 'numpy', id: '4444' }],
       },
       {
         text: '6.0.3',
-        id: 'version-6.0.3',
-        attributes: [
-          { text: 'buffer', id: 'version-6.0.3-name-buffer' },
-          { text: 'Buffer', id: 'version-6.0.3-name-Buffer' },
-        ],
+        id: '5555',
+        attributes: [{ text: 'buffer', id: '6666' }],
+      },
+      {
+        text: '1.1.1',
+        id: '7777',
+        manuallyAdded: true,
       },
     ];
-    const testHighlightedPackageNameIds: Array<string> = [
-      'version-6.0.3-name-buffer',
-    ];
+    const testHighlightedPackageNameId = '6666';
     const expectedSortedAttributedPackageVersions: Array<ListWithAttributesItem> =
       [
         {
-          text: '6.0.3',
-          id: 'version-6.0.3',
-          attributes: [
-            { text: 'buffer', id: 'version-6.0.3-name-buffer' },
-            { text: 'Buffer', id: 'version-6.0.3-name-Buffer' },
-          ],
+          text: '1.1.1',
+          id: '7777',
+          manuallyAdded: true,
         },
         {
-          text: '6.0',
-          id: 'version-6.0',
-          attributes: [{ text: 'Buffer', id: 'version-6.0-name-Buffer' }],
+          text: '6.0.3',
+          id: '5555',
+          attributes: [{ text: 'buffer', id: '6666' }],
         },
         {
           text: '1.24.0',
-          id: 'version-1.24.0',
-          attributes: [{ text: 'numpy', id: 'version-1.24.0-name-numpy' }],
+          id: '3333',
+          attributes: [{ text: 'numpy', id: '4444' }],
+        },
+        {
+          text: '6.0',
+          id: '1111',
+          attributes: [{ text: 'buffer', id: '2222' }],
         },
       ];
 
     const testSortedAttributedPackageVersions = sortAttributedPackageVersions(
       testAttributedPackageVersions,
-      testHighlightedPackageNameIds
+      testHighlightedPackageNameId
     );
 
     expect(testSortedAttributedPackageVersions).toEqual(

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/attribution-wizard-popup-helpers.test.tsx
@@ -7,11 +7,7 @@ import {
   ListWithAttributesItem,
   PackageAttributes,
 } from '../../../types/types';
-import {
-  getAttributionWizardListItems,
-  sortAttributedPackageItems,
-  sortAttributedPackageVersions,
-} from '../attribution-wizard-popup-helpers';
+import { getAttributionWizardListItems } from '../attribution-wizard-popup-helpers';
 
 describe('getAttributionWizardListItems', () => {
   it('yields correct output', () => {
@@ -101,90 +97,6 @@ describe('getAttributionWizardListItems', () => {
     );
     expect(testAttributedPackageVersionsWithManuallyAddedOnes).toEqual(
       expectedAttributedPackageVersionsWithManuallyAddedOnes
-    );
-  });
-});
-
-describe('sortAttributedPackageItems', () => {
-  it('yields correct output', () => {
-    const testAttributedPackageItems: Array<ListWithAttributesItem> = [
-      { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
-      { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
-      { text: 'numpy', id: '33333', manuallyAdded: true },
-    ];
-    const expectedSortedAttributedPackageItems: Array<ListWithAttributesItem> =
-      [
-        { text: 'numpy', id: '33333', manuallyAdded: true },
-        { text: 'boost', id: '22222', attributes: [{ text: '6 (60%)' }] },
-        { text: 'buffer', id: '1111', attributes: [{ text: '4 (40%)' }] },
-      ];
-
-    const testSortedAttributedPackageItems = sortAttributedPackageItems(
-      testAttributedPackageItems
-    );
-
-    expect(testSortedAttributedPackageItems).toEqual(
-      expectedSortedAttributedPackageItems
-    );
-  });
-});
-
-describe('sortAttributedPackageVersions', () => {
-  it('yields correct output', () => {
-    const testAttributedPackageVersions: Array<ListWithAttributesItem> = [
-      {
-        text: '6.0',
-        id: '1111',
-        attributes: [{ text: 'buffer', id: '2222' }],
-      },
-      {
-        text: '1.24.0',
-        id: '3333',
-        attributes: [{ text: 'numpy', id: '4444' }],
-      },
-      {
-        text: '6.0.3',
-        id: '5555',
-        attributes: [{ text: 'buffer', id: '6666' }],
-      },
-      {
-        text: '1.1.1',
-        id: '7777',
-        manuallyAdded: true,
-      },
-    ];
-    const testHighlightedPackageNameId = '6666';
-    const expectedSortedAttributedPackageVersions: Array<ListWithAttributesItem> =
-      [
-        {
-          text: '1.1.1',
-          id: '7777',
-          manuallyAdded: true,
-        },
-        {
-          text: '6.0.3',
-          id: '5555',
-          attributes: [{ text: 'buffer', id: '6666' }],
-        },
-        {
-          text: '1.24.0',
-          id: '3333',
-          attributes: [{ text: 'numpy', id: '4444' }],
-        },
-        {
-          text: '6.0',
-          id: '1111',
-          attributes: [{ text: 'buffer', id: '2222' }],
-        },
-      ];
-
-    const testSortedAttributedPackageVersions = sortAttributedPackageVersions(
-      testAttributedPackageVersions,
-      testHighlightedPackageNameId
-    );
-
-    expect(testSortedAttributedPackageVersions).toEqual(
-      expectedSortedAttributedPackageVersions
     );
   });
 });

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -3,10 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { max } from 'lodash';
 import {
   ListWithAttributesItem,
-  SelectedPackageAttributeIds,
+  PackageAttributeIds,
   PackageAttributes,
 } from '../../types/types';
 
@@ -14,18 +13,17 @@ export function getSelectedPackageAttributes(
   packageNamespaces: PackageAttributes,
   packageNames: PackageAttributes,
   packageVersions: PackageAttributes,
-  selectedPackageIds: SelectedPackageAttributeIds
+  selectedPackageIds: PackageAttributeIds
 ): {
   selectedPackageNamespace: string;
   selectedPackageName: string;
   selectedPackageVersion: string;
 } {
   const selectedPackageNamespace =
-    packageNamespaces[selectedPackageIds.selectedPackageNamespaceId].text;
-  const selectedPackageName =
-    packageNames[selectedPackageIds.selectedPackageNameId].text;
+    packageNamespaces[selectedPackageIds.namespaceId].text;
+  const selectedPackageName = packageNames[selectedPackageIds.nameId].text;
   const selectedPackageVersion =
-    packageVersions[selectedPackageIds.selectedPackageVersionId].text;
+    packageVersions[selectedPackageIds.versionId].text;
 
   return {
     selectedPackageNamespace,
@@ -108,115 +106,4 @@ function getCountText(count: number, totalAttributeCount: number): string {
   return percentage < 1
     ? `${count} (< 1%)`
     : `${count} (${percentage.toFixed(0)}%)`;
-}
-
-export function sortAttributedPackageItems(
-  attributedPackageItems: Array<ListWithAttributesItem>
-): Array<ListWithAttributesItem> {
-  return attributedPackageItems.sort(compareAttributedPackageItems);
-}
-function compareAttributedPackageItems(
-  attributedPackageItemA: ListWithAttributesItem,
-  attributedPackageItemB: ListWithAttributesItem
-): number {
-  const manuallyAddedA = Boolean(attributedPackageItemA.manuallyAdded);
-  const manuallyAddedB = Boolean(attributedPackageItemB.manuallyAdded);
-
-  if (manuallyAddedA !== manuallyAddedB) {
-    return manuallyAddedA ? -1 : 1;
-  } else if (manuallyAddedA && manuallyAddedB) {
-    const textA = attributedPackageItemA.text;
-    const textB = attributedPackageItemB.text;
-    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
-  }
-
-  const countA =
-    attributedPackageItemA.attributes !== undefined
-      ? parseInt(attributedPackageItemA.attributes[0].text.split(' ')[0])
-      : 0;
-  const countB =
-    attributedPackageItemB.attributes !== undefined
-      ? parseInt(attributedPackageItemB.attributes[0].text.split(' ')[0])
-      : 0;
-
-  if (countA !== countB) {
-    return countB - countA;
-  } else {
-    const textA = attributedPackageItemA.text;
-    const textB = attributedPackageItemB.text;
-    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
-  }
-}
-
-export function sortAttributedPackageVersions(
-  attributedPackageVersions: Array<ListWithAttributesItem>,
-  highlightedPackageNameId: string
-): Array<ListWithAttributesItem> {
-  return attributedPackageVersions.sort(
-    (attributedPackageVersionA, attributedPackageVersionB) =>
-      compareVersionAttributeHighlighting(
-        attributedPackageVersionA,
-        attributedPackageVersionB,
-        highlightedPackageNameId
-      )
-  );
-}
-
-function compareVersionAttributeHighlighting(
-  attributedPackageVersionA: ListWithAttributesItem,
-  attributedPackageVersionB: ListWithAttributesItem,
-  highlightedPackageNameId: string
-): number {
-  const manuallyAddedA = Boolean(attributedPackageVersionA.manuallyAdded);
-  const manuallyAddedB = Boolean(attributedPackageVersionB.manuallyAdded);
-
-  if (manuallyAddedA !== manuallyAddedB) {
-    return manuallyAddedA ? -1 : 1;
-  } else if (manuallyAddedA && manuallyAddedB) {
-    const textA = attributedPackageVersionA.text;
-    const textB = attributedPackageVersionB.text;
-    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
-  }
-
-  const attributeIdsA = attributedPackageVersionA.attributes?.map(
-    (attribute) => attribute.id
-  );
-  const attributeIdsB = attributedPackageVersionB.attributes?.map(
-    (attribute) => attribute.id
-  );
-
-  const matchA = attributeIdsA?.includes(highlightedPackageNameId);
-  const matchB = attributeIdsB?.includes(highlightedPackageNameId);
-
-  return matchA !== matchB
-    ? matchA
-      ? -1
-      : 1
-    : compareSemanticVersion(
-        attributedPackageVersionA.text,
-        attributedPackageVersionB.text
-      );
-}
-
-function compareSemanticVersion(versionA: string, versionB: string): number {
-  const versionASplit = versionA.split('.');
-  const versionBSplit = versionB.split('.');
-  const maxLength = max([versionASplit.length, versionBSplit.length]) ?? 0;
-  for (
-    let versionPartIndex = 0;
-    versionPartIndex < maxLength;
-    versionPartIndex++
-  ) {
-    const versionAPart = parseInt(versionASplit[versionPartIndex]);
-    const versionBPart = parseInt(versionBSplit[versionPartIndex]);
-
-    if (isNaN(versionAPart) || isNaN(versionBPart)) {
-      return isNaN(versionAPart) ? 1 : -1;
-    }
-
-    if (versionAPart - versionBPart !== 0) {
-      return versionAPart - versionBPart;
-    }
-  }
-  return 0;
 }

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -5,309 +5,101 @@
 
 import { max } from 'lodash';
 import {
-  AttributionData,
-  AttributionIdWithCount,
-  Attributions,
-  PackageInfo,
-  ResourcesToAttributions,
-} from '../../../shared/shared-types';
-import { ListWithAttributesItem } from '../../types/types';
-import { getAttributedChildren } from '../../util/get-attributed-children';
-import { shouldNotBeCalled } from '../../util/should-not-be-called';
+  ListWithAttributesItem,
+  SelectedPackageAttributeIds,
+  PackageAttributes,
+} from '../../types/types';
 
-interface TextAndCount {
-  text: string;
-  count: number;
-}
-
-interface NamesWithCounts {
-  [name: string]: number;
-}
-
-export function getAllAttributionIdsWithCountsFromResourceAndChildren(
-  selectedResourceId: string,
-  externalData: AttributionData,
-  manualData: AttributionData,
-  resolvedExternalAttributions: Set<string>
-): Array<AttributionIdWithCount> {
-  const externalAttributedChildren = getAttributedChildren(
-    externalData.resourcesWithAttributedChildren,
-    selectedResourceId
-  );
-  if (selectedResourceId in externalData.resourcesToAttributions) {
-    externalAttributedChildren.add(selectedResourceId);
-  }
-
-  const manualAttributedChildren = getAttributedChildren(
-    manualData.resourcesWithAttributedChildren,
-    selectedResourceId
-  );
-  if (selectedResourceId in manualData.resourcesToAttributions) {
-    manualAttributedChildren.add(selectedResourceId);
-  }
-
-  const externalAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
-    externalData.resourcesToAttributions,
-    externalAttributedChildren,
-    resolvedExternalAttributions
-  );
-  const manualAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
-    manualData.resourcesToAttributions,
-    manualAttributedChildren
-  );
-
-  return externalAttributionsWithCounts.concat(manualAttributionsWithCounts);
-}
-
-function getAggregatedAttributionIdsAndCounts(
-  resourcesToAttributions: ResourcesToAttributions,
-  attributedChildren: Set<string>,
-  resolvedExternalAttributions?: Set<string>
-): Array<AttributionIdWithCount> {
-  const attributionCount: { [attributionId: string]: number } = {};
-  attributedChildren.forEach((child: string) => {
-    resourcesToAttributions[child].forEach((attributionId: string) => {
-      if (
-        !resolvedExternalAttributions ||
-        !resolvedExternalAttributions.has(attributionId)
-      ) {
-        attributionCount[attributionId] =
-          (attributionCount[attributionId] || 0) + 1;
-      }
-    });
-  });
-
-  return Object.entries(attributionCount).map(([attributionId, count]) => ({
-    attributionId,
-    count,
-  }));
-}
-
-export function getPreSelectedPackageAttributeIds(popupPackage: PackageInfo): {
-  preSelectedPackageNamespaceId: string;
-  preSelectedPackageNameId: string;
-  preSelectedPackageVersionId: string;
-} {
-  const namespace = popupPackage.packageNamespace || '';
-  const name = popupPackage.packageName || '';
-  const version = popupPackage.packageVersion || '';
-
-  const preSelectedPackageNamespaceId = `namespace-${namespace}`;
-  const preSelectedPackageNameId = `name-${name}`;
-  const preSelectedPackageVersionId = `version-${version}`;
-
-  return {
-    preSelectedPackageNamespaceId,
-    preSelectedPackageNameId,
-    preSelectedPackageVersionId,
-  };
-}
-
-export function getAttributionWizardPackageListsItems(
-  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
-  externalAndManualAttributions: Attributions,
-  manuallyAddedNamespaces: Array<string>,
-  manuallyAddedNames: Array<string>,
-  manuallyAddedVersions: Array<string>,
-  selectedPackageNamespaceId: string,
-  selectedPackageNameId: string
+export function getSelectedPackageAttributes(
+  packageNamespaces: PackageAttributes,
+  packageNames: PackageAttributes,
+  packageVersions: PackageAttributes,
+  selectedPackageIds: SelectedPackageAttributeIds
 ): {
-  sortedAttributedPackageNamespacesWithManuallyAddedOnes: Array<ListWithAttributesItem>;
-  sortedAttributedPackageNamesWithManuallyAddedOnes: Array<ListWithAttributesItem>;
-  sortedAttributedPackageVersionsWithManuallyAddedOnes: Array<ListWithAttributesItem>;
   selectedPackageNamespace: string;
   selectedPackageName: string;
-  highlightedPackageNameIds: Array<string>;
+  selectedPackageVersion: string;
 } {
-  const totalAttributionCount = externalAndManualAttributionIdsWithCounts
-    .map((attributionIdWithCount) => attributionIdWithCount.count ?? 0)
-    .reduce(
-      (accumulatedCounts, currentCount) => accumulatedCounts + currentCount,
-      0
-    );
-
-  const packageNamespacesAndCounts = getPackageAttributesAndCounts(
-    externalAndManualAttributionIdsWithCounts,
-    externalAndManualAttributions,
-    'namespace'
-  );
-  const packageNamesAndCounts = getPackageAttributesAndCounts(
-    externalAndManualAttributionIdsWithCounts,
-    externalAndManualAttributions,
-    'name'
-  );
-
-  const sortedPackageNamespacesAndCounts = sortPackageAttributesAndCounts(
-    packageNamespacesAndCounts
-  );
-  const sortedPackageNamesAndCounts = sortPackageAttributesAndCounts(
-    packageNamesAndCounts
-  );
-
-  const sortedAttributedPackageNamespaces = getWizardListItems(
-    sortedPackageNamespacesAndCounts,
-    totalAttributionCount,
-    'namespace'
-  );
-  const sortedAttributedPackageNames = getWizardListItems(
-    sortedPackageNamesAndCounts,
-    totalAttributionCount,
-    'name'
-  );
-
-  const sortedAttributedPackageNamespacesWithManuallyAddedOnes =
-    concatenatePackageAttributesWithManuallyAddedOnes(
-      manuallyAddedNamespaces,
-      sortedAttributedPackageNamespaces,
-      'namespace'
-    );
-  const sortedAttributedPackageNamesWithManuallyAddedOnes =
-    concatenatePackageAttributesWithManuallyAddedOnes(
-      manuallyAddedNames,
-      sortedAttributedPackageNames,
-      'name'
-    );
-
-  const selectedPackageNamespace = filterForPackageAttributeId(
-    selectedPackageNamespaceId,
-    sortedAttributedPackageNamespacesWithManuallyAddedOnes
-  );
-  const selectedPackageName = filterForPackageAttributeId(
-    selectedPackageNameId,
-    sortedAttributedPackageNamesWithManuallyAddedOnes
-  );
-
-  const packageNamesToVersions = getPackageNamesToVersions(
-    externalAndManualAttributionIdsWithCounts,
-    externalAndManualAttributions
-  );
-  const attributedPackageVersions = getAttributionWizardPackageVersionListItems(
-    packageNamesToVersions
-  );
-  const packageNameWasManuallyAdded =
-    selectedPackageName in packageNamesToVersions;
-  const highlightedPackageNameIds = packageNameWasManuallyAdded
-    ? getHighlightedPackageNameIds(selectedPackageName, packageNamesToVersions)
-    : [];
-  const sortedAttributedPackageVersions = sortAttributedPackageVersions(
-    attributedPackageVersions,
-    highlightedPackageNameIds
-  );
-  const sortedAttributedPackageVersionsWithManuallyAddedOnes =
-    concatenatePackageAttributesWithManuallyAddedOnes(
-      manuallyAddedVersions,
-      sortedAttributedPackageVersions,
-      'version'
-    );
+  const selectedPackageNamespace =
+    packageNamespaces[selectedPackageIds.selectedPackageNamespaceId].text;
+  const selectedPackageName =
+    packageNames[selectedPackageIds.selectedPackageNameId].text;
+  const selectedPackageVersion =
+    packageVersions[selectedPackageIds.selectedPackageVersionId].text;
 
   return {
-    sortedAttributedPackageNamespacesWithManuallyAddedOnes,
-    sortedAttributedPackageNamesWithManuallyAddedOnes,
-    sortedAttributedPackageVersionsWithManuallyAddedOnes,
     selectedPackageNamespace,
     selectedPackageName,
-    highlightedPackageNameIds,
+    selectedPackageVersion,
   };
 }
 
-function getPackageAttributesAndCounts(
-  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
-  externalAndManualAttributions: Attributions,
-  packageAttributeId: 'namespace' | 'name'
-): NamesWithCounts {
-  const packageAttributesAndCounts: NamesWithCounts = {};
-  for (const attributionIdWithCount of externalAndManualAttributionIdsWithCounts) {
-    const packageInfo =
-      externalAndManualAttributions[attributionIdWithCount.attributionId];
-    const packageCount = attributionIdWithCount.count ?? 0;
+export function getAttributionWizardListItems(
+  packageNamespaces: PackageAttributes,
+  packageNames: PackageAttributes,
+  packageVersions: PackageAttributes,
+  totalAttributionCount: number
+): {
+  attributedPackageNamespacesWithManuallyAddedOnes: Array<ListWithAttributesItem>;
+  attributedPackageNamesWithManuallyAddedOnes: Array<ListWithAttributesItem>;
+  attributedPackageVersionsWithManuallyAddedOnes: Array<ListWithAttributesItem>;
+} {
+  const attributedPackageNamespacesWithManuallyAddedOnes = Object.entries(
+    packageNamespaces
+  ).map(([uuid, textAndCountAndManuallyAddedFlag]) => ({
+    text: textAndCountAndManuallyAddedFlag.text,
+    id: uuid,
+    manuallyAdded: textAndCountAndManuallyAddedFlag.manuallyAdded,
+    attributes: Boolean(textAndCountAndManuallyAddedFlag.manuallyAdded)
+      ? undefined
+      : [
+          {
+            text: getCountText(
+              textAndCountAndManuallyAddedFlag.count || 0,
+              totalAttributionCount
+            ),
+          },
+        ],
+  }));
 
-    let packageAttribute: string;
-    if (packageAttributeId === 'namespace') {
-      packageAttribute = packageInfo.packageNamespace || '';
-    } else if (packageAttributeId === 'name') {
-      packageAttribute = packageInfo.packageName || '';
-    } else {
-      shouldNotBeCalled(packageAttributeId);
-    }
+  const attributedPackageNamesWithManuallyAddedOnes = Object.entries(
+    packageNames
+  ).map(([uuid, textAndCountAndManuallyAddedFlag]) => ({
+    text: textAndCountAndManuallyAddedFlag.text,
+    id: uuid,
+    manuallyAdded: textAndCountAndManuallyAddedFlag.manuallyAdded,
+    attributes: Boolean(textAndCountAndManuallyAddedFlag.manuallyAdded)
+      ? undefined
+      : [
+          {
+            text: getCountText(
+              textAndCountAndManuallyAddedFlag.count || 0,
+              totalAttributionCount
+            ),
+          },
+        ],
+  }));
 
-    packageAttributesAndCounts[packageAttribute] =
-      (packageAttributesAndCounts[packageAttribute] ?? 0) + packageCount;
-  }
+  const attributedPackageVersionsWithManuallyAddedOnes = Object.entries(
+    packageVersions
+  ).map(([uuid, textAndRelatedIdsAndManuallyAddedFlag]) => ({
+    text: textAndRelatedIdsAndManuallyAddedFlag.text,
+    id: uuid,
+    manuallyAdded: textAndRelatedIdsAndManuallyAddedFlag.manuallyAdded,
+    attributes: Boolean(textAndRelatedIdsAndManuallyAddedFlag.manuallyAdded)
+      ? undefined
+      : Array.from(textAndRelatedIdsAndManuallyAddedFlag.relatedIds ?? []).map(
+          (relatedPackageNameIds) => ({
+            text: packageNames[relatedPackageNameIds].text,
+            id: relatedPackageNameIds,
+          })
+        ),
+  }));
 
-  return packageAttributesAndCounts;
-}
-
-function getPackageNamesToVersions(
-  containedExternalPackages: Array<AttributionIdWithCount>,
-  externalAttributions: Attributions
-): { [packageName: string]: Set<string> } {
-  const packageNamesToVersions: { [packageName: string]: Set<string> } = {};
-  for (const containedExternalPackage of containedExternalPackages) {
-    const packageInfo =
-      externalAttributions[containedExternalPackage.attributionId];
-
-    const packageName = packageInfo.packageName || '';
-    const packageVersion = packageInfo.packageVersion || '';
-
-    packageNamesToVersions[packageName] ??
-      (packageNamesToVersions[packageName] = new Set<string>());
-    packageNamesToVersions[packageName].add(packageVersion);
-  }
-
-  return packageNamesToVersions;
-}
-
-function sortPackageAttributesAndCounts(packageAttributesAndCounts: {
-  [text: string]: number;
-}): Array<TextAndCount> {
-  return Object.entries(packageAttributesAndCounts)
-    .map(([attributeName, count]) => ({
-      text: attributeName,
-      count,
-    }))
-    .sort(compareTextAndCount);
-}
-
-function compareTextAndCount(
-  textAndCount: TextAndCount,
-  otherTextAndCount: TextAndCount
-): number {
-  if (textAndCount.count !== otherTextAndCount.count) {
-    return otherTextAndCount.count - textAndCount.count;
-  } else {
-    return textAndCount.text.toLowerCase() <
-      otherTextAndCount.text.toLowerCase()
-      ? -1
-      : 1;
-  }
-}
-
-function getWizardListItems(
-  packageAttributesWithCounts: Array<TextAndCount>,
-  totalAttributeCount: number,
-  idPrefix: string
-): Array<ListWithAttributesItem> {
-  return packageAttributesWithCounts.map((packageAttributeAndCount) =>
-    getWizardListItem(packageAttributeAndCount, totalAttributeCount, idPrefix)
-  );
-}
-
-function getWizardListItem(
-  packageAttributeAndCount: TextAndCount,
-  totalAttributeCount: number,
-  idPrefix: string
-): ListWithAttributesItem {
-  const count = packageAttributeAndCount.count;
-  const packageAttribute = packageAttributeAndCount.text;
   return {
-    text: packageAttribute,
-    id: `${idPrefix}-${packageAttribute}`,
-    attributes: [
-      {
-        text: getCountText(count, totalAttributeCount),
-        id: `${idPrefix}-attribute-${packageAttribute}`,
-      },
-    ],
+    attributedPackageNamespacesWithManuallyAddedOnes,
+    attributedPackageNamesWithManuallyAddedOnes,
+    attributedPackageVersionsWithManuallyAddedOnes,
   };
 }
 
@@ -318,92 +110,54 @@ function getCountText(count: number, totalAttributeCount: number): string {
     : `${count} (${percentage.toFixed(0)}%)`;
 }
 
-export function getAttributionWizardPackageVersionListItems(packageNamesToVersions: {
-  [name: string]: Set<string>;
-}): Array<ListWithAttributesItem> {
-  const packageVersionsToNames: { [version: string]: Set<string> } = {};
-  for (const [name, versions] of Object.entries(packageNamesToVersions)) {
-    for (const version of versions) {
-      packageVersionsToNames[version] ??
-        (packageVersionsToNames[version] = new Set<string>());
-      packageVersionsToNames[version].add(name);
-    }
+export function sortAttributedPackageItems(
+  attributedPackageItems: Array<ListWithAttributesItem>
+): Array<ListWithAttributesItem> {
+  return attributedPackageItems.sort(compareAttributedPackageItems);
+}
+function compareAttributedPackageItems(
+  attributedPackageItemA: ListWithAttributesItem,
+  attributedPackageItemB: ListWithAttributesItem
+): number {
+  const manuallyAddedA = Boolean(attributedPackageItemA.manuallyAdded);
+  const manuallyAddedB = Boolean(attributedPackageItemB.manuallyAdded);
+
+  if (manuallyAddedA !== manuallyAddedB) {
+    return manuallyAddedA ? -1 : 1;
+  } else if (manuallyAddedA && manuallyAddedB) {
+    const textA = attributedPackageItemA.text;
+    const textB = attributedPackageItemB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
   }
 
-  const versions = Object.keys(packageVersionsToNames).sort();
-  const attributedPackageVersions: Array<ListWithAttributesItem> = [];
-  for (const version of versions) {
-    attributedPackageVersions.push({
-      text: version,
-      id: `version-${version}`,
-      attributes: Array.from(packageVersionsToNames[version])
-        .sort()
-        .map((packageName) => ({
-          text: `${packageName}`,
-          id: `version-${version}-name-${packageName}`,
-        })),
-    });
+  const countA =
+    attributedPackageItemA.attributes !== undefined
+      ? parseInt(attributedPackageItemA.attributes[0].text.split(' ')[0])
+      : 0;
+  const countB =
+    attributedPackageItemB.attributes !== undefined
+      ? parseInt(attributedPackageItemB.attributes[0].text.split(' ')[0])
+      : 0;
+
+  if (countA !== countB) {
+    return countB - countA;
+  } else {
+    const textA = attributedPackageItemA.text;
+    const textB = attributedPackageItemB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
   }
-
-  return attributedPackageVersions;
-}
-
-export function getHighlightedPackageNameIds(
-  selectedPackageName: string,
-  packageNamesToVersions: { [packageName: string]: Set<string> }
-): Array<string> {
-  return Array.from(packageNamesToVersions[selectedPackageName]).map(
-    (version) => `version-${version}-name-${selectedPackageName}`
-  );
-}
-
-export function filterForPackageAttributeId(
-  selectedPackageAttributeId: string,
-  packageAttributes: Array<ListWithAttributesItem>
-): string {
-  return selectedPackageAttributeId !== ''
-    ? packageAttributes.filter(
-        (item) => item.id === selectedPackageAttributeId
-      )[0].text
-    : '';
-}
-
-export function concatenatePackageAttributesWithManuallyAddedOnes(
-  manuallyAddedAttributes: Array<string>,
-  packageAttributes: Array<ListWithAttributesItem>,
-  attributeId: 'namespace' | 'name' | 'version'
-): Array<ListWithAttributesItem> {
-  return [
-    ...convertManuallyAddedListEntriesToListItems(
-      manuallyAddedAttributes,
-      attributeId
-    ),
-    ...packageAttributes,
-  ];
-}
-
-export function convertManuallyAddedListEntriesToListItems(
-  manuallyAddedListEntries: Array<string>,
-  packageAttributeId: string
-): Array<ListWithAttributesItem> {
-  return manuallyAddedListEntries.map((item) => ({
-    text: item,
-    id: `${packageAttributeId}-${item}`,
-    manuallyAdded: true,
-    attributes: undefined,
-  }));
 }
 
 export function sortAttributedPackageVersions(
   attributedPackageVersions: Array<ListWithAttributesItem>,
-  highlightedPackageNameIds: Array<string>
+  highlightedPackageNameId: string
 ): Array<ListWithAttributesItem> {
   return attributedPackageVersions.sort(
     (attributedPackageVersionA, attributedPackageVersionB) =>
       compareVersionAttributeHighlighting(
         attributedPackageVersionA,
         attributedPackageVersionB,
-        highlightedPackageNameIds
+        highlightedPackageNameId
       )
   );
 }
@@ -411,34 +165,33 @@ export function sortAttributedPackageVersions(
 function compareVersionAttributeHighlighting(
   attributedPackageVersionA: ListWithAttributesItem,
   attributedPackageVersionB: ListWithAttributesItem,
-  highlightedPackageNameIds: Array<string>
+  highlightedPackageNameId: string
 ): number {
+  const manuallyAddedA = Boolean(attributedPackageVersionA.manuallyAdded);
+  const manuallyAddedB = Boolean(attributedPackageVersionB.manuallyAdded);
+
+  if (manuallyAddedA !== manuallyAddedB) {
+    return manuallyAddedA ? -1 : 1;
+  } else if (manuallyAddedA && manuallyAddedB) {
+    const textA = attributedPackageVersionA.text;
+    const textB = attributedPackageVersionB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
+  }
+
   const attributeIdsA = attributedPackageVersionA.attributes?.map(
     (attribute) => attribute.id
   );
-
   const attributeIdsB = attributedPackageVersionB.attributes?.map(
     (attribute) => attribute.id
   );
 
-  let matchCounterA = 0;
-  let matchCounterB = 0;
-  for (const highlightedPackageNameId of highlightedPackageNameIds) {
-    const highlightedPackageName = highlightedPackageNameId.split('-').at(-1);
+  const matchA = attributeIdsA?.includes(highlightedPackageNameId);
+  const matchB = attributeIdsB?.includes(highlightedPackageNameId);
 
-    const numberOfMatchesA = attributeIdsA?.filter((attributeIdA) =>
-      attributeIdA.match(new RegExp(`${highlightedPackageName}`, 'i'))
-    ).length;
-    matchCounterA += numberOfMatchesA ?? 0;
-
-    const numberOfMatchesB = attributeIdsB?.filter((attributeIdB) =>
-      attributeIdB.match(new RegExp(`${highlightedPackageName}`, 'i'))
-    ).length;
-    matchCounterB += numberOfMatchesB ?? 0;
-  }
-
-  return matchCounterB - matchCounterA !== 0
-    ? matchCounterB - matchCounterA
+  return matchA !== matchB
+    ? matchA
+      ? -1
+      : 1
     : compareSemanticVersion(
         attributedPackageVersionA.text,
         attributedPackageVersionB.text
@@ -456,6 +209,11 @@ function compareSemanticVersion(versionA: string, versionB: string): number {
   ) {
     const versionAPart = parseInt(versionASplit[versionPartIndex]);
     const versionBPart = parseInt(versionBSplit[versionPartIndex]);
+
+    if (isNaN(versionAPart) || isNaN(versionBPart)) {
+      return isNaN(versionAPart) ? 1 : -1;
+    }
+
     if (versionAPart - versionBPart !== 0) {
       return versionAPart - versionBPart;
     }

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -14,6 +14,7 @@ import { TextBox } from '../InputElements/TextBox';
 import { attributionWizardStepClasses } from '../../shared-styles';
 import { ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT } from '../../shared-styles';
 import { SxProps } from '@mui/system';
+import { sortAttributedPackageVersions } from '../AttributionWizardPopup/attribution-wizard-popup-helpers';
 
 const classes = {
   listBox: {
@@ -23,12 +24,11 @@ const classes = {
 };
 interface AttributionWizardVersionStepProps {
   attributedPackageVersions: Array<ListWithAttributesItem>;
-  highlightedPackageNameIds: Array<string>;
+  highlightedPackageNameId: string;
   selectedPackageInfo: PackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
-  manuallyAddedVersions: Array<string>;
-  setManuallyAddedVersions(items: Array<string>): void;
+  addNewPackageVersion(items: string): void;
   listSx?: SxProps;
 }
 
@@ -52,14 +52,14 @@ export function AttributionWizardVersionStep(
         <ListWithAttributes
           listItems={props.attributedPackageVersions}
           selectedListItemId={props.selectedPackageVersionId}
-          highlightedAttributeIds={props.highlightedPackageNameIds}
+          highlightedAttributeIds={[props.highlightedPackageNameId]}
           handleListItemClick={props.handlePackageVersionListItemClick}
           showChipsForAttributes={true}
           showAddNewListItem={true}
-          manuallyAddedListItems={props.manuallyAddedVersions}
-          setManuallyAddedListItems={props.setManuallyAddedVersions}
+          setManuallyAddedListItems={props.addNewPackageVersion}
           title={'Package version'}
           listSx={props.listSx}
+          sortList={sortAttributedPackageVersions}
         />
       </MuiBox>
     </MuiBox>

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -14,7 +14,7 @@ import { TextBox } from '../InputElements/TextBox';
 import { attributionWizardStepClasses } from '../../shared-styles';
 import { ATTRIBUTION_WIZARD_PURL_TOTAL_HEIGHT } from '../../shared-styles';
 import { SxProps } from '@mui/system';
-import { sortAttributedPackageVersions } from '../AttributionWizardPopup/attribution-wizard-popup-helpers';
+import { sortAttributedPackageVersions } from './attribution-wizard-verstion-step-helpers';
 
 const classes = {
   listBox: {

--- a/src/Frontend/Components/AttributionWizardVersionStep/__tests__/attribution-wizard-version-step-helpers.test.ts
+++ b/src/Frontend/Components/AttributionWizardVersionStep/__tests__/attribution-wizard-version-step-helpers.test.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ListWithAttributesItem } from '../../../types/types';
+import { sortAttributedPackageVersions } from '../attribution-wizard-verstion-step-helpers';
+
+describe('sortAttributedPackageVersions', () => {
+  it('yields correct output', () => {
+    const testAttributedPackageVersions: Array<ListWithAttributesItem> = [
+      {
+        text: '6.0',
+        id: '1111',
+        attributes: [{ text: 'buffer', id: '2222' }],
+      },
+      {
+        text: '1.24.0',
+        id: '3333',
+        attributes: [{ text: 'numpy', id: '4444' }],
+      },
+      {
+        text: '6.0.3',
+        id: '5555',
+        attributes: [{ text: 'buffer', id: '6666' }],
+      },
+      {
+        text: '1.1.1',
+        id: '7777',
+        manuallyAdded: true,
+      },
+      {
+        text: 'v2',
+        id: '8888',
+        attributes: [{ text: 'invalid', id: '9999' }],
+      },
+    ];
+    const testHighlightedPackageNameIds = ['6666', '2222'];
+    const expectedSortedAttributedPackageVersions: Array<ListWithAttributesItem> =
+      [
+        {
+          text: '1.1.1',
+          id: '7777',
+          manuallyAdded: true,
+        },
+        {
+          text: '6.0',
+          id: '1111',
+          attributes: [{ text: 'buffer', id: '2222' }],
+        },
+        {
+          text: '6.0.3',
+          id: '5555',
+          attributes: [{ text: 'buffer', id: '6666' }],
+        },
+        {
+          text: '1.24.0',
+          id: '3333',
+          attributes: [{ text: 'numpy', id: '4444' }],
+        },
+        {
+          text: 'v2',
+          id: '8888',
+          attributes: [{ text: 'invalid', id: '9999' }],
+        },
+      ];
+
+    const testSortedAttributedPackageVersions = sortAttributedPackageVersions(
+      testAttributedPackageVersions,
+      testHighlightedPackageNameIds
+    );
+
+    expect(testSortedAttributedPackageVersions).toEqual(
+      expectedSortedAttributedPackageVersions
+    );
+  });
+});

--- a/src/Frontend/Components/AttributionWizardVersionStep/attribution-wizard-verstion-step-helpers.ts
+++ b/src/Frontend/Components/AttributionWizardVersionStep/attribution-wizard-verstion-step-helpers.ts
@@ -30,7 +30,8 @@ function compareVersionAttributeHighlighting(
 
   if (manuallyAddedA !== manuallyAddedB) {
     return manuallyAddedA ? -1 : 1;
-  } else if (manuallyAddedA && manuallyAddedB) {
+  }
+  if (manuallyAddedA && manuallyAddedB) {
     const textA = attributedPackageVersionA.text;
     const textB = attributedPackageVersionB.text;
     return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
@@ -70,7 +71,8 @@ function compareSemanticVersion(versionA: string, versionB: string): number {
 
   if (!versionAIsValid && !versionBIsValid) {
     return compareAlphabetically(versionA, versionB);
-  } else if (!versionAIsValid || !versionBIsValid) {
+  }
+  if (!versionAIsValid || !versionBIsValid) {
     return !versionAIsValid ? 1 : -1;
   }
 

--- a/src/Frontend/Components/AttributionWizardVersionStep/attribution-wizard-verstion-step-helpers.ts
+++ b/src/Frontend/Components/AttributionWizardVersionStep/attribution-wizard-verstion-step-helpers.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { max } from 'lodash';
+import { ListWithAttributesItem } from '../../types/types';
+
+export function sortAttributedPackageVersions(
+  attributedPackageVersions: Array<ListWithAttributesItem>,
+  highlightedPackageNameIds: Array<string>
+): Array<ListWithAttributesItem> {
+  return attributedPackageVersions.sort(
+    (attributedPackageVersionA, attributedPackageVersionB) =>
+      compareVersionAttributeHighlighting(
+        attributedPackageVersionA,
+        attributedPackageVersionB,
+        highlightedPackageNameIds
+      )
+  );
+}
+
+function compareVersionAttributeHighlighting(
+  attributedPackageVersionA: ListWithAttributesItem,
+  attributedPackageVersionB: ListWithAttributesItem,
+  highlightedPackageNameIds: Array<string>
+): number {
+  const manuallyAddedA = Boolean(attributedPackageVersionA.manuallyAdded);
+  const manuallyAddedB = Boolean(attributedPackageVersionB.manuallyAdded);
+
+  if (manuallyAddedA !== manuallyAddedB) {
+    return manuallyAddedA ? -1 : 1;
+  } else if (manuallyAddedA && manuallyAddedB) {
+    const textA = attributedPackageVersionA.text;
+    const textB = attributedPackageVersionB.text;
+    return textA.toLowerCase() < textB.toLowerCase() ? -1 : 1;
+  }
+
+  const attributeIdsA = attributedPackageVersionA.attributes?.map(
+    (attribute) => attribute.id
+  );
+  const attributeIdsB = attributedPackageVersionB.attributes?.map(
+    (attribute) => attribute.id
+  );
+
+  const numMatchesA =
+    attributeIdsA?.filter((attributeIdA) =>
+      attributeIdA !== undefined
+        ? highlightedPackageNameIds.includes(attributeIdA)
+        : false
+    ).length ?? 0;
+  const numMatchesB =
+    attributeIdsB?.filter((attributeIdB) =>
+      attributeIdB !== undefined
+        ? highlightedPackageNameIds.includes(attributeIdB)
+        : false
+    ).length ?? 0;
+
+  return numMatchesA !== numMatchesB
+    ? numMatchesB - numMatchesA
+    : compareSemanticVersion(
+        attributedPackageVersionA.text,
+        attributedPackageVersionB.text
+      );
+}
+
+function compareSemanticVersion(versionA: string, versionB: string): number {
+  const versionAIsValid = versionA.match(/^\d+(\.\d+)*$/);
+  const versionBIsValid = versionB.match(/^\d+(\.\d+)*$/);
+
+  if (!versionAIsValid && !versionBIsValid) {
+    return compareAlphabetically(versionA, versionB);
+  } else if (!versionAIsValid || !versionBIsValid) {
+    return !versionAIsValid ? 1 : -1;
+  }
+
+  const versionASplit = versionA.split('.');
+  const versionBSplit = versionB.split('.');
+  const maxLength = max([versionASplit.length, versionBSplit.length]) ?? 0;
+  for (
+    let versionPartIndex = 0;
+    versionPartIndex < maxLength;
+    versionPartIndex++
+  ) {
+    const versionAPart = parseInt(versionASplit[versionPartIndex]);
+    const versionBPart = parseInt(versionBSplit[versionPartIndex]);
+
+    if (isNaN(versionAPart) || isNaN(versionBPart)) {
+      return isNaN(versionAPart) ? -1 : 1;
+    }
+
+    if (versionAPart - versionBPart !== 0) {
+      return versionAPart - versionBPart;
+    }
+  }
+  return 0;
+}
+
+function compareAlphabetically(versionA: string, versionB: string): number {
+  return versionA.toLowerCase() < versionB.toLowerCase() ? -1 : 1;
+}

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -12,19 +12,11 @@ import {
 import { GlobalPopup } from '../GlobalPopup';
 import { PopupType } from '../../../enums/enums';
 import { screen } from '@testing-library/react';
-import {
-  Attributions,
-  ResourcesToAttributions,
-} from '../../../../shared/shared-types';
+import { Attributions } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { act } from 'react-dom/test-utils';
-import {
-  setManualData,
-  setExternalData,
-} from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
 describe('The GlobalPopUp', () => {
   it('does not open by default', () => {
@@ -145,46 +137,5 @@ describe('The GlobalPopUp', () => {
         'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.'
       )
     ).toBeInTheDocument();
-  });
-
-  it('opens the AttributionWizardPopup', () => {
-    const store = createTestAppStore();
-    const selectedResourceId = '/samplepath/';
-    const testExternalAttributions: Attributions = {
-      uuid_0: {
-        packageName: 'react',
-        packageNamespace: 'npm',
-      },
-    };
-    const testManualAttributions: Attributions = {
-      uuid_0: {
-        packageName: 'react',
-        packageNamespace: 'npm',
-      },
-    };
-    const testExternalResourcesToAttributions: ResourcesToAttributions = {
-      '/samplepath/subfolder': ['uuid_0'],
-    };
-    const testManualResourcesToAttributions: ResourcesToAttributions = {
-      selectedResourceId: ['uuid_0'],
-    };
-
-    store.dispatch(setSelectedResourceId(selectedResourceId));
-    store.dispatch(
-      setExternalData(
-        testExternalAttributions,
-        testExternalResourcesToAttributions
-      )
-    );
-    store.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
-    );
-
-    renderComponentWithStore(<GlobalPopup />, { store });
-
-    act(() => {
-      store.dispatch(openPopup(PopupType.AttributionWizardPopup, 'uuid_0'));
-    });
-    expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
+++ b/src/Frontend/Components/GlobalPopup/__tests__/GlobalPopup.test.tsx
@@ -12,11 +12,20 @@ import {
 import { GlobalPopup } from '../GlobalPopup';
 import { PopupType } from '../../../enums/enums';
 import { screen } from '@testing-library/react';
-import { Attributions } from '../../../../shared/shared-types';
+import {
+  Attributions,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { act } from 'react-dom/test-utils';
+import {
+  setExternalData,
+  setManualData,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
 
 describe('The GlobalPopUp', () => {
   it('does not open by default', () => {
@@ -137,5 +146,46 @@ describe('The GlobalPopUp', () => {
         'Do you really want to delete the selected attributions for all files? This action will delete 2 attributions.'
       )
     ).toBeInTheDocument();
+  });
+
+  it('opens the AttributionWizardPopup', () => {
+    const store = createTestAppStore();
+    const selectedResourceId = '/samplepath/';
+    const testExternalAttributions: Attributions = {
+      uuid_0: {
+        packageName: 'react',
+        packageNamespace: 'npm',
+      },
+    };
+    const testManualAttributions: Attributions = {
+      uuid_0: {
+        packageName: 'react',
+        packageNamespace: 'npm',
+      },
+    };
+    const testExternalResourcesToAttributions: ResourcesToAttributions = {
+      '/samplepath/subfolder': ['uuid_0'],
+    };
+    const testManualResourcesToAttributions: ResourcesToAttributions = {
+      selectedResourceId: ['uuid_0'],
+    };
+
+    store.dispatch(setSelectedResourceId(selectedResourceId));
+    store.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    store.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+
+    renderComponentWithStore(<GlobalPopup />, { store });
+
+    act(() => {
+      store.dispatch(openAttributionWizardPopup('uuid_0'));
+    });
+    expect(screen.getByText('Attribution Wizard')).toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -47,14 +47,17 @@ interface ListWithAttributesProps {
   listItems: Array<ListWithAttributesItem>;
   selectedListItemId: string;
   highlightedAttributeIds?: Array<string>;
-  handleListItemClick: (id: string) => void;
+  handleListItemClick(id: string): void;
   showChipsForAttributes: boolean;
   showAddNewListItem?: boolean;
-  manuallyAddedListItems?: Array<string>;
-  setManuallyAddedListItems?(items: Array<string>): void;
+  setManuallyAddedListItems?(items: string): void;
   title?: string;
   listSx?: SxProps;
   emptyTextFallback?: string;
+  sortList?(
+    items: Array<ListWithAttributesItem>,
+    highlightedAttributeId?: string
+  ): Array<ListWithAttributesItem>;
 }
 
 export function ListWithAttributes(
@@ -69,20 +72,25 @@ export function ListWithAttributes(
   }
 
   function handleAddNewInputClick(): void {
-    if (
-      !props.manuallyAddedListItems?.includes(textBoxInput) &&
-      props.setManuallyAddedListItems &&
-      props.manuallyAddedListItems
-    ) {
-      props.setManuallyAddedListItems([
-        textBoxInput,
-        ...props.manuallyAddedListItems,
-      ]);
+    if (props.setManuallyAddedListItems) {
+      props.setManuallyAddedListItems(textBoxInput);
     }
     setTextBoxInput('');
   }
 
   const textInputIsInvalid = !textBoxInput || !textBoxInput.trim().length;
+
+  const listItemsToDisplay =
+    props.sortList !== undefined
+      ? props.sortList.length === 1
+        ? props.sortList(props.listItems)
+        : props.sortList(
+            props.listItems,
+            props.highlightedAttributeIds !== undefined
+              ? props.highlightedAttributeIds[0]
+              : ''
+          )
+      : props.listItems;
 
   return (
     <MuiBox sx={classes.titleAndListBox}>
@@ -95,16 +103,17 @@ export function ListWithAttributes(
           styleClass: classes.list,
         })}
       >
-        {props.listItems.map((item, index) => (
+        {listItemsToDisplay.map((item, index) => (
           <ListWithAttributesListItem
             item={item}
+            highlightedAttributeIds={props.highlightedAttributeIds}
             key={`itemId-${item.id}`}
             handleListItemClick={props.handleListItemClick}
             isSelected={item.id === props.selectedListItemId}
             showChipsForAttributes={props.showChipsForAttributes}
             isFirstItem={index === 0}
-            isLastItem={index === props.listItems.length - 1}
-            listContainsSingleItem={props.listItems.length === 1}
+            isLastItem={index === listItemsToDisplay.length - 1}
+            listContainsSingleItem={listItemsToDisplay.length === 1}
             emptyTextFallback={props.emptyTextFallback}
           />
         ))}

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -56,7 +56,7 @@ interface ListWithAttributesProps {
   emptyTextFallback?: string;
   sortList?(
     items: Array<ListWithAttributesItem>,
-    highlightedAttributeId?: string
+    highlightedAttributeIds?: Array<string>
   ): Array<ListWithAttributesItem>;
 }
 
@@ -82,14 +82,7 @@ export function ListWithAttributes(
 
   const listItemsToDisplay =
     props.sortList !== undefined
-      ? props.sortList.length === 1
-        ? props.sortList(props.listItems)
-        : props.sortList(
-            props.listItems,
-            props.highlightedAttributeIds !== undefined
-              ? props.highlightedAttributeIds[0]
-              : ''
-          )
+      ? props.sortList(props.listItems, props.highlightedAttributeIds)
       : props.listItems;
 
   return (

--- a/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
+++ b/src/Frontend/Components/ListWithAttributes/ListWithAttributes.tsx
@@ -80,10 +80,9 @@ export function ListWithAttributes(
 
   const textInputIsInvalid = !textBoxInput || !textBoxInput.trim().length;
 
-  const listItemsToDisplay =
-    props.sortList !== undefined
-      ? props.sortList(props.listItems, props.highlightedAttributeIds)
-      : props.listItems;
+  const listItemsToDisplay = props.sortList
+    ? props.sortList(props.listItems, props.highlightedAttributeIds)
+    : props.listItems;
 
   return (
     <MuiBox sx={classes.titleAndListBox}>

--- a/src/Frontend/Components/ListWithAttributesListItem/ListWithAttributesListItem.tsx
+++ b/src/Frontend/Components/ListWithAttributesListItem/ListWithAttributesListItem.tsx
@@ -152,7 +152,7 @@ export function ListWithAttributesListItem(
                         sx={{
                           ...classes.styleChips,
                           ...(props.highlightedAttributeIds?.includes(
-                            attribute.id
+                            attribute.id || ''
                           )
                             ? classes.styleChipsHighlighted
                             : {}),

--- a/src/Frontend/Components/ListWithAttributesListItem/ListWithAttributesListItem.tsx
+++ b/src/Frontend/Components/ListWithAttributesListItem/ListWithAttributesListItem.tsx
@@ -12,6 +12,7 @@ import MuiListItemText from '@mui/material/ListItemText';
 import MuiBox from '@mui/material/Box';
 import { ManuallyAddedListItemIcon } from '../Icons/Icons';
 import { ListWithAttributesItem } from '../../types/types';
+import { SxProps } from '@mui/system/styleFunctionSx';
 
 const classes = {
   listItem: {
@@ -149,14 +150,10 @@ export function ListWithAttributesListItem(
                         label={attribute.text || ITEM_TEXT_FALLBACK}
                         variant={'filled'}
                         size={'small'}
-                        sx={{
-                          ...classes.styleChips,
-                          ...(props.highlightedAttributeIds?.includes(
-                            attribute.id || ''
-                          )
-                            ? classes.styleChipsHighlighted
-                            : {}),
-                        }}
+                        sx={getChipStyling(
+                          props.highlightedAttributeIds,
+                          attribute.id
+                        )}
                       />
                     ) : (
                       attribute.text || ITEM_TEXT_FALLBACK
@@ -176,4 +173,18 @@ export function ListWithAttributesListItem(
       </MuiListItemButton>
     </MuiListItem>
   );
+}
+
+function getChipStyling(
+  highlightedAttributeIds?: Array<string>,
+  attributeId?: string
+): SxProps {
+  const highlightedSx =
+    attributeId !== undefined
+      ? highlightedAttributeIds?.includes(attributeId)
+        ? classes.styleChipsHighlighted
+        : {}
+      : {};
+
+  return { ...classes.styleChips, ...highlightedSx };
 }

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -55,6 +55,7 @@ import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { PackageInfo } from '../../../shared/shared-types';
 import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
+import { openAttributionWizardPopup } from '../../state/actions/popup-actions/popup-actions';
 
 const classes = {
   hiddenIcon: {
@@ -325,9 +326,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
               hideResourceSpecificButtons ||
               props.hideAttributionWizardContextMenuItem,
             onClick: (): void => {
-              dispatch(
-                openPopup(PopupType.AttributionWizardPopup, attributionId)
-              );
+              dispatch(openAttributionWizardPopup(attributionId));
             },
           },
         ];

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -19,10 +19,16 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
-import { ButtonText } from '../../../enums/enums';
+import { ButtonText, PopupType } from '../../../enums/enums';
 import { clickOnButtonInPackageContextMenu } from '../../../test-helpers/context-menu-test-helpers';
 import { setMultiSelectSelectedAttributionIds } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { getMultiSelectSelectedAttributionIds } from '../../../state/selectors/attribution-view-resource-selectors';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
+import {
+  setExternalData,
+  setManualData,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
 const testResources: Resources = {
   thirdParty: {
@@ -260,42 +266,64 @@ describe('The PackageCard', () => {
     expect(updatedAttributions[anotherAttributionId].preSelected).toBeFalsy();
   });
 
-  // TODO: Uncomment as soon as attribution wizard context menu item is unhidden.
-  // it('opens AttributionWizardPopup via context menu', () => {
-  //   const testStore = createTestAppStore();
+  it('opens AttributionWizardPopup via context menu', () => {
+    const selectedResourceId = '/samplepath/';
+    const testManualAttributions: Attributions = {
+      uuid_0: {
+        packageType: 'generic',
+        packageName: 'react',
+        packageNamespace: 'npm',
+        packageVersion: '18.2.0',
+      },
+    };
+    const testManualResourcesToAttributions: ResourcesToAttributions = {
+      [selectedResourceId]: ['uuid_0'],
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        packageType: 'generic',
+        packageName: 'numpy',
+        packageNamespace: 'pip',
+        packageVersion: '1.24.1',
+      },
+    };
+    const testExternalResourcesToAttributions: ResourcesToAttributions = {
+      '/samplepath/file': ['uuid_1'],
+    };
 
-  //   const attributions: Attributions = {
-  //     uuid_1: { packageName: 'testPackage' },
-  //   };
-  //   const resourcesToManualAttributions: ResourcesToAttributions = {
-  //     '/thirdParty': ['uuid_1'],
-  //   };
-  //   testStore.dispatch(
-  //     setManualData(attributions, resourcesToManualAttributions)
-  //   );
-  //   testStore.dispatch(setSelectedResourceId('/thirdParty'));
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
 
-  //   renderComponentWithStore(
-  //     <PackageCard
-  //       cardId={'testCardId'}
-  //       packageInfo={{ packageName: 'testPackage' }}
-  //       attributionId={'uuid_1'}
-  //       cardConfig={{ isExternalAttribution: false, isSelected: true }}
-  //       onClick={doNothing}
-  //       hideContextMenuAndMultiSelect={false}
-  //       showCheckBox={false}
-  //     />,
-  //     { store: testStore }
-  //   );
+    renderComponentWithStore(
+      <PackageCard
+        cardId={'testCardId'}
+        packageInfo={{ packageName: 'testPackage' }}
+        attributionId={'uuid_0'}
+        cardConfig={{ isExternalAttribution: false, isSelected: true }}
+        onClick={doNothing}
+        hideContextMenuAndMultiSelect={false}
+        showCheckBox={false}
+      />,
+      { store: testStore }
+    );
 
-  //   clickOnButtonInPackageContextMenu(
-  //     screen,
-  //     'testPackage',
-  //     ButtonText.OpenAttributionWizardPopup
-  //   );
+    clickOnButtonInPackageContextMenu(
+      screen,
+      'testPackage',
+      ButtonText.OpenAttributionWizardPopup
+    );
 
-  //   expect(getOpenPopup(testStore.getState())).toBe(
-  //     PopupType.AttributionWizardPopup
-  //   );
-  // });
+    expect(getOpenPopup(testStore.getState())).toBe(
+      PopupType.AttributionWizardPopup
+    );
+  });
 });

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/attribution-wizard-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/attribution-wizard-popup.test.tsx
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { act, fireEvent, screen } from '@testing-library/react';
+import {
+  Attributions,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { GlobalPopup } from '../../../Components/GlobalPopup/GlobalPopup';
+import { PopupType, ButtonText } from '../../../enums/enums';
+import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
+import {
+  setExternalData,
+  setManualData,
+  setTemporaryPackageInfo,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+
+const selectedResourceId = '/samplepath/';
+const testManualAttributions: Attributions = {
+  uuid_0: {
+    packageType: 'generic',
+    packageName: 'react',
+    packageNamespace: 'npm',
+    packageVersion: '18.2.0',
+  },
+};
+const testManualResourcesToAttributions: ResourcesToAttributions = {
+  [selectedResourceId]: ['uuid_0'],
+};
+const testExternalAttributions: Attributions = {
+  uuid_1: {
+    packageType: 'generic',
+    packageName: 'numpy',
+    packageNamespace: 'pip',
+    packageVersion: '1.24.1',
+  },
+};
+const testExternalResourcesToAttributions: ResourcesToAttributions = {
+  '/samplepath/file': ['uuid_1'],
+};
+
+describe('AttributionWizardPopup', () => {
+  it('closes when clicking "cancel"', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+
+    act(() => {
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
+    });
+
+    expect(getOpenPopup(testStore.getState())).toBe(
+      PopupType.AttributionWizardPopup
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Cancel }));
+
+    expect(getOpenPopup(testStore.getState())).toBeNull();
+  });
+
+  it('changes temporary package info', () => {
+    const initialTemporaryPackageInfo = testManualAttributions.uuid_0;
+    const expectedChangedTemporaryPackageInfo = testExternalAttributions.uuid_1;
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testExternalResourcesToAttributions
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+
+    renderComponentWithStore(<GlobalPopup />, { store: testStore });
+    act(() => {
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
+    });
+
+    testStore.dispatch(setTemporaryPackageInfo(initialTemporaryPackageInfo));
+
+    fireEvent.click(screen.getByText('pip'));
+    fireEvent.click(screen.getByText('numpy'));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Next }));
+    fireEvent.click(screen.getByText('1.24.1'));
+    fireEvent.click(screen.getByRole('button', { name: ButtonText.Apply }));
+
+    const changedTemporaryPackageInfo = getTemporaryPackageInfo(
+      testStore.getState()
+    );
+    expect(changedTemporaryPackageInfo).toEqual(
+      expectedChangedTemporaryPackageInfo
+    );
+  });
+});

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -220,7 +220,7 @@ export function closeEditAttributionPopupOrOpenUnsavedPopup(
 }
 
 export function openAttributionWizardPopup(
-  popupAttributionId: string
+  originalAttributionId: string
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const selectedResourceId = getSelectedResourceId(getState());
@@ -229,7 +229,7 @@ export function openAttributionWizardPopup(
     const resolvedExternalAttributions = getResolvedExternalAttributions(
       getState()
     );
-    const manualAttributions = getManualAttributions(getState());
+    const manualAttributions = manualData.attributions;
 
     const allAttributionIdsOfResourceAndChildrenWithCounts =
       getAllAttributionIdsWithCountsFromResourceAndChildren(
@@ -253,7 +253,9 @@ export function openAttributionWizardPopup(
     );
 
     const originalAttribution =
-      popupAttributionId !== null ? manualAttributions[popupAttributionId] : {};
+      originalAttributionId !== null
+        ? manualAttributions[originalAttributionId]
+        : {};
 
     const {
       preSelectedPackageNamespaceId,
@@ -279,7 +281,9 @@ export function openAttributionWizardPopup(
     );
     dispatch(setAttributionWizardTotalAttributionCount(totalAttributionCount));
 
-    dispatch(openPopup(PopupType.AttributionWizardPopup, popupAttributionId));
+    dispatch(
+      openPopup(PopupType.AttributionWizardPopup, originalAttributionId)
+    );
   };
 }
 

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -55,7 +55,7 @@ import {
   setAttributionWizardPackageNames,
   setAttributionWizardPackageNamespaces,
   setAttributionWizardPackageVersions,
-  setAttributionWizardPopupAttribution,
+  setAttributionWizardOriginalAttribution,
   setAttributionWizardSelectedPackageIds,
   setAttributionWizardTotalAttributionCount,
 } from '../resource-actions/attribution-wizard-actions';
@@ -252,7 +252,7 @@ export function openAttributionWizardPopup(
       }
     );
 
-    const startingAttribution =
+    const originalAttribution =
       popupAttributionId !== null ? manualAttributions[popupAttributionId] : {};
 
     const {
@@ -260,25 +260,73 @@ export function openAttributionWizardPopup(
       preSelectedPackageNameId,
       preSelectedPackageVersionId,
     } = getPreSelectedPackageAttributeIds(
-      startingAttribution,
+      originalAttribution,
       packageNamespaces,
       packageNames,
       packageVersions
     );
 
-    dispatch(setAttributionWizardPopupAttribution(startingAttribution));
+    dispatch(setAttributionWizardOriginalAttribution(originalAttribution));
     dispatch(setAttributionWizardPackageNamespaces(packageNamespaces));
     dispatch(setAttributionWizardPackageNames(packageNames));
     dispatch(setAttributionWizardPackageVersions(packageVersions));
     dispatch(
       setAttributionWizardSelectedPackageIds({
-        selectedPackageNamespaceId: preSelectedPackageNamespaceId,
-        selectedPackageNameId: preSelectedPackageNameId,
-        selectedPackageVersionId: preSelectedPackageVersionId,
+        namespaceId: preSelectedPackageNamespaceId,
+        nameId: preSelectedPackageNameId,
+        versionId: preSelectedPackageVersionId,
       })
     );
     dispatch(setAttributionWizardTotalAttributionCount(totalAttributionCount));
 
     dispatch(openPopup(PopupType.AttributionWizardPopup, popupAttributionId));
+  };
+}
+
+export function closeAttributionWizardPopup(): AppThunkAction {
+  return (dispatch: AppThunkDispatch): void => {
+    const emptyAttributionWizardState = {
+      originalAttribution: {},
+      packageNamespaces: {},
+      packageNames: {},
+      packageVersions: {},
+      selectedPackageAttributeIds: {
+        namespaceId: '',
+        nameId: '',
+        versionId: '',
+      },
+      totalAttributionCount: null,
+    };
+
+    dispatch(
+      setAttributionWizardOriginalAttribution(
+        emptyAttributionWizardState.originalAttribution
+      )
+    );
+    dispatch(
+      setAttributionWizardPackageNamespaces(
+        emptyAttributionWizardState.packageNamespaces
+      )
+    );
+    dispatch(
+      setAttributionWizardPackageNames(emptyAttributionWizardState.packageNames)
+    );
+    dispatch(
+      setAttributionWizardPackageVersions(
+        emptyAttributionWizardState.packageVersions
+      )
+    );
+    dispatch(
+      setAttributionWizardSelectedPackageIds(
+        emptyAttributionWizardState.selectedPackageAttributeIds
+      )
+    );
+    dispatch(
+      setAttributionWizardTotalAttributionCount(
+        emptyAttributionWizardState.totalAttributionCount
+      )
+    );
+
+    dispatch(closePopup());
   };
 }

--- a/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo } from '../../../../shared/shared-types';
+import {
+  SelectedPackageAttributeIds,
+  PackageAttributes,
+} from '../../../types/types';
+import {
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES,
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS,
+  ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
+  ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
+  ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
+  SetAttributionWizardPackageNames,
+  SetAttributionWizardPackageNamespaces,
+  SetAttributionWizardPackageVersions,
+  SetAttributionWizardPopupAttribution,
+  SetAttributionWizardSelectedPackageIds,
+  SetAttributionWizardTotalAttributionCount,
+} from './types';
+
+export function setAttributionWizardPopupAttribution(
+  popupAttribution: PackageInfo
+): SetAttributionWizardPopupAttribution {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
+    payload: popupAttribution,
+  };
+}
+
+export function setAttributionWizardPackageNamespaces(
+  sortedPackageNamespacesWithUuidsAndCounts: PackageAttributes
+): SetAttributionWizardPackageNamespaces {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES,
+    payload: sortedPackageNamespacesWithUuidsAndCounts,
+  };
+}
+
+export function setAttributionWizardPackageNames(
+  sortedPackageNamesWithUuidsAndCounts: PackageAttributes
+): SetAttributionWizardPackageNames {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
+    payload: sortedPackageNamesWithUuidsAndCounts,
+  };
+}
+
+export function setAttributionWizardPackageVersions(
+  sortedPackageVersionsWithUuidsAndRelatedPackageNameIds: PackageAttributes
+): SetAttributionWizardPackageVersions {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS,
+    payload: sortedPackageVersionsWithUuidsAndRelatedPackageNameIds,
+  };
+}
+
+export function setAttributionWizardSelectedPackageIds(
+  packageIds: SelectedPackageAttributeIds
+): SetAttributionWizardSelectedPackageIds {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
+    payload: packageIds,
+  };
+}
+
+export function setAttributionWizardTotalAttributionCount(
+  totalAttributionCount: number | null
+): SetAttributionWizardTotalAttributionCount {
+  return {
+    type: ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
+    payload: totalAttributionCount,
+  };
+}

--- a/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
@@ -4,31 +4,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PackageInfo } from '../../../../shared/shared-types';
-import {
-  SelectedPackageAttributeIds,
-  PackageAttributes,
-} from '../../../types/types';
+import { PackageAttributeIds, PackageAttributes } from '../../../types/types';
 import {
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES,
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS,
-  ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
+  ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION,
   ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
   ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
   SetAttributionWizardPackageNames,
   SetAttributionWizardPackageNamespaces,
   SetAttributionWizardPackageVersions,
-  SetAttributionWizardPopupAttribution,
+  SetAttributionWizardOriginalAttribution,
   SetAttributionWizardSelectedPackageIds,
   SetAttributionWizardTotalAttributionCount,
 } from './types';
 
-export function setAttributionWizardPopupAttribution(
-  popupAttribution: PackageInfo
-): SetAttributionWizardPopupAttribution {
+export function setAttributionWizardOriginalAttribution(
+  originalAttribution: PackageInfo
+): SetAttributionWizardOriginalAttribution {
   return {
-    type: ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
-    payload: popupAttribution,
+    type: ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION,
+    payload: originalAttribution,
   };
 }
 
@@ -60,7 +57,7 @@ export function setAttributionWizardPackageVersions(
 }
 
 export function setAttributionWizardSelectedPackageIds(
-  packageIds: SelectedPackageAttributeIds
+  packageIds: PackageAttributeIds
 ): SetAttributionWizardSelectedPackageIds {
   return {
     type: ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../shared/shared-types';
 import {
   PanelPackage,
-  SelectedPackageAttributeIds,
+  PackageAttributeIds,
   PackageAttributes,
 } from '../../../types/types';
 
@@ -76,8 +76,8 @@ export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
 export const ACTION_TOGGLE_ACCORDION_SEARCH_FIELD =
   'ACTION_TOGGLE_ACCORDION_SEARCH_FIELD';
 export const ACTION_SET_PACKAGE_SEARCH_TERM = 'ACTION_SET_PACKAGE_SEARCH_TERM';
-export const ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION =
-  'ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION';
+export const ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION =
+  'ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION';
 export const ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES =
   'ACTION_SET_ATTRIBUTION_WIZARD_INITIAL_PACKAGE_NAMESPACES';
 export const ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES =
@@ -123,7 +123,7 @@ export type ResourceAction =
   | SetMultiSelectSelectedAttributionIds
   | ToggleAccordionSearchField
   | SetPackageSearchTerm
-  | SetAttributionWizardPopupAttribution
+  | SetAttributionWizardOriginalAttribution
   | SetAttributionWizardPackageNamespaces
   | SetAttributionWizardPackageNames
   | SetAttributionWizardPackageVersions
@@ -314,8 +314,8 @@ export interface SetPackageSearchTerm {
   payload: string;
 }
 
-export interface SetAttributionWizardPopupAttribution {
-  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION;
+export interface SetAttributionWizardOriginalAttribution {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION;
   payload: PackageInfo;
 }
 export interface SetAttributionWizardPackageNamespaces {
@@ -335,7 +335,7 @@ export interface SetAttributionWizardPackageVersions {
 
 export interface SetAttributionWizardSelectedPackageIds {
   type: typeof ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS;
-  payload: SelectedPackageAttributeIds;
+  payload: PackageAttributeIds;
 }
 
 export interface SetAttributionWizardTotalAttributionCount {

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -14,7 +14,11 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
-import { PanelPackage } from '../../../types/types';
+import {
+  PanelPackage,
+  SelectedPackageAttributeIds,
+  PackageAttributes,
+} from '../../../types/types';
 
 export const ACTION_SET_SELECTED_ATTRIBUTION_ID =
   'ACTION_SET_SELECTED_ATTRIBUTION_ID';
@@ -72,6 +76,18 @@ export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
 export const ACTION_TOGGLE_ACCORDION_SEARCH_FIELD =
   'ACTION_TOGGLE_ACCORDION_SEARCH_FIELD';
 export const ACTION_SET_PACKAGE_SEARCH_TERM = 'ACTION_SET_PACKAGE_SEARCH_TERM';
+export const ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION =
+  'ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION';
+export const ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES =
+  'ACTION_SET_ATTRIBUTION_WIZARD_INITIAL_PACKAGE_NAMESPACES';
+export const ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES =
+  'ACTION_SET_ATTRIBUTION_WIZARD_INITIAL_PACKAGE_NAMES';
+export const ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS =
+  'ACTION_SET_ATTRIBUTION_WIZARD_INITIAL_PACKAGE_VERSIONS';
+export const ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS =
+  'ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS';
+export const ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT =
+  'ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -106,7 +122,13 @@ export type ResourceAction =
   | SetExternalAttributionSources
   | SetMultiSelectSelectedAttributionIds
   | ToggleAccordionSearchField
-  | SetPackageSearchTerm;
+  | SetPackageSearchTerm
+  | SetAttributionWizardPopupAttribution
+  | SetAttributionWizardPackageNamespaces
+  | SetAttributionWizardPackageNames
+  | SetAttributionWizardPackageVersions
+  | SetAttributionWizardSelectedPackageIds
+  | SetAttributionWizardTotalAttributionCount;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -290,4 +312,33 @@ export interface ToggleAccordionSearchField {
 export interface SetPackageSearchTerm {
   type: typeof ACTION_SET_PACKAGE_SEARCH_TERM;
   payload: string;
+}
+
+export interface SetAttributionWizardPopupAttribution {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION;
+  payload: PackageInfo;
+}
+export interface SetAttributionWizardPackageNamespaces {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES;
+  payload: PackageAttributes;
+}
+
+export interface SetAttributionWizardPackageNames {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES;
+  payload: PackageAttributes;
+}
+
+export interface SetAttributionWizardPackageVersions {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS;
+  payload: PackageAttributes;
+}
+
+export interface SetAttributionWizardSelectedPackageIds {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS;
+  payload: SelectedPackageAttributeIds;
+}
+
+export interface SetAttributionWizardTotalAttributionCount {
+  type: typeof ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT;
+  payload: number | null;
 }

--- a/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AttributionData,
+  AttributionIdWithCount,
+  Attributions,
+  PackageInfo,
+} from '../../../../shared/shared-types';
+import { PackageAttributes } from '../../../types/types';
+import {
+  getAllAttributionIdsWithCountsFromResourceAndChildren,
+  getAttributionWizardInitialState,
+  getPackageVersionsWithRelatedPackageNameIds,
+  getPreSelectedPackageAttributeIds,
+} from '../open-attribution-wizard-popup-helpers';
+
+describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', () => {
+  it('yields correct output', () => {
+    const testSelectedResourceId = '/samplepath/';
+    const testExternalData: AttributionData = {
+      attributionsToResources: {},
+      resourcesWithAttributedChildren: {
+        '/samplepath/': new Set<string>([
+          '/samplepath/file_0',
+          '/samplepath/subfolder/file_1',
+          '/samplepath/subfolder/file_2',
+        ]),
+      },
+      resourcesToAttributions: {
+        '/samplepath/file_0': ['uuid_0'],
+        '/samplepath/subfolder/file_1': ['uuid_1'],
+        '/samplepath/subfolder/file_2': ['uuid_0'],
+      },
+      attributions: {},
+    };
+    const testManualData: AttributionData = {
+      attributionsToResources: {},
+      resourcesWithAttributedChildren: {
+        '/samplepath/': new Set<string>([
+          '/samplepath/subfolder/file_0',
+          '/samplepath/subfolder_2/file_3',
+          '/samplepath/subfolder_2/file_4',
+        ]),
+      },
+      resourcesToAttributions: {
+        '/samplepath/subfolder/file_0': ['uuid_2'],
+        '/samplepath/subfolder_2/file_3': ['uuid_3'],
+        '/samplepath/subfolder_2/file_4': ['uuid_4'],
+      },
+      attributions: {},
+    };
+    const testResolvedExternalAttributions: Set<string> = new Set<string>();
+
+    const expectedTestAttributionsWithCounts: Array<AttributionIdWithCount> = [
+      { attributionId: 'uuid_0', count: 2 },
+      { attributionId: 'uuid_1', count: 1 },
+      { attributionId: 'uuid_2', count: 1 },
+      { attributionId: 'uuid_3', count: 1 },
+      { attributionId: 'uuid_4', count: 1 },
+    ];
+
+    const testAttributionsWithCounts =
+      getAllAttributionIdsWithCountsFromResourceAndChildren(
+        testSelectedResourceId,
+        testExternalData,
+        testManualData,
+        testResolvedExternalAttributions
+      );
+
+    expect(testAttributionsWithCounts).toEqual(
+      expectedTestAttributionsWithCounts
+    );
+  });
+});
+
+describe('getAttributionWizardInitialState', () => {
+  it('yields correct output', () => {
+    const testExternalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount> =
+      [
+        { attributionId: '1111', count: 1 },
+        { attributionId: '2222', count: 1 },
+        { attributionId: '3333', count: 3 },
+      ];
+    const testExternalAndManualAttributions: Attributions = {
+      '1111': {
+        packageName: 'boost',
+        packageNamespace: 'npm',
+        packageVersion: '0.63.1',
+      },
+      '2222': {
+        packageName: 'buffer',
+        packageNamespace: 'npm',
+        packageVersion: '6.0.3',
+      },
+      '3333': {
+        packageName: 'numpy',
+        packageNamespace: 'pip',
+        packageVersion: '1.24.0',
+      },
+    };
+    const expectedPackageNamespacesValues = [
+      { text: 'npm', count: 2 },
+      { text: 'pip', count: 3 },
+    ];
+    const expectedPackageNamesValues = [
+      { text: 'boost', count: 1 },
+      { text: 'buffer', count: 1 },
+      { text: 'numpy', count: 3 },
+    ];
+    const expectedPackageVersionsValues = [
+      { text: '0.63.1' },
+      { text: '6.0.3' },
+      { text: '1.24.0' },
+    ];
+    const expectedTotalAttributionCount = 5;
+
+    const {
+      packageNamespaces: testPackageNamespaces,
+      packageNames: testPackageNames,
+      packageVersions: testPackageVersions,
+      totalAttributionCount: testTotalAttributionCount,
+    } = getAttributionWizardInitialState(
+      testExternalAndManualAttributionIdsWithCounts,
+      testExternalAndManualAttributions
+    );
+
+    expect(Object.values(testPackageNamespaces)).toEqual(
+      expectedPackageNamespacesValues
+    );
+    expect(Object.values(testPackageNames)).toEqual(expectedPackageNamesValues);
+    Object.values(testPackageVersions).forEach((packageVersion, index) => {
+      expect(packageVersion.text).toBe(
+        expectedPackageVersionsValues[index].text
+      );
+      expect(packageVersion).toHaveProperty('relatedIds');
+    });
+    expect(testTotalAttributionCount).toBe(expectedTotalAttributionCount);
+  });
+});
+
+describe('getPackageVersionsWithRelatedPackageNameIds', () => {
+  it('yields correct output', () => {
+    const testPackageVersionsToNames = {
+      '1.1.1': new Set<string>(['boost', 'buffer']),
+      '1.24.0': new Set<string>(['numpy']),
+    };
+    const testPackageNames: PackageAttributes = {
+      uuid_0: { text: 'buffer' },
+      uuid_1: { text: 'boost' },
+      uuid_2: { text: 'numpy' },
+    };
+    const expectedPackageVersionsValues = [
+      { text: '1.1.1', relatedIds: new Set<string>(['uuid_1', 'uuid_0']) },
+      { text: '1.24.0', relatedIds: new Set<string>(['uuid_2']) },
+    ];
+
+    const testPackageVersions = getPackageVersionsWithRelatedPackageNameIds(
+      testPackageVersionsToNames,
+      testPackageNames
+    );
+
+    expect(Object.values(testPackageVersions)).toEqual(
+      expectedPackageVersionsValues
+    );
+  });
+});
+
+describe('getPreSelectedPackageAttributeIds', () => {
+  it('yields correct output', () => {
+    const testStartingAttribution: PackageInfo = {
+      packageNamespace: 'npm',
+      packageName: 'buffer',
+      packageVersion: '6.0.3',
+    };
+    const testPackageNamespaces: PackageAttributes = {
+      '1111': { text: 'npm' },
+      '2222': { text: 'pip' },
+    };
+    const testPackageNames: PackageAttributes = {
+      '3333': { text: 'buffer' },
+      '4444': { text: 'numpy' },
+    };
+    const testPackageVersions: PackageAttributes = {
+      '5555': { text: '6.0.3' },
+      '6666': { text: '1.24.0' },
+    };
+    const expectedPreSelectedPackageAttributeIds = {
+      preSelectedPackageNamespaceId: '1111',
+      preSelectedPackageNameId: '3333',
+      preSelectedPackageVersionId: '5555',
+    };
+
+    const testPreSelectedPackageAttributeIds =
+      getPreSelectedPackageAttributeIds(
+        testStartingAttribution,
+        testPackageNamespaces,
+        testPackageNames,
+        testPackageVersions
+      );
+
+    expect(testPreSelectedPackageAttributeIds).toEqual(
+      expectedPreSelectedPackageAttributeIds
+    );
+  });
+});

--- a/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
+++ b/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
@@ -126,7 +126,7 @@ export function getAttributionWizardInitialState(
 function getPackageAttributes(
   externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
   externalAndManualAttributions: Attributions,
-  packageAttributeId: 'namespace' | 'name'
+  packageAttributeKey: 'namespace' | 'name'
 ): PackageAttributes {
   const packageAttributesAndCounts: NamesWithCounts = {};
   for (const attributionIdWithCount of externalAndManualAttributionIdsWithCounts) {
@@ -135,12 +135,12 @@ function getPackageAttributes(
     const packageCount = attributionIdWithCount.count ?? 0;
 
     let packageAttribute: string;
-    if (packageAttributeId === 'namespace') {
+    if (packageAttributeKey === 'namespace') {
       packageAttribute = packageInfo.packageNamespace || '';
-    } else if (packageAttributeId === 'name') {
+    } else if (packageAttributeKey === 'name') {
       packageAttribute = packageInfo.packageName || '';
     } else {
-      shouldNotBeCalled(packageAttributeId);
+      shouldNotBeCalled(packageAttributeKey);
     }
 
     packageAttributesAndCounts[packageAttribute] =

--- a/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
+++ b/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AttributionData,
+  AttributionIdWithCount,
+  ResourcesToAttributions,
+  PackageInfo,
+  Attributions,
+} from '../../../shared/shared-types';
+import { getAttributedChildren } from '../../util/get-attributed-children';
+import { shouldNotBeCalled } from '../../util/should-not-be-called';
+import { v4 as uuid4 } from 'uuid';
+import { PackageAttributes } from '../../types/types';
+
+interface NamesWithCounts {
+  [name: string]: number;
+}
+
+export function getAllAttributionIdsWithCountsFromResourceAndChildren(
+  selectedResourceId: string,
+  externalData: AttributionData,
+  manualData: AttributionData,
+  resolvedExternalAttributions: Set<string>
+): Array<AttributionIdWithCount> {
+  const externalAttributedChildren = getAttributedChildren(
+    externalData.resourcesWithAttributedChildren,
+    selectedResourceId
+  );
+  if (selectedResourceId in externalData.resourcesToAttributions) {
+    externalAttributedChildren.add(selectedResourceId);
+  }
+
+  const manualAttributedChildren = getAttributedChildren(
+    manualData.resourcesWithAttributedChildren,
+    selectedResourceId
+  );
+  if (selectedResourceId in manualData.resourcesToAttributions) {
+    manualAttributedChildren.add(selectedResourceId);
+  }
+
+  const externalAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
+    externalData.resourcesToAttributions,
+    externalAttributedChildren,
+    resolvedExternalAttributions
+  );
+  const manualAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
+    manualData.resourcesToAttributions,
+    manualAttributedChildren
+  );
+
+  return externalAttributionsWithCounts.concat(manualAttributionsWithCounts);
+}
+
+function getAggregatedAttributionIdsAndCounts(
+  resourcesToAttributions: ResourcesToAttributions,
+  attributedChildren: Set<string>,
+  resolvedExternalAttributions?: Set<string>
+): Array<AttributionIdWithCount> {
+  const attributionCount: { [attributionId: string]: number } = {};
+  attributedChildren.forEach((child: string) => {
+    resourcesToAttributions[child].forEach((attributionId: string) => {
+      if (
+        !resolvedExternalAttributions ||
+        !resolvedExternalAttributions.has(attributionId)
+      ) {
+        attributionCount[attributionId] =
+          (attributionCount[attributionId] || 0) + 1;
+      }
+    });
+  });
+
+  return Object.entries(attributionCount).map(([attributionId, count]) => ({
+    attributionId,
+    count,
+  }));
+}
+
+export function getAttributionWizardInitialState(
+  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
+  externalAndManualAttributions: Attributions
+): {
+  packageNamespaces: PackageAttributes;
+  packageNames: PackageAttributes;
+  packageVersions: PackageAttributes;
+  totalAttributionCount: number;
+} {
+  const totalAttributionCount = externalAndManualAttributionIdsWithCounts
+    .map((attributionIdWithCount) => attributionIdWithCount.count ?? 0)
+    .reduce(
+      (accumulatedCounts, currentCount) => accumulatedCounts + currentCount,
+      0
+    );
+
+  const packageNamespaces = getPackageAttributes(
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions,
+    'namespace'
+  );
+  const packageNames = getPackageAttributes(
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions,
+    'name'
+  );
+
+  const packageVersionsToNames = getPackageVersionsToNames(
+    externalAndManualAttributionIdsWithCounts,
+    externalAndManualAttributions
+  );
+
+  const packageVersions = getPackageVersionsWithRelatedPackageNameIds(
+    packageVersionsToNames,
+    packageNames
+  );
+
+  return {
+    packageNamespaces,
+    packageNames,
+    packageVersions,
+    totalAttributionCount,
+  };
+}
+
+function getPackageAttributes(
+  externalAndManualAttributionIdsWithCounts: Array<AttributionIdWithCount>,
+  externalAndManualAttributions: Attributions,
+  packageAttributeId: 'namespace' | 'name'
+): PackageAttributes {
+  const packageAttributesAndCounts: NamesWithCounts = {};
+  for (const attributionIdWithCount of externalAndManualAttributionIdsWithCounts) {
+    const packageInfo =
+      externalAndManualAttributions[attributionIdWithCount.attributionId];
+    const packageCount = attributionIdWithCount.count ?? 0;
+
+    let packageAttribute: string;
+    if (packageAttributeId === 'namespace') {
+      packageAttribute = packageInfo.packageNamespace || '';
+    } else if (packageAttributeId === 'name') {
+      packageAttribute = packageInfo.packageName || '';
+    } else {
+      shouldNotBeCalled(packageAttributeId);
+    }
+
+    packageAttributesAndCounts[packageAttribute] =
+      (packageAttributesAndCounts[packageAttribute] ?? 0) + packageCount;
+  }
+
+  const sortedPackageAttributes = Object.entries(
+    packageAttributesAndCounts
+  ).map(([attributeName, count]) => ({
+    text: attributeName,
+    count,
+  }));
+
+  return sortedPackageAttributes.reduce(
+    (accumulatedAttributes, currentAttribute) => ({
+      ...accumulatedAttributes,
+      [uuid4()]: currentAttribute,
+    }),
+    {}
+  );
+}
+
+function getPackageVersionsToNames(
+  attributionIdsWithCounts: Array<AttributionIdWithCount>,
+  attributions: Attributions
+): { [version: string]: Set<string> } {
+  const packageVersionsToNames: { [version: string]: Set<string> } = {};
+  for (const attributionIdWithCount of attributionIdsWithCounts) {
+    const packageInfo = attributions[attributionIdWithCount.attributionId];
+
+    const packageName = packageInfo.packageName || '';
+    const packageVersion = packageInfo.packageVersion || '';
+
+    packageVersionsToNames[packageVersion] ??
+      (packageVersionsToNames[packageVersion] = new Set<string>());
+    packageVersionsToNames[packageVersion].add(packageName);
+  }
+
+  return packageVersionsToNames;
+}
+
+export function getPackageVersionsWithRelatedPackageNameIds(
+  packageVersionsToNames: { [version: string]: Set<string> },
+  packageNames: PackageAttributes
+): PackageAttributes {
+  const versions = Object.keys(packageVersionsToNames);
+  const packageVersions: PackageAttributes = {};
+  for (const version of versions) {
+    const relatedPackageNames = packageVersionsToNames[version];
+
+    const relatedPackageNameIds = new Set<string>(
+      Object.entries(packageNames).flatMap(([uuid, textAndCount]) =>
+        relatedPackageNames.has(textAndCount.text) ? [uuid] : []
+      )
+    );
+
+    packageVersions[uuid4()] = {
+      text: version,
+      relatedIds: relatedPackageNameIds,
+    };
+  }
+
+  return packageVersions;
+}
+
+export function getPreSelectedPackageAttributeIds(
+  startingAttribution: PackageInfo,
+  packageNamespaces: PackageAttributes,
+  packageNames: PackageAttributes,
+  packageVersions: PackageAttributes
+): {
+  preSelectedPackageNamespaceId: string;
+  preSelectedPackageNameId: string;
+  preSelectedPackageVersionId: string;
+} {
+  const namespace = startingAttribution.packageNamespace || '';
+  const name = startingAttribution.packageName || '';
+  const version = startingAttribution.packageVersion || '';
+
+  const preSelectedPackageNamespaceId = Object.entries(
+    packageNamespaces
+  ).flatMap(([uuid, textAndCount]) =>
+    textAndCount.text === namespace ? [uuid] : []
+  )[0];
+  const preSelectedPackageNameId = Object.entries(packageNames).flatMap(
+    ([uuid, textAndCount]) => (textAndCount.text === name ? [uuid] : [])
+  )[0];
+  const preSelectedPackageVersionId = Object.entries(packageVersions).flatMap(
+    ([uuid, textAndRelatedId]) =>
+      textAndRelatedId.text === version ? [uuid] : []
+  )[0];
+
+  return {
+    preSelectedPackageNamespaceId,
+    preSelectedPackageNameId,
+    preSelectedPackageVersionId,
+  };
+}

--- a/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
+++ b/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
@@ -207,7 +207,7 @@ export function getPackageVersionsWithRelatedPackageNameIds(
 }
 
 export function getPreSelectedPackageAttributeIds(
-  startingAttribution: PackageInfo,
+  originalAttribution: PackageInfo,
   packageNamespaces: PackageAttributes,
   packageNames: PackageAttributes,
   packageVersions: PackageAttributes
@@ -216,9 +216,9 @@ export function getPreSelectedPackageAttributeIds(
   preSelectedPackageNameId: string;
   preSelectedPackageVersionId: string;
 } {
-  const namespace = startingAttribution.packageNamespace || '';
-  const name = startingAttribution.packageName || '';
-  const version = startingAttribution.packageVersion || '';
+  const namespace = originalAttribution.packageNamespace || '';
+  const name = originalAttribution.packageName || '';
+  const version = originalAttribution.packageVersion || '';
 
   const preSelectedPackageNamespaceId = Object.entries(
     packageNamespaces

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -13,7 +13,11 @@ import {
   Resources,
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
-import { PanelPackage } from '../../types/types';
+import {
+  PanelPackage,
+  SelectedPackageAttributeIds,
+  PackageAttributes,
+} from '../../types/types';
 import {
   EMPTY_ATTRIBUTION_DATA,
   EMPTY_FREQUENT_LICENSES,
@@ -54,6 +58,12 @@ import {
   ACTION_TOGGLE_ACCORDION_SEARCH_FIELD,
   ACTION_SET_PACKAGE_SEARCH_TERM,
   ResourceAction,
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES,
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
+  ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS,
+  ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
+  ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
+  ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
 } from '../actions/resource-actions/types';
 import {
   createManualAttribution,
@@ -107,6 +117,20 @@ export const initialResourceState: ResourceState = {
   fileSearchPopup: {
     fileSearch: '',
   },
+  attributionWizard: {
+    popupAttribution: {},
+    packageNamespaces: {},
+    packageNames: {},
+    packageVersions: {},
+    selectedPackageAttributeIds: {
+      selectedPackageNamespaceId: '',
+      selectedPackageNameId: '',
+      selectedPackageVersionId: '',
+    },
+    packageNamesToVersions: {},
+    packageVersionsToNames: {},
+    totalAttributionCount: null,
+  },
 };
 
 export type ResourceState = {
@@ -143,6 +167,16 @@ export type ResourceState = {
   };
   fileSearchPopup: {
     fileSearch: string;
+  };
+  attributionWizard: {
+    popupAttribution: PackageInfo;
+    packageNamespaces: PackageAttributes;
+    packageNames: PackageAttributes;
+    packageVersions: PackageAttributes;
+    selectedPackageAttributeIds: SelectedPackageAttributeIds;
+    packageNamesToVersions: { [name: string]: Set<string> };
+    packageVersionsToNames: { [version: string]: Set<string> };
+    totalAttributionCount: number | null;
   };
 };
 
@@ -602,6 +636,55 @@ export const resourceState = (
             ...state.auditView.accordionSearchField,
             searchTerm: action.payload,
           },
+        },
+      };
+
+    case ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          popupAttribution: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          packageNamespaces: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          packageNames: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          packageVersions: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          selectedPackageAttributeIds: action.payload,
+        },
+      };
+    case ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT:
+      return {
+        ...state,
+        attributionWizard: {
+          ...state.attributionWizard,
+          totalAttributionCount: action.payload,
         },
       };
     default:

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -15,7 +15,7 @@ import {
 import { PackagePanelTitle } from '../../enums/enums';
 import {
   PanelPackage,
-  SelectedPackageAttributeIds,
+  PackageAttributeIds,
   PackageAttributes,
 } from '../../types/types';
 import {
@@ -61,7 +61,7 @@ import {
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES,
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_VERSIONS,
-  ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION,
+  ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION,
   ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
   ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
 } from '../actions/resource-actions/types';
@@ -118,17 +118,15 @@ export const initialResourceState: ResourceState = {
     fileSearch: '',
   },
   attributionWizard: {
-    popupAttribution: {},
+    originalAttribution: {},
     packageNamespaces: {},
     packageNames: {},
     packageVersions: {},
     selectedPackageAttributeIds: {
-      selectedPackageNamespaceId: '',
-      selectedPackageNameId: '',
-      selectedPackageVersionId: '',
+      namespaceId: '',
+      nameId: '',
+      versionId: '',
     },
-    packageNamesToVersions: {},
-    packageVersionsToNames: {},
     totalAttributionCount: null,
   },
 };
@@ -169,13 +167,11 @@ export type ResourceState = {
     fileSearch: string;
   };
   attributionWizard: {
-    popupAttribution: PackageInfo;
+    originalAttribution: PackageInfo;
     packageNamespaces: PackageAttributes;
     packageNames: PackageAttributes;
     packageVersions: PackageAttributes;
-    selectedPackageAttributeIds: SelectedPackageAttributeIds;
-    packageNamesToVersions: { [name: string]: Set<string> };
-    packageVersionsToNames: { [version: string]: Set<string> };
+    selectedPackageAttributeIds: PackageAttributeIds;
     totalAttributionCount: number | null;
   };
 };
@@ -639,12 +635,12 @@ export const resourceState = (
         },
       };
 
-    case ACTION_SET_ATTRIBUTION_WIZARD_POPUP_ATTRIBUTION:
+    case ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION:
       return {
         ...state,
         attributionWizard: {
           ...state.attributionWizard,
-          popupAttribution: action.payload,
+          originalAttribution: action.payload,
         },
       };
     case ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES:

--- a/src/Frontend/state/selectors/attribution-wizard-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-wizard-selectors.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo } from '../../../shared/shared-types';
+import {
+  SelectedPackageAttributeIds,
+  State,
+  PackageAttributes,
+} from '../../types/types';
+
+export function getAttributionWizardPopupAttribution(
+  state: State
+): PackageInfo {
+  return state.resourceState.attributionWizard.popupAttribution;
+}
+
+export function getAttributionWizardPackageNamespaces(
+  state: State
+): PackageAttributes {
+  return state.resourceState.attributionWizard.packageNamespaces;
+}
+
+export function getAttributionWizardPackageNames(
+  state: State
+): PackageAttributes {
+  return state.resourceState.attributionWizard.packageNames;
+}
+
+export function getAttributionWizardPackageVersions(
+  state: State
+): PackageAttributes {
+  return state.resourceState.attributionWizard.packageVersions;
+}
+
+export function getAttributionWizardPackageNamesToVersions(state: State): {
+  [name: string]: Set<string>;
+} {
+  return state.resourceState.attributionWizard.packageNamesToVersions;
+}
+
+export function getAttributionWizardPackageVersionsToNames(state: State): {
+  [version: string]: Set<string>;
+} {
+  return state.resourceState.attributionWizard.packageNamesToVersions;
+}
+
+export function getAttributionWizardSelectedPackageIds(
+  state: State
+): SelectedPackageAttributeIds {
+  return state.resourceState.attributionWizard.selectedPackageAttributeIds;
+}
+
+export function getAttributionWizardTotalAttributionCount(
+  state: State
+): number | null {
+  return state.resourceState.attributionWizard.totalAttributionCount;
+}

--- a/src/Frontend/state/selectors/attribution-wizard-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-wizard-selectors.ts
@@ -5,15 +5,15 @@
 
 import { PackageInfo } from '../../../shared/shared-types';
 import {
-  SelectedPackageAttributeIds,
+  PackageAttributeIds,
   State,
   PackageAttributes,
 } from '../../types/types';
 
-export function getAttributionWizardPopupAttribution(
+export function getAttributionWizarOriginalAttribution(
   state: State
 ): PackageInfo {
-  return state.resourceState.attributionWizard.popupAttribution;
+  return state.resourceState.attributionWizard.originalAttribution;
 }
 
 export function getAttributionWizardPackageNamespaces(
@@ -34,21 +34,9 @@ export function getAttributionWizardPackageVersions(
   return state.resourceState.attributionWizard.packageVersions;
 }
 
-export function getAttributionWizardPackageNamesToVersions(state: State): {
-  [name: string]: Set<string>;
-} {
-  return state.resourceState.attributionWizard.packageNamesToVersions;
-}
-
-export function getAttributionWizardPackageVersionsToNames(state: State): {
-  [version: string]: Set<string>;
-} {
-  return state.resourceState.attributionWizard.packageNamesToVersions;
-}
-
-export function getAttributionWizardSelectedPackageIds(
+export function getAttributionWizardSelectedPackageAttributeIds(
   state: State
-): SelectedPackageAttributeIds {
+): PackageAttributeIds {
   return state.resourceState.attributionWizard.selectedPackageAttributeIds;
 }
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -162,8 +162,8 @@ export interface PackageAttributes {
   };
 }
 
-export interface SelectedPackageAttributeIds {
-  selectedPackageNamespaceId: string;
-  selectedPackageNameId: string;
-  selectedPackageVersionId: string;
+export interface PackageAttributeIds {
+  namespaceId: string;
+  nameId: string;
+  versionId: string;
 }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -144,7 +144,7 @@ export type ProgressBarType = 'FolderProgressBar' | 'TopProgressBar';
 
 export interface ListWithAttributesItemAttribute {
   text: string;
-  id: string;
+  id?: string;
 }
 
 export interface ListWithAttributesItem {
@@ -152,4 +152,18 @@ export interface ListWithAttributesItem {
   id: string;
   manuallyAdded?: boolean;
   attributes?: Array<ListWithAttributesItemAttribute>;
+}
+export interface PackageAttributes {
+  [uuid: string]: {
+    text: string;
+    count?: number;
+    relatedIds?: Set<string>;
+    manuallyAdded?: boolean;
+  };
+}
+
+export interface SelectedPackageAttributeIds {
+  selectedPackageNamespaceId: string;
+  selectedPackageNameId: string;
+  selectedPackageVersionId: string;
 }


### PR DESCRIPTION
Local `AttributionWizardPopup` state is moved to the global redux state.
Ids are now UUIDs. 
ListWithAttributes is sorted with a function that is passed via props.

No changes in UI.

Fix: #1345