### PR TITLE
Deduplicate Signals: Create attribution from merged signal

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -108,7 +108,8 @@
       "attributionConfidence": 80,
       "comment": "Comment A",
       "firstParty": true,
-      "packageName": "Should Be Merged"
+      "packageName": "Should Be Merged",
+      "originIds": ["abc"]
     },
     "578b448b-2ba8-4285-810f-ce7b11ac2101": {
       "source": {
@@ -118,7 +119,8 @@
       "attributionConfidence": 20,
       "comment": "Comment B",
       "firstParty": true,
-      "packageName": "Should Be Merged"
+      "packageName": "Should Be Merged",
+      "originIds": ["def"]
     },
     "578b448b-2ba8-4285-810f-ce7b11ac260c": {
       "source": {
@@ -293,18 +295,12 @@
       "bb61b094-b5ba-4bd0-b218-8ec96b7c5ae2",
       "585bf5b2-4da7-4de4-8e8f-38d142e42079"
     ],
-    "/Frontend/Types/types.ts": [
-      "5f1948d6-63fa-4f7e-b02b-7799083511fc"
-    ],
+    "/Frontend/Types/types.ts": ["5f1948d6-63fa-4f7e-b02b-7799083511fc"],
     "/Frontend/Components/ResourcePanel/ResourcePanel.tsx": [
       "578b448b-2ba8-4285-810f-ce7b11ac260c"
     ],
-    "/package.json": [
-      "1ec44343-f764-12e1-8d99-b8599fde8t68"
-    ],
-    "/ElectronBackend/Types/types.ts": [
-      "bb61b094-b5ba-4bd0-b218-8ec96b7c5ae1"
-    ]
+    "/package.json": ["1ec44343-f764-12e1-8d99-b8599fde8t68"],
+    "/ElectronBackend/Types/types.ts": ["bb61b094-b5ba-4bd0-b218-8ec96b7c5ae1"]
   },
   "frequentLicenses": [
     {
@@ -339,9 +335,7 @@
     "/package.json/dependencies/",
     "/package.json/devDependencies/"
   ],
-  "filesWithChildren": [
-    "/package.json/"
-  ],
+  "filesWithChildren": ["/package.json/"],
   "baseUrlsForSources": {
     "/": "https://github.com/opossum-tool/OpossumUI/blob/main/src/{path}?test=bla",
     "/Frontend/": "https://github.com/opossum-tool/opossumUI/{path}?test=87583cf6c5d859bef90ee2b37fffe7a485c4d7a4",

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -10,6 +10,7 @@ import {
   Attributions,
   DisplayPackageInfo,
   PackageInfo,
+  isDisplayPackageInfo,
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInAccordionPanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -28,6 +29,7 @@ import {
 import {
   getAttributionIdsWithCountForSource,
   getSortedSources,
+  convertDisplayPackageInfoToPackageInfo,
 } from './package-panel-helpers';
 import { prettifySource } from '../../util/prettify-source';
 import {
@@ -120,7 +122,15 @@ export function PackagePanel(
     switch (props.title) {
       case PackagePanelTitle.ExternalPackages:
       case PackagePanelTitle.ContainedExternalPackages:
-        dispatch(addToSelectedResource(props.attributions[attributionId]));
+        const packageInfo: PackageInfo | DisplayPackageInfo =
+          getAttributionFromDisplayAttributionWithCount(attributionId) ||
+          props.attributions[attributionId];
+
+        const packageInfoToAdd = isDisplayPackageInfo(packageInfo)
+          ? convertDisplayPackageInfoToPackageInfo(packageInfo)
+          : packageInfo;
+
+        dispatch(addToSelectedResource(packageInfoToAdd));
         break;
       case PackagePanelTitle.ContainedManualPackages:
         dispatch(addToSelectedResource(props.attributions[attributionId]));

--- a/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
@@ -6,8 +6,11 @@
 import {
   Attributions,
   ExternalAttributionSources,
+  DisplayPackageInfo,
+  PackageInfo,
 } from '../../../../shared/shared-types';
 import {
+  convertDisplayPackageInfoToPackageInfo,
   getAttributionIdsWithCountForSource,
   getSortedSources,
 } from '../package-panel-helpers';
@@ -175,5 +178,35 @@ describe('PackagePanel helpers', () => {
       'a_unknown',
       'b_unknown',
     ]);
+  });
+
+  it('convertDisplayPackageInfoToPackageInfo returns correct PackageInfo', () => {
+    const testDisplayPackageInfoA: DisplayPackageInfo = {
+      packageName: 'react',
+      type: 'DisplayPackageInfo',
+      comments: ['comment A', 'comment B'],
+      attributionIds: ['123', '456'],
+    };
+    const testDisplayPackageInfoB: DisplayPackageInfo = {
+      packageName: 'react',
+      type: 'DisplayPackageInfo',
+      comments: ['comment'],
+      attributionIds: ['123'],
+    };
+    const expectedPackageInfoA: PackageInfo = {
+      packageName: 'react',
+    };
+    const expectedPackageInfoB: PackageInfo = {
+      packageName: 'react',
+      comment: 'comment',
+    };
+    const testPackageInfoA = convertDisplayPackageInfoToPackageInfo(
+      testDisplayPackageInfoA
+    );
+    const testPackageInfoB = convertDisplayPackageInfoToPackageInfo(
+      testDisplayPackageInfoB
+    );
+    expect(testPackageInfoA).toEqual(expectedPackageInfoA);
+    expect(testPackageInfoB).toEqual(expectedPackageInfoB);
   });
 });

--- a/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
+++ b/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
@@ -5,10 +5,14 @@
 
 import {
   Attributions,
+  DisplayPackageInfo,
   ExternalAttributionSources,
+  PackageInfo,
   Source,
 } from '../../../shared/shared-types';
+import { getPackageInfoKeys } from '../../../shared/shared-util';
 import { AttributionIdWithCount } from '../../types/types';
+import { shouldNotBeCalled } from '../../util/should-not-be-called';
 
 export function getSortedSources(
   attributions: Attributions,
@@ -84,4 +88,60 @@ export function getAttributionIdsWithCountForSource(
       ? Boolean(source?.name && source?.name === sourceName)
       : !source;
   });
+}
+
+export function convertDisplayPackageInfoToPackageInfo(
+  displayPackageInfo: DisplayPackageInfo
+): PackageInfo {
+  const packageInfo: PackageInfo = {};
+
+  getPackageInfoKeys().forEach((packageInfoKey) => {
+    if (packageInfoKey in displayPackageInfo) {
+      switch (packageInfoKey) {
+        case 'packageName':
+        case 'packageVersion':
+        case 'packageNamespace':
+        case 'packageType':
+        case 'packagePURLAppendix':
+        case 'url':
+        case 'copyright':
+        case 'licenseName':
+        case 'licenseText':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'comment':
+          break;
+        case 'firstParty':
+        case 'preSelected':
+        case 'excludeFromNotice':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'attributionConfidence':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'followUp':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'source':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'originIds':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'criticality':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        default:
+          shouldNotBeCalled(packageInfoKey);
+      }
+    }
+    if (
+      displayPackageInfo.attributionIds.length === 1 &&
+      displayPackageInfo.comments
+    ) {
+      packageInfo.comment = displayPackageInfo.comments[0];
+    }
+  });
+
+  return packageInfo;
 }

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -308,4 +308,49 @@ describe('Add to attribution', () => {
     clickOnTab(screen, 'Local Tab');
     expectValueNotInAddToAttributionList(screen, 'Jquery, 16.5.0');
   });
+
+  it('adds a merged signal correctly', () => {
+    const testResources: Resources = {
+      folder1: { 'firstResource.js': 1 },
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_ext_1: {
+        packageName: 'Jquery',
+        packageVersion: '16.5.0',
+        originIds: ['abc'],
+        comment: 'It is a nice package.',
+      },
+      uuid_ext_2: {
+        packageName: 'Jquery',
+        packageVersion: '16.5.0',
+        originIds: ['def'],
+        comment: 'I do not like this package.',
+      },
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/folder1/': ['uuid_ext_1', 'uuid_ext_2'],
+    };
+
+    mockElectronBackend(
+      getParsedInputFileEnrichedWithTestData({
+        resources: testResources,
+        externalAttributions: testExternalAttributions,
+        resourcesToExternalAttributions: testResourcesToExternalAttributions,
+      })
+    );
+
+    renderComponentWithStore(<App />);
+
+    clickOnElementInResourceBrowser(screen, 'folder1');
+    clickOnTab(screen, 'Local Tab');
+    expectValueInAddToAttributionList(screen, 'Jquery, 16.5.0');
+
+    fireEvent.click(getCardInAttributionList(screen, 'Jquery, 16.5.0'));
+    expectValueInTextBox(screen, 'Comment 1', 'It is a nice package.');
+    expectValueInTextBox(screen, 'Comment 2', 'I do not like this package.');
+
+    clickAddIconOnCardInAttributionList(screen, 'Jquery, 16.5.0');
+    expectValueInTextBox(screen, 'Name', 'Jquery');
+    expectValueInTextBox(screen, 'Comment', '');
+  });
 });


### PR DESCRIPTION
### Summary of changes

Merged signals are added to manual attributions. Comments are removed.

### Context and reason for change

This is part of the story 'Deduplicate reused signals that are identical'.

### How can the changes be tested

Run test `add-to-attribution.test.tsx` or run the app, navigate to `menu.ts`, and add the contained merged signal.