### PR TITLE
Add field 'needsReview' to package info core

### DIFF
--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -19,7 +19,7 @@ import { createTempFolder, deleteFolder } from '../../test-helpers';
 const testCsvHeader =
   '"Index";"Confidence";"Comment";"Package Name";"Package Version";"Package Namespace";' +
   '"Package Type";"PURL Appendix";"URL";"Copyright";"License Name";"License Text (truncated)";"Source";"First Party";' +
-  '"Follow-up";"Origin Attribution IDs";"pre-selected";"exclude-from-notice";"criticality";"Resources"';
+  '"Follow-up";"Origin Attribution IDs";"pre-selected";"exclude-from-notice";"criticality";"needs-review";"Resources"';
 
 describe('writeCsvToFile', () => {
   it('writeCsvToFile short', async () => {
@@ -46,13 +46,13 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"'
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"'
     );
     deleteFolder(temporaryPath);
   });
@@ -117,10 +117,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
         '/b"'
     );
     deleteFolder(temporaryPath);
@@ -163,10 +163,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`
+      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`
     );
     deleteFolder(temporaryPath);
   });
@@ -453,25 +453,25 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"/test.file"'
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"'
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"";"/a"`
+      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"";"";"/a"`
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"'
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"'
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"'
     );
     deleteFolder(temporaryPath);
   });

--- a/src/ElectronBackend/output/writeCsvToFile.ts
+++ b/src/ElectronBackend/output/writeCsvToFile.ts
@@ -90,6 +90,7 @@ export function getHeadersFromColumns(columns: Array<KeysOfAttributionInfo>): {
     preSelected: 'pre-selected',
     excludeFromNotice: 'exclude-from-notice',
     criticality: 'criticality',
+    needsReview: 'needs-review',
   };
 
   const headers: { [key: string]: string } = {};

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -59,6 +59,7 @@ interface RawPackageInfo {
   preSelected?: boolean;
   excludeFromNotice?: boolean;
   criticality?: Criticality;
+  needsReview?: boolean;
 }
 
 export interface RawAttributions {

--- a/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
+++ b/src/Frontend/Components/PackagePanel/package-panel-helpers.ts
@@ -113,6 +113,7 @@ export function convertDisplayPackageInfoToPackageInfo(
           break;
         case 'firstParty':
         case 'preSelected':
+        case 'needsReview':
         case 'excludeFromNotice':
           packageInfo[packageInfoKey] = displayPackageInfo[packageInfoKey];
           break;

--- a/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
+++ b/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
@@ -28,6 +28,7 @@ export function getFormattedCellData(
     case 'firstParty':
     case 'followUp':
     case 'preSelected':
+    case 'needsReview':
     case 'excludeFromNotice':
       cellData = attributionInfo[config.attributionProperty] ? 'Yes' : 'No';
       break;

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -45,6 +45,7 @@ interface PackageInfoCore {
   preSelected?: boolean;
   excludeFromNotice?: boolean;
   criticality?: Criticality;
+  needsReview?: boolean;
 }
 
 export interface PackageInfo extends PackageInfoCore {

--- a/src/shared/shared-util.ts
+++ b/src/shared/shared-util.ts
@@ -27,6 +27,7 @@ export function getPackageInfoKeys(): Array<KeysOfPackageInfo> {
     preSelected: true,
     excludeFromNotice: true,
     criticality: true,
+    needsReview: true,
   };
   return Object.keys(packageInfoKeysObject) as Array<KeysOfPackageInfo>;
 }


### PR DESCRIPTION
### Summary of changes

Add field 'needsReview' to package info

### Context and reason for change

We are adding a checkbox to OpossumUI to signal if a review is required for an attribution.