### PR TITLE
Refactor DisplayPackageInfo: PackageCard

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
@@ -12,6 +12,7 @@ import { PackagePanelTitle } from '../../enums/enums';
 import {
   AttributionIdsWithCountAndResourceId,
   AttributionIdWithCount,
+  DisplayAttributionWithCount,
   PanelData,
 } from '../../types/types';
 import { AccordionWorkersContext } from '../WorkersContextProvider/WorkersContextProvider';
@@ -46,7 +47,7 @@ interface WorkerAccordionPanelProps {
   syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs;
   getDisplayAttributionIdsWithCount(
     workerArgs: ContainedAttributionsAccordionWorkerArgs
-  ): Array<AttributionIdWithCount>;
+  ): Array<AttributionIdWithCount | DisplayAttributionWithCount>;
   attributions: Attributions;
   isAddToPackageEnabled: boolean;
 }

--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/accordion-panel-helper.test.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/accordion-panel-helper.test.ts
@@ -33,7 +33,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid1',
         attribution: {
-          type: 'DisplayPackageInfo',
           attributionIds: ['uuid1', 'uuid2'],
           packageName: 'Typescript',
           attributionConfidence: 0,
@@ -61,7 +60,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid1',
         attribution: {
-          type: 'DisplayPackageInfo',
           packageName: 'Typescript',
           attributionConfidence: 0,
           attributionIds: ['uuid1'],
@@ -70,7 +68,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid2',
         attribution: {
-          type: 'DisplayPackageInfo',
           packageName: 'Typescript',
           attributionConfidence: 0,
           attributionIds: ['uuid2'],
@@ -101,7 +98,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid1',
         attribution: {
-          type: 'DisplayPackageInfo',
           attributionIds: ['uuid1', 'uuid2'],
           attributionConfidence: 20,
         },
@@ -141,7 +137,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid1',
         attribution: {
-          type: 'DisplayPackageInfo',
           attributionIds: ['uuid1', 'uuid2', 'uuid3', 'uuid4'],
           attributionConfidence: 0,
           comments: ['comment A', 'comment B'],
@@ -172,7 +167,6 @@ describe('getDisplayAttributionsWithCount', () => {
       {
         attributionId: 'uuid1',
         attribution: {
-          type: 'DisplayPackageInfo',
           attributionIds: ['uuid1', 'uuid2'],
           attributionConfidence: 0,
           originIds: ['uuid3', 'uuid4', 'uuid5'],

--- a/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
@@ -23,7 +23,7 @@ export function getDisplayContainedExternalPackagesWithCount(args: {
   externalData: Readonly<PanelAttributionData>;
   resolvedExternalAttributions: Readonly<Set<string>>;
   attributionsToHashes: Readonly<AttributionsToHashes>;
-}): Array<AttributionIdWithCount> {
+}): Array<DisplayAttributionWithCount> {
   const attributionIdsWithCount = getContainedExternalPackages(
     args.selectedResourceId,
     args.externalData.resourcesWithAttributedChildren,
@@ -101,13 +101,14 @@ function getDisplayAttributionWithCountFromAttributions(
     (attributionWithId) => attributionWithId[0]
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { comment, ...packageInfoWithoutComment } = attributionsWithIds[0][1];
+
   const attributionToShow: DisplayPackageInfo = {
-    ...attributionsWithIds[0][1],
-    type: 'DisplayPackageInfo',
+    ...packageInfoWithoutComment,
     attributionConfidence: displayAttributionConfidence,
     attributionIds,
   };
-  delete attributionToShow.comment;
   if (comments.length > 0) {
     attributionToShow.comments = comments;
   }

--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -14,6 +14,10 @@ import { PackageCardConfig } from '../../types/types';
 import { useAppDispatch } from '../../state/hooks';
 import { PackageList } from '../PackageList/PackageList';
 import { PackageCard } from '../PackageCard/PackageCard';
+import {
+  convertDisplayPackageInfoToPackageInfo,
+  convertPackageInfoToDisplayPackageInfo,
+} from '../../util/convert-package-info';
 
 const classes = {
   root: {
@@ -35,7 +39,10 @@ export function AllAttributionsPanel(
   const dispatch = useAppDispatch();
 
   function getPackageCard(attributionId: string): ReactElement | null {
-    const packageInfo = props.attributions && props.attributions[attributionId];
+    const displayPackageInfo = convertPackageInfoToDisplayPackageInfo(
+      props.attributions[attributionId],
+      [attributionId]
+    );
 
     function onCardClick(): void {
       dispatch(
@@ -47,12 +54,14 @@ export function AllAttributionsPanel(
     }
 
     function onAddClick(): void {
+      const packageInfo =
+        convertDisplayPackageInfoToPackageInfo(displayPackageInfo);
       dispatch(addToSelectedResource(packageInfo));
     }
 
     const cardConfig: PackageCardConfig = {
       isSelected: attributionId === props.selectedAttributionId,
-      isPreSelected: Boolean(packageInfo.preSelected),
+      isPreSelected: Boolean(displayPackageInfo.preSelected),
     };
 
     return (
@@ -61,10 +70,9 @@ export function AllAttributionsPanel(
         onClick={onCardClick}
         onIconClick={props.isAddToPackageEnabled ? onAddClick : undefined}
         cardConfig={cardConfig}
-        key={`PackageCard-${packageInfo.packageName}-${attributionId}`}
-        packageInfo={packageInfo}
+        key={`PackageCard-${displayPackageInfo.packageName}-${attributionId}`}
+        displayPackageInfo={displayPackageInfo}
         hideResourceSpecificButtons={true}
-        attributionId={attributionId}
         showOpenResourcesIcon={true}
       />
     );

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -566,7 +566,6 @@ describe('The AttributionColumn', () => {
     it('saves resolved external attributions', () => {
       const testPackageInfo: PackageInfo = {};
       const testTemporaryPackageInfo: DisplayPackageInfo = {
-        type: 'DisplayPackageInfo',
         attributionIds: ['TestId'],
       };
       const expectedSaveFileArgs: SaveFileArgs = {

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -12,6 +12,7 @@ import { checkboxClass } from '../../shared-styles';
 import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
 import { AttributionsViewPackageList } from '../PackageList/AttributionsViewPackageList';
+import { convertPackageInfoToDisplayPackageInfo } from '../../util/convert-package-info';
 
 const classes = {
   ...checkboxClass,
@@ -41,7 +42,10 @@ export function AttributionList(props: AttributionListProps): ReactElement {
   }).sort(getAlphabeticalComparer(attributions));
 
   function getAttributionCard(attributionId: string): ReactElement {
-    const packageInfo = attributions[attributionId];
+    const displayPackageInfo = convertPackageInfoToDisplayPackageInfo(
+      attributions[attributionId],
+      [attributionId]
+    );
 
     function isSelected(): boolean {
       return attributionId === props.selectedAttributionId;
@@ -53,17 +57,16 @@ export function AttributionList(props: AttributionListProps): ReactElement {
 
     const cardConfig: PackageCardConfig = {
       isSelected: isSelected(),
-      isPreSelected: Boolean(packageInfo.preSelected),
+      isPreSelected: Boolean(displayPackageInfo.preSelected),
     };
 
     return (
       <PackageCard
         cardId={`attribution-list-${attributionId}`}
-        attributionId={attributionId}
         onClick={onClick}
         cardConfig={cardConfig}
-        key={`AttributionCard-${packageInfo.packageName}-${attributionId}`}
-        packageInfo={packageInfo}
+        key={`AttributionCard-${displayPackageInfo.packageName}-${attributionId}`}
+        displayPackageInfo={displayPackageInfo}
         hideResourceSpecificButtons={true}
         showCheckBox={true}
       />

--- a/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
@@ -11,6 +11,7 @@ import {
   Attributions,
   PackageInfo,
   Resources,
+  isDisplayPackageInfo,
 } from '../../../../shared/shared-types';
 import {
   navigateToView,
@@ -131,7 +132,7 @@ describe('The EditAttributionPopup', () => {
         })
       )
     );
-    const changedTestTemporaryPackageInfo = {
+    const changedTestTemporaryPackageInfo: PackageInfo = {
       ...testTemporaryPackageInfo,
       comment: 'changed comment',
     };
@@ -145,8 +146,13 @@ describe('The EditAttributionPopup', () => {
 
     fireEvent.click(screen.queryByText(ButtonText.Save) as Element);
     expect(getOpenPopup(store.getState())).toBe(null);
-    expect(getTemporaryPackageInfo(store.getState()).comment).toBe(
-      changedTestTemporaryPackageInfo.comment
+    const resultingTemporaryPackageInfo = getTemporaryPackageInfo(
+      store.getState()
     );
+    if (!isDisplayPackageInfo(resultingTemporaryPackageInfo)) {
+      expect(resultingTemporaryPackageInfo.comment).toBe(
+        changedTestTemporaryPackageInfo.comment
+      );
+    }
   });
 });

--- a/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
+++ b/src/Frontend/Components/ManualAttributionList/ManualAttributionList.tsx
@@ -9,6 +9,7 @@ import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
 import { List } from '../List/List';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { PackageCardConfig } from '../../types/types';
+import { convertPackageInfoToDisplayPackageInfo } from '../../util/convert-package-info';
 
 const addNewAttributionButtonText = 'Add new attribution';
 const addNewAttributionButtonId = 'ADD_NEW_ATTRIBUTION_ID';
@@ -38,8 +39,12 @@ export function ManualAttributionList(
   }
 
   function getAttributionCard(attributionId: string): ReactElement {
-    const packageInfo = attributions[attributionId];
     const isButton = attributionId === addNewAttributionButtonId;
+
+    const displayPackageInfo = convertPackageInfoToDisplayPackageInfo(
+      attributions[attributionId],
+      isButton ? [''] : [attributionId]
+    );
 
     function isSelected(): boolean {
       return (
@@ -54,18 +59,17 @@ export function ManualAttributionList(
 
     const cardConfig: PackageCardConfig = {
       isSelected: isSelected(),
-      isPreSelected: Boolean(packageInfo.preSelected),
+      isPreSelected: Boolean(displayPackageInfo.preSelected),
     };
 
     return (
       <PackageCard
-        attributionId={isButton ? '' : attributionId}
         onClick={onClick}
         hideContextMenuAndMultiSelect={isButton}
         cardConfig={cardConfig}
-        key={`AttributionCard-${packageInfo.packageName}-${attributionId}`}
+        key={`AttributionCard-${displayPackageInfo.packageName}-${attributionId}`}
         cardId={`manual-${props.selectedResourceId}-${attributionId}`}
-        packageInfo={packageInfo}
+        displayPackageInfo={displayPackageInfo}
         showOpenResourcesIcon={!isButton}
         hideAttributionWizardContextMenuItem={props.attributionsFromParent}
       />

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -62,11 +62,11 @@ describe('The PackageCard', () => {
     );
     renderComponentWithStore(
       <PackageCard
-        attributionId={testAttributionId}
         cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
         cardId={'some_id'}
-        packageInfo={{
+        displayPackageInfo={{
           packageName: 'packageName',
+          attributionIds: [testAttributionId],
         }}
         onClick={doNothing}
       />,
@@ -114,11 +114,11 @@ describe('The PackageCard', () => {
     );
     renderComponentWithStore(
       <PackageCard
-        attributionId={testAttributionId}
         cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
         cardId={'some_id'}
-        packageInfo={{
+        displayPackageInfo={{
           packageName: 'packageName',
+          attributionIds: [testAttributionId],
         }}
         onClick={doNothing}
       />,
@@ -166,11 +166,11 @@ describe('The PackageCard', () => {
     );
     const { store } = renderComponentWithStore(
       <PackageCard
-        attributionId={testAttributionId}
         cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
         cardId={'some_id'}
-        packageInfo={{
+        displayPackageInfo={{
           packageName: 'packageName',
+          attributionIds: [testAttributionId],
         }}
         onClick={doNothing}
         showCheckBox={true}
@@ -217,22 +217,22 @@ describe('The PackageCard', () => {
     renderComponentWithStore(
       <div>
         <PackageCard
-          attributionId={testAttributionId}
           cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
           cardId={'some_id'}
-          packageInfo={{
+          displayPackageInfo={{
             packageName: 'packageName',
+            attributionIds: [testAttributionId],
           }}
           onClick={doNothing}
           showCheckBox={true}
         />
         ,
         <PackageCard
-          attributionId={anotherAttributionId}
           cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
           cardId={'some_id_2'}
-          packageInfo={{
+          displayPackageInfo={{
             packageName: 'packageName2',
+            attributionIds: [anotherAttributionId],
           }}
           onClick={doNothing}
           showCheckBox={true}
@@ -306,8 +306,10 @@ describe('The PackageCard', () => {
     renderComponentWithStore(
       <PackageCard
         cardId={'testCardId'}
-        packageInfo={{ packageName: 'testPackage' }}
-        attributionId={'uuid_0'}
+        displayPackageInfo={{
+          packageName: 'testPackage',
+          attributionIds: ['uuid_0'],
+        }}
         cardConfig={{ isExternalAttribution: false, isSelected: true }}
         onClick={doNothing}
         hideContextMenuAndMultiSelect={false}

--- a/src/Frontend/Components/PackageCard/__tests__/package-card-helpers.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/package-card-helpers.test.tsx
@@ -4,18 +4,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getPackageCardHighlighting } from '../package-card-helpers';
-import { PackageInfo } from '../../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../../shared/shared-types';
 import each from 'jest-each';
 import { HighlightingColor } from '../../../enums/enums';
 
 describe('The PackageCardHelper', () => {
   each([
-    [{}, HighlightingColor.DarkOrange],
-    [{ firstParty: true }, undefined],
-    [{ excludeFromNotice: true }, undefined],
+    [{ attributionIds: ['abc'] }, HighlightingColor.DarkOrange],
+    [{ firstParty: true, attributionIds: ['abc'] }, undefined],
+    [
+      {
+        excludeFromNotice: true,
+        attributionIds: ['abc'],
+      },
+      undefined,
+    ],
     [
       {
         packageName: 'some package name',
+        attributionIds: ['abc'],
       },
       HighlightingColor.LightOrange,
     ],
@@ -23,6 +30,7 @@ describe('The PackageCardHelper', () => {
       {
         licenseName: 'some license name',
         packageVersion: 'some package version',
+        attributionIds: ['abc'],
       },
       HighlightingColor.DarkOrange,
     ],
@@ -33,16 +41,17 @@ describe('The PackageCardHelper', () => {
         packageVersion: 'some package version',
         url: 'some url',
         copyright: 'some copyright',
+        attributionIds: ['abc'],
       },
       undefined,
     ],
   ]).it(
     'for %s packageInfo gives %s highlighting',
     (
-      packageInfo: PackageInfo,
+      displayPackageInfo: DisplayPackageInfo,
       expected_highlighting: HighlightingColor | undefined
     ) => {
-      const actualHighlighting = getPackageCardHighlighting(packageInfo);
+      const actualHighlighting = getPackageCardHighlighting(displayPackageInfo);
       expect(actualHighlighting).toEqual(expected_highlighting);
     }
   );

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -12,7 +12,7 @@ import {
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { HighlightingColor } from '../../enums/enums';
 import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 
@@ -71,7 +71,7 @@ export function getRightIcons(
 }
 
 export function getPackageCardHighlighting(
-  packageInfo: PackageInfo
+  packageInfo: DisplayPackageInfo
 ): HighlightingColor | undefined {
   if (packageInfo.excludeFromNotice || packageInfo.firstParty) return undefined;
   if (packageInfo.packageName === undefined)

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -29,7 +29,6 @@ import {
 import {
   getAttributionIdsWithCountForSource,
   getSortedSources,
-  convertDisplayPackageInfoToPackageInfo,
 } from './package-panel-helpers';
 import { prettifySource } from '../../util/prettify-source';
 import {
@@ -39,6 +38,10 @@ import {
   PackageCardConfig,
 } from '../../types/types';
 import { PackageCard } from '../PackageCard/PackageCard';
+import {
+  convertDisplayPackageInfoToPackageInfo,
+  convertPackageInfoToDisplayPackageInfo,
+} from '../../util/convert-package-info';
 
 const classes = {
   root: {
@@ -139,9 +142,12 @@ export function PackagePanel(
   }
 
   function getPackageCard(attributionId: string): ReactElement {
-    const packageInfo: PackageInfo | DisplayPackageInfo =
-      getAttributionFromDisplayAttributionWithCount(attributionId) ||
-      props.attributions[attributionId];
+    const displayPackageInfo: DisplayPackageInfo =
+      getAttributionFromDisplayAttributionWithCount(attributionId) ??
+      convertPackageInfoToDisplayPackageInfo(
+        props.attributions[attributionId],
+        [attributionId]
+      );
 
     const packageCount: number | undefined =
       props.attributionIdsWithCount.filter(
@@ -157,7 +163,7 @@ export function PackagePanel(
       ? getPreSelectedExternalAttributionIdsForSelectedResource().includes(
           attributionId
         )
-      : packageInfo.preSelected;
+      : displayPackageInfo.preSelected;
 
     const selectedAttributionId =
       selectedPackage && props.title === selectedPackage.panel
@@ -179,12 +185,11 @@ export function PackagePanel(
       <PackageCard
         onClick={(): void => onCardClick(attributionId)}
         onIconClick={props.isAddToPackageEnabled ? onIconClick : undefined}
-        key={`PackageCard-${packageInfo.packageName}-${attributionId}`}
+        key={`PackageCard-${displayPackageInfo.packageName}-${attributionId}`}
         packageCount={packageCount}
         hideResourceSpecificButtons={true}
         cardId={`package-${selectedResourceId}-${attributionId}`}
-        packageInfo={packageInfo}
-        attributionId={attributionId}
+        displayPackageInfo={displayPackageInfo}
         cardConfig={cardConfig}
         showOpenResourcesIcon={true}
       />

--- a/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
@@ -10,11 +10,11 @@ import {
   PackageInfo,
 } from '../../../../shared/shared-types';
 import {
-  convertDisplayPackageInfoToPackageInfo,
   getAttributionIdsWithCountForSource,
   getSortedSources,
 } from '../package-panel-helpers';
 import { AttributionIdWithCount } from '../../../types/types';
+import { convertDisplayPackageInfoToPackageInfo } from '../../../util/convert-package-info';
 
 const testAttributionSources: ExternalAttributionSources = {
   MERGER: { name: 'Suggested', priority: 11 },
@@ -183,13 +183,11 @@ describe('PackagePanel helpers', () => {
   it('convertDisplayPackageInfoToPackageInfo returns correct PackageInfo', () => {
     const testDisplayPackageInfoA: DisplayPackageInfo = {
       packageName: 'react',
-      type: 'DisplayPackageInfo',
       comments: ['comment A', 'comment B'],
       attributionIds: ['123', '456'],
     };
     const testDisplayPackageInfoB: DisplayPackageInfo = {
       packageName: 'react',
-      type: 'DisplayPackageInfo',
       comments: ['comment'],
       attributionIds: ['123'],
     };

--- a/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
+++ b/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
@@ -5,14 +5,10 @@
 
 import {
   Attributions,
-  DisplayPackageInfo,
   ExternalAttributionSources,
-  PackageInfo,
   Source,
 } from '../../../shared/shared-types';
-import { getPackageInfoKeys } from '../../../shared/shared-util';
 import { AttributionIdWithCount } from '../../types/types';
-import { shouldNotBeCalled } from '../../util/should-not-be-called';
 
 export function getSortedSources(
   attributions: Attributions,
@@ -88,60 +84,4 @@ export function getAttributionIdsWithCountForSource(
       ? Boolean(source?.name && source?.name === sourceName)
       : !source;
   });
-}
-
-export function convertDisplayPackageInfoToPackageInfo(
-  displayPackageInfo: DisplayPackageInfo
-): PackageInfo {
-  const packageInfo: PackageInfo = {};
-
-  getPackageInfoKeys().forEach((packageInfoKey) => {
-    if (packageInfoKey in displayPackageInfo) {
-      switch (packageInfoKey) {
-        case 'packageName':
-        case 'packageVersion':
-        case 'packageNamespace':
-        case 'packageType':
-        case 'packagePURLAppendix':
-        case 'url':
-        case 'copyright':
-        case 'licenseName':
-        case 'licenseText':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'comment':
-          break;
-        case 'firstParty':
-        case 'preSelected':
-        case 'excludeFromNotice':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'attributionConfidence':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'followUp':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'source':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'originIds':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        case 'criticality':
-          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
-          break;
-        default:
-          shouldNotBeCalled(packageInfoKey);
-      }
-    }
-    if (
-      displayPackageInfo.attributionIds.length === 1 &&
-      displayPackageInfo.comments
-    ) {
-      packageInfo.comment = displayPackageInfo.comments[0];
-    }
-  });
-
-  return packageInfo;
 }

--- a/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
+++ b/src/Frontend/Components/ReplaceAttributionPopup/ReplaceAttributionPopup.tsx
@@ -20,6 +20,7 @@ import { savePackageInfo } from '../../state/actions/resource-actions/save-actio
 import { setAttributionIdMarkedForReplacement } from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
 import MuiBox from '@mui/material/Box';
+import { convertPackageInfoToDisplayPackageInfo } from '../../util/convert-package-info';
 
 const classes = {
   typography: {
@@ -59,16 +60,18 @@ export function ReplaceAttributionPopup(): ReactElement {
   }
 
   function getPackageCard(attributionId: string): ReactElement {
-    const packageInfo = attributions[attributionId];
+    const displayPackageInfo = convertPackageInfoToDisplayPackageInfo(
+      attributions[attributionId],
+      [attributionId]
+    );
 
     return (
       <PackageCard
-        attributionId={attributionId}
         onClick={doNothing}
         cardConfig={{}}
         hideContextMenuAndMultiSelect={true}
         cardId={`attribution-list-${attributionId}`}
-        packageInfo={packageInfo}
+        displayPackageInfo={displayPackageInfo}
       />
     );
   }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -48,6 +48,8 @@ export interface Height {
 
 export type KeysOfPackageInfo = keyof PackageInfo;
 
+export type KeysOfDisplayPackageInfo = keyof DisplayPackageInfo;
+
 export interface PackageCardConfig {
   isExternalAttribution?: boolean;
   isSelected?: boolean;

--- a/src/Frontend/util/__tests__/get-card-labels-test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels-test.ts
@@ -126,7 +126,6 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
-    type: 'DisplayPackageInfo',
     attributionIds: ['abc'],
   };
   const testPropsWithoutVersion: DisplayPackageInfo = {
@@ -136,7 +135,6 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
-    type: 'DisplayPackageInfo',
     attributionIds: ['abc'],
   };
 
@@ -187,7 +185,6 @@ describe('Test addSecondLineOfPackageLabelFromAttribute', () => {
     comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
-    type: 'DisplayPackageInfo',
     attributionIds: ['abc'],
   };
   it('adds copyright', () => {

--- a/src/Frontend/util/convert-package-info.ts
+++ b/src/Frontend/util/convert-package-info.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfo, DisplayPackageInfo } from '../../shared/shared-types';
+import { getPackageInfoKeys } from '../../shared/shared-util';
+import { getDisplayPackageInfoKeys } from './get-display-package-info-keys';
+import { shouldNotBeCalled } from './should-not-be-called';
+
+export function convertPackageInfoToDisplayPackageInfo(
+  packageInfo: PackageInfo,
+  attributionIds: Array<string>
+): DisplayPackageInfo {
+  const displayPackageInfo: DisplayPackageInfo = {
+    attributionIds,
+  };
+  getDisplayPackageInfoKeys().forEach((displayPackageInfoKey) => {
+    switch (displayPackageInfoKey) {
+      case 'packageName':
+      case 'packageVersion':
+      case 'packageNamespace':
+      case 'packageType':
+      case 'packagePURLAppendix':
+      case 'url':
+      case 'copyright':
+      case 'licenseName':
+      case 'licenseText':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'firstParty':
+      case 'preSelected':
+      case 'excludeFromNotice':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'attributionConfidence':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'followUp':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'source':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'originIds':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'criticality':
+        displayPackageInfo[displayPackageInfoKey] =
+          packageInfo[displayPackageInfoKey];
+        break;
+      case 'comments':
+        if (packageInfo.comment) {
+          displayPackageInfo.comments = [packageInfo.comment];
+        }
+        break;
+      case 'attributionIds':
+        break;
+      default:
+        shouldNotBeCalled(displayPackageInfoKey);
+    }
+  });
+  return displayPackageInfo;
+}
+
+export function convertDisplayPackageInfoToPackageInfo(
+  displayPackageInfo: DisplayPackageInfo
+): PackageInfo {
+  const packageInfo: PackageInfo = {};
+
+  getPackageInfoKeys().forEach((packageInfoKey) => {
+    if (packageInfoKey in displayPackageInfo) {
+      switch (packageInfoKey) {
+        case 'packageName':
+        case 'packageVersion':
+        case 'packageNamespace':
+        case 'packageType':
+        case 'packagePURLAppendix':
+        case 'url':
+        case 'copyright':
+        case 'licenseName':
+        case 'licenseText':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'comment':
+          break;
+        case 'firstParty':
+        case 'preSelected':
+        case 'excludeFromNotice':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'attributionConfidence':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'followUp':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'source':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'originIds':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        case 'criticality':
+          packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
+          break;
+        default:
+          shouldNotBeCalled(packageInfoKey);
+      }
+    }
+    if (
+      displayPackageInfo.attributionIds.length === 1 &&
+      displayPackageInfo.comments
+    ) {
+      packageInfo.comment = displayPackageInfo.comments[0];
+    }
+  });
+
+  return packageInfo;
+}

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -22,18 +22,17 @@ const PRIORITIZED_DISPLAY_PACKAGE_INFO_ATTRIBUTES: Array<RelevantDisplayPackageI
 
 const FIRST_PARTY_TEXT = 'First party';
 
+// TODO: Delete and replace
 function convertPackageInfoToDisplayPackageInfo(
   packageInfo: PackageInfo
 ): DisplayPackageInfo {
   const displayPackageInfo: DisplayPackageInfo = {
     ...packageInfo,
-    type: 'DisplayPackageInfo',
     attributionIds: [],
   };
 
   if (packageInfo.comment) {
     displayPackageInfo.comments = [packageInfo.comment];
-    delete displayPackageInfo.comment;
   }
 
   return displayPackageInfo;

--- a/src/Frontend/util/get-display-package-info-keys.ts
+++ b/src/Frontend/util/get-display-package-info-keys.ts
@@ -3,14 +3,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { KeysOfPackageInfo } from '../Frontend/types/types';
-import { PackageInfo } from './shared-types';
+import { DisplayPackageInfo } from '../../shared/shared-types';
+import { KeysOfDisplayPackageInfo } from '../types/types';
 
-export function getPackageInfoKeys(): Array<KeysOfPackageInfo> {
+export function getDisplayPackageInfoKeys(): Array<KeysOfDisplayPackageInfo> {
   type KeysEnum<T> = { [P in keyof Required<T>]: true };
-  const packageInfoKeysObject: KeysEnum<PackageInfo> = {
+  const displayPackageInfoKeysObject: KeysEnum<DisplayPackageInfo> = {
     attributionConfidence: true,
-    comment: true,
     packageName: true,
     packageVersion: true,
     packageNamespace: true,
@@ -27,6 +26,10 @@ export function getPackageInfoKeys(): Array<KeysOfPackageInfo> {
     preSelected: true,
     excludeFromNotice: true,
     criticality: true,
+    comments: true,
+    attributionIds: true,
   };
-  return Object.keys(packageInfoKeysObject) as Array<KeysOfPackageInfo>;
+  return Object.keys(
+    displayPackageInfoKeysObject
+  ) as Array<KeysOfDisplayPackageInfo>;
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -51,8 +51,7 @@ export interface PackageInfo extends PackageInfoCore {
   comment?: string;
 }
 
-export interface DisplayPackageInfo extends PackageInfo {
-  type: 'DisplayPackageInfo';
+export interface DisplayPackageInfo extends PackageInfoCore {
   comments?: Array<string>;
   attributionIds: Array<string>;
 }
@@ -60,10 +59,7 @@ export interface DisplayPackageInfo extends PackageInfo {
 export function isDisplayPackageInfo(
   packageInfoOrDisplayPackageInfo: PackageInfo | DisplayPackageInfo
 ): packageInfoOrDisplayPackageInfo is DisplayPackageInfo {
-  return (
-    'type' in packageInfoOrDisplayPackageInfo &&
-    packageInfoOrDisplayPackageInfo.type === 'DisplayPackageInfo'
-  );
+  return 'attributionIds' in packageInfoOrDisplayPackageInfo;
 }
 
 export interface Source {


### PR DESCRIPTION
### Summary of changes

This is the first step of refactoring. `PackageCard` has been refactored to only rely on the new `DisplayPackageInfo`. The parents are changed such that they provide `DisplayPackageInfo` and convert back to `PackageInfo` when dispatching to the redux state.

### Context and reason for change

Separate business logic and display logic by using DisplayPackageInfo.