### PR TITLE
Revert "Do not zip mac release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             FILE: release/linux/OpossumUI-for-linux.AppImage
           - os: macos-latest
             SHIP: ship-mac
-            FILE: release/mac/OpossumUI.app
+            FILE: release/mac/OpossumUI-for-mac.zip
           - os: windows-latest
             SHIP: ship-win
             FILE: release/win/OpossumUI-for-win.exe

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "ship-win": "run-script-os",
     "ship-win:darwin:linux": "yarn build:prod && electron-builder --win --x64 --publish never && mkdir -p release/win && mv \"release/OpossumUI Setup 0.1.0.exe\" \"release/win/OpossumUI-for-win.exe\"",
     "ship-win:win32": "yarn build:prod && electron-builder --win --x64 --publish never && cd release && (if not exist win (mkdir win)) && move \"OpossumUI Setup 0.1.0.exe\" \"win/OpossumUI-for-win.exe\" && cd ..",
-    "ship-mac": "yarn build:prod && electron-builder --mac --x64 --publish never",
+    "ship-mac": "yarn build:prod && electron-builder --mac --x64 --publish never && zip -r -q 'release/mac/OpossumUI-for-mac.zip' 'release/mac/'",
     "ship": "yarn ship-linux && yarn ship-win && yarn ship-mac",
     "clean": "rm -rf ./build/ ./release/",
     "postinstall": "husky install && yarn update-commit-hash",


### PR DESCRIPTION
### Summary of changes

This reverts commit 1ffa7997ab93676b4b15e85dcaaca3513303e2fd.

### Context and reason for change

The action used for uploading release artifacts does only accept files. The mac release `OpossumUI.app`, however, is actually a folder. Therefore, the mac release was not uploaded on release.


