### PR TITLE
Use index for withAttributedChildren to save memory.

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/__tests__/AttributionWizardPopup.test.tsx
@@ -21,6 +21,8 @@ import {
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { openAttributionWizardPopup } from '../../../state/actions/popup-actions/popup-actions';
 import { AttributionWizardPopup } from '../AttributionWizardPopup';
+import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 
 const selectedResourceId = '/samplepath/';
 const testManualAttributions: Attributions = {
@@ -31,7 +33,7 @@ const testManualAttributions: Attributions = {
     packageVersion: '18.2.0',
   },
 };
-const testManualResourcesToAttributions: ResourcesToAttributions = {
+const testResourcesToManualAttributions: ResourcesToAttributions = {
   [selectedResourceId]: ['uuid_0'],
 };
 const testExternalAttributions: Attributions = {
@@ -42,7 +44,7 @@ const testExternalAttributions: Attributions = {
     packageVersion: '1.24.1',
   },
 };
-const testExternalResourcesToAttributions: ResourcesToAttributions = {
+const testResourcesToExternalAttributions: ResourcesToAttributions = {
   '/samplepath/file': ['uuid_1'],
 };
 
@@ -53,16 +55,17 @@ const versionListTitle = 'Package version';
 describe('AttributionWizardPopup', () => {
   it('renders with header, resource path, and buttons', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(setSelectedResourceId(selectedResourceId));
     testStore.dispatch(
-      setExternalData(
-        testExternalAttributions,
-        testExternalResourcesToAttributions
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+          resourcesToExternalAttributions: testResourcesToExternalAttributions,
+          manualAttributions: testManualAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        })
       )
     );
-    testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
-    );
+    testStore.dispatch(setSelectedResourceId(selectedResourceId));
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
     });
@@ -84,11 +87,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributions,
-        testExternalResourcesToAttributions
+        testResourcesToExternalAttributions
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -105,11 +108,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributions,
-        testExternalResourcesToAttributions
+        testResourcesToExternalAttributions
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -148,11 +151,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributions,
-        testExternalResourcesToAttributions
+        testResourcesToExternalAttributions
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -182,11 +185,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributions,
-        testExternalResourcesToAttributions
+        testResourcesToExternalAttributions
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -206,11 +209,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributions,
-        testExternalResourcesToAttributions
+        testResourcesToExternalAttributions
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));
@@ -275,7 +278,7 @@ describe('AttributionWizardPopup', () => {
       },
     };
 
-    const testExternalResourcesToAttributionsExtended: ResourcesToAttributions =
+    const testResourcesToExternalAttributionsExtended: ResourcesToAttributions =
       {
         '/samplepath/file': ['uuid_1', 'uuid_2'],
       };
