### PR TITLE
Support .opossum files: create info popup

### DIFF
--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -49,6 +49,12 @@ export async function loadJsonFromFilePath(
     resetState: true,
   });
 
+  // Uncomment and restart application to activate popup when opening a file
+  // TODO: Wire popup
+  // webContents.send(AllowedFrontendChannels.ShowFileSupportPopup, {
+  //   showFileSupportPopup: true,
+  // });
+
   log.info(`Starting to parse input file ${filePath}`);
   const parsingResult = await parseOpossumInputFile(filePath);
 

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -247,6 +247,15 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
+  function showFileSupportPopupListener(
+    event: IpcRendererEvent,
+    showFileSupportPopup: boolean
+  ): void {
+    if (showFileSupportPopup) {
+      dispatch(openPopup(PopupType.FileSupportPopup));
+    }
+  }
+
   useIpcRenderer(AllowedFrontendChannels.FileLoaded, fileLoadedListener, [
     dispatch,
   ]);
@@ -294,6 +303,11 @@ export function BackendCommunication(): ReactElement | null {
   useIpcRenderer(AllowedFrontendChannels.FileLoading, setFileLoadingListener, [
     dispatch,
   ]);
+  useIpcRenderer(
+    AllowedFrontendChannels.ShowFileSupportPopup,
+    showFileSupportPopupListener,
+    [dispatch]
+  );
 
   return null;
 }

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -16,7 +16,7 @@ import { Attributions, ExportType } from '../../../../shared/shared-types';
 describe('BackendCommunication', () => {
   it('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(10);
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(11);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
       expect.anything()

--- a/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
+++ b/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import MuiTypography from '@mui/material/Typography';
+import MuiBox from '@mui/material/Box';
+import { ButtonText } from '../../enums/enums';
+import { ButtonConfig } from '../../types/types';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { useAppDispatch } from '../../state/hooks';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+
+export const HEADER = 'Warning: Outdated input file format';
+
+const INFO_TEXT_PART_1 =
+  'You are trying to open a file with an outdated extension (".json" or ".json.gz"). \
+    OpossumUI now reads files with a ".opossum" extension by default. \
+    However, older file formats can still be opened but support may be \
+    discontinued in the future.';
+const INFO_TEXT_PART_2 =
+  'Would you like to create a new file with a ".opossum" extension from the current \
+    input file and proceed (recommended), or keep working with the old format?';
+
+const classes = {
+  content: {
+    display: 'flex',
+    gap: '25px',
+    flexDirection: 'column',
+    width: '520px',
+  },
+};
+
+export function FileSupportPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+  function close(): void {
+    dispatch(closePopup());
+  }
+
+  // TODO: Implement button handlers to wire popup
+  const handleYesButtonClick = close;
+  const handleNoButtonClick = close;
+
+  const createAndProceedButtonConfig: ButtonConfig = {
+    onClick: handleYesButtonClick,
+    buttonText: ButtonText.CreateAndProceed,
+    isDark: true,
+  };
+  const keepButtonConfig: ButtonConfig = {
+    onClick: handleNoButtonClick,
+    buttonText: ButtonText.Keep,
+  };
+
+  return (
+    <NotificationPopup
+      header={HEADER}
+      leftButtonConfig={createAndProceedButtonConfig}
+      rightButtonConfig={keepButtonConfig}
+      isOpen={true}
+      content={
+        <MuiBox sx={classes.content}>
+          <MuiTypography>{INFO_TEXT_PART_1}</MuiTypography>
+          <MuiTypography>{INFO_TEXT_PART_2}</MuiTypography>
+        </MuiBox>
+      }
+    ></NotificationPopup>
+  );
+}

--- a/src/Frontend/Components/FileSupportPopup/__tests__/FileSupportPopup.test.tsx
+++ b/src/Frontend/Components/FileSupportPopup/__tests__/FileSupportPopup.test.tsx
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { FileSupportPopup, HEADER } from '../FileSupportPopup';
+
+describe('FileSupportPopup', () => {
+  it('renders', () => {
+    renderComponentWithStore(<FileSupportPopup />);
+    expect(screen.getByText(HEADER)).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -21,6 +21,7 @@ import { EditAttributionPopup } from '../EditAttributionPopup/EditAttributionPop
 import { PackageSearchPopup } from '../PackageSearchPopup/PackageSearchPopup';
 import { ChangedInputFilePopup } from '../ChangedInputFilePopup/ChangedInputFilePopup';
 import { AttributionWizardPopup } from '../AttributionWizardPopup/AttributionWizardPopup';
+import { FileSupportPopup } from '../FileSupportPopup/FileSupportPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -52,6 +53,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <ChangedInputFilePopup />;
     case PopupType.AttributionWizardPopup:
       return <AttributionWizardPopup />;
+    case PopupType.FileSupportPopup:
+      return <FileSupportPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -20,7 +20,7 @@ import { setResources } from '../../../state/actions/resource-actions/all-views-
 describe('TopBar', () => {
   it('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(10);
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(11);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
       expect.anything()

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -25,6 +25,7 @@ export enum PopupType {
   PackageSearchPopup = 'PackageSearchPopup',
   ChangedInputFilePopup = 'ChangedInputFilePopup',
   AttributionWizardPopup = 'AttributionWizardPopup',
+  FileSupportPopup = 'FileSupportPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -51,6 +52,7 @@ export enum ButtonText {
   Confirm = 'Confirm',
   ConfirmGlobally = 'Confirm globally',
   ConfirmSelectedGlobally = 'Confirm selected globally',
+  CreateAndProceed = 'Create and proceed',
   Delete = 'Delete',
   DeleteGlobally = 'Delete globally',
   DeleteSelectedGlobally = 'Delete selected globally',

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -24,6 +24,7 @@ export enum AllowedFrontendChannels {
   SaveFileRequest = 'save-file-request',
   SetBaseURLForRoot = 'set-base-url-for-root',
   ShowChangedInputFilePopup = 'show-changed-input-file-pop-up',
+  ShowFileSupportPopup = 'show-file-support-popup',
   ShowSearchPopup = 'show-search-pop-up',
   ShowProjectMetadataPopup = 'show-project-metadata-pop-up',
   ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',


### PR DESCRIPTION
### Summary of changes

Implement a new popup for providing information to the user if an outdated
filetype (other than .opossum) is opened. The corresponding component is
not wired.

### How can the changes be tested

Uncomment lines 58-60 in `importFromFile.ts`, restart application, and open a file. The popup should be displayed. Since it is not wired, the file will load anyway, independent of the user decision.

#### Screenshots of the popup
Initial version:
![Unbenannt](https://user-images.githubusercontent.com/83081698/220075873-3383191a-c85f-4dc8-b99d-f38132e5b371.PNG)

Latest version:
![Unbenannt](https://user-images.githubusercontent.com/83081698/220287026-3e4636f8-d534-4aa7-b043-bac6cbadf0dd.PNG)