### PR TITLE
Attribution Wizard: Prevent empty attributions

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -102,6 +102,8 @@ export function AttributionWizardPopup(): ReactElement {
     selectedPackageAttributeIds
   );
 
+  const selectedPackageNameIsValid = selectedPackageName !== '';
+
   const dispatch = useAppDispatch();
   function closeAttributionWizardPopupHandler(): void {
     dispatch(closeAttributionWizardPopup());
@@ -118,11 +120,6 @@ export function AttributionWizardPopup(): ReactElement {
   const [selectedWizardStepId, setSelectedWizardStepId] = useState<string>(
     wizardStepIds[0]
   );
-
-  const isPackageNamespaceAndNameSelected =
-    selectedPackageAttributeIds.namespaceId !== '' &&
-    selectedPackageAttributeIds.nameId !== '';
-  const isPackageVersionSelected = selectedPackageAttributeIds.versionId !== '';
 
   const {
     attributedPackageNamespacesWithManuallyAddedOnes,
@@ -224,11 +221,11 @@ export function AttributionWizardPopup(): ReactElement {
   const nextButtonConfig: ButtonConfig = {
     buttonText: ButtonText.Next,
     onClick: handleNextClick,
-    disabled: !isPackageNamespaceAndNameSelected,
+    disabled: !selectedPackageNameIsValid,
     isDark: true,
-    tooltipText: isPackageNamespaceAndNameSelected
-      ? ''
-      : 'Please select package namespace and name to continue',
+    tooltipText: !selectedPackageNameIsValid
+      ? 'Please select a valid package name to continue'
+      : '',
     tooltipPlacement: 'top',
   };
   const backButtonConfig: ButtonConfig = {
@@ -246,12 +243,7 @@ export function AttributionWizardPopup(): ReactElement {
   const applyButtonConfig: ButtonConfig = {
     buttonText: ButtonText.Apply,
     onClick: handleApplyClick,
-    disabled: !isPackageVersionSelected,
     isDark: true,
-    tooltipText: !isPackageVersionSelected
-      ? 'Please select package version to apply changes'
-      : '',
-    tooltipPlacement: 'top',
   };
 
   return (

--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -261,4 +261,47 @@ describe('AttributionWizardPopup', () => {
     expect(versionIconButton).toBeDisabled();
     expect(screen.getByText('new_version')).toBeInTheDocument();
   });
+
+  it("disables the 'next' button if a package name with an empty string (displayed as a dash) is selected", () => {
+    const testExternalAttributionsExtended = {
+      ...testExternalAttributions,
+      ...{
+        uuid_2: {
+          packageType: 'generic',
+          packageName: '',
+          packageNamespace: 'npm',
+          packageVersion: '0.9.9',
+        },
+      },
+    };
+
+    const testExternalResourcesToAttributionsExtended: ResourcesToAttributions =
+      {
+        '/samplepath/file': ['uuid_1', 'uuid_2'],
+      };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributionsExtended,
+        testExternalResourcesToAttributionsExtended
+      )
+    );
+    testStore.dispatch(
+      setManualData(testManualAttributions, testManualResourcesToAttributions)
+    );
+    act(() => {
+      testStore.dispatch(openAttributionWizardPopup('uuid_0'));
+    });
+    renderComponentWithStore(<AttributionWizardPopup />, { store: testStore });
+
+    expect(screen.getByRole('button', { name: ButtonText.Next })).toBeEnabled();
+
+    fireEvent.click(screen.getByText('-'));
+
+    expect(
+      screen.getByRole('button', { name: ButtonText.Next })
+    ).toBeDisabled();
+  });
 });


### PR DESCRIPTION
### Summary of changes

The apply button is disabled as long as the generated purl is invalid. This includes empty attributions but also ensures that a truthy package name is given. Additionally, booleans indicating whether a package name, namespace, or version is selected are removed since these are always true due to pre-selection. 

### Context and reason for change

Empty attributions are forbidden and should be avoided.

### How can the changes be tested

Open the attribution wizard and select empty package name.

Fix: #1451
