### PR TITLE
Allow user to cancel opening file

### DIFF
--- a/src/Frontend/Components/FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup.tsx
+++ b/src/Frontend/Components/FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup.tsx
@@ -34,9 +34,13 @@ const classes = {
 export function FileSupportDotOpossumAlreadyExistsPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
+  function close(): void {
+    dispatch(closePopup());
+  }
+
   const handleOpenDotOpossumButtonClick = (): void => {
     window.electronAPI.openDotOpossumFile();
-    dispatch(closePopup());
+    close();
   };
 
   const OpenDotOpossumButtonConfig: ButtonConfig = {
@@ -56,6 +60,8 @@ export function FileSupportDotOpossumAlreadyExistsPopup(): ReactElement {
           <MuiTypography>{INFO_TEXT_PART_2}</MuiTypography>
         </MuiBox>
       }
+      onBackdropClick={close}
+      onEscapeKeyDown={close}
     />
   );
 }

--- a/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
+++ b/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
@@ -34,13 +34,17 @@ const classes = {
 export function FileSupportPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
+  function close(): void {
+    dispatch(closePopup());
+  }
+
   const handleCreateAndProceedButtonClick = (): void => {
     window.electronAPI.convertInputFileToDotOpossum();
-    dispatch(closePopup());
+    close();
   };
   const handleKeepButtonClick = (): void => {
     window.electronAPI.useOutdatedInpuFileFormat();
-    dispatch(closePopup());
+    close();
   };
 
   const createAndProceedButtonConfig: ButtonConfig = {
@@ -65,6 +69,8 @@ export function FileSupportPopup(): ReactElement {
           <MuiTypography>{INFO_TEXT_PART_2}</MuiTypography>
         </MuiBox>
       }
+      onBackdropClick={close}
+      onEscapeKeyDown={close}
     />
   );
 }


### PR DESCRIPTION
### Summary of changes

We allow the user to cancel the process by clicking away or by pressing ESC.

### Context and reason for change

Before this change the user had no way to cancel a file opening operation after one of the new file support popups was shown. 

### How can the changes be tested

Open an outdated input file and check that the popup can be closed as described above.