### PR TITLE
Deprecate originId field in input files

### DIFF
--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -140,7 +140,8 @@
           },
           "originId": {
             "type": "string",
-            "description": "Can be set to track a signal from the tooling that generated the input file. Will be copied into the output when the signal is converted into an attribution."
+            "description": "Deprecated - originIds should be used instead. Can be set to track a signal from the tooling that generated the input file. Will be copied into the output when the signal is converted into an attribution.",
+            "deprecated": true
           },
           "originIds": {
             "type": "array",


### PR DESCRIPTION
### Summary of changes

Deprecate the originId filed in input files

### Context and reason for change

In #1561, identical signals are merged in OpossumUI. This means that one signal may have multiple origins. In order to support this, the field `originIds` was introduced, and now `originId` is deprecated.
