### PR TITLE
Fix the failing file import when no external attributions

### DIFF
--- a/src/ElectronBackend/input/parseFile.ts
+++ b/src/ElectronBackend/input/parseFile.ts
@@ -33,7 +33,13 @@ export async function parseOpossumFile(
   await new Promise<void>((resolve) => {
     fs.readFile(opossumfilePath, (err, data) => {
       if (err) throw err;
-      JSZip.loadAsync(data).then((zip) => {
+      JSZip.loadAsync(data).then(async (zip) => {
+        if ('output.json' in zip.files) {
+          await zip.files['output.json'].async('text').then((content) => {
+            parsedOutputData = parseOutputJsonContent(content, opossumfilePath);
+          });
+        }
+
         zip.files['input.json']
           .async('text')
           .then((content) => {
@@ -46,11 +52,6 @@ export async function parseOpossumFile(
             error = err;
           })
           .then(resolve);
-        if ('output.json' in zip.files) {
-          zip.files['output.json'].async('text').then((content) => {
-            parsedOutputData = parseOutputJsonContent(content, opossumfilePath);
-          });
-        }
       });
     });
   });


### PR DESCRIPTION
### Summary of changes

We do not read input and output files in parallel, instead, first read output, after that input.json and finish.

### Context and reason for change

Issue #1441

### How can the changes be tested

Open one of the .opossum files in performance_tests folder.
