### PR TITLE
Show resources for merged signals

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -56,7 +56,11 @@ import {
   getRightIcons,
 } from './package-card-helpers';
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
-import { PackageInfo } from '../../../shared/shared-types';
+import {
+  isDisplayPackageInfo,
+  DisplayPackageInfo,
+  PackageInfo,
+} from '../../../shared/shared-types';
 import MuiBox from '@mui/material/Box';
 import { openAttributionWizardPopup } from '../../state/actions/popup-actions/popup-actions';
 
@@ -77,7 +81,7 @@ const classes = {
 
 interface PackageCardProps {
   cardId: string;
-  packageInfo: PackageInfo;
+  packageInfo: PackageInfo | DisplayPackageInfo;
   attributionId: string;
   packageCount?: number;
   cardConfig: PackageCardConfig;
@@ -396,13 +400,19 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     />
   ) : undefined;
 
+  const attributionIdsForResourcePathPopup = isDisplayPackageInfo(
+    props.packageInfo
+  )
+    ? props.packageInfo.attributionIds
+    : [attributionId];
+
   return (
     <MuiBox sx={!props.showCheckBox ? classes.multiSelectPackageCard : {}}>
       {showAssociatedResourcesPopup &&
         !Boolean(props.hideContextMenuAndMultiSelect) && (
           <ResourcePathPopup
             closePopup={(): void => setShowAssociatedResourcesPopup(false)}
-            attributionId={props.attributionId}
+            attributionIds={attributionIdsForResourcePathPopup}
             isExternalAttribution={Boolean(
               props.cardConfig.isExternalAttribution
             )}

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -5,16 +5,17 @@
 
 import React, { ReactElement } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import {
-  getExternalAttributionsToResources,
-  getManualAttributionsToResources,
-} from '../../state/selectors/all-views-resource-selectors';
 import { useWindowHeight } from '../../util/use-window-height';
 import { useAppSelector } from '../../state/hooks';
 import { ButtonText } from '../../enums/enums';
 import MuiBox from '@mui/material/Box';
 import { treeClasses } from '../../shared-styles';
 import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
+import { getAllResourcePathsForAttributions } from './resource-path-popup-helpers';
+import {
+  getExternalAttributionsToResources,
+  getManualAttributionsToResources,
+} from '../../state/selectors/all-views-resource-selectors';
 
 const VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 236;
 const HORIZONTAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 112;
@@ -22,7 +23,7 @@ const POPUP_CONTENT_PADDING = 48;
 
 interface ResourcePathPopupProps {
   closePopup(): void;
-  attributionId: string;
+  attributionIds: Array<string>;
   isExternalAttribution: boolean;
 }
 
@@ -33,10 +34,12 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
   const manualAttributionsToResources = useAppSelector(
     getManualAttributionsToResources
   );
-  const allResourceIds = props.isExternalAttribution
-    ? externalAttributionsToResources[props.attributionId]
-    : manualAttributionsToResources[props.attributionId];
-
+  const allResourcePaths = getAllResourcePathsForAttributions(
+    props.attributionIds,
+    props.isExternalAttribution
+      ? externalAttributionsToResources
+      : manualAttributionsToResources
+  );
   const maxTreeHeight: number =
     useWindowHeight() - VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES;
   const header = `Resources for selected ${
@@ -60,7 +63,7 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
           )}
         >
           <ResourcesTree
-            resourcePaths={allResourceIds}
+            resourcePaths={allResourcePaths}
             highlightSelectedResources={true}
             maxHeight={maxTreeHeight}
             sx={treeClasses.tree(

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/ResourcePathPopup.test.tsx
@@ -40,7 +40,7 @@ function HelperComponent(props: HelperComponentProps): ReactElement {
   return (
     <ResourcePathPopup
       closePopup={doNothing}
-      attributionId={'uuid_1'}
+      attributionIds={['uuid_1']}
       isExternalAttribution={props.isExternalAttribution}
     />
   );

--- a/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
+++ b/src/Frontend/Components/ResourcePathPopup/__tests__/resource-path-popup-helpers.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AttributionsToResources } from '../../../../shared/shared-types';
+import { getAllResourcePathsForAttributions } from '../resource-path-popup-helpers';
+
+describe('getAllResourcePathsForAttributions', () => {
+  it('gets resource paths for attributions', () => {
+    const attributionsToResources: AttributionsToResources = {
+      uuid1: ['/some/path1', '/some/other/path1'],
+      uuid2: ['/some/path2'],
+      uuid3: ['/some/path3'],
+    };
+
+    const attributionIds = ['uuid1', 'uuid2'];
+    const expectedResourcesPaths = [
+      '/some/path1',
+      '/some/other/path1',
+      '/some/path2',
+    ];
+
+    const resourcesPaths = getAllResourcePathsForAttributions(
+      attributionIds,
+      attributionsToResources
+    );
+
+    expect(resourcesPaths.sort()).toEqual(expectedResourcesPaths.sort());
+  });
+
+  it('deduplicates resource paths', () => {
+    const attributionsToResources: AttributionsToResources = {
+      uuid1: ['/some/path'],
+      uuid2: ['/some/path'],
+      uuid3: ['/some/path'],
+    };
+
+    const attributionIds = ['uuid1', 'uuid2', 'uuid3'];
+
+    const resourcesPaths = getAllResourcePathsForAttributions(
+      attributionIds,
+      attributionsToResources
+    );
+
+    const expectedResourcesPaths = ['/some/path'];
+    expect(resourcesPaths).toEqual(expectedResourcesPaths);
+  });
+});

--- a/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
+++ b/src/Frontend/Components/ResourcePathPopup/resource-path-popup-helpers.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AttributionsToResources } from '../../../shared/shared-types';
+
+export function getAllResourcePathsForAttributions(
+  attributionIds: Array<string>,
+  attributionsToResources: AttributionsToResources
+): Array<string> {
+  const resourceIds = attributionIds.flatMap(
+    (attributionId) => attributionsToResources[attributionId]
+  );
+  const deduplicatedResourceIds = Array.from(new Set(resourceIds));
+  return deduplicatedResourceIds;
+}


### PR DESCRIPTION
### Summary of changes

The resource path popup shows resources for all attributions of a merged package.

### Context and reason for change

Currently, it is possible that there are many identical signals that only differ by the comment. This should be fixed. In this PR, the resource path popup is updated to display resource paths for all attributions of a merged package, instead of just one.
