### PR TITLE
Deduplicate Signals: Populate externalAttributionsToHashes

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -6,6 +6,7 @@
 import {
   AttributionData,
   Attributions,
+  AttributionsToHashes,
   BaseUrlsForSources,
   DiscreteConfidence,
   FrequentLicenses,
@@ -20,6 +21,7 @@ import {
   getAttributionBreakpoints,
   getBaseUrlsForSources,
   getExternalAttributionSources,
+  getExternalAttributionsToHashes,
   getExternalData,
   getFilesWithChildren,
   getFrequentLicensesNameOrder,
@@ -76,6 +78,20 @@ describe('loadFromFile', () => {
           name: 'Test document',
           documentConfidence: 99,
         },
+      },
+      doNotChangeMe1: {
+        packageName: 'name',
+        comment: 'comment1',
+        originIds: ['abc'],
+        preSelected: true,
+        attributionConfidence: 1,
+      },
+      doNotChangeMe2: {
+        packageName: 'name',
+        comment: 'comment2',
+        originIds: ['def'],
+        preSelected: false,
+        attributionConfidence: 2,
       },
     };
     const testResourcesToExternalAttributions: ResourcesToAttributions = {
@@ -137,6 +153,10 @@ describe('loadFromFile', () => {
         '/root/src/': new Set<string>().add('/root/src/something.js'),
       },
     };
+    const expectedExternalAttributionsToHashes: AttributionsToHashes = {
+      doNotChangeMe1: '9263f76013801519989b1ba42aa42825de74ad93',
+      doNotChangeMe2: '9263f76013801519989b1ba42aa42825de74ad93',
+    };
 
     const testStore = createTestAppStore();
     expect(testStore.getState().resourceState).toMatchObject(
@@ -169,5 +189,8 @@ describe('loadFromFile', () => {
     expect(getExternalAttributionSources(testStore.getState())).toEqual({
       SC: { name: 'ScanCode', priority: 1 },
     });
+    expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
+      expectedExternalAttributionsToHashes
+    );
   });
 });

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -4,11 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ParsedFileContent } from '../../../../shared/shared-types';
+import { createExternalAttributionsToHashes } from '../../helpers/load-action-helpers';
 import { AppThunkAction, AppThunkDispatch } from '../../types';
 import {
   setAttributionBreakpoints,
   setBaseUrlsForSources,
   setExternalAttributionSources,
+  setExternalAttributionsToHashes,
   setExternalData,
   setFilesWithChildren,
   setFrequentLicenses,
@@ -59,5 +61,11 @@ export function loadFromFile(
     parsedFileContent.resolvedExternalAttributions.forEach((attribution) =>
       dispatch(addResolvedExternalAttribution(attribution))
     );
+
+    const externalAttributionsToHashes = createExternalAttributionsToHashes(
+      parsedFileContent.externalAttributions.attributions
+    );
+
+    dispatch(setExternalAttributionsToHashes(externalAttributionsToHashes));
   };
 }

