### PR TITLE
Included data to Total column in Attribution Count Table

### DIFF
--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -50,6 +50,14 @@ export function AttributionCountPerSourcePerLicenseTable(
       (sourceName) => sourceName.charAt(0).toUpperCase() + sourceName.slice(1)
     );
 
+  Object.entries(
+    props.licenseCounts.attributionCountPerSourcePerLicense
+  ).forEach(
+    ([licenseName, value]) =>
+      (value[TOTAL_SOURCES_TITLE] =
+        props.licenseCounts.totalAttributionsPerLicense[licenseName])
+  );
+
   return (
     <ProjectLicensesTable
       title={props.title}


### PR DESCRIPTION

### Summary of changes

Included Total license count to the AttributionCountPerSourcePerLicenseTable.

### Context and reason for change

Fix #1557

### How can the changes be tested

See ProjectStatisticsPopup
![image](https://user-images.githubusercontent.com/85183359/231735081-3757d96b-eb25-46b0-9b88-8cf8dcbfea30.png)

