### PR TITLE
Disallow magic numbers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,10 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 2,
     '@typescript-eslint/await-thenable': 2,
     '@typescript-eslint/require-await': 2,
+    '@typescript-eslint/no-magic-numbers': [
+      'error',
+      { ignore: [-1, 0, 1, 2, 100] },
+    ],
     '@typescript-eslint/no-unnecessary-type-assertion': 2,
     'object-shorthand': 2,
     'react/prop-types': 'off',

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -203,7 +203,10 @@ describe('Test of loading function', () => {
       corruptJsonPath
     );
 
-    expect(mainWindow.webContents.send).toHaveBeenCalledTimes(3);
+    const expectedNumberOfCalls = 3;
+    expect(mainWindow.webContents.send).toHaveBeenCalledTimes(
+      expectedNumberOfCalls
+    );
 
     expect(getMessageBoxForParsingError).toHaveBeenCalled();
     expect(getGlobalBackendState()).toEqual(expectedBackendState);

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -53,7 +53,8 @@ describe('cleanNonExistentAttributions', () => {
       '/file1': ['attr2', 'attr4'],
       '/file3': ['attr4'],
     });
-    expect(mockCallback.mock.calls.length).toBe(3);
+    const expectedNumberOfCalls = 3;
+    expect(mockCallback.mock.calls.length).toBe(expectedNumberOfCalls);
     expect(mockCallback.mock.calls[0][1]).toContain('/file1');
     expect(mockCallback.mock.calls[1][1]).toContain('/file2');
     expect(mockCallback.mock.calls[2][1]).toContain('/file4');

--- a/src/ElectronBackend/main/__tests__/main.test.ts
+++ b/src/ElectronBackend/main/__tests__/main.test.ts
@@ -58,7 +58,8 @@ describe('The App backend', () => {
   it('calls ipc handler', async () => {
     await main();
 
-    expect(ipcMain.handle).toHaveBeenCalledTimes(10);
+    const expectedTotalNumberOfCalls = 10;
+    expect(ipcMain.handle).toHaveBeenCalledTimes(expectedTotalNumberOfCalls);
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
       1,
       IpcChannel.ConvertInputFile,
@@ -70,42 +71,49 @@ describe('The App backend', () => {
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       3,
       IpcChannel.OpenDotOpossumFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       4,
       IpcChannel.OpenFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       5,
       IpcChannel.SaveFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       6,
       IpcChannel.DeleteFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       7,
       IpcChannel.KeepFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       8,
       IpcChannel.SendErrorInformation,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       9,
       IpcChannel.ExportFile,
       expect.any(Function)
     );
     expect(ipcMain.handle).toHaveBeenNthCalledWith(
-      10,
+      expectedTotalNumberOfCalls,
       IpcChannel.OpenLink,
       expect.any(Function)
     );

--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -147,6 +147,7 @@ describe('writeCsvToFile', () => {
     };
 
     const expectedResources =
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       manyResources.slice(0, 225).join('\n') +
       ' ... (resources shortened, 25 paths are not displayed)';
 
@@ -438,8 +439,9 @@ describe('writeCsvToFile', () => {
       },
     };
 
+    const maxLength = 30000;
     const expectedLicenseText =
-      testLicenseText.substring(0, 30000) + '... (text shortened)';
+      testLicenseText.substring(0, maxLength) + '... (text shortened)';
 
     const temporaryPath: string = createTempFolder();
     const csvPath = path.join(upath.toUnix(temporaryPath), 'test.csv');

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -11,12 +11,20 @@ import {
 } from '../attribution-column-helpers';
 
 describe('The AttributionColumn helpers', () => {
+  const windowHeight = 1080;
+
   it('getLicenseTextMaxRows in audit view', () => {
-    expect(getLicenseTextMaxRows(1080, View.Audit)).toEqual(29);
+    const expectedLicenseTextMaxRows = 29;
+    expect(getLicenseTextMaxRows(windowHeight, View.Audit)).toEqual(
+      expectedLicenseTextMaxRows
+    );
   });
 
   it('getLicenseTextMaxRows in attribution view', () => {
-    expect(getLicenseTextMaxRows(1080, View.Attribution)).toEqual(31);
+    const expectedLicenseTextMaxRows = 31;
+    expect(getLicenseTextMaxRows(windowHeight, View.Attribution)).toEqual(
+      expectedLicenseTextMaxRows
+    );
   });
 
   it('selectedPackageIsResolved returns true', () => {

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -53,8 +53,10 @@ export function getLicenseTextMaxRows(
 ): number {
   const heightOfTextBoxes = 480;
   const heightOfNonLicenseTextComponents =
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     heightOfTextBoxes + (view === View.Audit ? 34 : 0);
   const licenseTextMaxHeight = windowHeight - heightOfNonLicenseTextComponents;
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   return Math.floor(licenseTextMaxHeight / 19);
 }
 
@@ -292,6 +294,7 @@ export function useRows(
   commentRows: number;
 } {
   const [isLicenseTextShown, setIsLicenseTextShown] = useState<boolean>(false);
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const reduceRowsCount = smallerLicenseTextOrCommentField ? 5 : 1;
   const licenseTextRows =
     getLicenseTextMaxRows(useWindowHeight(), view) - reduceRowsCount;
@@ -300,6 +303,7 @@ export function useRows(
     setIsLicenseTextShown(false);
   }, [resetViewIfThisIdChanges]);
 
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const copyrightRows = isLicenseTextShown ? 1 : 6;
   const commentRows = isLicenseTextShown
     ? 1

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -58,6 +58,7 @@ export function AttributionView(): ReactElement {
     setShowMultiselect(!showMultiSelect);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const countAndSearchAndFilterOffset = showMultiSelect ? 137 : 80;
 
   return (

--- a/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/attribution-wizard-popup-helpers.tsx
@@ -102,7 +102,8 @@ export function getAttributionWizardListItems(
 }
 
 function getCountText(count: number, totalAttributeCount: number): string {
-  const percentage = (count / totalAttributeCount) * 100;
+  const percentageFactor = 100;
+  const percentage = (count / totalAttributeCount) * percentageFactor;
   return percentage < 1
     ? `${count} (< 1%)`
     : `${count} (${percentage.toFixed(0)}%)`;

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -16,7 +16,8 @@ import { Attributions, ExportType } from '../../../../shared/shared-types';
 describe('BackendCommunication', () => {
   it('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(11);
+    const expectedNumberOfCalls = 11;
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(expectedNumberOfCalls);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
       expect.anything()

--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -128,6 +128,7 @@ export function ContextMenu(props: ContextMenuProps): ReactElement | null {
     }
     setAnchorPosition({
       left: event.clientX - 2,
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       top: event.clientY - 4,
     });
     setAnchorElement(event.currentTarget);

--- a/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/Frontend/Components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -44,7 +44,10 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
 
-    expect(window.electronAPI.sendErrorInformation).toHaveBeenCalledTimes(3);
+    const expectedNumberOfCalls = 3;
+    expect(window.electronAPI.sendErrorInformation).toHaveBeenCalledTimes(
+      expectedNumberOfCalls
+    );
 
     expect(window.electronAPI.on).toHaveBeenCalledTimes(1);
     expect(window.electronAPI.on).toHaveBeenCalledWith(

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -6,10 +6,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { ReactElement, ReactNode } from 'react';
 import {
-  FetchLicenseInformationButton,
-  FetchStatus,
   FETCH_DATA_BUTTON_DISABLED_TOOLTIP,
   FETCH_DATA_TOOLTIP,
+  FetchLicenseInformationButton,
+  FetchStatus,
   useFetchPackageInfo,
 } from '../FetchLicenseInformationButton';
 import {
@@ -66,8 +66,9 @@ describe('FetchLicenseInformationButton', () => {
 
     it("shows fetching error 'Request failed with status code 404'", () => {
       const MOCK_URL = 'https://github.com/opossum-tool/Oposs';
+      const notFoundStatus = 404;
 
-      axiosMock.onGet(MOCK_URL).replyOnce(404, {});
+      axiosMock.onGet(MOCK_URL).replyOnce(notFoundStatus, {});
 
       renderComponentWithStore(
         <FetchLicenseInformationButton url={MOCK_URL} disabled={false} />
@@ -84,8 +85,9 @@ describe('FetchLicenseInformationButton', () => {
 
     it('shows fetch data tooltip after successful fetch', () => {
       const MOCK_URL = 'https://pypi.org/project/pip';
+      const okStatus = 200;
 
-      axiosMock.onGet(MOCK_URL).replyOnce(200, {
+      axiosMock.onGet(MOCK_URL).replyOnce(okStatus, {
         license: { spdx_id: 'Apache-2.0' },
         content: 'TGljZW5zZSBUZXh0', // "License Text" in base64
         html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',
@@ -144,7 +146,8 @@ describe('useFetchPackageInfo', () => {
   });
 
   it('fetches data', async () => {
-    axiosMock.onGet(GITHUB_URL).replyOnce(200, {
+    const okStatus = 200;
+    axiosMock.onGet(GITHUB_URL).replyOnce(okStatus, {
       license: { spdx_id: 'Apache-2.0' },
       content: 'TGljZW5zZSBUZXh0', // "License Text" in base64
       html_url: 'https://github.com/opossum-tool/OpossumUI/blob/main/LICENSE',

--- a/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
+++ b/src/Frontend/Components/FileSearchPopup/FileSearchPopup.tsx
@@ -18,6 +18,7 @@ export function FileSearchPopup(): ReactElement {
   const fileSearchPopupOffset = 260;
   const maxPossibleHeightInPx = useWindowHeight() - fileSearchPopupOffset;
   const resourceListMaxHeightInPx =
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     500 > maxPossibleHeightInPx ? maxPossibleHeightInPx : 500;
 
   function close(): void {

--- a/src/Frontend/Components/FileSearchPopup/__tests__/FileSearchPopup.test.tsx
+++ b/src/Frontend/Components/FileSearchPopup/__tests__/FileSearchPopup.test.tsx
@@ -43,9 +43,11 @@ describe('FileSearch popup ', () => {
   });
 
   each([
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     ['eagleBlu', 4],
     ['test.js', 2],
     ['non-existing-file', 0],
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     ['eagleblu', 4],
   ]).it(
     'search for %s results in %s results',
@@ -63,6 +65,7 @@ describe('FileSearch popup ', () => {
         jest.advanceTimersByTime(debounceWaitTimeInMs);
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expect(screen.queryAllByText('/', { exact: false })).toHaveLength(9);
 
       fireEvent.change(screen.getByRole('searchbox'), {
@@ -104,6 +107,7 @@ describe('FileSearch popup ', () => {
 
     jest.advanceTimersByTime(smallWaitTimeInMs);
 
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expect(screen.queryAllByText('/', { exact: false })).toHaveLength(9);
 
     act(() => {
@@ -134,8 +138,10 @@ describe('FileSearch popup ', () => {
       jest.advanceTimersByTime(debounceWaitTimeInMs);
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expect(screen.queryAllByText('/', { exact: false })).toHaveLength(4);
     expect(screen.queryAllByText('/eagleBlu/', { exact: false })).toHaveLength(
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       4
     );
   });

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -56,6 +56,7 @@ const classes = {
   },
   dropdownStyle: {
     '& paper': {
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       maxHeight: `${ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP}px`,
       left: '7px !important',
     },

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -34,7 +34,8 @@ function maxHeightWasGiven(
 }
 
 export function List(props: ListProps): ReactElement {
-  const cardHeight = props.cardVerticalDistance || 24;
+  const defaultCardHeight = 24;
+  const cardHeight = props.cardVerticalDistance || defaultCardHeight;
   const maxHeight = maxHeightWasGiven(props.max)
     ? props.max.height
     : props.max.numberOfDisplayedItems * cardHeight;

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -167,14 +167,16 @@ interface ListCardProps {
 
 export function ListCard(props: ListCardProps): ReactElement | null {
   function getDisplayedCount(): string {
+    const digitsInAThousand = 4;
+    const digitsInAMillion = 7;
     const count = props.count ? props.count.toString() : '';
 
-    if (count.length < 4) {
+    if (count.length < digitsInAThousand) {
       return count;
-    } else if (count.length < 7) {
-      return `${count.slice(0, -3)}k`;
+    } else if (count.length < digitsInAMillion) {
+      return `${count.slice(0, -(digitsInAThousand - 1))}k`;
     } else {
-      return `${count.slice(0, -6)}M`;
+      return `${count.slice(0, -(digitsInAMillion - 1))}M`;
     }
   }
 

--- a/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -83,7 +85,11 @@ export function PackageSearchPopup(): ReactElement {
   const [currentSearchTerm, setCurrentSearchTerm] = useState<string>(
     getInitialSearchTerm(temporaryPackageInfo)
   );
-  const debouncedSearchTerm = useDebounceInput(currentSearchTerm, 500);
+  const debounceDelayInMs = 500;
+  const debouncedSearchTerm = useDebounceInput(
+    currentSearchTerm,
+    debounceDelayInMs
+  );
   const { isLoading, data, isError, error } = useQuery(
     ['clearlyDefinedPackageSearch', debouncedSearchTerm],
     () => searchPackagesOnClearlyDefined(debouncedSearchTerm),

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,9 +25,11 @@ describe('ClearlyDefinedPackageCard', () => {
   });
   const testCoordinate = 'sqlalchemy';
   const definitionEndpoint = `https://api.clearlydefined.io/definitions/${testCoordinate}`;
+  const okStatus = 200;
+  const notFoundStatus = 404;
 
   it('renders after successful fetch', async () => {
-    axiosMock.onGet(definitionEndpoint).replyOnce(200, {
+    axiosMock.onGet(definitionEndpoint).replyOnce(okStatus, {
       licensed: {
         declared: 'MIT',
         facets: {
@@ -82,7 +86,7 @@ describe('ClearlyDefinedPackageCard', () => {
   it('shows error message when fetch fails', async () => {
     // suppress output to console
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    axiosMock.onGet(definitionEndpoint).replyOnce(404);
+    axiosMock.onGet(definitionEndpoint).replyOnce(notFoundStatus);
 
     renderComponentWithStore(
       <QueryClientProvider client={queryClient}>

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,16 +34,19 @@ describe('PackageSearchPopup', () => {
       },
     },
   });
+  const okStatus = 200;
+  const serverErrorStatus = 500;
+  const notFoundStatus = 404;
 
   it('performs search successfully', async () => {
-    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(200, []);
+    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(okStatus, []);
     axiosMock
       .onGet(requestURLSearchEndpoint)
-      .replyOnce(200, ['sqlalchemy/1.4.1', 'sqlalchemy/1.3.0']);
+      .replyOnce(okStatus, ['sqlalchemy/1.4.1', 'sqlalchemy/1.3.0']);
 
     axiosMock
       .onGet(`${baseURLDefinitionEndpoint}sqlalchemy/1.4.1`)
-      .replyOnce(200, {
+      .replyOnce(okStatus, {
         licensed: {
           declared: 'MIT',
           facets: {
@@ -68,7 +73,7 @@ describe('PackageSearchPopup', () => {
 
     axiosMock
       .onGet(`${baseURLDefinitionEndpoint}sqlalchemy/1.3.0`)
-      .replyOnce(200, {
+      .replyOnce(okStatus, {
         licensed: {
           declared: 'MIT',
           facets: {
@@ -102,7 +107,7 @@ describe('PackageSearchPopup', () => {
     fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
     act(() => {
       // advance timer as form is debounced
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(serverErrorStatus);
     });
 
     expect(await screen.findByText('sqlalchemy/1.3.0'));
@@ -113,8 +118,8 @@ describe('PackageSearchPopup', () => {
   it('shows an error message', async () => {
     // suppress output to console
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(200, []);
-    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(404);
+    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(okStatus, []);
+    axiosMock.onGet(requestURLSearchEndpoint).replyOnce(notFoundStatus);
 
     renderComponentWithStore(
       <QueryClientProvider client={queryClient}>
@@ -126,7 +131,7 @@ describe('PackageSearchPopup', () => {
     fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
     act(() => {
       // advance timer as form is debounced
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(serverErrorStatus);
     });
 
     expect(
@@ -137,7 +142,7 @@ describe('PackageSearchPopup', () => {
   });
 
   it('shows a message when nothing is found', async () => {
-    axiosMock.onGet(requestURLSearchEndpoint).reply(200, []);
+    axiosMock.onGet(requestURLSearchEndpoint).reply(okStatus, []);
 
     renderComponentWithStore(
       <QueryClientProvider client={queryClient}>
@@ -149,7 +154,7 @@ describe('PackageSearchPopup', () => {
     fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
     act(() => {
       // advance timer as form is debounced
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(serverErrorStatus);
     });
 
     expect(await screen.findByText('No results found'));

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/fetch-license-from-clearly-defined.test.ts
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/fetch-license-from-clearly-defined.test.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +14,8 @@ describe('fetchFromClearlyDefined', () => {
   const requestURL = `https://api.clearlydefined.io/definitions/${testCoordinate}`;
 
   it('parses payload correctly', async () => {
-    axiosMock.onGet(requestURL).replyOnce(200, {
+    const okStatus = 200;
+    axiosMock.onGet(requestURL).replyOnce(okStatus, {
       licensed: {
         declared: 'MIT',
         facets: {
@@ -50,7 +53,10 @@ describe('fetchFromClearlyDefined', () => {
   });
 
   it('reject in correct payload', async () => {
-    axiosMock.onGet(requestURL).replyOnce(200, { someRandomField: 'value' });
+    const okStatus = 200;
+    axiosMock
+      .onGet(requestURL)
+      .replyOnce(okStatus, { someRandomField: 'value' });
     await expect(fetchFromClearlyDefined(testCoordinate)).rejects.toBeTruthy();
   });
 });

--- a/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/progress-bar-helpers.test.tsx
@@ -142,23 +142,28 @@ describe('ProgressBar helpers', () => {
 
   each([
     [
-      [20.1, 29.9, 0.1, 50.0],
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      [20.1, 29.9, 0.1, 50.0], // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       [20, 30, 1, 49],
     ],
     [
-      [0.0, 0.1, 0.9, 99.0],
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      [0.0, 0.1, 0.9, 99.0], // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       [0, 1, 1, 98],
     ],
     [
-      [10.0, 0.1, 89.4, 0.1],
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      [10.0, 0.1, 89.4, 0.1], // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       [10, 1, 88, 1],
     ],
     [
-      [0, 0, 100.2, 0],
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      [0, 0, 100.2, 0], // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       [0, 0.0, 100, 0],
     ],
     [
-      [33, 33, 1, 33],
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      [33, 33, 1, 33], // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       [33, 33, 1, 33],
     ],
   ]).it(

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -169,6 +169,7 @@ describe('The ProjectStatisticsPopup', () => {
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
     expect(screen.getAllByText('License name')).toHaveLength(2);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expect(screen.getAllByText('Total')).toHaveLength(3);
     expect(screen.getByText('Follow up')).toBeInTheDocument();
     expect(screen.getByText('First party')).toBeInTheDocument();

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -226,6 +226,7 @@ export function aggregateAttributionPropertiesFromAttributions(
 export function getMostFrequentLicenses(
   licenseCounts: LicenseCounts
 ): Array<PieChartData> {
+  const numberOfDisplayedLicenses = 5;
   const mostFrequentLicenses: Array<PieChartData> = [];
 
   for (const license of Object.keys(
@@ -240,9 +241,9 @@ export function getMostFrequentLicenses(
     (a, b) => b.count - a.count
   );
 
-  if (sortedMostFrequentLicenses.length > 5) {
+  if (sortedMostFrequentLicenses.length > numberOfDisplayedLicenses) {
     const sortedTopFiveFrequentLicensesAndOther =
-      sortedMostFrequentLicenses.slice(0, 5);
+      sortedMostFrequentLicenses.slice(0, numberOfDisplayedLicenses);
 
     const total = Object.values(
       licenseCounts.totalAttributionsPerSource

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -32,9 +32,9 @@ import { getResourceBrowserTreeItemLabel } from './get-resource-browser-tree-ite
 import { useWindowHeight } from '../../util/use-window-height';
 import { topBarHeight } from '../TopBar/TopBar';
 import {
-  treeClasses,
   TREE_ROOT_FOLDER_LABEL,
   TREE_ROW_HEIGHT,
+  treeClasses,
 } from '../../shared-styles';
 
 export function ResourceBrowser(): ReactElement | null {
@@ -106,6 +106,7 @@ export function ResourceBrowser(): ReactElement | null {
       );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const maxTreeHeight: number = useWindowHeight() - topBarHeight - 4;
 
   return resources ? (

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -90,7 +90,9 @@ export function ResourceDetailsTabs(
   const dispatch = useAppDispatch();
 
   enum Tabs {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     Local = 0,
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     Global = 1,
   }
   const [selectedTab, setSelectedTab] = useState<Tabs>(Tabs.Local);

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -20,7 +20,8 @@ import { setResources } from '../../../state/actions/resource-actions/all-views-
 describe('TopBar', () => {
   it('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(11);
+    const totalNumberOfCalls = 11;
+    expect(window.electronAPI.on).toHaveBeenCalledTimes(totalNumberOfCalls);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
       expect.anything()

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -103,6 +103,7 @@ describe('The ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'firstResource.js');
       expectValueInTextBox(screen, 'Name', 'Angular');
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 5, 0, 0);
       expectContextMenuForNotPreSelectedAttributionMultipleResources(
         screen,
@@ -131,6 +132,7 @@ describe('The ContextMenu', () => {
       expectConfirmDeletionPopupVisible(screen);
       clickOnButton(screen, ButtonText.Confirm);
       expectValueNotInTextBox(screen, 'Name', 'React');
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 4, 0, 0);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
@@ -158,6 +160,7 @@ describe('The ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
       expectValueNotInTextBox(screen, 'Name', 'React');
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 2, 0, 0);
 
       clickOnElementInResourceBrowser(screen, 'thirdResource.js');
@@ -177,6 +180,7 @@ describe('The ContextMenu', () => {
       );
       expectConfirmDeletionPopupVisible(screen);
       clickOnButton(screen, ButtonText.Confirm);
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
     });
 
@@ -233,6 +237,7 @@ describe('The ContextMenu', () => {
       );
       expectConfirmDeletionPopupNotVisible(screen);
       expectValueNotInTextBox(screen, 'Name', 'React');
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 4, 0);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
@@ -258,6 +263,7 @@ describe('The ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
       expectValueNotInTextBox(screen, 'Name', 'React');
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 2, 0);
 
       clickOnElementInResourceBrowser(screen, 'thirdResource.js');
@@ -276,6 +282,7 @@ describe('The ContextMenu', () => {
         ButtonText.DeleteGlobally
       );
       expectConfirmDeletionPopupNotVisible(screen);
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
     });
   });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -132,6 +132,7 @@ describe('In Audit View the ContextMenu', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
     expectValueInConfidenceField(screen, '10');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 0, 4, 0);
     expectContextMenuForPreSelectedAttributionMultipleResources(
       screen,
@@ -145,6 +146,7 @@ describe('In Audit View the ContextMenu', () => {
     );
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 1, 3, 0);
     expectNoConfirmationButtonsShown(screen, 'React, 16.5.0');
 
@@ -167,6 +169,7 @@ describe('In Audit View the ContextMenu', () => {
     );
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 3, 1, 0);
     expectContextMenuForNotPreSelectedAttributionMultipleResources(
       screen,
@@ -193,6 +196,7 @@ describe('In Audit View the ContextMenu', () => {
     expectValueInTextBox(screen, 'Name', 'Vue');
     expectValueNotInConfidenceField(screen, '90');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 4, 0, 0);
 
     expectContextMenuForNotPreSelectedAttributionSingleResource(

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
@@ -77,6 +77,7 @@ describe('The App in Audit View', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
     expectValueInConfidenceField(screen, '10');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 5, 0, 0);
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
@@ -86,6 +87,7 @@ describe('The App in Audit View', () => {
     expectConfirmDeletionPopupVisible(screen);
     clickOnButton(screen, ButtonText.Confirm);
     expectValueNotInTextBox(screen, 'Name', 'React');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 4, 0, 0);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
@@ -98,6 +100,7 @@ describe('The App in Audit View', () => {
     expectConfirmDeletionPopupVisible(screen);
     clickOnButton(screen, ButtonText.Confirm);
     expectValueNotInTextBox(screen, 'Name', 'React');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 2, 0, 0);
 
     clickOnElementInResourceBrowser(screen, 'thirdResource.js');
@@ -116,6 +119,7 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectConfirmDeletionPopupVisible(screen);
     clickOnButton(screen, ButtonText.Confirm);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
   });
 
@@ -164,6 +168,7 @@ describe('The App in Audit View', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
     expectValueInConfidenceField(screen, '10');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 5, 0);
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
@@ -172,6 +177,7 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectConfirmDeletionPopupNotVisible(screen);
     expectValueNotInTextBox(screen, 'Name', 'React');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 4, 0);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
@@ -183,6 +189,7 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.DeleteGlobally);
     expectConfirmDeletionPopupNotVisible(screen);
     expectValueNotInTextBox(screen, 'Name', 'React');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 2, 0);
 
     clickOnElementInResourceBrowser(screen, 'thirdResource.js');
@@ -200,6 +207,7 @@ describe('The App in Audit View', () => {
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectConfirmDeletionPopupNotVisible(screen);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 0, 0);
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -243,6 +243,7 @@ describe('The App in Audit View', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
     expectValueInConfidenceField(screen, '10');
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 0, 4, 0);
     expectButton(screen, ButtonText.Confirm);
     expectButton(screen, ButtonText.ConfirmGlobally);
@@ -250,6 +251,7 @@ describe('The App in Audit View', () => {
     clickOnButton(screen, ButtonText.Confirm);
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 1, 3, 0);
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
@@ -267,6 +269,7 @@ describe('The App in Audit View', () => {
     clickOnButton(screen, ButtonText.ConfirmGlobally);
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 3, 1, 0);
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
@@ -290,6 +293,7 @@ describe('The App in Audit View', () => {
     clickOnButton(screen, ButtonText.Confirm);
     expectValueNotInConfidenceField(screen, '90');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 4, 0, 0);
     expectButtonIsNotShown(screen, ButtonText.Confirm);
   });

--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -102,7 +102,8 @@ describe('The getUpdatedProgressBarData function', () => {
       attributionBreakpoints: new Set<string>(),
       filesWithChildren: new Set<string>(),
     });
-    expect(progressBarData.fileCount).toEqual(4);
+    const expectedNumberOfFiles = 4;
+    expect(progressBarData.fileCount).toEqual(expectedNumberOfFiles);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(2);
     expect(
@@ -210,7 +211,8 @@ describe('The getUpdatedProgressBarData function', () => {
       attributionBreakpoints: new Set<string>(),
       filesWithChildren: new Set<string>(),
     });
-    expect(progressBarData.fileCount).toEqual(4);
+    const expectedNumberOfFiles = 4;
+    expect(progressBarData.fileCount).toEqual(expectedNumberOfFiles);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(1);
     expect(
@@ -312,9 +314,11 @@ describe('The getUpdatedProgressBarData function', () => {
       attributionBreakpoints: testAttributionBreakpoints,
       filesWithChildren: new Set<string>(),
     });
-    expect(progressBarData.fileCount).toEqual(12);
+    const expectedNumberOfFiles = 12;
+    expect(progressBarData.fileCount).toEqual(expectedNumberOfFiles);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(2);
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(5);
     expect(
       progressBarData.resourcesWithNonInheritedExternalAttributionOnly
@@ -379,7 +383,8 @@ describe('The getUpdatedProgressBarData function', () => {
       attributionBreakpoints: new Set<string>(),
       filesWithChildren: testFilesWithChildren,
     });
-    expect(progressBarData.fileCount).toEqual(3);
+    const expectedNumberOfFiles = 3;
+    expect(progressBarData.fileCount).toEqual(expectedNumberOfFiles);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(2);
     expect(progressBarData.filesWithOnlyPreSelectedAttributionCount).toEqual(1);
     expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(0);

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -92,10 +92,14 @@ export function addSecondLineOfPackageLabelFromAttribute(
 }
 
 export function addPreambleToCopyright(originalCopyright: string): string {
+  const copyrightPrefixLength = 3;
+  const copyrightLength = 9;
   let copyright = originalCopyright;
   if (
-    originalCopyright.substring(0, 3).toLowerCase() !== '(c)' &&
-    originalCopyright.substring(0, 9).toLowerCase() !== 'copyright'
+    originalCopyright.substring(0, copyrightPrefixLength).toLowerCase() !==
+      '(c)' &&
+    originalCopyright.substring(0, copyrightLength).toLowerCase() !==
+      'copyright'
   ) {
     copyright = `(c) ${originalCopyright}`;
   }

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -16,7 +16,7 @@ import {
 
 const ELECTRON_LAUNCH_TEST_TIMEOUT = 75000;
 export const E2E_TEST_TIMEOUT = 120000;
-export const EXPECT_TIMEOUT = 15000;
+export const EXPECT_TIMEOUT = 20000;
 
 export async function getApp(
   commandLineArg?: string

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -21,7 +21,9 @@ export enum Criticality {
 }
 
 export enum DiscreteConfidence {
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   High = 80,
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   Low = 20,
 }
 


### PR DESCRIPTION

### Summary of changes

In order to improve readability of our code, magic numbers are now forbidden by the linter. Current errors are fixed. Many are just ignored and have to be fixed successively.

### Context and reason for change

Improve readability of our code.

### How can the changes be tested

`yarn lint`
