### PR TITLE
Add .opossum support: Add script to generate dot opossum files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@
 # testing
 /coverage
 /src/commitInfo.json
+/example-files/*.opossum
 /example-files/*_attributions.json
 /example-files/*_follow_up.csv
 /example-files/*_component_list.csv
 /example-files/*.spdx.yaml
 /example-files/*.spdx.json
+/example-files/performance_tests/*.opossum
 /example-files/performance_tests/*_attributions.json
 /example-files/performance_tests/*_follow_up.csv
 /example-files/performance_tests/*_component_list.csv

--- a/example-files/scripts/generateDotOpossum.js
+++ b/example-files/scripts/generateDotOpossum.js
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const fs = require('fs');
+const JSZip = require('jszip');
+const glob = require('glob');
+const path = require('path');
+
+const exampleFilesDirectory = path.join(__dirname, '..');
+
+const { inputFilePaths, attributionFilePaths } =
+  getInputAndAttributionFilePaths(exampleFilesDirectory);
+
+for (const inputFilePath of inputFilePaths) {
+  const inputFilePathParsed = path.parse(inputFilePath);
+  const inputFileDirectory = inputFilePathParsed.dir;
+  const dotOpossumFileName = `${inputFilePathParsed.name}.opossum`;
+  const dotOpossumFilePath = path.join(inputFileDirectory, dotOpossumFileName);
+
+  if (!fs.existsSync(dotOpossumFilePath)) {
+    const dotOpossumArchive = new JSZip();
+    const dotOpossumWriteStream = fs.createWriteStream(dotOpossumFilePath);
+
+    addInputJsonToArchive(dotOpossumArchive, inputFilePath);
+
+    addAttributionsJsonToArchive(
+      dotOpossumArchive,
+      inputFilePath,
+      attributionFilePaths
+    );
+
+    dotOpossumArchive
+      .generateAsync({
+        type: 'nodebuffer',
+        streamFiles: true,
+        compression: 'DEFLATE',
+        compressionOptions: { level: 9 },
+      })
+      .then((output) => dotOpossumWriteStream.write(output));
+
+    console.log('Created: ' + dotOpossumFilePath);
+  } else {
+    console.log('File does already exist: ' + dotOpossumFilePath);
+  }
+}
+
+function getInputAndAttributionFilePaths(exampleFilesDirectory) {
+  const jsonFilePaths = glob.sync(`${exampleFilesDirectory}/**/*.json`);
+  const inputFilePaths = [];
+  const attributionFilePaths = [];
+  jsonFilePaths.forEach((filePath) =>
+    filePath.endsWith('_attributions.json')
+      ? attributionFilePaths.push(filePath)
+      : inputFilePaths.push(filePath)
+  );
+  return { inputFilePaths, attributionFilePaths };
+}
+
+function addInputJsonToArchive(archive, inputFilePath) {
+  const inputJson = fs.readFileSync(inputFilePath, { encoding: 'utf-8' });
+  archive.file('input.json', inputJson);
+}
+
+function addAttributionsJsonToArchive(
+  archive,
+  inputFilePath,
+  attributionFilePaths
+) {
+  const expectedAssociatedAttributionFilePath =
+    inputFilePath.slice(0, -5) + '_attributions.json';
+  if (attributionFilePaths.includes(expectedAssociatedAttributionFilePath)) {
+    const outputJson = fs.readFileSync(expectedAssociatedAttributionFilePath, {
+      encoding: 'utf-8',
+    });
+    archive.file('output.json', outputJson);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "update-commit-hash": "run-script-os",
     "update-commit-hash:darwin:linux": "COMMIT_INFO=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD); echo \"{\\\"commitInfo\\\" : \\\"$COMMIT_INFO\\\" }\" > \"src/commitInfo.json\";\n",
     "update-commit-hash:win32": "build_scripts/get_app_version_for_windows.bat",
+    "generate-dot-opossum": "yarn node example-files/scripts/generateDotOpossum.js",
     "generate-notice": "run-script-os",
     "generate-notice:darwin:linux": "mkdir -p notices && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",
     "generate-notice:win32": "(if not exist notices (mkdir notices)) && yarn licenses generate-disclaimer --ignore-platform --production > notices/notices.txt && yarn node build_scripts/generateNotices.js",


### PR DESCRIPTION
### Summary of changes

`yarn generate-dot-opossum` scans `example-files` and generates `.opossum` files. `.opossum` files are ignored by git.

### Context and reason for change

Needed for dev. 

### How can the changes be tested

Run script and take a look into `example-files`.