### PR TITLE
Deduplicate Signals: Provide Hide Functionality.

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -6,7 +6,10 @@
 
 import React, { ChangeEvent, ReactElement } from 'react';
 
-import { PackageInfo } from '../../../shared/shared-types';
+import {
+  PackageInfo,
+  isDisplayPackageInfo,
+} from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   getAttributionIdMarkedForReplacement,
@@ -31,7 +34,7 @@ import {
   getFollowUpChangeHandler,
   getMergeButtonsDisplayState,
   getResolvedToggleHandler,
-  selectedPackageIsResolved,
+  selectedPackagesAreResolved,
   usePurl,
   useRows,
 } from './attribution-column-helpers';
@@ -85,9 +88,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const resolvedExternalAttributions = useAppSelector(
     getResolvedExternalAttributions
   );
-  const temporaryPackageInfo: PackageInfo = useAppSelector(
-    getTemporaryPackageInfo
-  );
+  const temporaryPackageInfo = useAppSelector(getTemporaryPackageInfo);
   const packageInfoWereModified = useAppSelector(
     wereTemporaryPackageInfoModified
   );
@@ -247,6 +248,12 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     !props.displayPackageInfo.firstParty &&
     !props.displayPackageInfo.excludeFromNotice;
 
+  const attributionIdsToResolveOrUnresolve = isDisplayPackageInfo(
+    temporaryPackageInfo
+  )
+    ? temporaryPackageInfo.attributionIds
+    : []; // TODO: remove when refactoring
+
   return (
     <MuiBox sx={classes.root}>
       <PackageSubPanel
@@ -314,12 +321,12 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       <ButtonRow
         showButtonGroup={props.showManualAttributionData}
         resolvedToggleHandler={getResolvedToggleHandler(
-          selectedPackageId,
+          attributionIdsToResolveOrUnresolve,
           resolvedExternalAttributions,
           dispatch
         )}
-        selectedPackageIsResolved={selectedPackageIsResolved(
-          selectedPackageId,
+        selectedPackageIsResolved={selectedPackagesAreResolved(
+          attributionIdsToResolveOrUnresolve,
           resolvedExternalAttributions
         )}
         areButtonsHidden={props.areButtonsHidden}

--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -57,7 +57,11 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
           />
         ) : (
           <ToggleButton
-            buttonText={ButtonText.Hide}
+            buttonText={
+              props.selectedPackageIsResolved
+                ? ButtonText.Unhide
+                : ButtonText.Hide
+            }
             sx={classes.resolveButton}
             selected={props.selectedPackageIsResolved}
             handleChange={props.resolvedToggleHandler}

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -8,27 +8,19 @@ import { screen } from '@testing-library/react';
 import React from 'react';
 import {
   DiscreteConfidence,
+  DisplayPackageInfo,
   FollowUp,
   FrequentLicenses,
   PackageInfo,
   SaveFileArgs,
   Source,
 } from '../../../../shared/shared-types';
-import {
-  ButtonText,
-  CheckboxLabel,
-  PackagePanelTitle,
-} from '../../../enums/enums';
+import { ButtonText, CheckboxLabel } from '../../../enums/enums';
 import {
   setFrequentLicenses,
-  setResources,
   setTemporaryPackageInfo,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import {
-  addResolvedExternalAttribution,
-  setDisplayedPackage,
-  setSelectedResourceId,
-} from '../../../state/actions/resource-actions/audit-view-simple-actions';
+import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import {
@@ -37,7 +29,6 @@ import {
 } from '../../../test-helpers/general-test-helpers';
 import { doNothing } from '../../../util/do-nothing';
 import { AttributionColumn } from '../AttributionColumn';
-import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import {
   clickGoToLinkIcon,
   expectGoToLinkButtonIsDisabled,
@@ -573,18 +564,20 @@ describe('The AttributionColumn', () => {
 
   describe('The ResolveButton', () => {
     it('saves resolved external attributions', () => {
-      const testTemporaryPackageInfo: PackageInfo = {};
+      const testPackageInfo: PackageInfo = {};
+      const testTemporaryPackageInfo: DisplayPackageInfo = {
+        type: 'DisplayPackageInfo',
+        attributionIds: ['TestId'],
+      };
       const expectedSaveFileArgs: SaveFileArgs = {
         manualAttributions: {},
-        resolvedExternalAttributions: new Set<string>()
-          .add('TestExternalAttribution')
-          .add('TestId'),
+        resolvedExternalAttributions: new Set<string>().add('TestId'),
         resourcesToAttributions: {},
       };
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testTemporaryPackageInfo}
+          displayPackageInfo={testPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -596,17 +589,7 @@ describe('The AttributionColumn', () => {
         />
       );
       act(() => {
-        store.dispatch(setSelectedAttributionId('TestId'));
-        store.dispatch(setResources({}));
-        store.dispatch(
-          setDisplayedPackage({
-            panel: PackagePanelTitle.ExternalPackages,
-            attributionId: 'TestId',
-          })
-        );
-        store.dispatch(
-          addResolvedExternalAttribution('TestExternalAttribution')
-        );
+        store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
       });
 
       clickOnButton(screen, 'resolve attribution');

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -7,7 +7,7 @@ import { View } from '../../../enums/enums';
 import {
   getLicenseTextMaxRows,
   getMergeButtonsDisplayState,
-  selectedPackageIsResolved,
+  selectedPackagesAreResolved,
 } from '../attribution-column-helpers';
 
 describe('The AttributionColumn helpers', () => {
@@ -29,19 +29,31 @@ describe('The AttributionColumn helpers', () => {
 
   it('selectedPackageIsResolved returns true', () => {
     expect(
-      selectedPackageIsResolved('123', new Set<string>().add('123'))
+      selectedPackagesAreResolved(['123'], new Set<string>().add('123'))
     ).toEqual(true);
   });
 
   it('selectedPackageIsResolved returns false if empty attributionId', () => {
-    expect(selectedPackageIsResolved('', new Set<string>().add('123'))).toEqual(
-      false
-    );
+    expect(
+      selectedPackagesAreResolved([''], new Set<string>().add('123'))
+    ).toEqual(false);
+  });
+
+  it('selectedPackageIsResolved returns false if empty array of attributionIds', () => {
+    expect(
+      selectedPackagesAreResolved([], new Set<string>().add('123'))
+    ).toEqual(false);
   });
 
   it('selectedPackageIsResolved returns false if id does not match', () => {
     expect(
-      selectedPackageIsResolved('123', new Set<string>().add('321'))
+      selectedPackagesAreResolved(['123'], new Set<string>().add('321'))
+    ).toEqual(false);
+  });
+
+  it('selectedPackageIsResolved returns false if only a subset matches', () => {
+    expect(
+      selectedPackagesAreResolved(['123', '456'], new Set<string>().add('123'))
     ).toEqual(false);
   });
 });

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -119,28 +119,34 @@ export function getFirstPartyChangeHandler(
 }
 
 export function getResolvedToggleHandler(
-  attributionId: string,
+  attributionIds: Array<string>,
   resolvedExternalAttributions: Set<string>,
   dispatch: AppThunkDispatch
 ): () => void {
   return (): void => {
-    if (attributionId) {
-      if (resolvedExternalAttributions.has(attributionId)) {
+    if (
+      selectedPackagesAreResolved(attributionIds, resolvedExternalAttributions)
+    ) {
+      for (const attributionId of attributionIds) {
         dispatch(removeResolvedExternalAttribution(attributionId));
-      } else {
+      }
+    } else {
+      for (const attributionId of attributionIds) {
         dispatch(addResolvedExternalAttribution(attributionId));
       }
-      dispatch(saveManualAndResolvedAttributionsToFile());
     }
+    dispatch(saveManualAndResolvedAttributionsToFile());
   };
 }
 
-export function selectedPackageIsResolved(
-  attributionId: string,
+export function selectedPackagesAreResolved(
+  attributionIds: Array<string>,
   resolvedExternalAttributions: Set<string>
 ): boolean {
-  return attributionId
-    ? resolvedExternalAttributions.has(attributionId)
+  return attributionIds.length > 0
+    ? attributionIds.every((attributionId) =>
+        resolvedExternalAttributions.has(attributionId)
+      )
     : false;
 }
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -43,7 +43,7 @@ import {
   getMergeButtonsDisplayState,
   getResolvedToggleHandler,
   MergeButtonDisplayState,
-  selectedPackageIsResolved,
+  selectedPackagesAreResolved,
 } from '../AttributionColumn/attribution-column-helpers';
 import {
   setAttributionIdMarkedForReplacement,
@@ -151,6 +151,10 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     selectedView === View.Attribution
       ? getPackageCardHighlighting(manualAttributions[attributionId])
       : undefined;
+
+  const displayAttributionIds = isDisplayPackageInfo(props.packageInfo)
+    ? props.packageInfo.attributionIds
+    : [attributionId]; // TODO: consider this when refactoring
 
   function getContextMenuItems(): Array<ContextMenuItem> {
     function openConfirmDeletionPopup(): void {
@@ -289,14 +293,14 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
             onClick: (): void => setShowAssociatedResourcesPopup(true),
           },
           {
-            buttonText: selectedPackageIsResolved(
-              attributionId,
+            buttonText: selectedPackagesAreResolved(
+              displayAttributionIds,
               resolvedExternalAttributions
             )
               ? ButtonText.Unhide
               : ButtonText.Hide,
             onClick: getResolvedToggleHandler(
-              attributionId,
+              displayAttributionIds,
               resolvedExternalAttributions,
               dispatch
             ),
@@ -400,19 +404,13 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     />
   ) : undefined;
 
-  const attributionIdsForResourcePathPopup = isDisplayPackageInfo(
-    props.packageInfo
-  )
-    ? props.packageInfo.attributionIds
-    : [attributionId];
-
   return (
     <MuiBox sx={!props.showCheckBox ? classes.multiSelectPackageCard : {}}>
       {showAssociatedResourcesPopup &&
         !Boolean(props.hideContextMenuAndMultiSelect) && (
           <ResourcePathPopup
             closePopup={(): void => setShowAssociatedResourcesPopup(false)}
-            attributionIds={attributionIdsForResourcePathPopup}
+            attributionIds={displayAttributionIds}
             isExternalAttribution={Boolean(
               props.cardConfig.isExternalAttribution
             )}

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -142,6 +142,7 @@ export function PackagePanel(
     const packageInfo: PackageInfo | DisplayPackageInfo =
       getAttributionFromDisplayAttributionWithCount(attributionId) ||
       props.attributions[attributionId];
+
     const packageCount: number | undefined =
       props.attributionIdsWithCount.filter(
         (attributionIdWithCount) =>

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -48,6 +48,7 @@ import {
   expectValueNotInConfidenceField,
 } from '../../../test-helpers/attribution-column-test-helpers';
 import { clickOnElementInResourceBrowser } from '../../../test-helpers/resource-browser-test-helpers';
+import { setExternalAttributionsToHashes } from '../../../state/actions/resource-actions/all-views-simple-actions';
 
 const testResources: Resources = {
   folder1: { 'firstResource.js': 1 },
@@ -264,6 +265,103 @@ describe('In Audit View the ContextMenu', () => {
       'Signals'
     );
     expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+  });
+
+  it('hide / unhide works correctly for merged signals', () => {
+    const testResources: Resources = {
+      'firstResource.js': 1,
+      'secondResource.js': 1,
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'React',
+        packageVersion: '16.5.0',
+      },
+      uuid_2: {
+        packageName: 'React',
+        packageVersion: '16.5.0',
+      },
+      uuid_3: {
+        packageName: 'Vue',
+        packageVersion: '1.2.0',
+      },
+    };
+    const testExternalAttributionsToHashes = {
+      uuid_1: 'a',
+      uuid_2: 'a',
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/firstResource.js': ['uuid_1', 'uuid_2', 'uuid_3'],
+      '/secondResource.js': ['uuid_1', 'uuid_2', 'uuid_3'],
+    };
+
+    mockElectronBackend(
+      getParsedInputFileEnrichedWithTestData({
+        resources: testResources,
+        externalAttributions: testExternalAttributions,
+        resourcesToExternalAttributions: testResourcesToExternalAttributions,
+      })
+    );
+    const { store } = renderComponentWithStore(<App />);
+    store.dispatch(
+      setExternalAttributionsToHashes(testExternalAttributionsToHashes)
+    );
+
+    clickOnElementInResourceBrowser(screen, 'firstResource.js');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+
+    clickOnButtonInPackageInPackagePanelContextMenu(
+      screen,
+      'React, 16.5.0',
+      'Signals',
+      ButtonText.Hide
+    );
+    expectAddIconInAddToAttributionCardIsHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+    expectContextMenuForHiddenExternalAttributionInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      'Signals'
+    );
+    expectContextMenuForExternalAttributionInPackagePanel(
+      screen,
+      'Vue, 1.2.0',
+      'Signals'
+    );
+
+    clickOnElementInResourceBrowser(screen, 'secondResource.js');
+    expectAddIconInAddToAttributionCardIsHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+    expectContextMenuForHiddenExternalAttributionInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      'Signals'
+    );
+    expectContextMenuForExternalAttributionInPackagePanel(
+      screen,
+      'Vue, 1.2.0',
+      'Signals'
+    );
+
+    clickOnButtonInPackageInPackagePanelContextMenu(
+      screen,
+      'React, 16.5.0',
+      'Signals',
+      ButtonText.Unhide
+    );
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+    expectContextMenuForExternalAttributionInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      'Signals'
+    );
+    expectContextMenuForExternalAttributionInPackagePanel(
+      screen,
+      'Vue, 1.2.0',
+      'Signals'
+    );
   });
 
   describe('replaces attributions', () => {

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -396,6 +396,81 @@ describe('The App in Audit View', () => {
     expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
   });
 
+  it('resolve button is shown and works for merged signals', () => {
+    const mockChannelReturn: ParsedFileContent = {
+      ...EMPTY_PARSED_FILE_CONTENT,
+      resources: {
+        folder1: { 'firstResource.js': 1 },
+      },
+
+      externalAttributions: {
+        attributions: {
+          uuid_1: {
+            packageName: 'React',
+            packageVersion: '16.5.0',
+          },
+          uuid_2: {
+            packageName: 'React',
+            packageVersion: '16.5.0',
+          },
+          uuid_3: {
+            packageName: 'Vue',
+            packageVersion: '1.2.0',
+            licenseText: 'Permission is not granted',
+          },
+          uuid_4: {
+            packageName: 'JQuery',
+            packageVersion: '16.5.0',
+            licenseText: 'Permission is hereby granted',
+          },
+        },
+        resourcesToAttributions: {
+          '/folder1/firstResource.js': ['uuid_1', 'uuid_2', 'uuid_3'],
+        },
+      },
+    };
+    mockElectronBackend(mockChannelReturn);
+    renderComponentWithStore(<App />);
+
+    clickOnElementInResourceBrowser(screen, 'folder1');
+    expectPackageInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      PackagePanelTitle.ContainedExternalPackages
+    );
+    expectPackageInPackagePanel(
+      screen,
+      'Vue, 1.2.0',
+      PackagePanelTitle.ContainedExternalPackages
+    );
+
+    clickOnPackageInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      PackagePanelTitle.ContainedExternalPackages
+    );
+    clickOnButton(screen, 'resolve attribution');
+    expectPackageNotInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      PackagePanelTitle.ContainedExternalPackages
+    );
+
+    clickOnElementInResourceBrowser(screen, 'firstResource.js');
+    expectAddIconInAddToAttributionCardIsHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+
+    clickOnPackageInPackagePanel(
+      screen,
+      'React, 16.5.0',
+      PackagePanelTitle.ExternalPackages
+    );
+    clickOnButton(screen, 'resolve attribution');
+
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'React, 16.5.0');
+    expectAddIconInAddToAttributionCardIsNotHidden(screen, 'Vue, 1.2.0');
+  });
+
   it('replaces attributions', () => {
     const expectedSaveFileArgs: SaveFileArgs = {
       manualAttributions: {

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -10,6 +10,7 @@ import {
   AttributionsToHashes,
   AttributionsToResources,
   BaseUrlsForSources,
+  DisplayPackageInfo,
   ExternalAttributionSources,
   FrequentLicenseName,
   LicenseTexts,
@@ -98,7 +99,9 @@ export function getFrequentLicensesTexts(state: State): LicenseTexts {
   return state.resourceState.allViews.frequentLicenses.texts;
 }
 
-export function getTemporaryPackageInfo(state: State): PackageInfo {
+export function getTemporaryPackageInfo(
+  state: State
+): PackageInfo | DisplayPackageInfo {
   return state.resourceState.allViews.temporaryPackageInfo;
 }
 


### PR DESCRIPTION
### Summary of changes

Enabled hide feature for merged signals in PackageCard context menu as well as in AttributionColumn.

### Context and reason for change

Is part of the story 'Deduplicate reused signals that are identical'.

### How can the changes be tested

With new tests in `audit-view.test.tsx` as well as`context-menu-audit-view.test.tsx` and with the test file `opossum-input.json` (merged signal attached to `menu.ts`).