--- a/src/Frontend/state/helpers/__tests__/load-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/load-action-helpers.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Attributions } from '../../../../shared/shared-types';
+import { createExternalAttributionsToHashes } from '../load-action-helpers';
+
+describe('createExternalAttributionsToHashes', () => {
+  it('yields correct results', () => {
+    const testExternalAttributions: Attributions = {
+      uuid1: {
+        attributionConfidence: 1,
+        comment: 'comment1',
+        packageName: 'name',
+        originIds: ['abc'],
+        preSelected: true,
+      },
+      uuid2: {
+        attributionConfidence: 2,
+        comment: 'comment2',
+        packageName: 'name',
+        originIds: ['def'],
+        preSelected: false,
+      },
+      uuid3: {
+        packageName: 'name',
+      },
+      uuid4: {
+        licenseName: '',
+        firstParty: true,
+      },
+      uuid5: {
+        firstParty: true,
+      },
+      uuid6: {
+        packageName: '',
+      },
+      uuid7: {
+        firstParty: false,
+      },
+    };
+
+    const testExternalAttributionsToHashes = createExternalAttributionsToHashes(
+      testExternalAttributions
+    );
+
+    expect(testExternalAttributionsToHashes.uuid1).toBeDefined();
+    expect(testExternalAttributionsToHashes.uuid2).toBeDefined();
+    expect(testExternalAttributionsToHashes.uuid3).toBeDefined();
+    expect(testExternalAttributionsToHashes.uuid4).toBeDefined();
+    expect(testExternalAttributionsToHashes.uuid5).toBeDefined();
+    expect(testExternalAttributionsToHashes.uuid6).toBeUndefined();
+    expect(testExternalAttributionsToHashes.uuid7).toBeUndefined();
+
+    expect(testExternalAttributionsToHashes.uuid1).toEqual(
+      testExternalAttributionsToHashes.uuid2
+    );
+    expect(testExternalAttributionsToHashes.uuid1).toEqual(
+      testExternalAttributionsToHashes.uuid3
+    );
+    expect(testExternalAttributionsToHashes.uuid1).not.toEqual(
+      testExternalAttributionsToHashes.uuid4
+    );
+    expect(testExternalAttributionsToHashes.uuid4).toEqual(
+      testExternalAttributionsToHashes.uuid5
+    );
+  });
+});

--- a/src/Frontend/state/helpers/load-action-helpers.ts
+++ b/src/Frontend/state/helpers/load-action-helpers.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import objectHash from 'object-hash';
+import {
+  Attributions,
+  AttributionsToHashes,
+  PackageInfo,
+} from '../../../shared/shared-types';
+
+const FIELDS_TO_IGNORE_WHEN_HASHING_ATTRIBUTIONS = new Set<string>([
+  'comment',
+  'attributionConfidence',
+  'originIds',
+  'preSelected',
+]);
+
+export function createExternalAttributionsToHashes(
+  externalAttributions: Attributions
+): AttributionsToHashes {
+  const hashOptions = {
+    excludeKeys: (key: string): boolean =>
+      FIELDS_TO_IGNORE_WHEN_HASHING_ATTRIBUTIONS.has(key),
+  };
+
+  const externalAttributionsToHashes: AttributionsToHashes = {};
+  const hashesToExternalAttributions: { [hash: string]: Array<string> } = {};
+
+  for (const [attributionId, attribution] of Object.entries(
+    externalAttributions
+  )) {
+    if (attribution.firstParty || attribution.packageName) {
+      const attributionKeys = Object.keys(attribution) as Array<
+        keyof PackageInfo
+      >;
+      attributionKeys.forEach(
+        (key) =>
+          (attribution[key] === undefined || attribution[key] === '') &&
+          delete attribution[key]
+      );
+
+      const hash = objectHash(attribution, hashOptions);
+
+      hashesToExternalAttributions[hash]
+        ? hashesToExternalAttributions[hash].push(attributionId)
+        : (hashesToExternalAttributions[hash] = [attributionId]);
+    }
+  }
+
+  Object.entries(hashesToExternalAttributions).forEach(
+    ([hash, attributionIds]) => {
+      if (attributionIds.length > 1) {
+        attributionIds.forEach(
+          (attributionId) =>
+            (externalAttributionsToHashes[attributionId] = hash)
+        );
+      }
+    }
+  );
+
+  return externalAttributionsToHashes;
+}


### PR DESCRIPTION
### Summary of changes

After the parsed input data is sent to the frontend, calculate externalAttributionsToHashes and write it to the redux state. The following fields are ignored when hashing attributions: 'comment', 'attributionConfidence',  'originIds', and 'preSelected'. Furthermore, the following values are considered equal: null, undefined, and ''.

### Context and reason for change

Part of the story 'Deduplicate reused signals that are identical'.

### How can the changes be tested

Run new test in `action-and-reducer-helpers.test.ts` or log the data when opening a new file.