### PR TITLE
Opossum format in backend state

### DIFF
--- a/src/ElectronBackend/enums/enums.ts
+++ b/src/ElectronBackend/enums/enums.ts
@@ -7,3 +7,8 @@ export enum UserRoles {
   Vetting = 'VETTING',
   QA = 'QA',
 }
+
+export enum LoadedFileFormat {
+  Opossum = 'OPOSSUM',
+  Json = 'JSON',
+}

--- a/src/ElectronBackend/errorHandling/errorHandling.ts
+++ b/src/ElectronBackend/errorHandling/errorHandling.ts
@@ -15,6 +15,7 @@ import log from 'electron-log';
 import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import { loadInputAndOutputFromFilePath } from '../input/importFromFile';
 import { getGlobalBackendState } from '../main/globalBackendState';
+import { getLoadedFilePath } from '../utils/getLoadedFile';
 
 export function createListenerCallbackWithErrorHandling(
   webContents: WebContents,
@@ -124,7 +125,7 @@ function performButtonAction(
       webContents.send(AllowedFrontendChannels.RestoreFrontend);
       loadInputAndOutputFromFilePath(
         webContents,
-        globalBackendState.resourceFilePath as string
+        getLoadedFilePath(globalBackendState) as string
       );
       break;
     case 1:

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -39,9 +39,9 @@ import {
   parseInputJsonFile,
   parseOutputJsonFile,
   parseOpossumFile,
-  addOutputToOpossumFile,
 } from './parseFile';
 import { isOpossumFileFormat } from '../utils/isOpossumFileFormat';
+import { writeOutputJsonToOpossumFile } from '../output/writeJsonToOpossumFile';
 
 function isJsonParsingError(object: unknown): object is JsonParsingError {
   return (object as JsonParsingError).type === 'jsonParsingError';
@@ -90,7 +90,6 @@ export async function loadInputAndOutputFromFilePath(
   const [externalAttributions, inputContainsCriticalExternalAttributions] =
     parseRawAttributions(parsedInputData.externalAttributions);
   const projectId = parsedInputData.metadata.projectId;
-  const inputFileMD5Checksum = getGlobalBackendState().inputFileChecksum;
   const resourcesToAttributions = parsedInputData.resourcesToAttributions;
 
   if (parsedOutputData === null) {
@@ -106,6 +105,7 @@ export async function loadInputAndOutputFromFilePath(
         filePath,
         '_attributions.json'
       );
+      const inputFileMD5Checksum = getGlobalBackendState().inputFileChecksum;
       parsedOutputData = parseOrCreateOutputJsonFile(
         outputJsonPath,
         externalAttributions,
@@ -191,7 +191,7 @@ async function createOutputInOpossumFile(
     resourcesToExternalAttributions,
     projectId
   );
-  await addOutputToOpossumFile(filePath, attributionJSON);
+  await writeOutputJsonToOpossumFile(filePath, attributionJSON);
   log.info('... Successfully wrote output in .opssum file.');
 
   log.info(`Starting to parse output file in ${filePath} ...`);

--- a/src/ElectronBackend/input/parseFile.ts
+++ b/src/ElectronBackend/input/parseFile.ts
@@ -17,7 +17,6 @@ import * as OpossumOutputFileSchema from './OpossumOutputFileSchema.json';
 import Asm from 'stream-json/Assembler';
 import { Parser, parser } from 'stream-json';
 import JSZip from 'jszip';
-import log from 'electron-log';
 
 const jsonSchemaValidator = new Validator();
 const validationOptions: Options = {
@@ -66,35 +65,6 @@ export async function parseOpossumFile(
     input: parsedInputData as ParsedOpossumInputFile,
     output: parsedOutputData as ParsedOpossumOutputFile,
   };
-}
-
-export async function addOutputToOpossumFile(
-  opossumfilePath: string,
-  outputfileData: unknown
-): Promise<void> {
-  const new_zip = new JSZip();
-
-  await new Promise<void>((resolve) => {
-    fs.readFile(opossumfilePath, (err, data) => {
-      if (err) throw err;
-      new_zip.loadAsync(data).then(() => {
-        new_zip.file('output.json', JSON.stringify(outputfileData));
-        const writeStream = fs.createWriteStream(opossumfilePath);
-        new_zip
-          .generateNodeStream({
-            type: 'nodebuffer',
-            streamFiles: true,
-            compression: 'DEFLATE',
-            compressionOptions: { level: 1 },
-          })
-          .pipe(writeStream)
-          .on('finish', () => {
-            log.info('opossum file was overwritten!');
-            resolve();
-          });
-      });
-    });
-  });
 }
 
 export function parseInputJsonFile(

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -17,6 +17,7 @@ import {
   getPathOfNoticeDocument,
 } from './notice-document-helpers';
 import { ExportType } from '../../shared/shared-types';
+import { isFileLoaded } from '../utils/getLoadedFile';
 
 export function createMenu(mainWindow: BrowserWindow): Menu {
   const webContents = mainWindow.webContents;
@@ -99,7 +100,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         {
           label: 'Project Metadata',
           click(): void {
-            if (getGlobalBackendState().resourceFilePath) {
+            if (isFileLoaded(getGlobalBackendState())) {
               webContents.send(
                 AllowedFrontendChannels.ShowProjectMetadataPopup,
                 {
@@ -112,7 +113,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
         {
           label: 'Project Statistics',
           click(): void {
-            if (getGlobalBackendState().resourceFilePath) {
+            if (isFileLoaded(getGlobalBackendState())) {
               webContents.send(
                 AllowedFrontendChannels.ShowProjectStatisticsPopup,
                 {
@@ -152,7 +153,7 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           label: 'Search for Files and Directories',
           accelerator: 'CmdOrCtrl+F',
           click(): void {
-            if (getGlobalBackendState().resourceFilePath) {
+            if (isFileLoaded(getGlobalBackendState())) {
               webContents.send(AllowedFrontendChannels.ShowSearchPopup, {
                 showSearchPopup: true,
               });

--- a/src/ElectronBackend/output/__tests__/writeJsonToOpossumFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeJsonToOpossumFile.test.ts
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import * as path from 'path';
+import * as upath from 'upath';
+import {
+  OpossumOutputFile,
+  ParsedOpossumInputAndOutput,
+  ParsedOpossumInputFile,
+  ParsedOpossumOutputFile,
+} from '../../types/types';
+import { Criticality, FollowUp } from '../../../shared/shared-types';
+import { createTempFolder, deleteFolder } from '../../test-helpers';
+import {
+  writeOpossumFile,
+  writeOutputJsonToOpossumFile,
+} from '../writeJsonToOpossumFile';
+import { parseOpossumFile } from '../../input/parseFile';
+
+const metadata = {
+  projectId: '2a58a469-738e-4508-98d3-a27bce6e71f7',
+  fileCreationDate: '2',
+};
+
+const inputFileContent: ParsedOpossumInputFile = {
+  metadata,
+  resources: {
+    a: 1,
+    folder: {},
+  },
+  externalAttributions: {
+    uuid_1: {
+      source: {
+        name: 'REUSER:HHC',
+        documentConfidence: 13,
+      },
+      packageName: 'my app',
+      packageVersion: '1.2.3',
+      packageNamespace: 'org.apache.xmlgraphics',
+      packageType: 'maven',
+      packagePURLAppendix:
+        '?repository_url=repo.spring.io/release#everybody/loves/dogs',
+      copyright: '(c) first party',
+      firstParty: true,
+      excludeFromNotice: true,
+      criticality: Criticality.High,
+    },
+  },
+  frequentLicenses: [
+    {
+      shortName: 'MIT',
+      fullName: 'MIT license',
+      defaultText: 'MIT license text',
+    },
+  ],
+  resourcesToAttributions: {
+    '/a': ['uuid_1'],
+    '/folder': ['uuid_1'],
+  },
+  externalAttributionSources: {
+    SC: { name: 'ScanCode', priority: 1000 },
+    OTHERSOURCE: { name: 'Crystal ball', priority: 2 },
+  },
+};
+
+const outputFileContent: OpossumOutputFile = {
+  metadata,
+  manualAttributions: {
+    uuid_2: {
+      packageName: 'minimal attribution',
+    },
+    uuid_3: {
+      packageName: 'full info attribution',
+      packageVersion: '1.0',
+      packageNamespace: 'org.apache.xmlgraphics',
+      packagePURLAppendix:
+        '?repository_url=repo.spring.io/release#everybody/loves/dogs',
+      packageType: 'maven',
+      firstParty: true,
+      followUp: FollowUp,
+      attributionConfidence: 100,
+      comment: 'I found it!',
+      url: 'https://www.theauthor.com/package',
+      copyright: '(c) many people 1989',
+      licenseName: 'MIT',
+      licenseText: 'This is totally an MIT license!!111!',
+      originId: '846f978e-8479-4b25-a010-63c1deac2e45',
+    },
+  },
+  resourcesToAttributions: {
+    mypath: ['uuid_1', 'uuid_2'],
+  },
+  resolvedExternalAttributions: [],
+};
+
+const parsedOutputFileContent: ParsedOpossumOutputFile = {
+  metadata,
+  manualAttributions: {
+    uuid_2: {
+      packageName: 'minimal attribution',
+    },
+    uuid_3: {
+      packageName: 'full info attribution',
+      packageVersion: '1.0',
+      packageNamespace: 'org.apache.xmlgraphics',
+      packagePURLAppendix:
+        '?repository_url=repo.spring.io/release#everybody/loves/dogs',
+      packageType: 'maven',
+      firstParty: true,
+      followUp: FollowUp,
+      attributionConfidence: 100,
+      comment: 'I found it!',
+      url: 'https://www.theauthor.com/package',
+      copyright: '(c) many people 1989',
+      licenseName: 'MIT',
+      licenseText: 'This is totally an MIT license!!111!',
+      originId: '846f978e-8479-4b25-a010-63c1deac2e45',
+    },
+  },
+  resourcesToAttributions: {
+    mypath: ['uuid_1', 'uuid_2'],
+  },
+  resolvedExternalAttributions: new Set(),
+};
+
+describe('writeOutputJsonToOpossumFile', () => {
+  it('writes new output', async () => {
+    const temporaryPath: string = createTempFolder();
+    const opossumPath = path.join(upath.toUnix(temporaryPath), 'test.opossum');
+    await writeOpossumFile(opossumPath, inputFileContent, null);
+
+    await writeOutputJsonToOpossumFile(opossumPath, outputFileContent);
+
+    const parsingResult = (await parseOpossumFile(
+      opossumPath
+    )) as ParsedOpossumInputAndOutput;
+    expect(parsingResult.input).toStrictEqual(inputFileContent);
+    expect(parsingResult.output).toStrictEqual(parsedOutputFileContent);
+
+    deleteFolder(temporaryPath);
+  });
+
+  it('overwrites existing output', async () => {
+    const temporaryPath: string = createTempFolder();
+    const opossumPath = path.join(upath.toUnix(temporaryPath), 'test.opossum');
+    const outputToBeOverwritten = { test: 'test' };
+    await writeOpossumFile(
+      opossumPath,
+      inputFileContent,
+      outputToBeOverwritten
+    );
+
+    await writeOutputJsonToOpossumFile(opossumPath, outputFileContent);
+
+    const parsingResult = (await parseOpossumFile(
+      opossumPath
+    )) as ParsedOpossumInputAndOutput;
+    expect(parsingResult.input).toStrictEqual(inputFileContent);
+    expect(parsingResult.output).toStrictEqual(parsedOutputFileContent);
+
+    deleteFolder(temporaryPath);
+  });
+});

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -23,6 +23,7 @@ export interface GlobalBackendState {
   projectTitle?: string;
   resourceFilePath?: string;
   attributionFilePath?: string;
+  opossumFilePath?: string;
   followUpFilePath?: string;
   compactBomFilePath?: string;
   detailedBomFilePath?: string;

--- a/src/ElectronBackend/utils/__tests__/getLoadedFile.test.ts
+++ b/src/ElectronBackend/utils/__tests__/getLoadedFile.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { LoadedFileFormat } from '../../enums/enums';
+import { GlobalBackendState } from '../../types/types';
+import {
+  getLoadedFilePath,
+  getLoadedFileType,
+  isFileLoaded,
+} from '../getLoadedFile';
+
+describe('getLoadedFilePath', () => {
+  it('Finds json file', () => {
+    const resourceFilePath = '/some/path.json';
+    const attributionFilePath = '/some/other_path.json';
+    const globalBackendState: GlobalBackendState = {
+      resourceFilePath,
+      attributionFilePath,
+    };
+
+    const loadedFilePath = getLoadedFilePath(globalBackendState);
+    expect(loadedFilePath).toEqual(resourceFilePath);
+  });
+
+  it('Finds opossum file', () => {
+    const opossumFilePath = '/some/path.opossum';
+    const globalBackendState: GlobalBackendState = {
+      opossumFilePath,
+    };
+
+    const loadedFilePath = getLoadedFilePath(globalBackendState);
+    expect(loadedFilePath).toEqual(opossumFilePath);
+  });
+
+  it('Returns null if no input file exists', () => {
+    const globalBackendState: GlobalBackendState = {};
+
+    const loadedFilePath = getLoadedFilePath(globalBackendState);
+    expect(loadedFilePath).toBeNull;
+  });
+});
+
+describe('isFileLoaded', () => {
+  it('Finds json file', () => {
+    const resourceFilePath = '/some/path.json';
+    const globalBackendState: GlobalBackendState = {
+      resourceFilePath,
+    };
+
+    expect(isFileLoaded(globalBackendState));
+  });
+
+  it('Finds opossum file', () => {
+    const opossumFilePath = '/some/path.opossum';
+    const globalBackendState: GlobalBackendState = {
+      opossumFilePath,
+    };
+
+    expect(isFileLoaded(globalBackendState));
+  });
+
+  it('Returns false', () => {
+    const globalBackendState: GlobalBackendState = {};
+
+    expect(!isFileLoaded(globalBackendState));
+  });
+});
+
+describe('getLoadedFileType', () => {
+  it('Finds json file', () => {
+    const resourceFilePath = '/some/path.json';
+    const globalBackendState: GlobalBackendState = {
+      resourceFilePath,
+    };
+
+    const loadedFileType = getLoadedFileType(globalBackendState);
+    expect(loadedFileType).toEqual(LoadedFileFormat.Json);
+  });
+
+  it('Finds opossum file', () => {
+    const opossumFilePath = '/some/path.opossum';
+    const globalBackendState: GlobalBackendState = {
+      opossumFilePath,
+    };
+
+    const loadedFileType = getLoadedFileType(globalBackendState);
+    expect(loadedFileType).toEqual(LoadedFileFormat.Opossum);
+  });
+
+  it('Throws error if no file exists', () => {
+    const globalBackendState: GlobalBackendState = {};
+
+    expect(() => getLoadedFileType(globalBackendState)).toThrow(
+      'Tried to get file type when no file is loaded'
+    );
+  });
+});

--- a/src/ElectronBackend/utils/getLoadedFile.ts
+++ b/src/ElectronBackend/utils/getLoadedFile.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { LoadedFileFormat } from '../enums/enums';
+import { GlobalBackendState } from '../types/types';
+
+export function getLoadedFilePath(
+  globalBackendState: GlobalBackendState
+): string | null {
+  if (globalBackendState.resourceFilePath) {
+    return globalBackendState.resourceFilePath;
+  } else if (globalBackendState.opossumFilePath) {
+    return globalBackendState.opossumFilePath;
+  }
+  return null;
+}
+
+export function isFileLoaded(globalBackendState: GlobalBackendState): boolean {
+  return (
+    globalBackendState.resourceFilePath !== undefined ||
+    globalBackendState.opossumFilePath !== undefined
+  );
+}
+
+export function getLoadedFileType(
+  globalBackendState: GlobalBackendState
+): LoadedFileFormat {
+  if (globalBackendState.resourceFilePath) {
+    return LoadedFileFormat.Json;
+  } else if (globalBackendState.opossumFilePath) {
+    return LoadedFileFormat.Opossum;
+  } else throw Error('Tried to get file type when no file is loaded');
+}


### PR DESCRIPTION
### Summary of changes

Previously, paths to `.opossum` files and input `.json` files were both stored in the same field `GlobalBackendState.resourceFilePath`. We add a field `GlobalBackendState.opossumFilePath` for .opossum files.

### Context and reason for change

This makes it clear in the code which type of file is is loaded.