### PR TITLE
Handle attributions with missing package name in terms of styling

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -17,6 +17,7 @@ import { SearchPackagesIcon } from '../Icons/Icons';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
 import { openUrl } from '../../util/open-url';
+import { HighlightingColor } from '../../enums/enums';
 
 const iconClasses = { clickableIcon, disabledIcon };
 
@@ -72,6 +73,7 @@ export function PackageSubPanel(props: PackageSubPanelProps): ReactElement {
               props.displayPackageInfo
             )
           }
+          highlightingColor={HighlightingColor.DarkOrange}
         />
         <TextBox
           sx={{

--- a/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
@@ -10,7 +10,8 @@ import { getManualAttributions } from '../../state/selectors/all-views-resource-
 import { OpossumColors } from '../../shared-styles';
 import {
   FollowUpIcon,
-  IncompletePackagesIcon,
+  IncompleteAttributionsIcon,
+  MissingPackageNameIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import pickBy from 'lodash/pickBy';
@@ -36,6 +37,9 @@ const classes = {
   incompleteAttributionIcon: {
     color: OpossumColors.lightOrange,
   },
+  missingPackageNameIcon: {
+    color: OpossumColors.darkOrange,
+  },
 };
 
 interface AttributionCountsPanelProps {
@@ -56,6 +60,10 @@ export function AttributionCountsPanel(
 
   const numberOfIncompleteAttributions = Object.keys(
     pickBy(attributions, (value: PackageInfo) => isPackageInfoIncomplete(value))
+  ).length;
+
+  const numberOfAttributionsWithoutPackageName = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => !value.packageName)
   ).length;
 
   return (
@@ -80,13 +88,17 @@ export function AttributionCountsPanel(
         }}
       />
       {`, ${numberOfIncompleteAttributions}`}
-      <IncompletePackagesIcon
+      <IncompleteAttributionsIcon
         sx={{
           ...classes.incompleteAttributionIcon,
           ...classes.icons,
         }}
       />
-      )
+      {`, ${numberOfAttributionsWithoutPackageName}`}
+      <MissingPackageNameIcon
+        sx={{ ...classes.icons, ...classes.missingPackageNameIcon }}
+      />
+      {')'}
     </MuiTypography>
   );
 }

--- a/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
@@ -34,7 +34,7 @@ describe('The Attribution Counts Panel', () => {
     [testOtherManualUuid]: {
       attributionConfidence: 0,
       comment: 'Some other comment',
-      packageName: 'Test other package',
+      packageName: '',
       packageVersion: '2.0',
       copyright: 'other Copyright John Doe',
       licenseText: 'Some other license text',
@@ -60,7 +60,8 @@ describe('The Attribution Counts Panel', () => {
     act(() => {
       store.dispatch(navigateToView(View.Attribution));
     });
-
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(
+      screen.getByText(/Attributions \(2 total, 1, 0, 1, 1\)/, { exact: true })
+    );
   });
 });

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -226,7 +226,7 @@ export function SearchPackagesIcon(props: IconProps): ReactElement {
   );
 }
 
