### PR TITLE
Add needsReview to output json schema

### DIFF
--- a/src/ElectronBackend/input/OpossumOutputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumOutputFileSchema.json
@@ -38,7 +38,7 @@
           },
           "packageNamespace": {
             "type": "string",
-            "description": "Namespace of the pacakge, e.g. Github user (part of a package URL)"
+            "description": "Namespace of the package, e.g. Github user (part of a package URL)"
           },
           "packageType": {
             "type": "string",
@@ -105,6 +105,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "needsReview": {
+            "type": "boolean",
+            "description": "Indicates that the information in an attribution needs further review."
           }
         },
         "required": [],

--- a/src/ElectronBackend/input/__tests__/parseFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseFile.test.ts
@@ -118,6 +118,7 @@ const correctOutput: OpossumOutputFile = {
       packageName: 'Some package',
       packageVersion: '16.0.1',
       licenseText: '',
+      needsReview: true,
     },
   },
   resourcesToAttributions: {


### PR DESCRIPTION
### Summary of changes

Add needsReview to output json schema

### Context and reason for change

We are adding a checkbox to OpossumUI to signal if a review is required for an attribution.

### How can the changes be tested

Modify an existing Opossum output file and add the needsReview flag to an attribution. Open the file in OpossumUI.
