### PR TITLE
Add text field stack for comments

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -106,7 +106,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     setIsLicenseTextShown,
     licenseTextRows,
     copyrightRows,
-    commentRows,
+    commentBoxHeight,
   } = useRows(
     view,
     props.resetViewIfThisIdChanges,
@@ -285,7 +285,8 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         showHighlight={showHighlight}
       />
       <AuditingSubPanel
-        commentRows={commentRows}
+        commentBoxHeight={commentBoxHeight}
+        isCommentsBoxCollapsed={isLicenseTextShown}
         setUpdateTemporaryPackageInfoFor={
           props.setUpdateTemporaryPackageInfoFor
         }

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -19,6 +19,7 @@ import { useAppSelector } from '../../state/hooks';
 import { checkboxClass } from '../../shared-styles';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import MuiBox from '@mui/material/Box';
+import { TextFieldStack } from '../TextFieldStack/TextFieldStack';
 
 const classes = {
   ...checkboxClass,
@@ -38,7 +39,8 @@ interface AuditingSubPanelProps {
   isEditable: boolean;
   displayPackageInfo: PackageInfo;
   showManualAttributionData: boolean;
-  commentRows: number;
+  isCommentsBoxCollapsed: boolean;
+  commentBoxHeight: number;
   followUpChangeHandler(event: React.ChangeEvent<HTMLInputElement>): void;
   excludeFromNoticeChangeHandler(
     event: React.ChangeEvent<HTMLInputElement>
@@ -135,15 +137,16 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
           />
         ) : null}
       </MuiBox>
-      <TextBox
+      <TextFieldStack
         isEditable={props.isEditable}
-        sx={classes.textBox}
-        title={'Comment'}
-        text={props.displayPackageInfo.comment}
-        minRows={props.commentRows}
-        maxRows={props.commentRows}
-        multiline={true}
-        handleChange={props.setUpdateTemporaryPackageInfoFor('comment')}
+        comments={
+          props.displayPackageInfo.comment
+            ? [props.displayPackageInfo.comment]
+            : []
+        }
+        isCollapsed={props.isCommentsBoxCollapsed}
+        commentBoxHeight={props.commentBoxHeight}
+        handleChange={props.setUpdateTemporaryPackageInfoFor}
       />
     </MuiPaper>
   );

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -27,6 +27,9 @@ import { PanelPackage } from '../../types/types';
 
 const PRE_SELECTED_LABEL = 'Attribution was pre-selected';
 const MARKED_FOR_REPLACEMENT_LABEL = 'Attribution is marked for replacement';
+const HEIGHT_OF_TEXT_BOXES_IN_ATTRIBUTION_VIEW = 480;
+const HEIGHT_OF_TEXT_BOXES_IN_AUDIT_VIEW = 514;
+const ROW_HEIGHT = 19;
 
 export function getDisplayTexts(
   temporaryPackageInfo: PackageInfo,
@@ -51,13 +54,12 @@ export function getLicenseTextMaxRows(
   windowHeight: number,
   view: View
 ): number {
-  const heightOfTextBoxes = 480;
   const heightOfNonLicenseTextComponents =
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    heightOfTextBoxes + (view === View.Audit ? 34 : 0);
+    view === View.Audit
+      ? HEIGHT_OF_TEXT_BOXES_IN_AUDIT_VIEW
+      : HEIGHT_OF_TEXT_BOXES_IN_ATTRIBUTION_VIEW;
   const licenseTextMaxHeight = windowHeight - heightOfNonLicenseTextComponents;
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-  return Math.floor(licenseTextMaxHeight / 19);
+  return Math.floor(licenseTextMaxHeight / ROW_HEIGHT);
 }
 
 export function getDiscreteConfidenceChangeHandler(
@@ -291,7 +293,7 @@ export function useRows(
   setIsLicenseTextShown: Dispatch<SetStateAction<boolean>>;
   licenseTextRows: number;
   copyrightRows: number;
-  commentRows: number;
+  commentBoxHeight: number;
 } {
   const [isLicenseTextShown, setIsLicenseTextShown] = useState<boolean>(false);
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
@@ -308,12 +310,15 @@ export function useRows(
   const commentRows = isLicenseTextShown
     ? 1
     : Math.max(licenseTextRows - 2, 1) - reduceRowsCount;
+  const commentBoxHeight = isLicenseTextShown
+    ? ROW_HEIGHT
+    : commentRows * ROW_HEIGHT;
 
   return {
     isLicenseTextShown,
     setIsLicenseTextShown,
     licenseTextRows,
     copyrightRows,
-    commentRows,
+    commentBoxHeight,
   };
 }

--- a/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
+++ b/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ChangeEvent, ReactElement } from 'react';
+import { TextBox } from '../InputElements/TextBox';
+import MuiBox from '@mui/material/Box';
+
+const classes = {
+  textBox: {
+    width: '100%',
+    margin: 'normal',
+  },
+  textBoxPanel: {
+    overflow: 'auto',
+  },
+};
+
+interface TextFieldStackProps {
+  isCollapsed: boolean;
+  isEditable: boolean;
+  comments: string[];
+  handleChange(
+    propertyToUpdate: string
+  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  showHighlight?: boolean;
+  commentBoxHeight: number;
+}
+
+export function TextFieldStack(props: TextFieldStackProps): ReactElement {
+  const filteredComments = props.comments.filter(
+    (comment) => comment.replace(/\s/g, '') != ''
+  );
+  if (filteredComments.length == 0) {
+    filteredComments.push('');
+  }
+  return props.isCollapsed ? (
+    <MuiBox>
+      <TextBox
+        isEditable={false}
+        sx={classes.textBox}
+        title={getCollapsedCommentText(filteredComments)}
+        text={''}
+        minRows={1}
+        maxRows={1}
+        handleChange={props.handleChange('comment')}
+      />
+    </MuiBox>
+  ) : (
+    <MuiBox sx={{ ...classes.textBoxPanel, height: props.commentBoxHeight }}>
+      {filteredComments.map((comment, index) => {
+        const numLines = Math.max(comment.split('\n').length, 1);
+        return (
+          <MuiBox key={index} marginTop={1}>
+            <TextBox
+              isEditable={props.isEditable}
+              sx={classes.textBox}
+              title={`Comment ${filteredComments.length == 1 ? '' : index + 1}`}
+              text={comment}
+              minRows={numLines}
+              maxRows={numLines}
+              multiline={true}
+              handleChange={props.handleChange('comment')}
+            />
+          </MuiBox>
+        );
+      })}
+    </MuiBox>
+  );
+}
+
+export function getCollapsedCommentText(filteredComments: string[]): string {
+  if (filteredComments.length == 1) {
+    return filteredComments[0] == '' ? 'No comments' : '1 comment (collapsed)';
+  } else {
+    return `${filteredComments.length} comments (collapsed)`;
+  }
+}

--- a/src/Frontend/Components/TextFieldStack/__tests__/TextFieldStack.test.tsx
+++ b/src/Frontend/Components/TextFieldStack/__tests__/TextFieldStack.test.tsx
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { doNothing } from '../../../util/do-nothing';
+import { TextFieldStack } from '../TextFieldStack';
+
+describe('The TextFieldStack', () => {
+  it('renders comment TextBoxes with right titles and content', () => {
+    const isEditable = false;
+    const comments = [
+      'This is the first comment',
+      'This is the second comment',
+      'This is the third comment',
+      'This is the forth comment',
+    ];
+    const isCollapsed = false;
+    const commentBoxHeight = 300;
+
+    render(
+      <TextFieldStack
+        isEditable={isEditable}
+        comments={comments}
+        isCollapsed={isCollapsed}
+        commentBoxHeight={commentBoxHeight}
+        handleChange={(): (() => void) => doNothing}
+      />
+    );
+    comments.forEach((comment, index) => {
+      expect(screen.getByLabelText(`Comment ${index + 1}`));
+      expect(screen.getByDisplayValue(comment));
+    });
+  });
+
+  it('renders number of comments if collapsed', () => {
+    const isEditable = false;
+    const comments = [
+      'This is the first comment',
+      'This is the second comment',
+      'This is the third comment',
+      'This is the forth comment',
+    ];
+    const isCollapsed = true;
+    const commentBoxHeight = 300;
+
+    render(
+      <TextFieldStack
+        isEditable={isEditable}
+        comments={comments}
+        isCollapsed={isCollapsed}
+        commentBoxHeight={commentBoxHeight}
+        handleChange={(): (() => void) => doNothing}
+      />
+    );
+    expect(screen.getByLabelText('4 comments (collapsed)'));
+  });
+
+  it('renders correct message in case of one comment', () => {
+    const isEditable = false;
+    const comments = ['This is the first comment'];
+    const isCollapsed = true;
+    const commentBoxHeight = 300;
+
+    render(
+      <TextFieldStack
+        isEditable={isEditable}
+        comments={comments}
+        isCollapsed={isCollapsed}
+        commentBoxHeight={commentBoxHeight}
+        handleChange={(): (() => void) => doNothing}
+      />
+    );
+    expect(screen.getByLabelText('1 comment (collapsed)'));
+  });
+
+  it('renders correct message in case of no comment', () => {
+    const isEditable = false;
+    const comments: string[] = [];
+    const isCollapsed = true;
+    const commentBoxHeight = 300;
+
+    render(
+      <TextFieldStack
+        isEditable={isEditable}
+        comments={comments}
+        isCollapsed={isCollapsed}
+        commentBoxHeight={commentBoxHeight}
+        handleChange={(): (() => void) => doNothing}
+      />
+    );
+    expect(screen.getByLabelText('No comments'));
+  });
+});


### PR DESCRIPTION
### Summary of changes

Introduced new component that accepts an array of comments and displays them as an array of text fields for signals and attributions.

### Context and reason for change

We want to enable a signal or attribution to have multiple comments (i.e. if two identical signals with different comments are merged).

### How can the changes be tested

- Checkout PR
- Run tests in: `src/Frontend/Components/CommentTextFieldArray/__tests__/CommentTextFieldArray.test.tsx`
- In `src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx` replace the value for `comments` in the call of the `CommentTextFieldArray` by an hard coded array of strings and check the result in the app.
