### PR TITLE
Do not zip mac release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             FILE: release/linux/OpossumUI-for-linux.AppImage
           - os: macos-latest
             SHIP: ship-mac
-            FILE: release/mac/OpossumUI-for-mac.zip
+            FILE: release/mac/OpossumUI.app
           - os: windows-latest
             SHIP: ship-win
             FILE: release/win/OpossumUI-for-win.exe

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "ship-win": "run-script-os",
     "ship-win:darwin:linux": "yarn build:prod && electron-builder --win --x64 --publish never && mkdir -p release/win && mv \"release/OpossumUI Setup 0.1.0.exe\" \"release/win/OpossumUI-for-win.exe\"",
     "ship-win:win32": "yarn build:prod && electron-builder --win --x64 --publish never && cd release && (if not exist win (mkdir win)) && move \"OpossumUI Setup 0.1.0.exe\" \"win/OpossumUI-for-win.exe\" && cd ..",
-    "ship-mac": "yarn build:prod && electron-builder --mac --x64 --publish never && zip -r -q 'release/mac/OpossumUI-for-mac.zip' 'release/mac/'",
+    "ship-mac": "yarn build:prod && electron-builder --mac --x64 --publish never",
     "ship": "yarn ship-linux && yarn ship-win && yarn ship-mac",
     "clean": "rm -rf ./build/ ./release/",
     "postinstall": "husky install && yarn update-commit-hash",


### PR DESCRIPTION
### Summary of changes

The zipping operation is removed. 

### Context and reason for change

The release for mac a has size of approximately 293MB and 285 when zipped. The advantage for the user is that no unzipping is necessary.

### How can the changes be tested

Run `yarn ship-mac` and test release. The Github action is hard to test.
