### PR TITLE
Deduplicate Signals: Adapt Redux State

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -20,6 +20,7 @@ import {
   getExternalAttributions,
   getExternalAttributionSources,
   getExternalAttributionsToResources,
+  getExternalAttributionsToHashes,
   getFrequentLicensesNameOrder,
   getFrequentLicensesTexts,
   getIsSavingDisabled,
@@ -36,6 +37,7 @@ import {
   resetResourceState,
   setBaseUrlsForSources,
   setExternalAttributionSources,
+  setExternalAttributionsToHashes,
   setExternalData,
   setFrequentLicenses,
   setManualData,
@@ -259,5 +261,16 @@ describe('The load and navigation simple actions', () => {
     expect(getExternalAttributionSources(testStore.getState())).toEqual({
       SC: { name: 'Scancode', priority: 1 },
     });
+  });
+
+  it('sets and gets externalAttributionsToHashes', () => {
+    const testExternalAttributionsToHashes = { uuid: '0123-4567' };
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setExternalAttributionsToHashes(testExternalAttributionsToHashes)
+    );
+    expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
+      testExternalAttributionsToHashes
+    );
   });
 });

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -5,6 +5,7 @@
 
 import {
   Attributions,
+  AttributionsToHashes,
   BaseUrlsForSources,
   ExternalAttributionSources,
   FrequentLicenses,
@@ -20,6 +21,7 @@ import {
   ACTION_SET_BASE_URLS_FOR_SOURCES,
   ACTION_SET_EXTERNAL_ATTRIBUTION_DATA,
   ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES,
+  ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES,
   ACTION_SET_FILES_WITH_CHILDREN,
   ACTION_SET_FREQUENT_LICENSES,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
@@ -30,6 +32,7 @@ import {
   SetAttributionBreakpoints,
   SetBaseUrlsForSources,
   SetExternalAttributionSources,
+  SetExternalAttributionsToHashes,
   SetExternalDataAction,
   SetFilesWithChildren,
   SetFrequentLicensesAction,
@@ -127,5 +130,14 @@ export function setExternalAttributionSources(
   return {
     type: ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES,
     payload: externalAttributionSources,
+  };
+}
+
+export function setExternalAttributionsToHashes(
+  externalAttributionsToHashes: AttributionsToHashes
+): SetExternalAttributionsToHashes {
+  return {
+    type: ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES,
+    payload: externalAttributionsToHashes,
   };
 }

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -6,6 +6,7 @@
 import {
   AttributionData,
   Attributions,
+  AttributionsToHashes,
   BaseUrlsForSources,
   ExternalAttributionSources,
   FrequentLicenses,
@@ -88,6 +89,8 @@ export const ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS =
   'ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS';
 export const ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT =
   'ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT';
+export const ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES =
+  'ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -128,7 +131,8 @@ export type ResourceAction =
   | SetAttributionWizardPackageNames
   | SetAttributionWizardPackageVersions
   | SetAttributionWizardSelectedPackageIds
-  | SetAttributionWizardTotalAttributionCount;
+  | SetAttributionWizardTotalAttributionCount
+  | SetExternalAttributionsToHashes;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -341,4 +345,9 @@ export interface SetAttributionWizardSelectedPackageIds {
 export interface SetAttributionWizardTotalAttributionCount {
   type: typeof ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT;
   payload: number | null;
+}
+
+export interface SetExternalAttributionsToHashes {
+  type: typeof ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES;
+  payload: AttributionsToHashes;
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -5,6 +5,7 @@
 
 import {
   AttributionData,
+  AttributionsToHashes,
   BaseUrlsForSources,
   ExternalAttributionSources,
   FrequentLicenses,
@@ -64,6 +65,7 @@ import {
   ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION,
   ACTION_SET_ATTRIBUTION_WIZARD_SELECTED_PACKAGE_IDS,
   ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT,
+  ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES,
 } from '../actions/resource-actions/types';
 import {
   createManualAttribution,
@@ -96,6 +98,7 @@ export const initialResourceState: ResourceState = {
     baseUrlsForSources: {},
     externalAttributionSources: {},
     attributionIdMarkedForReplacement: '',
+    externalAttributionsToHashes: {},
   },
   auditView: {
     selectedResourceId: '',
@@ -145,6 +148,7 @@ export type ResourceState = {
     baseUrlsForSources: BaseUrlsForSources;
     externalAttributionSources: ExternalAttributionSources;
     attributionIdMarkedForReplacement: string;
+    externalAttributionsToHashes: AttributionsToHashes;
   };
   auditView: {
     selectedResourceId: string;
@@ -681,6 +685,14 @@ export const resourceState = (
         attributionWizard: {
           ...state.attributionWizard,
           totalAttributionCount: action.payload,
+        },
+      };
+    case ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES:
+      return {
+        ...state,
+        allViews: {
+          ...state.allViews,
+          externalAttributionsToHashes: action.payload,
         },
       };
     default:

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -8,6 +8,7 @@ import {
   AttributionData,
   Attributions,
   AttributionsToResources,
+  AttributionsToHashes,
   BaseUrlsForSources,
   ExternalAttributionSources,
   FrequentLicenseName,
@@ -191,4 +192,10 @@ export function getExternalAttributionSources(
 
 export function getAttributionIdMarkedForReplacement(state: State): string {
   return state.resourceState.allViews.attributionIdMarkedForReplacement;
+}
+
+export function getExternalAttributionsToHashes(
+  state: State
+): AttributionsToHashes {
+  return state.resourceState.allViews.externalAttributionsToHashes;
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -70,6 +70,10 @@ export interface AttributionsToResources {
   [uuid: string]: Array<string>;
 }
 
+export interface AttributionsToHashes {
+  [uuid: string]: string;
+}
+
 export interface ResourcesWithAttributedChildren {
   [path: string]: Set<string>;
 }


### PR DESCRIPTION
### Summary of changes

Add a new object, 'externalAttributionToHash', to the redux state. Add a corresponding action for setting it and a selector for getting it.

### Context and reason for change

 #1525

### How can the changes be tested

Run new test in `all-views-simple-actions.test.ts`.