### PR TITLE
Group signals in folder content by hash 

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
@@ -19,12 +19,12 @@ import {
 import { isIdOfResourceWithChildren } from '../../util/can-resource-have-children';
 import { SyncAccordionPanel } from './SyncAccordionPanel';
 import {
-  getContainedExternalPackages,
   getContainedManualPackages,
   getExternalAttributionIdsWithCount,
   PanelAttributionData,
 } from '../../util/get-contained-packages';
 import { AttributionIdWithCount } from '../../types/types';
+import { getMergedContainedExternalPackagesWithCount } from './accordion-panel-helpers';
 
 interface AggregatedAttributionsPanelProps {
   isAddToPackageEnabled: boolean;
@@ -35,9 +35,7 @@ export function AggregatedAttributionsPanel(
 ): ReactElement {
   const manualData = useAppSelector(getManualData);
   const externalData = useAppSelector(getExternalData);
-  const externalAttributionsToHashes = useAppSelector(
-    getExternalAttributionsToHashes
-  );
+  const attributionsToHashes = useAppSelector(getExternalAttributionsToHashes);
 
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const resolvedExternalAttributions: Set<string> = useAppSelector(
@@ -56,8 +54,14 @@ export function AggregatedAttributionsPanel(
       selectedResourceId,
       externalData,
       resolvedExternalAttributions,
+      attributionsToHashes,
     }),
-    [selectedResourceId, externalData, resolvedExternalAttributions]
+    [
+      selectedResourceId,
+      externalData,
+      resolvedExternalAttributions,
+      attributionsToHashes,
+    ]
   );
 
   const manualPanelData: PanelAttributionData = {
@@ -92,7 +96,7 @@ export function AggregatedAttributionsPanel(
           )
         }
         attributions={externalData.attributions}
-        attributionsToHashes={externalAttributionsToHashes}
+        attributionsToHashes={attributionsToHashes}
         isAddToPackageEnabled={props.isAddToPackageEnabled}
       />
       {isIdOfResourceWithChildren(selectedResourceId) ? (
@@ -101,14 +105,16 @@ export function AggregatedAttributionsPanel(
             title={PackagePanelTitle.ContainedExternalPackages}
             workerArgs={containedExternalPackagesWorkerArgs}
             syncFallbackArgs={containedExternalPackagesSyncFallbackArgs}
-            getAttributionIdsWithCount={getContainedExternalPackages}
+            getMergedAttributionIdsWithCount={
+              getMergedContainedExternalPackagesWithCount
+            }
             attributions={externalData.attributions}
             isAddToPackageEnabled={props.isAddToPackageEnabled}
           />
           <WorkerAccordionPanel
             title={PackagePanelTitle.ContainedManualPackages}
             workerArgs={containedManualPackagesWorkerArgs}
-            getAttributionIdsWithCount={getContainedManualPackages}
+            getMergedAttributionIdsWithCount={getContainedManualPackages}
             attributions={manualData.attributions}
             isAddToPackageEnabled={props.isAddToPackageEnabled}
           />

--- a/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { ReactElement, useContext, useMemo, useState } from 'react';
-import { Attributions } from '../../../shared/shared-types';
+import {
+  Attributions,
+  AttributionsToHashes,
+} from '../../../shared/shared-types';
 import { AccordionPanel } from './AccordionPanel';
 import { PackagePanelTitle } from '../../enums/enums';
 import {
@@ -26,6 +29,7 @@ type ContainedAttributionsAccordionWorkerArgs =
 interface ContainedExternalAttributionsAccordionWorkerArgs {
   selectedResourceId: string;
   externalData?: PanelAttributionData;
+  attributionsToHashes?: AttributionsToHashes;
   resolvedExternalAttributions: Set<string>;
 }
 
@@ -40,7 +44,7 @@ interface WorkerAccordionPanelProps {
     | PackagePanelTitle.ContainedManualPackages;
   workerArgs: ContainedAttributionsAccordionWorkerArgs;
   syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs;
-  getAttributionIdsWithCount(
+  getMergedAttributionIdsWithCount(
     workerArgs: ContainedAttributionsAccordionWorkerArgs
   ): Array<AttributionIdWithCount>;
   attributions: Attributions;
@@ -76,7 +80,7 @@ export function WorkerAccordionPanel(
       worker,
       props.title,
       setAttributionIdsWithCountAndResourceId,
-      props.getAttributionIdsWithCount,
+      props.getMergedAttributionIdsWithCount,
       props.syncFallbackArgs
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -117,7 +121,7 @@ async function loadAttributionIdsWithCount(
   setAttributionIdsWithCountAndResourceId: (
     attributionIdsWithCountAndResourceId: AttributionIdsWithCountAndResourceId
   ) => void,
-  getAttributionIdsWithCount: (
+  getMergedAttributionIdsWithCount: (
     workerArgs: ContainedAttributionsAccordionWorkerArgs
   ) => Array<AttributionIdWithCount>,
   syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs
@@ -139,7 +143,7 @@ async function loadAttributionIdsWithCount(
           panelTitle,
           Error('Web Worker execution error.'),
           setAttributionIdsWithCountAndResourceId,
-          getAttributionIdsWithCount,
+          getMergedAttributionIdsWithCount,
           workerArgs,
           syncFallbackArgs
         );
@@ -152,7 +156,7 @@ async function loadAttributionIdsWithCount(
       panelTitle,
       error,
       setAttributionIdsWithCountAndResourceId,
-      getAttributionIdsWithCount,
+      getMergedAttributionIdsWithCount,
       workerArgs,
       syncFallbackArgs
     );
@@ -165,20 +169,18 @@ function logErrorAndComputeInMainProcess(
   setAttributionIdsWithCountAndResourceId: (
     attributionIdsWithCountAndResourceId: AttributionIdsWithCountAndResourceId
   ) => void,
-  getAttributionIdsWithCount: (
+  getMergedAttributionIdsWithCount: (
     workerArgs: ContainedAttributionsAccordionWorkerArgs
   ) => Array<AttributionIdWithCount>,
   workerArgs: ContainedAttributionsAccordionWorkerArgs,
   syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs
 ): void {
-  console.info(`Error in ResourceDetailsTab ${panelTitle}: `, error);
-
-  const attributionIdsWithCount = getAttributionIdsWithCount(
+  const mergedAttributionIdsWithCount = getMergedAttributionIdsWithCount(
     syncFallbackArgs || workerArgs
   );
 
   setAttributionIdsWithCountAndResourceId({
     resourceId: workerArgs.selectedResourceId,
-    attributionIdsWithCount,
+    attributionIdsWithCount: mergedAttributionIdsWithCount,
   });
 }

--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AggregatedAttributionsPanel.test.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AggregatedAttributionsPanel.test.tsx
@@ -212,12 +212,63 @@ describe('The AggregatedAttributionsPanel', () => {
       { store: testStore }
     );
 
-    const packagesPanel = getPackagePanel(screen, 'Signals');
+    const signalsPanel = getPackagePanel(screen, 'Signals');
     // eslint-disable-next-line testing-library/prefer-screen-queries, jest-dom/prefer-in-document
-    expect(queryAllByText(packagesPanel, 'jQuery, 16.0.0')).toHaveLength(1);
+    expect(queryAllByText(signalsPanel, 'jQuery, 16.0.0')).toHaveLength(1);
   });
 
-  it('does not merge signals without n hash', () => {
+  it('shows merged identical signals in folder content', () => {
+    const testResources: Resources = {
+      root: {},
+    };
+    const testExternalAttribution: PackageInfo = {
+      packageName: 'jQuery',
+      packageVersion: '16.0.0',
+      comment: 'ManualPackage',
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_1: testExternalAttribution,
+      uuid_2: testExternalAttribution,
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/root/': ['uuid_1', 'uuid_2'],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          externalAttributions: testExternalAttributions,
+          resourcesToExternalAttributions: testResourcesToExternalAttributions,
+        })
+      )
+    );
+    testStore.dispatch(setSelectedResourceId('/'));
+    testStore.dispatch(
+      setExternalAttributionsToHashes({
+        uuid_1: '1',
+        uuid_2: '1',
+      })
+    );
+
+    renderComponentWithStore(
+      <AggregatedAttributionsPanel isAddToPackageEnabled={true} />,
+      { store: testStore }
+    );
+
+    const signalsInFolderContentPanel = getPackagePanel(
+      screen,
+      'Signals in Folder Content'
+    );
+    expect(
+      // eslint-disable-next-line testing-library/prefer-screen-queries
+      queryAllByText(signalsInFolderContentPanel, 'jQuery, 16.0.0')
+      // eslint-disable-next-line jest-dom/prefer-in-document
+    ).toHaveLength(1);
+  });
+
+  it('does not merge signals without a hash', () => {
     const testResources: Resources = {
       root: {},
     };

--- a/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
@@ -13,6 +13,30 @@ import {
   AttributionIdWithCount,
   MergedAttributionWithCount,
 } from '../../types/types';
+import {
+  getContainedExternalPackages,
+  PanelAttributionData,
+} from '../../util/get-contained-packages';
+
+export function getMergedContainedExternalPackagesWithCount(args: {
+  selectedResourceId: string;
+  externalData: Readonly<PanelAttributionData>;
+  resolvedExternalAttributions: Readonly<Set<string>>;
+  attributionsToHashes: Readonly<AttributionsToHashes>;
+}): Array<AttributionIdWithCount> {
+  const attributionIdsWithCount = getContainedExternalPackages(
+    args.selectedResourceId,
+    args.externalData.resourcesWithAttributedChildren,
+    args.externalData.attributions,
+    args.externalData.resourcesToAttributions,
+    args.resolvedExternalAttributions
+  );
+  return getMergedAttributionsWithCount(
+    attributionIdsWithCount,
+    args.externalData.attributions,
+    args.attributionsToHashes
+  );
+}
 
 export function getMergedAttributionsWithCount(
   attributionsWithIdCount: Array<AttributionIdWithCount>,

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -9,7 +9,6 @@ import { PackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
 import {
   getAttributionBreakpoints,
-  getExternalData,
   getManualData,
   getTemporaryPackageInfo,
 } from '../../state/selectors/all-views-resource-selectors';
@@ -42,7 +41,6 @@ export function ResourceDetailsAttributionColumn(
   props: ResourceDetailsAttributionColumnProps
 ): ReactElement | null {
   const manualData = useAppSelector(getManualData);
-  const externalData = useAppSelector(getExternalData);
   const displayedPackage: PanelPackage | null =
     useAppSelector(getDisplayedPackage);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
@@ -128,8 +126,7 @@ export function ResourceDetailsAttributionColumn(
   const displayPackageInfo: PackageInfo = getDisplayPackageInfo(
     displayedPackage,
     temporaryPackageInfo,
-    manualData.attributions,
-    externalData.attributions
+    manualData.attributions
   );
 
   const showSaveGloballyButton: boolean = hasAttributionMultipleResources(

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
@@ -10,27 +10,19 @@ import { PanelPackage } from '../../types/types';
 export function getDisplayPackageInfo(
   selectedPackage: PanelPackage | null,
   temporaryPackageInfo: PackageInfo,
-  manualAttributions: Attributions,
-  externalAttributions: Attributions
+  manualAttributions: Attributions
 ): PackageInfo {
-  const panelsWhereToShowTemporaryPackageInfos: Array<PackagePanelTitle> = [
-    PackagePanelTitle.ManualPackages,
-    PackagePanelTitle.ExternalPackages,
-    // TODO: PackagePanelTitle.ContainedExternalPackages should use the same logic
-  ];
-
-  if (
-    !selectedPackage ||
-    panelsWhereToShowTemporaryPackageInfos.includes(selectedPackage.panel)
-  ) {
-    return temporaryPackageInfo;
-  }
-
   let displayPackageInfo = {};
 
+  if (!selectedPackage) {
+    displayPackageInfo = temporaryPackageInfo;
+  }
+
   switch (selectedPackage?.panel) {
+    case PackagePanelTitle.ManualPackages:
+    case PackagePanelTitle.ExternalPackages:
     case PackagePanelTitle.ContainedExternalPackages:
-      displayPackageInfo = externalAttributions[selectedPackage.attributionId];
+      displayPackageInfo = temporaryPackageInfo;
       break;
     case PackagePanelTitle.ContainedManualPackages:
     case PackagePanelTitle.AllAttributions:

--- a/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
+++ b/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
@@ -7,6 +7,7 @@ import React, { FC, ReactNode, useMemo } from 'react';
 import { useAppSelector } from '../../state/hooks';
 import {
   getAttributionBreakpoints,
+  getExternalAttributionsToHashes,
   getExternalData,
   getFilesWithChildren,
   getResources,
@@ -26,6 +27,7 @@ export const AccordionWorkersContextProvider: FC<{
   children: ReactNode | null;
 }> = ({ children }) => {
   const externalAttributionData = useAppSelector(getExternalData);
+  const attributionsToHashes = useAppSelector(getExternalAttributionsToHashes);
 
   const externalData: PanelAttributionData = useMemo(
     () => ({
@@ -44,12 +46,12 @@ export const AccordionWorkersContextProvider: FC<{
         { externalData: null }
       );
       resourceDetailsTabsWorkers.containedExternalAttributionsAccordionWorker.postMessage(
-        { externalData }
+        { externalData, attributionsToHashes }
       );
     } catch (error) {
       console.info('Web worker error in workers context provider: ', error);
     }
-  }, [externalData]);
+  }, [externalData, attributionsToHashes]);
 
   return (
     <AccordionWorkersContext.Provider value={resourceDetailsTabsWorkers}>

--- a/src/Frontend/util/get-contained-packages.ts
+++ b/src/Frontend/util/get-contained-packages.ts
@@ -7,6 +7,7 @@ import {
   Attributions,
   PackageInfo,
   ResourcesToAttributions,
+  ResourcesWithAttributedChildren,
 } from '../../shared/shared-types';
 import { getAttributedChildren } from './get-attributed-children';
 import { AttributionIdWithCount } from '../types/types';
@@ -24,21 +25,23 @@ export function getExternalAttributionIdsWithCount(
   }));
 }
 
-export function getContainedExternalPackages(args: {
-  selectedResourceId: string;
-  externalData: Readonly<PanelAttributionData>;
-  resolvedExternalAttributions: Readonly<Set<string>>;
-}): Array<AttributionIdWithCount> {
+export function getContainedExternalPackages(
+  selectedResourceId: string,
+  resourcesWithAttributedChildren: Readonly<ResourcesWithAttributedChildren>,
+  externalAttributions: Readonly<Attributions>,
+  resourcesToExternalAttributions: Readonly<ResourcesToAttributions>,
+  resolvedExternalAttributions: Readonly<Set<string>>
+): Array<AttributionIdWithCount> {
   const externalAttributedChildren = getAttributedChildren(
-    args.externalData.resourcesWithAttributedChildren,
-    args.selectedResourceId
+    resourcesWithAttributedChildren,
+    selectedResourceId
   );
 
   return computeAggregatedAttributionsFromChildren(
-    args.externalData.attributions,
-    args.externalData.resourcesToAttributions,
+    externalAttributions,
+    resourcesToExternalAttributions,
     externalAttributedChildren,
-    args.resolvedExternalAttributions
+    resolvedExternalAttributions
   );
 }
 

--- a/src/Frontend/web-workers/contained-external-attributions-accordion-worker.ts
+++ b/src/Frontend/web-workers/contained-external-attributions-accordion-worker.ts
@@ -2,32 +2,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  PanelAttributionData,
-  getContainedExternalPackages,
-} from '../util/get-contained-packages';
+import { PanelAttributionData } from '../util/get-contained-packages';
 import { AttributionIdsWithCountAndResourceId } from '../types/types';
+import { getMergedContainedExternalPackagesWithCount } from '../Components/AggregatedAttributionsPanel/accordion-panel-helpers';
+import { AttributionsToHashes } from '../../shared/shared-types';
 
 let cachedExternalData: PanelAttributionData | null = null;
+let cachedAttributionsToHashes: AttributionsToHashes | null = null;
 
 self.onmessage = ({
-  data: { selectedResourceId, externalData, resolvedExternalAttributions },
+  data: {
+    selectedResourceId,
+    externalData,
+    resolvedExternalAttributions,
+    attributionsToHashes,
+  },
 }): void => {
   // externalData = null is used to empty the cached data
   if (externalData !== undefined) {
     cachedExternalData = externalData;
   }
 
+  if (attributionsToHashes !== undefined) {
+    cachedAttributionsToHashes = attributionsToHashes;
+  }
+
   if (selectedResourceId) {
-    if (cachedExternalData) {
-      const attributionIdsWithCount = getContainedExternalPackages({
-        selectedResourceId,
-        externalData: cachedExternalData,
-        resolvedExternalAttributions,
-      });
+    if (cachedExternalData && cachedAttributionsToHashes) {
+      const mergedAttributionIdsWithCount =
+        getMergedContainedExternalPackagesWithCount({
+          selectedResourceId,
+          externalData: cachedExternalData,
+          resolvedExternalAttributions,
+          attributionsToHashes: cachedAttributionsToHashes,
+        });
       const output: AttributionIdsWithCountAndResourceId = {
         resourceId: selectedResourceId,
-        attributionIdsWithCount,
+        attributionIdsWithCount: mergedAttributionIdsWithCount,
       };
 
       self.postMessage({


### PR DESCRIPTION
### Summary of changes

Group "Signals in Folder Content" by hash

### Context and reason for change

Currently, it is possible that there are many identical signals that only differ by the comment. This should be fixed. In this PR, the "Signals in Folder Content" section of the attribution view is updated to only show one signal per hash.
