### PR TITLE
POC of .opossum file [DRAFT]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 0,
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-empty-function': 0,
-    '@typescript-eslint/no-explicit-any': 2,
+    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': 2,
     '@typescript-eslint/explicit-function-return-type': 2,
     '@typescript-eslint/await-thenable': 2,

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -15,13 +15,17 @@ import {
 import { getGlobalBackendState } from '../main/globalBackendState';
 import {
   cleanNonExistentAttributions,
-  cleanNonExistentResolvedExternalAttributions,
   parseFrequentLicenses,
   parseRawAttributions,
   sanitizeRawBaseUrlsForSources,
   sanitizeResourcesToAttributions,
 } from './parseInputData';
-import { parseOpossumInputFile, parseOpossumOutputFile } from './parseFile';
+import {
+  parseOpossumInputFile,
+  parseOpossumOutputFile,
+  readZip,
+  writeZip,
+} from './parseFile';
 import {
   JsonParsingError,
   OpossumOutputFile,
@@ -48,9 +52,29 @@ export async function loadJsonFromFilePath(
   webContents.send(AllowedFrontendChannels.ResetLoadedFile, {
     resetState: true,
   });
+  let zipFilePath;
+  if (filePath.endsWith('.zip')) {
+    zipFilePath = filePath;
+  } else {
+    zipFilePath = getFilePathWithAppendix(filePath, '_out.zip');
+  }
+  let manualAttributions;
+  let parsingResult;
+  let opossumOutputData;
 
-  log.info(`Starting to parse input file ${filePath}`);
-  const parsingResult = await parseOpossumInputFile(filePath);
+  if (fs.existsSync(zipFilePath)) {
+    log.info(`Starting to read zip file ${zipFilePath} ...`);
+    [parsingResult, opossumOutputData] = await readZip(zipFilePath);
+    log.info('... Successfully read zip file.\n');
+    [manualAttributions] = parseRawAttributions(
+      opossumOutputData.manualAttributions
+    );
+  } else {
+    opossumOutputData = {};
+    manualAttributions = {};
+    log.info(`Starting to parse input file ${filePath}`);
+    parsingResult = await parseOpossumInputFile(filePath);
+  }
 
   if (isJsonParsingError(parsingResult)) {
     log.info('Invalid input file.');
@@ -70,7 +94,7 @@ export async function loadJsonFromFilePath(
   const projectId = parsingResult.metadata.projectId;
   const inputFileChecksum = getGlobalBackendState().inputFileChecksum;
 
-  if (!fs.existsSync(manualAttributionFilePath)) {
+  if (!fs.existsSync(manualAttributionFilePath) && !filePath.endsWith('.zip')) {
     log.info(`Starting to create output file, project ID is ${projectId}`);
     createOutputFile(
       manualAttributionFilePath,
@@ -81,12 +105,24 @@ export async function loadJsonFromFilePath(
     );
     log.info('... Successfully created output file.');
   }
-  log.info(`Starting to parse output file ${manualAttributionFilePath} ...`);
-  const opossumOutputData = parseOpossumOutputFile(manualAttributionFilePath);
-  const [manualAttributions] = parseRawAttributions(
-    opossumOutputData.manualAttributions
-  );
-  log.info('... Successfully parsed output file.');
+
+  if (!fs.existsSync(zipFilePath)) {
+    log.info(`Starting to parse output file ${manualAttributionFilePath} ...`);
+    opossumOutputData = parseOpossumOutputFile(manualAttributionFilePath);
+    [manualAttributions] = parseRawAttributions(
+      opossumOutputData.manualAttributions
+    );
+    log.info('... Successfully parsed output file.');
+
+    log.info(`Starting to write zip file ${zipFilePath} ...`);
+    writeZip(
+      zipFilePath,
+      JSON.stringify(parsingResult),
+      JSON.stringify(opossumOutputData)
+    );
+    log.info('... Successfully created zip file.');
+  }
+
   log.info('Parsing frequent licenses from input');
   const frequentLicenses = parseFrequentLicenses(
     parsingResult.frequentLicenses
@@ -116,11 +152,7 @@ export async function loadJsonFromFilePath(
       resourcesToAttributions: resourcesToExternalAttributions,
     },
     frequentLicenses,
-    resolvedExternalAttributions: cleanNonExistentResolvedExternalAttributions(
-      webContents,
-      opossumOutputData.resolvedExternalAttributions,
-      externalAttributions
-    ),
+    resolvedExternalAttributions: new Set(),
     attributionBreakpoints: new Set(parsingResult.attributionBreakpoints ?? []),
     filesWithChildren: new Set(parsingResult.filesWithChildren ?? []),
     baseUrlsForSources: sanitizeRawBaseUrlsForSources(

--- a/src/ElectronBackend/input/parseFile.ts
+++ b/src/ElectronBackend/input/parseFile.ts
@@ -15,6 +15,8 @@ import * as OpossumInputFileSchema from './OpossumInputFileSchema.json';
 import * as OpossumOutputFileSchema from './OpossumOutputFileSchema.json';
 import Asm from 'stream-json/Assembler';
 import { Parser, parser } from 'stream-json';
+import JSZip from 'jszip';
+import log from 'electron-log';
 
 const jsonSchemaValidator = new Validator();
 const validationOptions: Options = {
@@ -46,6 +48,80 @@ export function parseOpossumOutputFile(
       ? new Set(resolvedExternalAttributions as Array<string>)
       : new Set(),
   } as ParsedOpossumOutputFile;
+}
+
+export function writeZip(
+  zipfilePath: string,
+  inputfileData: string,
+  outputfileData: string
+): void {
+  const writeStream = fs.createWriteStream(zipfilePath);
+  const zip = new JSZip();
+  zip.file('input.json', inputfileData);
+  zip.file('output.json', outputfileData);
+  zip
+    .generateNodeStream({
+      type: 'nodebuffer',
+      streamFiles: true,
+      compression: 'DEFLATE',
+      compressionOptions: { level: 1 },
+    })
+    .pipe(writeStream)
+    .on('end', () => {
+      log.info('zip file created!');
+      process.exit();
+    });
+}
+
+export async function readZip(zipfilePath: string): Promise<any> {
+  let parsedOutputData: any;
+  let parsedInputData: any;
+  const sleep = (ms: number): Promise<unknown> =>
+    new Promise((r) => setTimeout(r, ms));
+  fs.readFile(zipfilePath, function (err, data): void {
+    if (err) throw err;
+    JSZip.loadAsync(data).then(function (zip) {
+      zip.files['input.json'].async('text').then(function (content) {
+        parsedInputData = JSON.parse(content);
+      });
+      zip.files['output.json'].async('text').then(function (content) {
+        parsedOutputData = JSON.parse(content);
+      });
+    });
+  });
+  await sleep(2000);
+  return [
+    parsedInputData as ParsedOpossumInputFile,
+    parsedOutputData as ParsedOpossumOutputFile,
+  ];
+}
+
+export function addFileToZip(
+  zipfilePath: string,
+  outputfileData: string
+): void {
+  const new_zip = new JSZip();
+  fs.readFile(zipfilePath, function (err, data) {
+    if (err) throw err;
+    new_zip.loadAsync(data).then(function (zip) {
+      zip.files['output.json'].async('text').then(function () {
+        new_zip.file('output.json', outputfileData);
+        const writeStream = fs.createWriteStream(zipfilePath);
+        new_zip
+          .generateNodeStream({
+            type: 'nodebuffer',
+            streamFiles: true,
+            compression: 'DEFLATE',
+            compressionOptions: { level: 1 },
+          })
+          .pipe(writeStream)
+          .on('end', () => {
+            log.info('zip file was overwritten!');
+            process.exit();
+          });
+      });
+    });
+  });
 }
 
 export function parseOpossumInputFile(

--- a/src/ElectronBackend/main/dialogs.ts
+++ b/src/ElectronBackend/main/dialogs.ts
@@ -11,7 +11,10 @@ export function openFileDialog(): Array<string> | undefined {
     ? dialog.showOpenDialogSync(window, {
         properties: ['openFile'],
         filters: [
-          { name: 'Opossum Input File', extensions: ['json', 'json.gz'] },
+          {
+            name: 'Opossum Input File',
+            extensions: ['json', 'json.gz', 'zip'],
+          },
         ],
       })
     : undefined;

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -24,7 +24,6 @@ import {
 } from '../errorHandling/errorHandling';
 import { loadJsonFromFilePath } from '../input/importFromFile';
 import { writeCsvToFile } from '../output/writeCsvToFile';
-import { writeJsonToFile } from '../output/writeJsonToFile';
 import {
   GlobalBackendState,
   KeysOfAttributionInfo,
@@ -39,7 +38,7 @@ import fs from 'fs';
 import { writeSpdxFile } from '../output/writeSpdxFile';
 import log from 'electron-log';
 import { createMenu } from './menu';
-import { parseOpossumOutputFile } from '../input/parseFile';
+import { addFileToZip, parseOpossumOutputFile } from '../input/parseFile';
 import hash from 'object-hash';
 import upath from 'upath';
 import { getFilePathWithAppendix } from '../utils/getFilePathWithAppendix';
@@ -75,10 +74,22 @@ export function getSaveFileListener(
           ),
         };
 
-        writeJsonToFile(
-          globalBackendState.attributionFilePath,
-          attributionFileContent
-        );
+        // writeJsonToFile(
+        //   globalBackendState.attributionFilePath,
+        //   attributionFileContent
+        // );
+        if (globalBackendState.resourceFilePath) {
+          let zipFilePath;
+          if (globalBackendState.resourceFilePath.endsWith('.zip')) {
+            zipFilePath = globalBackendState.resourceFilePath;
+          } else {
+            zipFilePath = getFilePathWithAppendix(
+              globalBackendState.resourceFilePath,
+              '_out.zip'
+            );
+          }
+          addFileToZip(zipFilePath, JSON.stringify(attributionFileContent));
+        }
       }
     }
   );


### PR DESCRIPTION
 POC to proceed with actual implementation.

### Summary of changes

Implemented POC of one opossum file (.zip) which contain both input.json and attribution.json. 

### Context and reason for change

One file is more convenient to use.

### How can the changes be tested

Run OpossumUI and open any .json file -> find zipped file in the same folder as .json.