-export function IncompletePackagesIcon(props: IconProps): ReactElement {
+export function IncompleteAttributionsIcon(props: IconProps): ReactElement {
   return (
     <MuiTooltip sx={classes.tooltip} title="contains incomplete information">
       <RectangleIcon
@@ -249,6 +249,20 @@ export function ManuallyAddedListItemIcon(props: IconProps): ReactElement {
       placement={'left'}
     >
       <AutoAwesomeIcon sx={props.sx} />
+    </MuiTooltip>
+  );
+}
+
+export function MissingPackageNameIcon(props: IconProps): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="is missing a package name">
+      <RectangleIcon
+        aria-label={'Missing packagename icon'}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
+      />
     </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -14,7 +14,7 @@ import {
   FileIcon,
   FirstPartyIcon,
   FollowUpIcon,
-  IncompletePackagesIcon,
+  IncompleteAttributionsIcon,
   PreSelectedIcon,
   SearchPackagesIcon,
   SignalIcon,
@@ -70,7 +70,7 @@ describe('The Icons', () => {
   });
 
   it('renders IncompletePackagesIcon', () => {
-    render(<IncompletePackagesIcon />);
+    render(<IncompleteAttributionsIcon />);
 
     expect(screen.getByLabelText('Incomplete icon'));
   });

--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -55,7 +55,9 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
         freeSolo
         sx={{
           ...(props.isHighlighted
-            ? { '&.MuiAutocomplete-root': classes.highlightedTextField }
+            ? {
+                '&.MuiAutocomplete-root': classes.defaultHighlightedTextField,
+              }
             : {}),
           ...classes.popper,
         }}

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -42,7 +42,7 @@ export function Dropdown(props: DropdownProps): ReactElement {
         sx={{
           ...inputElementClasses.textField,
           ...(props.isHighlighted
-            ? inputElementClasses.highlightedTextField
+            ? inputElementClasses.defaultHighlightedTextField
             : {}),
         }}
         select

--- a/src/Frontend/Components/InputElements/NumberBox.tsx
+++ b/src/Frontend/Components/InputElements/NumberBox.tsx
@@ -23,7 +23,7 @@ export function NumberBox(props: NumericProps): ReactElement {
         sx={{
           ...inputElementClasses.textField,
           ...(props.isHighlighted
-            ? inputElementClasses.highlightedTextField
+            ? inputElementClasses.defaultHighlightedTextField
             : {}),
         }}
         label={props.title}

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -9,6 +9,9 @@ import { inputElementClasses, InputElementProps } from './shared';
 import MuiInputAdornment from '@mui/material/InputAdornment';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
+import { HighlightingColor } from '../../enums/enums';
+import { SystemStyleObject } from '@mui/system/styleFunctionSx';
+import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 interface TextProps extends InputElementProps {
   textFieldSx?: SxProps;
@@ -17,20 +20,32 @@ interface TextProps extends InputElementProps {
   maxRows?: number;
   endIcon?: ReactElement;
   multiline?: boolean;
+  highlightingColor?: HighlightingColor;
 }
 
 export function TextBox(props: TextProps): ReactElement {
+  const isDefaultHighlighting =
+    props.highlightingColor === HighlightingColor.LightOrange ||
+    props.highlightingColor === undefined;
+
+  const highlightedStyling = isDefaultHighlighting
+    ? inputElementClasses.defaultHighlightedTextField
+    : props.highlightingColor === HighlightingColor.DarkOrange
+    ? inputElementClasses.strongHighlightedTextField
+    : {};
+
+  const textBoxSx = getSxFromPropsAndClasses({
+    sxProps: props.isHighlighted ? highlightedStyling : {},
+    styleClass: {
+      ...(props.textFieldSx as SystemStyleObject),
+      ...inputElementClasses.textField,
+    },
+  });
   return (
     <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
-        sx={{
-          ...props.textFieldSx,
-          ...inputElementClasses.textField,
-          ...(props.isHighlighted
-            ? inputElementClasses.highlightedTextField
-            : {}),
-        }}
+        sx={textBoxSx}
         label={props.title}
         InputProps={{
           inputProps: {

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -35,13 +35,23 @@ export const inputElementClasses = {
       },
     },
   },
-  highlightedTextField: {
+  defaultHighlightedTextField: {
     '& div': {
       backgroundColor: OpossumColors.lightOrange,
       borderRadius: '0px',
     },
     '& label': {
       backgroundColor: OpossumColors.lightOrange,
+      padding: '1px 3px',
+    },
+  },
+  strongHighlightedTextField: {
+    '& div': {
+      backgroundColor: OpossumColors.darkOrange,
+      borderRadius: '0px',
+    },
+    '& label': {
+      backgroundColor: OpossumColors.darkOrange,
       padding: '1px 3px',
     },
   },

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -11,25 +11,13 @@ import { Criticality } from '../../../shared/shared-types';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
 import { merge } from 'lodash';
+import { HighlightingColor } from '../../enums/enums';
 
 const defaultCardHeight = '40px';
 const hoveredSelectedBackgroundColor = OpossumColors.middleBlueOnHover;
 const hoveredBackgroundColor = OpossumColors.lightestBlueOnHover;
 const defaultBackgroundColor = OpossumColors.lightestBlue;
 const packageBorder = `1px ${OpossumColors.white} solid`;
-
-const getHighlightedBackground = (
-  highlightColor: string,
-  backgroundColor: string
-): string => {
-  return (
-    'linear-gradient(225deg, ' +
-    highlightColor +
-    ' 44.5px, ' +
-    backgroundColor +
-    ' 0) 0 0/100% 40px no-repeat'
-  );
-};
 
 const classes = {
   root: {
@@ -54,19 +42,6 @@ const classes = {
       background: hoveredBackgroundColor,
     },
   },
-  highlightedPackage: {
-    border: packageBorder,
-    background: getHighlightedBackground(
-      OpossumColors.lightOrange,
-      defaultBackgroundColor
-    ),
-    '&:hover': {
-      background: getHighlightedBackground(
-        OpossumColors.lightOrangeOnHover,
-        hoveredBackgroundColor
-      ),
-    },
-  },
   externalAttribution: {
     background: defaultBackgroundColor,
     '&:hover': {
@@ -87,18 +62,6 @@ const classes = {
     background: OpossumColors.middleBlue,
     '&:hover': {
       background: hoveredSelectedBackgroundColor,
-    },
-  },
-  highlightedSelected: {
-    background: getHighlightedBackground(
-      OpossumColors.lightOrange,
-      OpossumColors.middleBlue
-    ),
-    '&:hover': {
-      background: getHighlightedBackground(
-        OpossumColors.lightOrangeOnHover,
-        hoveredSelectedBackgroundColor
-      ),
     },
   },
   hoveredSelected: {
@@ -199,7 +162,7 @@ interface ListCardProps {
   leftIcon?: JSX.Element;
   rightIcons?: Array<JSX.Element>;
   leftElement?: JSX.Element;
-  highlightedCard?: boolean;
+  highlighting?: HighlightingColor;
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
@@ -216,7 +179,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
   }
 
   return (
-    <MuiBox sx={getSx(props.cardConfig, props.highlightedCard)}>
+    <MuiBox sx={getSx(props.cardConfig, props.highlighting)}>
       {props.leftElement ? props.leftElement : null}
       <MuiBox
         sx={{
@@ -287,7 +250,10 @@ export function ListCard(props: ListCardProps): ReactElement | null {
   );
 }
 
-function getSx(cardConfig: ListCardConfig, highlightedCard?: boolean): SxProps {
+function getSx(
+  cardConfig: ListCardConfig,
+  highlighting?: HighlightingColor
+): SxProps {
   let sxProps: SxProps = { ...classes.root };
 
   if (cardConfig.isResource) {
@@ -326,15 +292,78 @@ function getSx(cardConfig: ListCardConfig, highlightedCard?: boolean): SxProps {
     if (cardConfig.isContextMenuOpen) {
       sxProps = merge(sxProps, classes.hoveredSelected);
     } else {
-      if (highlightedCard) {
-        sxProps = merge(sxProps, classes.highlightedSelected);
+      if (highlighting) {
+        sxProps = merge(
+          sxProps,
+          getHighlightedListCardStyle(highlighting, true)
+        );
       } else {
         sxProps = merge(sxProps, classes.selected);
       }
     }
-  } else if (highlightedCard) {
-    sxProps = merge(sxProps, classes.highlightedPackage);
+  } else if (highlighting) {
+    sxProps = merge(sxProps, getHighlightedListCardStyle(highlighting, false));
   }
 
   return sxProps;
+}
+
+function getHighlightedListCardStyle(
+  color: HighlightingColor,
+  selected: boolean
+): SxProps {
+  const highlightColor =
+    color === HighlightingColor.LightOrange
+      ? OpossumColors.lightOrange
+      : OpossumColors.darkOrange;
+  const backgroundColor = selected
+    ? OpossumColors.middleBlue
+    : defaultBackgroundColor;
+  const highlightColorOnHover =
+    color === HighlightingColor.LightOrange
+      ? OpossumColors.lightOrangeOnHover
+      : OpossumColors.darkOrangeOnHover;
+  const backgroundColorOnHover = selected
+    ? hoveredSelectedBackgroundColor
+    : hoveredBackgroundColor;
+
+  return getHighlightedStyleClass(
+    highlightColor,
+    backgroundColor,
+    highlightColorOnHover,
+    backgroundColorOnHover,
+    packageBorder
+  );
+}
+
+function getHighlightedStyleClass(
+  highlightColor: string,
+  backgroundColor: string,
+  highlightColorOnHover: string,
+  backgroundColorOnHover: string,
+  border: string
+): SxProps {
+  return {
+    border,
+    background: getHighlightedBackground(highlightColor, backgroundColor),
+    '&:hover': {
+      background: getHighlightedBackground(
+        highlightColorOnHover,
+        backgroundColorOnHover
+      ),
+    },
+  };
+}
+
+function getHighlightedBackground(
+  highlightColor: string,
+  backgroundColor: string
+): string {
+  return (
+    'linear-gradient(225deg, ' +
+    highlightColor +
+    ' 44.5px, ' +
+    backgroundColor +
+    ' 0) 0 0/100% 40px no-repeat'
+  );
 }

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -50,10 +50,13 @@ import {
   setMultiSelectSelectedAttributionIds,
 } from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { Checkbox } from '../Checkbox/Checkbox';
-import { getKey, getRightIcons } from './package-card-helpers';
+import {
+  getKey,
+  getPackageCardHighlighting,
+  getRightIcons,
+} from './package-card-helpers';
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { PackageInfo } from '../../../shared/shared-types';
-import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
 
 const classes = {
@@ -139,9 +142,10 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       : undefined,
   };
 
-  const highlightedAttribution =
-    selectedView === View.Attribution &&
-    isPackageInfoIncomplete(manualAttributions[attributionId]);
+  const highlighting =
+    selectedView === View.Attribution
+      ? getPackageCardHighlighting(manualAttributions[attributionId])
+      : undefined;
 
   function getContextMenuItems(): Array<ContextMenuItem> {
     function openConfirmDeletionPopup(): void {
@@ -424,7 +428,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             openResourcesIcon
           )}
           leftElement={leftElement}
-          highlightedCard={highlightedAttribution}
+          highlighting={highlighting}
         />
       </ContextMenu>
     </MuiBox>

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -12,6 +12,9 @@ import {
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
+import { PackageInfo } from '../../../shared/shared-types';
+import { HighlightingColor } from '../../enums/enums';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 
 export function getKey(prefix: string, cardId: string): string {
   return `${prefix}-${cardId}`;
@@ -65,4 +68,15 @@ export function getRightIcons(
   }
 
   return rightIcons;
+}
+
+export function getPackageCardHighlighting(
+  packageInfo: PackageInfo
+): HighlightingColor | undefined {
+  if (!packageInfo) return undefined;
+  if (packageInfo.packageName === undefined)
+    return HighlightingColor.DarkOrange;
+  return isPackageInfoIncomplete(packageInfo)
+    ? HighlightingColor.LightOrange
+    : undefined;
 }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -98,3 +98,8 @@ export enum CriticalityTypes {
   MediumCriticality = 'Medium',
   NoCriticality = 'Not critical',
 }
+
+export enum HighlightingColor {
+  LightOrange = 'Light Orange',
+  DarkOrange = 'Dark Orange',
+}

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -35,6 +35,8 @@ export const OpossumColors = {
   mediumOrange: 'hsl(20, 100%, 72%)',
   orange: 'hsl(16, 100%, 50%)',
   pastelRed: 'hsl(0, 70%, 70%)',
+  darkOrange: 'hsl(20, 80%, 78%)',
+  darkOrangeOnHover: 'hsl(20, 80%, 65%)',
   red: 'hsl(0, 100%, 45%)',
   brown: 'hsl(33, 55%, 44%)',
 };


### PR DESCRIPTION
### Summary of changes

If the package name is missing, the package cards in attribution view are highlighted with dark orange color. The background color of the corresponding text box changes accordingly.

### Context and reason for change

The user gets more feedback and is alerted if the package name is missing.

Screenshot:
![Unbenannt](https://user-images.githubusercontent.com/83081698/220964979-5a2cb513-14cf-43bd-9c12-1dd0eb9715a9.PNG)