@@ -285,11 +288,11 @@ describe('AttributionWizardPopup', () => {
     testStore.dispatch(
       setExternalData(
         testExternalAttributionsExtended,
-        testExternalResourcesToAttributionsExtended
+        testResourcesToExternalAttributionsExtended
       )
     );
     testStore.dispatch(
-      setManualData(testManualAttributions, testManualResourcesToAttributions)
+      setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     act(() => {
       testStore.dispatch(openAttributionWizardPopup('uuid_0'));

--- a/src/Frontend/Components/ResourceBrowser/get-resource-browser-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-resource-browser-tree-item-label.tsx
@@ -149,9 +149,13 @@ function containsExternalAttribution(
   nodeId: string,
   resourcesWithExternalAttributedChildren: ResourcesWithAttributedChildren
 ): boolean {
+  const nodeIndex =
+    resourcesWithExternalAttributedChildren.pathsToIndices[nodeId];
+
   return (
-    resourcesWithExternalAttributedChildren &&
-    nodeId in resourcesWithExternalAttributedChildren
+    nodeIndex !== undefined &&
+    resourcesWithExternalAttributedChildren.attributedChildren[nodeIndex] !==
+      undefined
   );
 }
 
@@ -161,7 +165,7 @@ function containsManualAttribution(
 ): boolean {
   return (
     resourcesWithManualAttributedChildren &&
-    nodeId in resourcesWithManualAttributedChildren
+    nodeId in resourcesWithManualAttributedChildren.pathsToIndices
   );
 }
 

--- a/src/Frontend/shared-constants.ts
+++ b/src/Frontend/shared-constants.ts
@@ -13,7 +13,11 @@ export const EMPTY_ATTRIBUTION_DATA: AttributionData = {
   attributions: {},
   resourcesToAttributions: {},
   attributionsToResources: {},
-  resourcesWithAttributedChildren: {},
+  resourcesWithAttributedChildren: {
+    paths: [],
+    pathsToIndices: {},
+    attributedChildren: {},
+  },
 };
 
 export const EMPTY_FREQUENT_LICENSES: FrequentLicenses = {

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -405,7 +405,15 @@ describe('The actions called from the unsaved popup', () => {
           reactUuid: ['/somethingElse.js'],
         },
         resourcesWithAttributedChildren: {
-          '/': new Set<string>().add('/somethingElse.js'),
+          attributedChildren: {
+            '1': new Set<number>().add(2),
+          },
+          pathsToIndices: {
+            '/': 1,
+            '/something.js': 0,
+            '/somethingElse.js': 2,
+          },
+          paths: ['/something.js', '/', '/somethingElse.js'],
         },
       };
 

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -239,8 +239,10 @@ export function openAttributionWizardPopup(
     const allAttributionIdsOfResourceAndChildrenWithCounts =
       getAllAttributionIdsWithCountsFromResourceAndChildren(
         selectedResourceId,
-        externalData,
-        manualData,
+        externalData.resourcesToAttributions,
+        externalData.resourcesWithAttributedChildren,
+        manualData.resourcesToAttributions,
+        manualData.resourcesWithAttributedChildren,
         resolvedExternalAttributions
       );
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -123,8 +123,19 @@ describe('The load and navigation simple actions', () => {
     };
     const expectedResourcesWithAttributedChildren: ResourcesWithAttributedChildren =
       {
-        '/': new Set<string>().add('/some/path1').add('/some/path2'),
-        '/some/': new Set<string>().add('/some/path1').add('/some/path2'),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(0).add(3),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(0).add(3),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/some/': 2,
+          '/some/path1': 0,
+          '/some/path2': 3,
+        },
+        paths: ['/some/path1', '/', '/some/', '/some/path2'],
       };
 
     const testStore = createTestAppStore();
@@ -133,7 +144,11 @@ describe('The load and navigation simple actions', () => {
     expect(getManualAttributionsToResources(testStore.getState())).toEqual({});
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState())
-    ).toEqual({});
+    ).toEqual({
+      attributedChildren: {},
+      pathsToIndices: {},
+      paths: [],
+    });
 
     testStore.dispatch(
       setManualData(testAttributions, testResourcesToAttributions)
@@ -167,8 +182,19 @@ describe('The load and navigation simple actions', () => {
     };
     const expectedResourcesWithAttributedChildren: ResourcesWithAttributedChildren =
       {
-        '/': new Set<string>().add('/some/path1').add('/some/path2'),
-        '/some/': new Set<string>().add('/some/path1').add('/some/path2'),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(0).add(3),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(0).add(3),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/some/': 2,
+          '/some/path1': 0,
+          '/some/path2': 3,
+        },
+        paths: ['/some/path1', '/', '/some/', '/some/path2'],
       };
 
     const testStore = createTestAppStore();
@@ -181,7 +207,11 @@ describe('The load and navigation simple actions', () => {
     );
     expect(
       getResourcesWithExternalAttributedChildren(testStore.getState())
-    ).toEqual({});
+    ).toEqual({
+      attributedChildren: {},
+      pathsToIndices: {},
+      paths: [],
+    });
 
     testStore.dispatch(
       setExternalData(testAttributions, testResourcesToAttributions)

--- a/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/audit-view-simple-actions.test.ts
@@ -112,8 +112,19 @@ describe('The audit view simple actions', () => {
     expect(
       getResourcesWithExternalAttributedChildren(testStore.getState())
     ).toMatchObject({
-      '/root/': new Set(['/root/src/', '/root/external/']),
-      '/': new Set(['/root/src/', '/root/external/']),
+      attributedChildren: {
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '1': new Set<number>().add(0).add(3),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '2': new Set<number>().add(0).add(3),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/external/': 3,
+        '/root/src/': 0,
+      },
+      paths: ['/root/src/', '/', '/root/', '/root/external/'],
     });
 
     expectedResolvedExternalAttributions.add(uuid1).add(uuid2);
@@ -174,8 +185,17 @@ describe('The audit view simple actions', () => {
     expect(
       getResourcesWithExternalAttributedChildren(testStore.getState())
     ).toEqual({
-      '/root/': new Set(['/root/src/']),
-      '/': new Set(['/root/src/']),
+      attributedChildren: {
+        '1': new Set<number>().add(0),
+        '2': new Set<number>().add(0),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/external/': 3,
+        '/root/src/': 0,
+      },
+      paths: ['/root/src/', '/', '/root/', '/root/external/'],
     });
 
     testStore.dispatch(addResolvedExternalAttribution(uuid3));
@@ -184,7 +204,16 @@ describe('The audit view simple actions', () => {
     );
     expect(
       getResourcesWithExternalAttributedChildren(testStore.getState())
-    ).toEqual({});
+    ).toEqual({
+      attributedChildren: {},
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/external/': 3,
+        '/root/src/': 0,
+      },
+      paths: ['/root/src/', '/', '/root/', '/root/external/'],
+    });
 
     testStore.dispatch(removeResolvedExternalAttribution(uuid2));
     expect(getResolvedExternalAttributions(testStore.getState())).toEqual(
@@ -194,8 +223,19 @@ describe('The audit view simple actions', () => {
     expect(
       getResourcesWithExternalAttributedChildren(testStore.getState())
     ).toEqual({
-      '/root/': new Set(['/root/external/']),
-      '/': new Set(['/root/external/']),
+      attributedChildren: {
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '1': new Set<number>().add(3),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '2': new Set<number>().add(3),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/external/': 3,
+        '/root/src/': 0,
+      },
+      paths: ['/root/src/', '/', '/root/', '/root/external/'],
     });
   });
 });

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -135,9 +135,18 @@ describe('loadFromFile', () => {
         '4d9f0b16-fbff-11ea-adc1-0242ac120002': ['/root/src/something.js'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/root/src/something.js'),
-        '/root/': new Set<string>().add('/root/src/something.js'),
-        '/root/src/': new Set<string>().add('/root/src/something.js'),
+        attributedChildren: {
+          '1': new Set<number>().add(0),
+          '2': new Set<number>().add(0),
+          '3': new Set<number>().add(0),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/root/': 2,
+          '/root/src/': 3,
+          '/root/src/something.js': 0,
+        },
+        paths: ['/root/src/something.js', '/', '/root/', '/root/src/'],
       },
     };
     const expectedExternalData: AttributionData = {
@@ -148,9 +157,27 @@ describe('loadFromFile', () => {
         test_id: ['/thirdParty/package_1.tr.gz'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/root/src/something.js'),
-        '/root/': new Set<string>().add('/root/src/something.js'),
-        '/root/src/': new Set<string>().add('/root/src/something.js'),
+        attributedChildren: {
+          '1': new Set<number>().add(0),
+          '2': new Set<number>().add(0),
+          '3': new Set<number>().add(0),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/root/': 2,
+          '/root/src/': 3,
+          '/root/src/something.js': 0,
+          '/thirdParty/': 5,
+          '/thirdParty/package_1.tr.gz': 4,
+        },
+        paths: [
+          '/root/src/something.js',
+          '/',
+          '/root/',
+          '/root/src/',
+          '/thirdParty/package_1.tr.gz',
+          '/thirdParty/',
+        ],
       },
     };
     const expectedExternalAttributionsToHashes: AttributionsToHashes = {

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -199,7 +199,11 @@ describe('The savePackageInfo action', () => {
     expect(getResourcesToManualAttributions(testStore.getState())).toEqual({});
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState())
-    ).toEqual({});
+    ).toEqual({
+      attributedChildren: {},
+      pathsToIndices: {},
+      paths: [],
+    });
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
 
     testStore.dispatch(
@@ -211,8 +215,16 @@ describe('The savePackageInfo action', () => {
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState())
     ).toEqual({
-      '/': new Set().add('/root/src/'),
-      '/root/': new Set().add('/root/src/'),
+      attributedChildren: {
+        '1': new Set<number>().add(0),
+        '2': new Set<number>().add(0),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/src/': 0,
+      },
+      paths: ['/root/src/', '/', '/root/'],
     });
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
   });
@@ -240,9 +252,18 @@ describe('The savePackageInfo action', () => {
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState())
     ).toEqual({
-      '/': new Set().add('/root/src/something.js'),
-      '/root/': new Set().add('/root/src/something.js'),
-      '/root/src/': new Set().add('/root/src/something.js'),
+      attributedChildren: {
+        '1': new Set().add(0),
+        '2': new Set().add(0),
+        '3': new Set().add(0),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/src/': 3,
+        '/root/src/something.js': 0,
+      },
+      paths: ['/root/src/something.js', '/', '/root/', '/root/src/'],
     });
 
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
@@ -261,9 +282,18 @@ describe('The savePackageInfo action', () => {
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState())
     ).toEqual({
-      '/': new Set().add('/root/src/something.js'),
-      '/root/': new Set().add('/root/src/something.js'),
-      '/root/src/': new Set().add('/root/src/something.js'),
+      attributedChildren: {
+        '1': new Set<number>().add(0),
+        '2': new Set<number>().add(0),
+        '3': new Set<number>().add(0),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/src/': 3,
+        '/root/src/something.js': 0,
+      },
+      paths: ['/root/src/something.js', '/', '/root/', '/root/src/'],
     });
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
   });
@@ -290,18 +320,50 @@ describe('The savePackageInfo action', () => {
     };
     const expectedResourcesWithManualAttributedChildren1: ResourcesWithAttributedChildren =
       {
-        '/': new Set<string>()
-          .add('/root/src/something.js')
-          .add('/root/somethingElse.js'),
-        '/root/': new Set<string>()
-          .add('/root/src/something.js')
-          .add('/root/somethingElse.js'),
-        '/root/src/': new Set<string>().add('/root/src/something.js'),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(0).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(0).add(4),
+          '3': new Set<number>().add(0),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/root/': 2,
+          '/root/somethingElse.js': 4,
+          '/root/src/': 3,
+          '/root/src/something.js': 0,
+        },
+        paths: [
+          '/root/src/something.js',
+          '/',
+          '/root/',
+          '/root/src/',
+          '/root/somethingElse.js',
+        ],
       };
     const expectedResourcesWithManualAttributedChildren2: ResourcesWithAttributedChildren =
       {
-        '/': new Set<string>().add('/root/somethingElse.js'),
-        '/root/': new Set<string>().add('/root/somethingElse.js'),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/root/': 2,
+          '/root/somethingElse.js': 4,
+          '/root/src/': 3,
+          '/root/src/something.js': 0,
+        },
+        paths: [
+          '/root/src/something.js',
+          '/',
+          '/root/',
+          '/root/src/',
+          '/root/somethingElse.js',
+        ],
       };
     const emptyTestTemporaryPackageInfo: PackageInfo = {};
 
@@ -516,9 +578,15 @@ describe('The savePackageInfo action', () => {
         uuid1: ['/something.js', '/somethingElse.js'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set()
-          .add('/something.js')
-          .add('/somethingElse.js') as Set<string>,
+        attributedChildren: {
+          '1': new Set<number>().add(0).add(2),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/something.js': 0,
+          '/somethingElse.js': 2,
+        },
+        paths: ['/something.js', '/', '/somethingElse.js'],
       },
     };
 
@@ -583,10 +651,17 @@ describe('The savePackageInfo action', () => {
         [testUuid]: ['/something.js', '/folder/somethingElse.js'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/something.js')
-          .add('/folder/somethingElse.js'),
-        '/folder/': new Set<string>().add('/folder/somethingElse.js'),
+        attributedChildren: {
+          '1': new Set<number>().add(0).add(2),
+          '3': new Set<number>().add(2),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/folder/': 3,
+          '/folder/somethingElse.js': 2,
+          '/something.js': 0,
+        },
+        paths: ['/something.js', '/', '/folder/somethingElse.js', '/folder/'],
       },
     };
 
@@ -837,9 +912,15 @@ describe('The unlinkAttributionAndSavePackageInfo action', () => {
         vueUuid: ['/something.js'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set()
-          .add('/something.js')
-          .add('/somethingElse.js') as Set<string>,
+        attributedChildren: {
+          '1': new Set<number>().add(0).add(2),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/something.js': 0,
+          '/somethingElse.js': 2,
+        },
+        paths: ['/something.js', '/', '/somethingElse.js'],
       },
     };
 
@@ -877,7 +958,14 @@ describe('The deleteAttributionAndSave action', () => {
       attributions: {},
       resourcesToAttributions: {},
       attributionsToResources: {},
-      resourcesWithAttributedChildren: {},
+      resourcesWithAttributedChildren: {
+        attributedChildren: {},
+        pathsToIndices: {
+          '/': 1,
+          '/file1': 0,
+        },
+        paths: ['/file1', '/'],
+      },
     };
     const testStore = createTestAppStore();
     testStore.dispatch(
@@ -908,7 +996,14 @@ describe('The deleteAttributionAndSave action', () => {
       attributions: {},
       resourcesToAttributions: {},
       attributionsToResources: {},
-      resourcesWithAttributedChildren: {},
+      resourcesWithAttributedChildren: {
+        attributedChildren: {},
+        pathsToIndices: {
+          '/': 1,
+          '/file1': 0,
+        },
+        paths: ['/file1', '/'],
+      },
     };
     const testStore = createTestAppStore();
     testStore.dispatch(
@@ -952,9 +1047,17 @@ describe('The deleteAttributionAndSave action', () => {
         uuid1: ['/file1'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/file1'),
+        attributedChildren: {
+          '1': new Set<number>().add(0),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/file1': 0,
+        },
+        paths: ['/file1', '/'],
       },
     };
+
     const testStore = createTestAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -1006,7 +1109,15 @@ describe('The deleteAttributionGloballyAndSave action', () => {
         vueUuid: ['/somethingElse.js'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set().add('/somethingElse.js') as Set<string>,
+        attributedChildren: {
+          '1': new Set<number>().add(2),
+        },
+        pathsToIndices: {
+          '/': 1,
+          '/something.js': 0,
+          '/somethingElse.js': 2,
+        },
+        paths: ['/something.js', '/', '/somethingElse.js'],
       },
     };
 

--- a/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
@@ -107,14 +107,30 @@ describe('computeChildrenWithAttributions', () => {
     );
 
     expect(result).toEqual({
-      '/': new Set().add('/root/src/').add('/root/src/something.js/subfolder'),
-      '/root/': new Set()
-        .add('/root/src/')
-        .add('/root/src/something.js/subfolder'),
-      '/root/src/': new Set().add('/root/src/something.js/subfolder'),
-      '/root/src/something.js/': new Set().add(
-        '/root/src/something.js/subfolder'
-      ),
+      attributedChildren: {
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '0': new Set<number>().add(3),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '1': new Set<number>().add(0).add(3),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '2': new Set<number>().add(0).add(3),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '4': new Set<number>().add(3),
+      },
+      pathsToIndices: {
+        '/': 1,
+        '/root/': 2,
+        '/root/src/': 0,
+        '/root/src/something.js/': 4,
+        '/root/src/something.js/subfolder': 3,
+      },
+      paths: [
+        '/root/src/',
+        '/',
+        '/root/',
+        '/root/src/something.js/subfolder',
+        '/root/src/something.js/',
+      ],
     });
   });
 });

--- a/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
@@ -3,11 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  AttributionData,
-  Attributions,
-  PackageInfo,
-} from '../../../../shared/shared-types';
+import { Attributions, PackageInfo } from '../../../../shared/shared-types';
 import {
   AttributionIdWithCount,
   PackageAttributes,
@@ -18,42 +14,26 @@ import {
   getPackageVersionsWithRelatedPackageNameIds,
   getPreSelectedPackageAttributeIds,
 } from '../open-attribution-wizard-popup-helpers';
+import { computeChildrenWithAttributions } from '../action-and-reducer-helpers';
 
 describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', () => {
   it('yields correct output', () => {
     const testSelectedResourceId = '/samplepath/';
-    const testExternalData: AttributionData = {
-      attributionsToResources: {},
-      resourcesWithAttributedChildren: {
-        '/samplepath/': new Set<string>([
-          '/samplepath/file_0',
-          '/samplepath/subfolder/file_1',
-          '/samplepath/subfolder/file_2',
-        ]),
-      },
-      resourcesToAttributions: {
-        '/samplepath/file_0': ['uuid_0'],
-        '/samplepath/subfolder/file_1': ['uuid_1'],
-        '/samplepath/subfolder/file_2': ['uuid_0'],
-      },
-      attributions: {},
+    const testResourcesToExternalAttributions = {
+      '/samplepath/file_0': ['uuid_0'],
+      '/samplepath/subfolder/file_1': ['uuid_1'],
+      '/samplepath/subfolder/file_2': ['uuid_0'],
     };
-    const testManualData: AttributionData = {
-      attributionsToResources: {},
-      resourcesWithAttributedChildren: {
-        '/samplepath/': new Set<string>([
-          '/samplepath/subfolder/file_0',
-          '/samplepath/subfolder_2/file_3',
-          '/samplepath/subfolder_2/file_4',
-        ]),
-      },
-      resourcesToAttributions: {
-        '/samplepath/subfolder/file_0': ['uuid_2'],
-        '/samplepath/subfolder_2/file_3': ['uuid_3'],
-        '/samplepath/subfolder_2/file_4': ['uuid_4'],
-      },
-      attributions: {},
+    const testResourcesWithExternallyAttributedChildren =
+      computeChildrenWithAttributions(testResourcesToExternalAttributions);
+    const testResourcesToManualAttributions = {
+      '/samplepath/subfolder/file_0': ['uuid_2'],
+      '/samplepath/subfolder_2/file_3': ['uuid_3'],
+      '/samplepath/subfolder_2/file_4': ['uuid_4'],
     };
+    const testResourcesWithManuallyAttributedChildren =
+      computeChildrenWithAttributions(testResourcesToManualAttributions);
+
     const testResolvedExternalAttributions: Set<string> = new Set<string>();
 
     const expectedTestAttributionsWithCounts: Array<AttributionIdWithCount> = [
@@ -67,8 +47,10 @@ describe('getExternalAndManualAttributionIdsWithCountsFromResourceAndChildren', 
     const testAttributionsWithCounts =
       getAllAttributionIdsWithCountsFromResourceAndChildren(
         testSelectedResourceId,
-        testExternalData,
-        testManualData,
+        testResourcesToExternalAttributions,
+        testResourcesWithExternallyAttributedChildren,
+        testResourcesToManualAttributions,
+        testResourcesWithManuallyAttributedChildren,
         testResolvedExternalAttributions
       );
 

--- a/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
@@ -60,7 +60,14 @@ describe('The deleteManualAttribution function', () => {
         [testUuid]: ['/first/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/first/'),
+        attributedChildren: {
+          '0': new Set<number>().add(1),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+        },
+        paths: ['/', '/first/'],
       },
     };
     const newManualData: AttributionData = deleteManualAttribution(
@@ -71,7 +78,14 @@ describe('The deleteManualAttribution function', () => {
     expect(isEmpty(newManualData.attributions)).toBe(true);
     expect(isEmpty(newManualData.resourcesToAttributions)).toBe(true);
     expect(isEmpty(newManualData.attributionsToResources)).toBe(true);
-    expect(isEmpty(newManualData.resourcesWithAttributedChildren)).toBe(true);
+    expect(newManualData.resourcesWithAttributedChildren).toEqual({
+      attributedChildren: {},
+      pathsToIndices: {
+        '/': 0,
+        '/first/': 1,
+      },
+      paths: ['/', '/first/'],
+    });
   });
 
   it('correctly maintains childrenFromAttributedResources', () => {
@@ -95,7 +109,14 @@ describe('The deleteManualAttribution function', () => {
         [testAnotherUuid]: ['/first/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/first/'),
+        attributedChildren: {
+          '0': new Set<number>().add(1),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+        },
+        paths: ['/', '/first/'],
       },
     };
     const newManualData: AttributionData = deleteManualAttribution(
@@ -113,7 +134,14 @@ describe('The deleteManualAttribution function', () => {
       '000': ['/first/'],
     });
     expect(newManualData.resourcesWithAttributedChildren).toEqual({
-      '/': new Set().add('/first/'),
+      attributedChildren: {
+        '0': new Set<number>().add(1),
+      },
+      pathsToIndices: {
+        '/': 0,
+        '/first/': 1,
+      },
+      paths: ['/', '/first/'],
     });
   });
 });
@@ -138,7 +166,11 @@ describe('The updateManualAttribution function', () => {
       attributionsToResources: {
         [testUuid]: ['/something.js', 'somethingElse.js'],
       },
-      resourcesWithAttributedChildren: {},
+      resourcesWithAttributedChildren: {
+        attributedChildren: {},
+        pathsToIndices: {},
+        paths: [],
+      },
     };
 
     const newManualData: AttributionData = updateManualAttribution(
@@ -176,14 +208,21 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
         uuid1: ['/first/', '/first/second/', '/first/second/third/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/')
-          .add('/first/second/third/'),
-        '/first/': new Set<string>()
-          .add('/first/second/')
-          .add('/first/second/third/'),
-        '/first/second/': new Set<string>().add('/first/second/third/'),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(2).add(3),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(2).add(3),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+        },
+        paths: ['/', '/first/', '/first/second/', '/first/second/third/'],
       },
     };
 
@@ -200,7 +239,16 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
         uuid1: ['/first/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>().add('/first/'),
+        attributedChildren: {
+          '0': new Set<number>().add(1),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+        },
+        paths: ['/', '/first/', '/first/second/', '/first/second/third/'],
       },
     };
 
@@ -242,21 +290,30 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
         uuid3: ['/first/', '/first/second/', '/first/second/third/fourth'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 
@@ -287,19 +344,30 @@ describe('_removeManualAttributionFromChildrenIfAllAreIdentical', () => {
         uuid3: ['/first/', '/first/second/third/fourth'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 
@@ -348,21 +416,30 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
         uuid3: ['/first/', '/first/second/', '/first/second/third/fourth'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 
@@ -395,19 +472,30 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
         uuid3: ['/first/', '/first/second/third/fourth'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 
@@ -438,21 +526,30 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
         uuid2: ['/first/second/third/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 
@@ -476,21 +573,30 @@ describe('_removeAttributionsFromChildrenAndParents', () => {
         uuid2: ['/first/second/third/'],
       },
       resourcesWithAttributedChildren: {
-        '/': new Set<string>()
-          .add('/first/')
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/': new Set<string>()
-          .add('/first/second/')
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/': new Set<string>()
-          .add('/first/second/third/')
-          .add('/first/second/third/fourth'),
-        '/first/second/third/': new Set<string>().add(
-          '/first/second/third/fourth'
-        ),
+        attributedChildren: {
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '0': new Set<number>().add(1).add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(2).add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '2': new Set<number>().add(3).add(4),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '3': new Set<number>().add(4),
+        },
+        pathsToIndices: {
+          '/': 0,
+          '/first/': 1,
+          '/first/second/': 2,
+          '/first/second/third/': 3,
+          '/first/second/third/fourth': 4,
+        },
+        paths: [
+          '/',
+          '/first/',
+          '/first/second/',
+          '/first/second/third/',
+          '/first/second/third/fourth',
+        ],
       },
     };
 

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -34,9 +34,13 @@ export function getMatchingAttributionId(
 export function computeChildrenWithAttributions(
   resourcesToAttributions: ResourcesToAttributions
 ): ResourcesWithAttributedChildren {
-  const childrenWithAttributions = {};
+  const childrenWithAttributions: ResourcesWithAttributedChildren = {
+    paths: [],
+    pathsToIndices: {},
+    attributedChildren: {},
+  };
   for (const path of Object.keys(resourcesToAttributions)) {
-    _addParentsToResourcesWithAttributedChildren(
+    _addPathAndParentsToResourcesWithAttributedChildren(
       path,
       childrenWithAttributions
     );
@@ -45,17 +49,45 @@ export function computeChildrenWithAttributions(
   return childrenWithAttributions;
 }
 
-export function _addParentsToResourcesWithAttributedChildren(
+export function _addPathAndParentsToResourcesWithAttributedChildren(
   attributedPath: string,
   childrenWithAttributions: ResourcesWithAttributedChildren
 ): void {
+  const attributedPathIndex =
+    addPathToIndexesIfMissingInResourcesWithAttributedChildren(
+      childrenWithAttributions,
+      attributedPath
+    );
+
   getParents(attributedPath).forEach((parent) => {
-    if (!(parent in childrenWithAttributions)) {
-      childrenWithAttributions[parent] = new Set();
+    const parentIndex =
+      addPathToIndexesIfMissingInResourcesWithAttributedChildren(
+        childrenWithAttributions,
+        parent
+      );
+
+    if (
+      childrenWithAttributions.attributedChildren[parentIndex] === undefined
+    ) {
+      childrenWithAttributions.attributedChildren[parentIndex] = new Set();
     }
 
-    childrenWithAttributions[parent].add(attributedPath);
+    childrenWithAttributions.attributedChildren[parentIndex].add(
+      attributedPathIndex
+    );
   });
+}
+
+export function addPathToIndexesIfMissingInResourcesWithAttributedChildren(
+  childrenWithAttributions: ResourcesWithAttributedChildren,
+  path: string
+): number {
+  if (childrenWithAttributions.pathsToIndices[path] === undefined) {
+    const newLength = childrenWithAttributions.paths.push(path);
+    childrenWithAttributions.pathsToIndices[path] = newLength - 1;
+  }
+
+  return childrenWithAttributions.pathsToIndices[path];
 }
 
 export function getAttributionDataFromSetAttributionDataPayload(payload: {

--- a/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
+++ b/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
@@ -4,10 +4,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  AttributionData,
   ResourcesToAttributions,
   PackageInfo,
   Attributions,
+  ResourcesWithAttributedChildren,
 } from '../../../shared/shared-types';
 import { getAttributedChildren } from '../../util/get-attributed-children';
 import { shouldNotBeCalled } from '../../util/should-not-be-called';
@@ -20,33 +20,35 @@ interface NamesWithCounts {
 
 export function getAllAttributionIdsWithCountsFromResourceAndChildren(
   selectedResourceId: string,
-  externalData: AttributionData,
-  manualData: AttributionData,
+  resourcesToExternalAttributions: ResourcesToAttributions,
+  resourcesWithExternallyAttributedChildren: ResourcesWithAttributedChildren,
+  resourcesToManualAttributions: ResourcesToAttributions,
+  resourcesWithManuallyAttributedChildren: ResourcesWithAttributedChildren,
   resolvedExternalAttributions: Set<string>
 ): Array<AttributionIdWithCount> {
-  const externalAttributedChildren = getAttributedChildren(
-    externalData.resourcesWithAttributedChildren,
+  const externalAttributedChildren: Set<string> = getAttributedChildren(
+    resourcesWithExternallyAttributedChildren,
     selectedResourceId
   );
-  if (selectedResourceId in externalData.resourcesToAttributions) {
+  if (selectedResourceId in resourcesToExternalAttributions) {
     externalAttributedChildren.add(selectedResourceId);
   }
 
-  const manualAttributedChildren = getAttributedChildren(
-    manualData.resourcesWithAttributedChildren,
+  const manualAttributedChildren: Set<string> = getAttributedChildren(
+    resourcesWithManuallyAttributedChildren,
     selectedResourceId
   );
-  if (selectedResourceId in manualData.resourcesToAttributions) {
+  if (selectedResourceId in resourcesToManualAttributions) {
     manualAttributedChildren.add(selectedResourceId);
   }
 
   const externalAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
-    externalData.resourcesToAttributions,
+    resourcesToExternalAttributions,
     externalAttributedChildren,
     resolvedExternalAttributions
   );
   const manualAttributionsWithCounts = getAggregatedAttributionIdsAndCounts(
-    manualData.resourcesToAttributions,
+    resourcesToManualAttributions,
     manualAttributedChildren
   );
 

--- a/src/Frontend/util/__tests__/get-attributed-children.test.tsx
+++ b/src/Frontend/util/__tests__/get-attributed-children.test.tsx
@@ -9,18 +9,30 @@ import { getAttributedChildren } from '../get-attributed-children';
 describe('getAttributedChildren', () => {
   const testResourcesWithExternalAttributedChildren: ResourcesWithAttributedChildren =
     {
-      '/directory': new Set()
-        .add('/directory/subdirectory')
-        .add(
-          '/directory/subdirectory/secondsub/thirdsubdirectory'
-        ) as Set<string>,
-      '/anotherdirectory': new Set().add(
-        '/anotherdirectory/subdirectory'
-      ) as Set<string>,
+      attributedChildren: {
+        '0': new Set<number>().add(1).add(2),
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        '3': new Set<number>().add(4),
+      },
+      pathsToIndices: {
+        '/directory': 0,
+        '/directory/subdirectory': 1,
+        '/directory/subdirectory/secondsub/thirdsubdirectory': 2,
+        '/anotherdirectory': 3,
+        '/anotherdirectory/subdirectory': 4,
+      },
+      paths: [
+        '/directory',
+        '/directory/subdirectory',
+        '/directory/subdirectory/secondsub/thirdsubdirectory',
+        '/anotherdirectory',
+        '/anotherdirectory/subdirectory',
+      ],
     };
   const expectedResult = new Set()
     .add('/directory/subdirectory')
     .add('/directory/subdirectory/secondsub/thirdsubdirectory');
+
   it('with existing attributed children', () => {
     const result = getAttributedChildren(
       testResourcesWithExternalAttributedChildren,

--- a/src/Frontend/util/get-attributed-children.ts
+++ b/src/Frontend/util/get-attributed-children.ts
@@ -9,8 +9,19 @@ export function getAttributedChildren(
   resourcesWithAttributedChildren: ResourcesWithAttributedChildren,
   resourceId: string
 ): Set<string> {
-  return resourcesWithAttributedChildren &&
-    resourceId in resourcesWithAttributedChildren
-    ? resourcesWithAttributedChildren[resourceId]
-    : new Set();
+  const resourceIndex: number | undefined =
+    resourcesWithAttributedChildren?.pathsToIndices[resourceId];
+  if (resourceIndex === undefined) {
+    return new Set();
+  }
+
+  const attributedChildrenIds = new Set<string>();
+  resourcesWithAttributedChildren.attributedChildren[resourceIndex]?.forEach(
+    (resourceIndex) =>
+      attributedChildrenIds.add(
+        resourcesWithAttributedChildren.paths[resourceIndex]
+      )
+  );
+
+  return attributedChildrenIds;
 }

--- a/src/Frontend/util/lodash-extension-utils.ts
+++ b/src/Frontend/util/lodash-extension-utils.ts
@@ -40,8 +40,18 @@ export function removeFromArrayCloneAndDeleteKeyFromObjectIfEmpty<T>(
 }
 
 export function removeFromSetCloneAndDeleteKeyFromObjectIfEmpty<T>(
+  object: Record<number, Set<T>>,
+  setKey: number,
+  element: T
+): void;
+export function removeFromSetCloneAndDeleteKeyFromObjectIfEmpty<T>(
   object: Record<string, Set<T>>,
   setKey: string,
+  element: T
+): void;
+export function removeFromSetCloneAndDeleteKeyFromObjectIfEmpty<T>(
+  object: Record<string | number, Set<T>>,
+  setKey: string | number,
   element: T
 ): void {
   if (!object[setKey]) {

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -88,7 +88,9 @@ export interface AttributionsToHashes {
 }
 
 export interface ResourcesWithAttributedChildren {
-  [path: string]: Set<string>;
+  paths: Array<string>;
+  pathsToIndices: { [path: string]: number };
+  attributedChildren: { [index: number]: Set<number> };
 }
 
 export interface InputFileAttributionData {


### PR DESCRIPTION
### Summary of changes

ResourcesWithAttributedChildren type has been changed from: 
````
export interface ResourcesWithAttributedChildren {
  [path: string]: Set<string>;
}
````
to:
````
export interface ResourcesWithAttributedChildren {
  paths: Array<string>;
  pathToIndex: { [path: string]: number };
  attributedChildren: { [index: number]: Set<number> };
}
````

### Context and reason for change

This change reduces a lot the memory use, increasing the size of input files that can be handled without crashes.

### How can the changes be tested

<!-- optional -->

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
