### PR TITLE
Refactor DisplayPackageInfo: `temporaryPackageInfo`

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/accordion-panel-helpers.ts
@@ -51,11 +51,11 @@ export function getDisplayContainedManualPackagesWithCount(args: {
   const displayAttributionIdsWithCount: Array<DisplayAttributionWithCount> = [];
 
   attributionIdsWithCount.forEach(({ attributionId, count }): void => {
-    const attribution: PackageInfo =
+    const packageInfo: PackageInfo =
       args.manualData.attributions[attributionId];
     displayAttributionIdsWithCount.push(
       getDisplayAttributionWithCountFromAttributions([
-        [attributionId, attribution, count],
+        [attributionId, packageInfo, count],
       ])
     );
   });
@@ -74,18 +74,18 @@ export function getDisplayExternalAttributionsWithCount(
   } = {};
 
   attributionIdsWithCount.forEach(({ attributionId, count }): void => {
-    const attribution: PackageInfo = attributions[attributionId];
+    const packageInfo: PackageInfo = attributions[attributionId];
     const savedHash = externalAttributionsToHashes[attributionId];
 
     if (savedHash) {
       if (!hashToAttributions[savedHash]) {
         hashToAttributions[savedHash] = [];
       }
-      hashToAttributions[savedHash].push([attributionId, attribution, count]);
+      hashToAttributions[savedHash].push([attributionId, packageInfo, count]);
     } else {
       displayAttributionIdsWithCount.push(
         getDisplayAttributionWithCountFromAttributions([
-          [attributionId, attribution, count],
+          [attributionId, packageInfo, count],
         ])
       );
     }

--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -5,20 +5,19 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ReactElement } from 'react';
-import { Attributions } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import { selectAttributionInAccordionPanelOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { addToSelectedResource } from '../../state/actions/resource-actions/save-actions';
 import { OpossumColors } from '../../shared-styles';
-import { PackageCardConfig } from '../../types/types';
+import {
+  DisplayAttributionWithCount,
+  PackageCardConfig,
+} from '../../types/types';
 import { useAppDispatch } from '../../state/hooks';
 import { PackageList } from '../PackageList/PackageList';
 import { PackageCard } from '../PackageCard/PackageCard';
-import {
-  convertDisplayPackageInfoToPackageInfo,
-  convertPackageInfoToDisplayPackageInfo,
-} from '../../util/convert-package-info';
-import { getDisplayAttributionWithCountFromAttributions } from '../../util/get-display-attributions-with-count-from-attributions';
+import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
+import { getAttributionFromDisplayAttributionsWithCount } from '../../util/get-attribution-from-display-attributions-with-count';
 
 const classes = {
   root: {
@@ -28,7 +27,7 @@ const classes = {
 };
 
 interface AllAttributionsPanelProps {
-  attributions: Attributions;
+  displayAttributions: Array<DisplayAttributionWithCount>;
   selectedAttributionId: string | null;
   isAddToPackageEnabled: boolean;
 }
@@ -38,24 +37,18 @@ export function AllAttributionsPanel(
 ): ReactElement {
   const dispatch = useAppDispatch();
 
-  const displayAttributionsWithCounts = Object.entries(props.attributions).map(
-    ([attributionId, packageInfo]) =>
-      getDisplayAttributionWithCountFromAttributions([
-        [attributionId, packageInfo, undefined],
-      ])
-  );
-
   function getPackageCard(attributionId: string): ReactElement | null {
-    const displayPackageInfo = convertPackageInfoToDisplayPackageInfo(
-      props.attributions[attributionId],
-      [attributionId]
+    const displayPackageInfo = getAttributionFromDisplayAttributionsWithCount(
+      attributionId,
+      props.displayAttributions
     );
 
     function onCardClick(): void {
       dispatch(
         selectAttributionInAccordionPanelOrOpenUnsavedPopup(
           PackagePanelTitle.AllAttributions,
-          attributionId
+          attributionId,
+          displayPackageInfo
         )
       );
     }
@@ -88,7 +81,7 @@ export function AllAttributionsPanel(
   return (
     <MuiPaper sx={classes.root} elevation={0} square={true}>
       <PackageList
-        displayAttributionsWithCount={displayAttributionsWithCounts}
+        displayAttributionsWithCount={props.displayAttributions}
         getAttributionCard={getPackageCard}
         maxNumberOfDisplayedItems={20}
         listTitle={PackagePanelTitle.AllAttributions}

--- a/src/Frontend/Components/AllAttributionsPanel/__tests__/AllAttributionsPanel.test.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/__tests__/AllAttributionsPanel.test.tsx
@@ -25,11 +25,41 @@ import {
   expectGlobalOnlyContextMenuForNotPreselectedAttribution,
   testCorrectMarkAndUnmarkForReplacementInContextMenu,
 } from '../../../test-helpers/context-menu-test-helpers';
+import { DisplayAttributionWithCount } from '../../../types/types';
 
 describe('The AllAttributionsPanel', () => {
   const testManualAttributionUuid1 = '374ba87a-f68b-11ea-adc1-0242ac120002';
   const testManualAttributionUuid2 = '374bac4e-f68b-11ea-adc1-0242ac120002';
   const testManualAttributionUuid3 = '374bar8a-f68b-11ea-adc1-0242ac120002';
+  const testManualDisplayAttributions: Array<DisplayAttributionWithCount> = [
+    {
+      attributionId: testManualAttributionUuid1,
+      attribution: {
+        packageVersion: '1.0',
+        packageName: 'Typescript',
+        licenseText: ' test License text',
+        attributionIds: [testManualAttributionUuid1],
+      },
+    },
+    {
+      attributionId: testManualAttributionUuid2,
+      attribution: {
+        packageVersion: '2.0',
+        packageName: 'React',
+        licenseText: ' test license text',
+        attributionIds: [testManualAttributionUuid2],
+      },
+    },
+    {
+      attributionId: testManualAttributionUuid3,
+      attribution: {
+        packageVersion: '3.0',
+        packageName: 'Vue',
+        licenseText: ' test license text',
+        attributionIds: [testManualAttributionUuid3],
+      },
+    },
+  ];
   const testManualAttributions: Attributions = {
     [testManualAttributionUuid1]: {
       packageVersion: '1.0',
@@ -51,7 +81,7 @@ describe('The AllAttributionsPanel', () => {
   it('renders empty list', () => {
     renderComponentWithStore(
       <AllAttributionsPanel
-        attributions={{}}
+        displayAttributions={[]}
         selectedAttributionId={null}
         isAddToPackageEnabled={true}
       />
@@ -59,6 +89,16 @@ describe('The AllAttributionsPanel', () => {
   });
 
   it('renders non-empty list', () => {
+    const testDisplayAttributions: Array<DisplayAttributionWithCount> = [
+      {
+        attributionId: 'uuid1',
+        attribution: { packageName: 'name 1', attributionIds: ['uuid1'] },
+      },
+      {
+        attributionId: 'uuid2',
+        attribution: { packageName: 'name 2', attributionIds: ['uuid2'] },
+      },
+    ];
     const testAttributions: Attributions = {
       uuid1: { packageName: 'name 1' },
       uuid2: { packageName: 'name 2' },
@@ -73,7 +113,7 @@ describe('The AllAttributionsPanel', () => {
     );
     renderComponentWithStore(
       <AllAttributionsPanel
-        attributions={testAttributions}
+        displayAttributions={testDisplayAttributions}
         selectedAttributionId={null}
         isAddToPackageEnabled={true}
       />,
@@ -94,7 +134,7 @@ describe('The AllAttributionsPanel', () => {
     );
     const { store } = renderComponentWithStore(
       <AllAttributionsPanel
-        attributions={testManualAttributions}
+        displayAttributions={testManualDisplayAttributions}
         selectedAttributionId={testManualAttributionUuid2}
         isAddToPackageEnabled={true}
       />,
@@ -112,6 +152,36 @@ describe('The AllAttributionsPanel', () => {
       root: { src: { file_1: 1, file_2: 1 } },
       file: 1,
     };
+    const testManualDisplayAttributions: Array<DisplayAttributionWithCount> = [
+      {
+        attributionId: 'uuid_1',
+        attribution: {
+          packageName: 'jQuery',
+          packageVersion: '16.0.0',
+          comments: ['ManualPackage'],
+          attributionIds: ['uuid_1'],
+        },
+      },
+      {
+        attributionId: 'uuid_2',
+        attribution: {
+          packageName: 'React',
+          packageVersion: '16.0.0',
+          comments: ['ManualPackage'],
+          attributionIds: ['uuid_2'],
+        },
+      },
+      {
+        attributionId: 'uuid_3',
+        attribution: {
+          packageName: 'Vue',
+          packageVersion: '16.0.0',
+          comments: ['ManualPackage'],
+          preSelected: true,
+          attributionIds: ['uuid_3'],
+        },
+      },
+    ];
     const testManualAttributions: Attributions = {
       uuid_1: {
         packageName: 'jQuery',
@@ -147,7 +217,7 @@ describe('The AllAttributionsPanel', () => {
     );
     renderComponentWithStore(
       <AllAttributionsPanel
-        attributions={testManualAttributions}
+        displayAttributions={testManualDisplayAttributions}
         selectedAttributionId={null}
         isAddToPackageEnabled={true}
       />,

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -7,9 +7,7 @@ import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
 import {
   DiscreteConfidence,
-  isDisplayPackageInfo,
   DisplayPackageInfo,
-  PackageInfo,
 } from '../../../shared/shared-types';
 import { CheckboxLabel } from '../../enums/enums';
 import { doNothing } from '../../util/do-nothing';
@@ -42,7 +40,7 @@ const classes = {
 
 interface AuditingSubPanelProps {
   isEditable: boolean;
-  displayPackageInfo: PackageInfo | DisplayPackageInfo;
+  displayPackageInfo: DisplayPackageInfo;
   showManualAttributionData: boolean;
   isCommentsBoxCollapsed: boolean;
   commentBoxHeight: number;
@@ -144,21 +142,11 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
       </MuiBox>
       <TextFieldStack
         isEditable={props.isEditable}
-        comments={getComments(props.displayPackageInfo)}
+        comments={props.displayPackageInfo.comments || []}
         isCollapsed={props.isCommentsBoxCollapsed}
         commentBoxHeight={props.commentBoxHeight}
         handleChange={props.setUpdateTemporaryPackageInfoFor}
       />
     </MuiPaper>
   );
-}
-
-function getComments(
-  displayPackageInfo: PackageInfo | DisplayPackageInfo
-): Array<string> {
-  if (isDisplayPackageInfo(displayPackageInfo)) {
-    return displayPackageInfo.comments || [];
-  } else {
-    return displayPackageInfo.comment ? [displayPackageInfo.comment] : [];
-  }
 }

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -5,7 +5,7 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
@@ -13,7 +13,7 @@ import MuiBox from '@mui/material/Box';
 
 interface CopyrightSubPanelProps {
   isEditable: boolean;
-  displayPackageInfo: PackageInfo;
+  displayPackageInfo: DisplayPackageInfo;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -5,7 +5,7 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
 import { doNothing } from '../../util/do-nothing';
 import { TextBox } from '../InputElements/TextBox';
@@ -58,7 +58,7 @@ const classes = {
 
 interface LicenseSubPanelProps {
   isEditable: boolean;
-  displayPackageInfo: PackageInfo;
+  displayPackageInfo: DisplayPackageInfo;
   isLicenseTextShown: boolean;
   licenseTextRows: number;
   showHighlight?: boolean;

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -6,7 +6,7 @@
 
 import MuiPaper from '@mui/material/Paper';
 import React, { ChangeEvent, ReactElement } from 'react';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -22,7 +22,7 @@ import { HighlightingColor } from '../../enums/enums';
 const iconClasses = { clickableIcon, disabledIcon };
 
 interface PackageSubPanelProps {
-  displayPackageInfo: PackageInfo;
+  displayPackageInfo: DisplayPackageInfo;
   setUpdateTemporaryPackageInfoFor(
     propertyToUpdate: string
   ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -4,58 +4,58 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
 import React from 'react';
+import { screen } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import {
   DiscreteConfidence,
   DisplayPackageInfo,
   FollowUp,
   FrequentLicenses,
-  PackageInfo,
   SaveFileArgs,
   Source,
 } from '../../../../shared/shared-types';
 import { ButtonText, CheckboxLabel } from '../../../enums/enums';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 import {
   setFrequentLicenses,
   setTemporaryPackageInfo,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import {
-  clickOnButton,
-  clickOnCheckbox,
-} from '../../../test-helpers/general-test-helpers';
-import { doNothing } from '../../../util/do-nothing';
-import { AttributionColumn } from '../AttributionColumn';
 import {
   clickGoToLinkIcon,
   expectGoToLinkButtonIsDisabled,
   expectValueInTextBox,
   insertValueIntoTextBox,
 } from '../../../test-helpers/attribution-column-test-helpers';
-import { act } from 'react-dom/test-utils';
+import {
+  clickOnButton,
+  clickOnCheckbox,
+} from '../../../test-helpers/general-test-helpers';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { doNothing } from '../../../util/do-nothing';
+import { AttributionColumn } from '../AttributionColumn';
 
 describe('The AttributionColumn', () => {
   it('renders TextBoxes with right titles and content', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
       packageVersion: '16.5.0',
       packagePURLAppendix: '?appendix',
       packageNamespace: 'namespace',
       packageType: 'type',
-      comment: 'some comment',
+      comments: ['some comment'],
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
       licenseName: 'Made up license name',
       url: 'www.1999.com',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -109,9 +109,10 @@ describe('The AttributionColumn', () => {
       screen.getByDisplayValue('Permission is hereby granted', { exact: false })
     );
     expect(screen.getByLabelText('Comment'));
-    expect(
-      screen.getByDisplayValue(testTemporaryPackageInfo.comment as string)
-    );
+    const testComment = testTemporaryPackageInfo.comments
+      ? testTemporaryPackageInfo.comments[0]
+      : '';
+    expect(screen.getByDisplayValue(testComment));
     expect(screen.queryAllByText('PURL')).toHaveLength(2);
     expect(
       screen.getByDisplayValue('pkg:type/namespace/jQuery@16.5.0?appendix')
@@ -119,23 +120,23 @@ describe('The AttributionColumn', () => {
   });
 
   it('renders qualifier in the purl correctly', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
       packageVersion: '16.5.0',
       packagePURLAppendix: '?appendix',
       packageNamespace: 'namespace',
       packageType: 'type',
-      comment: 'some comment',
+      comments: ['some comment'],
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
       licenseName: 'Made up license name',
       url: 'www.1999.com',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -165,23 +166,23 @@ describe('The AttributionColumn', () => {
   });
 
   it('sorts qualifier in the purl alphabetically', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
       packageVersion: '16.5.0',
       packagePURLAppendix: '?appendix',
       packageNamespace: 'namespace',
       packageType: 'type',
-      comment: 'some comment',
+      comments: ['some comment'],
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
       licenseName: 'Made up license name',
       url: 'www.1999.com',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -211,23 +212,23 @@ describe('The AttributionColumn', () => {
   });
 
   it('removes special symbol from the end of the purl if nothing follows', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
       packageVersion: '16.5.0',
       packagePURLAppendix: '?appendix',
       packageNamespace: 'namespace',
       packageType: 'type',
-      comment: 'some comment',
+      comments: ['some comment'],
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
       licenseName: 'Made up license name',
       url: 'www.1999.com',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -249,13 +250,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('renders a TextBox for the source, if it is defined', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       source: { name: 'The Source', documentConfidence: 10 },
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -277,13 +278,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('renders a checkbox for Follow-up', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -305,13 +306,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('renders a checkbox for Exclude from notice', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -337,13 +338,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('renders an url icon and opens a link in browser', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       url: 'https://www.testurl.com/',
+      attributionIds: [],
     };
-    renderComponentWithStore(
+    const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -354,6 +355,9 @@ describe('The AttributionColumn', () => {
         onDeleteGloballyButtonClick={doNothing}
       />
     );
+    act(() => {
+      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    });
 
     expect(screen.getByLabelText('Url icon'));
     clickGoToLinkIcon(screen, 'Url icon');
@@ -363,13 +367,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('opens a link without protocol', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       url: 'www.testurl.com',
+      attributionIds: [],
     };
-    renderComponentWithStore(
+    const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -380,6 +384,9 @@ describe('The AttributionColumn', () => {
         onDeleteGloballyButtonClick={doNothing}
       />
     );
+    act(() => {
+      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    });
 
     clickGoToLinkIcon(screen, 'Url icon');
     expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
@@ -388,13 +395,13 @@ describe('The AttributionColumn', () => {
   });
 
   it('disables url icon if empty url', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       url: '',
+      attributionIds: [],
     };
-    renderComponentWithStore(
+    const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        displayPackageInfo={testTemporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
         setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -405,6 +412,9 @@ describe('The AttributionColumn', () => {
         onDeleteGloballyButtonClick={doNothing}
       />
     );
+    act(() => {
+      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    });
 
     clickGoToLinkIcon(screen, 'Url icon');
     expect(global.window.electronAPI.openLink).not.toHaveBeenCalled();
@@ -413,11 +423,13 @@ describe('The AttributionColumn', () => {
 
   describe('there are different license text labels', () => {
     it('shows standard text if editable and non frequent license', () => {
-      const testTemporaryPackageInfo: PackageInfo = { packageName: 'jQuery' };
-      renderComponentWithStore(
+      const testTemporaryPackageInfo: DisplayPackageInfo = {
+        packageName: 'jQuery',
+        attributionIds: [],
+      };
+      const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testTemporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -428,6 +440,9 @@ describe('The AttributionColumn', () => {
           onDeleteGloballyButtonClick={doNothing}
         />
       );
+      act(() => {
+        store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+      });
 
       expect(
         screen.getByLabelText(
@@ -437,14 +452,14 @@ describe('The AttributionColumn', () => {
     });
 
     it('shows shortened text if not editable and frequent license', () => {
-      const testTemporaryPackageInfo: PackageInfo = {
+      const testTemporaryPackageInfo: DisplayPackageInfo = {
         packageName: 'jQuery',
         licenseName: 'Mit',
+        attributionIds: [],
       };
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={false}
-          displayPackageInfo={testTemporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -455,6 +470,9 @@ describe('The AttributionColumn', () => {
           onDeleteGloballyButtonClick={doNothing}
         />
       );
+      act(() => {
+        store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+      });
       const testFrequentLicenses: FrequentLicenses = {
         nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
         texts: { MIT: 'text' },
@@ -467,14 +485,14 @@ describe('The AttributionColumn', () => {
     });
 
     it('shows long text if editable and frequent license', () => {
-      const testTemporaryPackageInfo: PackageInfo = {
+      const testTemporaryPackageInfo: DisplayPackageInfo = {
         packageName: 'jQuery',
         licenseName: 'mit',
+        attributionIds: [],
       };
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testTemporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -485,6 +503,9 @@ describe('The AttributionColumn', () => {
           onDeleteGloballyButtonClick={doNothing}
         />
       );
+      act(() => {
+        store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+      });
       const testFrequentLicenses: FrequentLicenses = {
         nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
         texts: { MIT: 'text' },
@@ -503,11 +524,11 @@ describe('The AttributionColumn', () => {
 
   describe('while changing the first party value', () => {
     it('sets first party flag when checking first party', () => {
-      const testTemporaryPackageInfo: PackageInfo = {};
+      const testTemporaryPackageInfo: DisplayPackageInfo =
+        EMPTY_DISPLAY_PACKAGE_INFO;
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testTemporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -518,6 +539,9 @@ describe('The AttributionColumn', () => {
           onDeleteGloballyButtonClick={doNothing}
         />
       );
+      act(() => {
+        store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+      });
 
       expect(
         getTemporaryPackageInfo(store.getState()).copyright
@@ -529,14 +553,14 @@ describe('The AttributionColumn', () => {
 
     it('leaves copyright unchanged when checking first party', () => {
       const testCopyright = 'Test Copyright';
-      const testTemporaryPackageInfo: PackageInfo = {
+      const testTemporaryPackageInfo: DisplayPackageInfo = {
         copyright: testCopyright,
         firstParty: true,
+        attributionIds: [],
       };
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testTemporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}
@@ -564,7 +588,6 @@ describe('The AttributionColumn', () => {
 
   describe('The ResolveButton', () => {
     it('saves resolved external attributions', () => {
-      const testPackageInfo: PackageInfo = {};
       const testTemporaryPackageInfo: DisplayPackageInfo = {
         attributionIds: ['TestId'],
       };
@@ -576,7 +599,6 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          displayPackageInfo={testPackageInfo}
           setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
           onSaveButtonClick={doNothing}
           setTemporaryPackageInfo={(): (() => void) => doNothing}

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -7,9 +7,9 @@
 import { View } from '../../enums/enums';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import {
+  DisplayPackageInfo,
   FollowUp,
   FrequentLicenseName,
-  PackageInfo,
 } from '../../../shared/shared-types';
 import { AppThunkDispatch } from '../../state/types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -22,7 +22,10 @@ import {
   setIsSavingDisabled,
 } from '../../state/actions/resource-actions/save-actions';
 import { useWindowHeight } from '../../util/use-window-height';
-import { generatePurlFromPackageInfo, parsePurl } from '../../util/handle-purl';
+import {
+  generatePurlFromDisplayPackageInfo,
+  parsePurl,
+} from '../../util/handle-purl';
 import { PanelPackage } from '../../types/types';
 
 const PRE_SELECTED_LABEL = 'Attribution was pre-selected';
@@ -32,7 +35,7 @@ const HEIGHT_OF_TEXT_BOXES_IN_AUDIT_VIEW = 514;
 const ROW_HEIGHT = 19;
 
 export function getDisplayTexts(
-  temporaryPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   selectedAttributionId: string,
   attributionIdMarkedForReplacement: string,
   view: View
@@ -63,7 +66,7 @@ export function getLicenseTextMaxRows(
 }
 
 export function getDiscreteConfidenceChangeHandler(
-  temporaryPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<{ value: unknown }>) => void {
   return (event): void => {
@@ -77,7 +80,7 @@ export function getDiscreteConfidenceChangeHandler(
 }
 
 export function getFollowUpChangeHandler(
-  temporaryPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
@@ -91,7 +94,7 @@ export function getFollowUpChangeHandler(
 }
 
 export function getExcludeFromNoticeChangeHandler(
-  temporaryPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
@@ -105,7 +108,7 @@ export function getExcludeFromNoticeChangeHandler(
 }
 
 export function getFirstPartyChangeHandler(
-  temporaryPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   dispatch: AppThunkDispatch
 ): (event: React.ChangeEvent<HTMLInputElement>) => void {
   return (event): void => {
@@ -216,15 +219,14 @@ export function getMergeButtonsDisplayState(currentState: {
 export function usePurl(
   dispatch: AppThunkDispatch,
   packageInfoWereModified: boolean,
-  temporaryPackageInfo: PackageInfo,
-  displayPackageInfo: PackageInfo,
+  temporaryPackageInfo: DisplayPackageInfo,
   selectedPackage: PanelPackage | null,
   selectedAttributionId: string | null
 ): {
   temporaryPurl: string;
   isDisplayedPurlValid: boolean;
   handlePurlChange: (event: React.ChangeEvent<{ value: string }>) => void;
-  updatePurl: (packageInfo: PackageInfo) => void;
+  updatePurl: (displayPackageInfo: DisplayPackageInfo) => void;
 } {
   const [temporaryPurl, setTemporaryPurl] = useState<string>('');
   const isDisplayedPurlValid: boolean = parsePurl(temporaryPurl).isValid;
@@ -245,17 +247,19 @@ export function usePurl(
 
   useEffect(
     () => {
-      setTemporaryPurl(generatePurlFromPackageInfo(displayPackageInfo) || '');
+      setTemporaryPurl(
+        generatePurlFromDisplayPackageInfo(temporaryPackageInfo) || ''
+      );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       selectedPackage?.panel,
       selectedPackage?.attributionId,
       selectedAttributionId,
-      displayPackageInfo.packageType,
-      displayPackageInfo.packageNamespace,
-      displayPackageInfo.packageName,
-      displayPackageInfo.packageVersion,
+      temporaryPackageInfo.packageType,
+      temporaryPackageInfo.packageNamespace,
+      temporaryPackageInfo.packageName,
+      temporaryPackageInfo.packageVersion,
     ]
   );
 
@@ -278,8 +282,8 @@ export function usePurl(
     }
   }
 
-  function updatePurl(packageInfo: PackageInfo): void {
-    const purl = generatePurlFromPackageInfo(packageInfo);
+  function updatePurl(displayPackageInfo: DisplayPackageInfo): void {
+    const purl = generatePurlFromDisplayPackageInfo(displayPackageInfo);
     setTemporaryPurl(purl);
   }
 

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -6,7 +6,7 @@
 import MuiTypography from '@mui/material/Typography';
 import React, { ReactElement, useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { getTemporaryPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 import {
@@ -26,6 +26,7 @@ import { PopupType } from '../../enums/enums';
 import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 import MuiBox from '@mui/material/Box';
 import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
+import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 
 const VERTICAL_RESOURCE_COLUMN_PADDING = 24;
 const VERTICAL_RESOURCE_HEADER_AND_FOOTER_SIZE = 72;
@@ -72,7 +73,11 @@ export function AttributionDetailsViewer(): ReactElement | null {
 
   const dispatchSavePackageInfo = useCallback(() => {
     dispatch(
-      savePackageInfo(null, selectedAttributionId, temporaryPackageInfo)
+      savePackageInfo(
+        null,
+        selectedAttributionId,
+        convertDisplayPackageInfoToPackageInfo(temporaryPackageInfo)
+      )
     );
   }, [dispatch, selectedAttributionId, temporaryPackageInfo]);
 
@@ -111,12 +116,13 @@ export function AttributionDetailsViewer(): ReactElement | null {
         isEditable={true}
         showManualAttributionData={true}
         areButtonsHidden={false}
-        displayPackageInfo={temporaryPackageInfo}
         setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoFor}
         onSaveButtonClick={dispatchSavePackageInfo}
         onDeleteButtonClick={deleteAttribution}
-        setTemporaryPackageInfo={(packageInfo: PackageInfo): void => {
-          dispatch(setTemporaryPackageInfo(packageInfo));
+        setTemporaryPackageInfo={(
+          displayPackageInfo: DisplayPackageInfo
+        ): void => {
+          dispatch(setTemporaryPackageInfo(displayPackageInfo));
         }}
         saveFileRequestListener={saveFileRequestListener}
       />

--- a/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import {
   Attributions,
   DiscreteConfidence,
+  DisplayPackageInfo,
   PackageInfo,
 } from '../../../../shared/shared-types';
 import { View } from '../../../enums/enums';
@@ -19,16 +20,18 @@ import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/ge
 import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { setTemporaryPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { convertPackageInfoToDisplayPackageInfo } from '../../../util/convert-package-info';
 
 describe('The AttributionDetailsViewer', () => {
   it('renders TextBoxes with right titles and content', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
-      comment: 'some comment',
+      comments: ['some comment'],
       packageName: 'Some package',
       packageVersion: '16.5.0',
       copyright: 'Copyright Doe 2019',
       licenseText: 'Permission is hereby granted',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(<AttributionDetailsViewer />);
     act(() => {
@@ -45,8 +48,9 @@ describe('The AttributionDetailsViewer', () => {
       )
     );
     expect(screen.queryAllByText('Comment'));
-    expect(
-      screen.getByDisplayValue(testTemporaryPackageInfo.comment as string)
+
+    testTemporaryPackageInfo.comments?.forEach((comment) =>
+      expect(screen.getByDisplayValue(comment))
     );
     expect(screen.queryAllByText('Name'));
     expect(
@@ -91,7 +95,13 @@ describe('The AttributionDetailsViewer', () => {
       );
       store.dispatch(navigateToView(View.Attribution));
       store.dispatch(setSelectedAttributionId('uuid_1'));
-      store.dispatch(setTemporaryPackageInfo(expectedPackageInfo));
+      store.dispatch(
+        setTemporaryPackageInfo(
+          convertPackageInfoToDisplayPackageInfo(expectedPackageInfo, [
+            'uuid_1',
+          ])
+        )
+      );
     });
     expect(screen.getByDisplayValue('React'));
 

--- a/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
+++ b/src/Frontend/Components/AttributionWizardPackageStep/AttributionWizardPackageStep.tsx
@@ -5,9 +5,9 @@
 
 import React, { ReactElement } from 'react';
 import MuiBox from '@mui/material/Box';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { ListWithAttributesItem } from '../../types/types';
-import { generatePurlFromPackageInfo } from '../../util/handle-purl';
+import { generatePurlFromDisplayPackageInfo } from '../../util/handle-purl';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
 import { TextBox } from '../InputElements/TextBox';
 import { doNothing } from '../../util/do-nothing';
@@ -28,7 +28,7 @@ const classes = {
 interface AttributionWizardPackageStepProps {
   attributedPackageNamespaces: Array<ListWithAttributesItem>;
   attributedPackageNames: Array<ListWithAttributesItem>;
-  selectedPackageInfo: PackageInfo;
+  selectedDisplayPackageInfo: DisplayPackageInfo;
   selectedPackageNamespaceId: string;
   selectedPackageNameId: string;
   handlePackageNamespaceListItemClick: (id: string) => void;
@@ -43,10 +43,10 @@ export function AttributionWizardPackageStep(
   props: AttributionWizardPackageStepProps
 ): ReactElement {
   const selectedPackageInfoWithoutVersion = {
-    ...props.selectedPackageInfo,
+    ...props.selectedDisplayPackageInfo,
     packageVersion: undefined,
   };
-  const temporaryPurl = generatePurlFromPackageInfo(
+  const temporaryPurl = generatePurlFromDisplayPackageInfo(
     selectedPackageInfoWithoutVersion
   );
 

--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -18,13 +18,13 @@ import {
   getAttributionWizardListItems,
   getSelectedPackageAttributes,
 } from './attribution-wizard-popup-helpers';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   getAttributionWizardPackageNames,
   getAttributionWizardPackageNamespaces,
   getAttributionWizardPackageVersions,
-  getAttributionWizarOriginalAttribution,
+  getAttributionWizarOriginalDisplayPackageInfo,
   getAttributionWizardSelectedPackageAttributeIds,
   getAttributionWizardTotalAttributionCount,
 } from '../../state/selectors/attribution-wizard-selectors';
@@ -76,8 +76,8 @@ const classes = {
 };
 
 export function AttributionWizardPopup(): ReactElement {
-  const originalAttribution = useAppSelector(
-    getAttributionWizarOriginalAttribution
+  const originalDisplayPackageInfo = useAppSelector(
+    getAttributionWizarOriginalDisplayPackageInfo
   );
   const packageNamespaces = useAppSelector(
     getAttributionWizardPackageNamespaces
@@ -132,13 +132,14 @@ export function AttributionWizardPopup(): ReactElement {
     totalAttributionCount || 1
   );
 
-  const selectedPackageInfo: PackageInfo = {
-    packageType: originalAttribution.packageType ?? 'generic',
+  const selectedDisplayPackageInfo: DisplayPackageInfo = {
+    packageType: originalDisplayPackageInfo.packageType ?? 'generic',
     packageName: selectedPackageName ? selectedPackageName : undefined,
     packageNamespace: selectedPackageNamespace
       ? selectedPackageNamespace
       : undefined,
     packageVersion: selectedPackageVersion ? selectedPackageVersion : undefined,
+    attributionIds: [],
   };
 
   function addNewPackageNamespace(newNamespace: string): void {
@@ -211,8 +212,8 @@ export function AttributionWizardPopup(): ReactElement {
   function handleApplyClick(): void {
     dispatch(
       setTemporaryPackageInfo({
-        ...originalAttribution,
-        ...selectedPackageInfo,
+        ...originalDisplayPackageInfo,
+        ...selectedDisplayPackageInfo,
       })
     );
     closeAttributionWizardPopupHandler();
@@ -281,7 +282,7 @@ export function AttributionWizardPopup(): ReactElement {
                 attributedPackageNames={
                   attributedPackageNamesWithManuallyAddedOnes
                 }
-                selectedPackageInfo={selectedPackageInfo}
+                selectedDisplayPackageInfo={selectedDisplayPackageInfo}
                 selectedPackageNamespaceId={
                   selectedPackageAttributeIds.namespaceId
                 }
@@ -300,7 +301,7 @@ export function AttributionWizardPopup(): ReactElement {
                 attributedPackageVersions={
                   attributedPackageVersionsWithManuallyAddedOnes
                 }
-                selectedPackageInfo={selectedPackageInfo}
+                selectedDisplayPackageInfo={selectedDisplayPackageInfo}
                 highlightedPackageNameId={selectedPackageAttributeIds.nameId}
                 selectedPackageVersionId={selectedPackageAttributeIds.versionId}
                 handlePackageVersionListItemClick={

--- a/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
+++ b/src/Frontend/Components/AttributionWizardVersionStep/AttributionWizardVersionStep.tsx
@@ -7,8 +7,8 @@ import React, { ReactElement } from 'react';
 import MuiBox from '@mui/material/Box';
 import { ListWithAttributesItem } from '../../types/types';
 import { ListWithAttributes } from '../ListWithAttributes/ListWithAttributes';
-import { PackageInfo } from '../../../shared/shared-types';
-import { generatePurlFromPackageInfo } from '../../util/handle-purl';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
+import { generatePurlFromDisplayPackageInfo } from '../../util/handle-purl';
 import { doNothing } from '../../util/do-nothing';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionWizardStepClasses } from '../../shared-styles';
@@ -25,7 +25,7 @@ const classes = {
 interface AttributionWizardVersionStepProps {
   attributedPackageVersions: Array<ListWithAttributesItem>;
   highlightedPackageNameId: string;
-  selectedPackageInfo: PackageInfo;
+  selectedDisplayPackageInfo: DisplayPackageInfo;
   selectedPackageVersionId: string;
   handlePackageVersionListItemClick: (id: string) => void;
   addNewPackageVersion(items: string): void;
@@ -35,7 +35,9 @@ interface AttributionWizardVersionStepProps {
 export function AttributionWizardVersionStep(
   props: AttributionWizardVersionStepProps
 ): ReactElement {
-  const temporaryPurl = generatePurlFromPackageInfo(props.selectedPackageInfo);
+  const temporaryPurl = generatePurlFromDisplayPackageInfo(
+    props.selectedDisplayPackageInfo
+  );
 
   return (
     <MuiBox sx={attributionWizardStepClasses.root}>

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -14,7 +14,7 @@ import {
   getTemporaryPackageInfo,
 } from '../../state/selectors/all-views-resource-selectors';
 import { setTemporaryPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import {
   savePackageInfo,
   savePackageInfoIfSavingIsNotDisabled,
@@ -22,6 +22,7 @@ import {
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
 import { closeEditAttributionPopupOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
+import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 
 export function EditAttributionPopup(): ReactElement {
   const dispatch = useAppDispatch();
@@ -41,7 +42,13 @@ export function EditAttributionPopup(): ReactElement {
   }, [dispatch, popupAttributionId, temporaryPackageInfo]);
 
   const dispatchSavePackageInfo = useCallback(() => {
-    dispatch(savePackageInfo(null, popupAttributionId, temporaryPackageInfo));
+    dispatch(
+      savePackageInfo(
+        null,
+        popupAttributionId,
+        convertDisplayPackageInfoToPackageInfo(temporaryPackageInfo)
+      )
+    );
   }, [dispatch, popupAttributionId, temporaryPackageInfo]);
 
   function checkForModifiedPackageInfoBeforeClosing(): void {
@@ -61,10 +68,11 @@ export function EditAttributionPopup(): ReactElement {
           isEditable
           areButtonsHidden
           showManualAttributionData
-          displayPackageInfo={temporaryPackageInfo}
           setUpdateTemporaryPackageInfoFor={setUpdateTemporaryPackageInfoFor}
-          setTemporaryPackageInfo={(packageInfo: PackageInfo): void => {
-            dispatch(setTemporaryPackageInfo(packageInfo));
+          setTemporaryPackageInfo={(
+            displayPackageInfo: DisplayPackageInfo
+          ): void => {
+            dispatch(setTemporaryPackageInfo(displayPackageInfo));
           }}
           saveFileRequestListener={saveFileRequestListener}
           smallerLicenseTextOrCommentField

--- a/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/__tests__/EditAttributionPopup.test.tsx
@@ -9,9 +9,8 @@ import React from 'react';
 import { EditAttributionPopup } from '../EditAttributionPopup';
 import {
   Attributions,
-  PackageInfo,
+  DisplayPackageInfo,
   Resources,
-  isDisplayPackageInfo,
 } from '../../../../shared/shared-types';
 import {
   navigateToView,
@@ -25,6 +24,7 @@ import { getOpenPopup } from '../../../state/selectors/view-selector';
 import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
 import { getTemporaryPackageInfo } from '../../../state/selectors/all-views-resource-selectors';
 import { act } from 'react-dom/test-utils';
+import { convertDisplayPackageInfoToPackageInfo } from '../../../util/convert-package-info';
 
 describe('The EditAttributionPopup', () => {
   const testResources: Resources = {
@@ -33,21 +33,24 @@ describe('The EditAttributionPopup', () => {
       'package_2.tr.gz': 1,
     },
   };
-  const testTemporaryPackageInfo: PackageInfo = {
+  const testTemporaryPackageInfo: DisplayPackageInfo = {
     attributionConfidence: 20,
     packageName: 'jQuery',
     packageVersion: '16.5.0',
     packagePURLAppendix: '?appendix',
     packageNamespace: 'namespace',
     packageType: 'type',
-    comment: 'some comment',
+    comments: ['some comment'],
     copyright: 'Copyright Doe Inc. 2019',
     licenseText: 'Permission is hereby granted',
     licenseName: 'Made up license name',
     url: 'www.1999.com',
+    attributionIds: [],
   };
   const testAttributions: Attributions = {
-    test_selected_id: testTemporaryPackageInfo,
+    test_selected_id: convertDisplayPackageInfoToPackageInfo(
+      testTemporaryPackageInfo
+    ),
     test_marked_id: { packageName: 'Vue' },
   };
   const testResourcesToManualAttributions = {
@@ -73,7 +76,12 @@ describe('The EditAttributionPopup', () => {
     );
     act(() => {
       store.dispatch(setSelectedAttributionId('test_selected_id'));
-      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+      store.dispatch(
+        setTemporaryPackageInfo({
+          ...testTemporaryPackageInfo,
+          attributionIds: ['test_selected_id'],
+        })
+      );
     });
 
     expect(screen.getByText(expectedHeader)).toBeInTheDocument();
@@ -132,9 +140,10 @@ describe('The EditAttributionPopup', () => {
         })
       )
     );
-    const changedTestTemporaryPackageInfo: PackageInfo = {
+    const changedTestTemporaryPackageInfo: DisplayPackageInfo = {
       ...testTemporaryPackageInfo,
-      comment: 'changed comment',
+      attributionIds: ['test_selected_id'],
+      comments: ['changed comment'],
     };
     act(() => {
       store.dispatch(setSelectedAttributionId('test_selected_id'));
@@ -149,10 +158,9 @@ describe('The EditAttributionPopup', () => {
     const resultingTemporaryPackageInfo = getTemporaryPackageInfo(
       store.getState()
     );
-    if (!isDisplayPackageInfo(resultingTemporaryPackageInfo)) {
-      expect(resultingTemporaryPackageInfo.comment).toBe(
-        changedTestTemporaryPackageInfo.comment
-      );
-    }
+
+    expect(resultingTemporaryPackageInfo.comments).toEqual(
+      changedTestTemporaryPackageInfo.comments
+    );
   });
 });

--- a/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
+++ b/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
@@ -30,6 +30,7 @@ import {
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { setTemporaryPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { getSelectedResourceId } from '../../../state/selectors/audit-view-resource-selectors';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 
 function setupTestState(
   store: EnhancedTestStore,
@@ -69,17 +70,22 @@ describe('NotSavedPopup and do not change view', () => {
   it('renders a NotSavedPopup and click reset', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store);
-    store.dispatch(setTemporaryPackageInfo({ packageName: 'test name' }));
+    store.dispatch(
+      setTemporaryPackageInfo({ packageName: 'test name', attributionIds: [] })
+    );
 
     expect(screen.getByText('Warning')).toBeInTheDocument();
     expect(getTemporaryPackageInfo(store.getState())).toEqual({
       packageName: 'test name',
+      attributionIds: [],
     });
 
     fireEvent.click(screen.queryByText(ButtonText.Undo) as Element);
     expect(getOpenPopup(store.getState())).toBe(null);
     expect(getSelectedResourceId(store.getState())).toBe('test_id');
-    expect(getTemporaryPackageInfo(store.getState())).toEqual({});
+    expect(getTemporaryPackageInfo(store.getState())).toEqual(
+      EMPTY_DISPLAY_PACKAGE_INFO
+    );
     expect(isAuditViewSelected(store.getState())).toBe(true);
   });
 
@@ -123,17 +129,22 @@ describe('NotSavedPopup and change view', () => {
   it('renders a NotSavedPopup and click reset', () => {
     const { store } = renderComponentWithStore(<NotSavedPopup />);
     setupTestState(store, View.Attribution);
-    store.dispatch(setTemporaryPackageInfo({ packageName: 'test name' }));
+    store.dispatch(
+      setTemporaryPackageInfo({ packageName: 'test name', attributionIds: [] })
+    );
 
     expect(screen.getByText('Warning')).toBeInTheDocument();
     expect(getTemporaryPackageInfo(store.getState())).toEqual({
       packageName: 'test name',
+      attributionIds: [],
     });
 
     fireEvent.click(screen.queryByText(ButtonText.Undo) as Element);
     expect(getOpenPopup(store.getState())).toBeFalsy();
     expect(getSelectedResourceId(store.getState())).toBe('test_id');
-    expect(getTemporaryPackageInfo(store.getState())).toEqual({});
+    expect(getTemporaryPackageInfo(store.getState())).toEqual(
+      EMPTY_DISPLAY_PACKAGE_INFO
+    );
     expect(isAttributionViewSelected(store.getState())).toBe(true);
   });
 });

--- a/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/package-panel-helpers.test.ts
@@ -3,17 +3,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  ExternalAttributionSources,
-  DisplayPackageInfo,
-  PackageInfo,
-} from '../../../../shared/shared-types';
+import { ExternalAttributionSources } from '../../../../shared/shared-types';
 import {
   getAttributionIdsWithCountForSource,
   getSortedSources,
 } from '../package-panel-helpers';
 import { DisplayAttributionWithCount } from '../../../types/types';
-import { convertDisplayPackageInfoToPackageInfo } from '../../../util/convert-package-info';
 
 const testAttributionSources: ExternalAttributionSources = {
   MERGER: { name: 'Suggested', priority: 11 },
@@ -176,33 +171,5 @@ describe('PackagePanel helpers', () => {
       'a_unknown',
       'b_unknown',
     ]);
-  });
-
-  it('convertDisplayPackageInfoToPackageInfo returns correct PackageInfo', () => {
-    const testDisplayPackageInfoA: DisplayPackageInfo = {
-      packageName: 'react',
-      comments: ['comment A', 'comment B'],
-      attributionIds: ['123', '456'],
-    };
-    const testDisplayPackageInfoB: DisplayPackageInfo = {
-      packageName: 'react',
-      comments: ['comment'],
-      attributionIds: ['123'],
-    };
-    const expectedPackageInfoA: PackageInfo = {
-      packageName: 'react',
-    };
-    const expectedPackageInfoB: PackageInfo = {
-      packageName: 'react',
-      comment: 'comment',
-    };
-    const testPackageInfoA = convertDisplayPackageInfoToPackageInfo(
-      testDisplayPackageInfoA
-    );
-    const testPackageInfoB = convertDisplayPackageInfoToPackageInfo(
-      testDisplayPackageInfoB
-    );
-    expect(testPackageInfoA).toEqual(expectedPackageInfoA);
-    expect(testPackageInfoB).toEqual(expectedPackageInfoB);
   });
 });

--- a/src/Frontend/Components/PackageSearchPopup/ClearlyDefinedPackageCard.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/ClearlyDefinedPackageCard.tsx
@@ -20,6 +20,7 @@ import { fetchFromClearlyDefined } from './fetch-from-clearly-defined';
 import { Alert } from '../Alert/Alert';
 import { baseIcon } from '../../shared-styles';
 import MuiBox from '@mui/material/Box';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 
 interface ClearlyDefinedPackageCardProps {
   coordinate: string;
@@ -114,7 +115,9 @@ export function ClearlyDefinedPackageCard(
               tooltipPlacement={'right'}
               disabled={!Boolean(data)}
               onClick={(): void => {
-                dispatch(setTemporaryPackageInfo(data ?? {}));
+                dispatch(
+                  setTemporaryPackageInfo(data ?? EMPTY_DISPLAY_PACKAGE_INFO)
+                );
                 dispatch(closePopup());
               }}
               icon={<PlusIcon sx={classes.baseIcon} />}

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/ClearlyDefinedPackageCard.test.tsx
@@ -80,6 +80,7 @@ describe('ClearlyDefinedPackageCard', () => {
       packageType: 'pypi',
       copyright: 'Copyright Jane Doe\nCopyright John Doe',
       url: 'https://pypi.org/project/SQLAlchemy/1.4.1',
+      attributionIds: [],
     });
     expect(getOpenPopup(store.getState())).toBeNull();
   });

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/fetch-license-from-clearly-defined.test.ts
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/fetch-license-from-clearly-defined.test.ts
@@ -49,6 +49,7 @@ describe('fetchFromClearlyDefined', () => {
       copyright: 'Copyright Jane Doe\nCopyright John Doe',
       licenseName: 'MIT',
       url: 'https://pypi.org/project/SQLAlchemy/1.4.14',
+      attributionIds: [],
     });
   });
 

--- a/src/Frontend/Components/PackageSearchPopup/fetch-from-clearly-defined.ts
+++ b/src/Frontend/Components/PackageSearchPopup/fetch-from-clearly-defined.ts
@@ -4,7 +4,7 @@
 
 import { Schema, Validator } from 'jsonschema';
 import axios from 'axios';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 
 const jsonSchemaValidator = new Validator();
 
@@ -101,7 +101,7 @@ const clearlyDefinedSchema: Schema = {
 
 export async function fetchFromClearlyDefined(
   coordinate: string
-): Promise<PackageInfo> {
+): Promise<DisplayPackageInfo> {
   const response = await axios.get(
     `https://api.clearlydefined.io/definitions/${coordinate}`
   );
@@ -121,6 +121,7 @@ export async function fetchFromClearlyDefined(
     url:
       payload?.described.urls?.version ??
       payload?.described.sourceLocation?.url,
+    attributionIds: [],
   };
 }
 

--- a/src/Frontend/Components/ProgressBar/__tests__/FolderProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/FolderProgressBar.test.tsx
@@ -39,21 +39,21 @@ describe('FolderProgressBar', () => {
     const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
     const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
     const testExternalAttributionUuid = 'b5da73d4-f400-11ea-adc1-0242ac120003';
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
     };
-    const secondTestTemporaryPackageInfo: PackageInfo = {
+    const secondTestPackageInfo: PackageInfo = {
       packageVersion: '2.0',
       packageName: 'not assigned test Package',
       licenseText: ' test not assigned License text',
       preSelected: true,
     };
     const testManualAttributions: Attributions = {
-      [testManualAttributionUuid_1]: testTemporaryPackageInfo,
-      [testManualAttributionUuid_2]: secondTestTemporaryPackageInfo,
+      [testManualAttributionUuid_1]: testPackageInfo,
+      [testManualAttributionUuid_2]: secondTestPackageInfo,
     };
 
     const testExternalAttributions: Attributions = {
@@ -117,21 +117,21 @@ describe('FolderProgressBar', () => {
     const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
     const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
     const testExternalAttributionUuid = 'b5da73d4-f400-11ea-adc1-0242ac120003';
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
     };
-    const secondTestTemporaryPackageInfo: PackageInfo = {
+    const secondTestPackageInfo: PackageInfo = {
       packageVersion: '2.0',
       packageName: 'not assigned test Package',
       licenseText: ' test not assigned License text',
       preSelected: true,
     };
     const testManualAttributions: Attributions = {
-      [testManualAttributionUuid_1]: testTemporaryPackageInfo,
-      [testManualAttributionUuid_2]: secondTestTemporaryPackageInfo,
+      [testManualAttributionUuid_1]: testPackageInfo,
+      [testManualAttributionUuid_2]: secondTestPackageInfo,
     };
 
     const testExternalAttributions: Attributions = {

--- a/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
@@ -40,21 +40,21 @@ describe('TopProgressBar', () => {
     const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
     const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
     const testExternalAttributionUuid = 'b5da73d4-f400-11ea-adc1-0242ac120003';
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
     };
-    const secondTestTemporaryPackageInfo: PackageInfo = {
+    const secondTestPackageInfo: PackageInfo = {
       packageVersion: '2.0',
       packageName: 'not assigned test Package',
       licenseText: ' test not assigned License text',
       preSelected: true,
     };
     const testManualAttributions: Attributions = {
-      [testManualAttributionUuid_1]: testTemporaryPackageInfo,
-      [testManualAttributionUuid_2]: secondTestTemporaryPackageInfo,
+      [testManualAttributionUuid_1]: testPackageInfo,
+      [testManualAttributionUuid_2]: secondTestPackageInfo,
     };
 
     const testExternalAttributions: Attributions = {
@@ -119,21 +119,21 @@ describe('TopProgressBar', () => {
     const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
     const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
 
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testPackageInfo: PackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
     };
-    const secondTestTemporaryPackageInfo: PackageInfo = {
+    const secondTestPackageInfo: PackageInfo = {
       packageVersion: '2.0',
       packageName: 'not assigned test Package',
       licenseText: ' test not assigned License text',
       preSelected: true,
     };
     const testManualAttributions: Attributions = {
-      [testManualAttributionUuid_1]: testTemporaryPackageInfo,
-      [testManualAttributionUuid_2]: secondTestTemporaryPackageInfo,
+      [testManualAttributionUuid_1]: testPackageInfo,
+      [testManualAttributionUuid_2]: secondTestPackageInfo,
     };
 
     const testHighlyCriticalExternalAttributionUuid =

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -5,7 +5,7 @@
 
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
 import {
   getAttributionBreakpoints,
@@ -15,7 +15,6 @@ import {
 import { PanelPackage } from '../../types/types';
 import { hasAttributionMultipleResources } from '../../util/has-attribution-multiple-resources';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
-import { getDisplayPackageInfo } from './resource-details-attribution-column-helpers';
 import {
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
@@ -32,6 +31,7 @@ import {
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { setUpdateTemporaryPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
+import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 
 interface ResourceDetailsAttributionColumnProps {
   showParentAttributions: boolean;
@@ -59,7 +59,7 @@ export function ResourceDetailsAttributionColumn(
         unlinkAttributionAndSavePackageInfo(
           selectedResourceId,
           attributionIdOfSelectedPackageInManualPanel,
-          temporaryPackageInfo
+          convertDisplayPackageInfoToPackageInfo(temporaryPackageInfo)
         )
       );
     }
@@ -70,14 +70,14 @@ export function ResourceDetailsAttributionColumn(
       savePackageInfo(
         selectedResourceId,
         attributionIdOfSelectedPackageInManualPanel,
-        temporaryPackageInfo
+        convertDisplayPackageInfoToPackageInfo(temporaryPackageInfo)
       )
     );
   }
 
   function openConfirmDeletionPopup(): void {
     if (!attributionIdOfSelectedPackageInManualPanel) return;
-    if (displayPackageInfo.preSelected) {
+    if (temporaryPackageInfo.preSelected) {
       dispatch(
         deleteAttributionAndSave(
           selectedResourceId,
@@ -97,7 +97,7 @@ export function ResourceDetailsAttributionColumn(
   function openConfirmDeletionGloballyPopup(): void {
     if (!attributionIdOfSelectedPackageInManualPanel) return;
 
-    if (displayPackageInfo.preSelected) {
+    if (temporaryPackageInfo.preSelected) {
       dispatch(
         deleteAttributionGloballyAndSave(
           attributionIdOfSelectedPackageInManualPanel
@@ -122,12 +122,6 @@ export function ResourceDetailsAttributionColumn(
       )
     );
   }
-
-  const displayPackageInfo: PackageInfo = getDisplayPackageInfo(
-    displayedPackage,
-    temporaryPackageInfo,
-    manualData.attributions
-  );
 
   const showSaveGloballyButton: boolean = hasAttributionMultipleResources(
     attributionIdOfSelectedPackageInManualPanel,
@@ -169,7 +163,6 @@ export function ResourceDetailsAttributionColumn(
       areButtonsHidden={
         displayedPackage.panel !== PackagePanelTitle.ManualPackages
       }
-      displayPackageInfo={displayPackageInfo}
       showParentAttributions={props.showParentAttributions}
       showSaveGloballyButton={showSaveGloballyButton}
       hideDeleteButtons={hideDeleteButtons}
@@ -183,8 +176,10 @@ export function ResourceDetailsAttributionColumn(
           : dispatchSavePackageInfo
       }
       onSaveGloballyButtonClick={dispatchSavePackageInfo}
-      setTemporaryPackageInfo={(packageInfo: PackageInfo): void => {
-        dispatch(setTemporaryPackageInfo(packageInfo));
+      setTemporaryPackageInfo={(
+        displayPackageInfo: DisplayPackageInfo
+      ): void => {
+        dispatch(setTemporaryPackageInfo(displayPackageInfo));
       }}
       saveFileRequestListener={saveFileRequestListener}
       onDeleteButtonClick={openConfirmDeletionPopup}

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {
   Attributions,
   DiscreteConfidence,
-  PackageInfo,
+  DisplayPackageInfo,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
 import {
@@ -26,21 +26,23 @@ import { act, screen } from '@testing-library/react';
 
 const testManualLicense = 'Manual attribution license.';
 const testManualLicense2 = 'Another manual attribution license.';
-const testTemporaryPackageInfo: PackageInfo = {
+const testTemporaryPackageInfo: DisplayPackageInfo = {
   packageName: 'React',
   packageVersion: '16.5.0',
   licenseText: testManualLicense,
+  attributionIds: [],
 };
-const testTemporaryPackageInfo2: PackageInfo = {
+const testTemporaryPackageInfo2: DisplayPackageInfo = {
   packageName: 'Vue.js',
   packageVersion: '2.6.11',
   licenseText: testManualLicense2,
+  attributionIds: [],
 };
 
 function getTestTemporaryAndExternalStateWithParentAttribution(
   store: EnhancedTestStore,
   selectedResourceId: string,
-  temporaryPackageInfo: PackageInfo
+  temporaryPackageInfo: DisplayPackageInfo
 ): void {
   const manualAttributions: Attributions = {
     uuid_1: testTemporaryPackageInfo,
@@ -69,13 +71,14 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 
 describe('The ResourceDetailsAttributionColumn', () => {
   it('renders TextBoxes with right titles and content', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
-      comment: 'some comment',
+      comments: ['some comment'],
       packageName: 'Some package',
       packageVersion: '16.5.0',
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(
       <ResourceDetailsAttributionColumn showParentAttributions={true} />
@@ -94,9 +97,11 @@ describe('The ResourceDetailsAttributionColumn', () => {
       )
     );
     expect(screen.queryAllByText('Comment'));
-    expect(
-      screen.getByDisplayValue(testTemporaryPackageInfo.comment as string)
-    );
+    const testComment =
+      testTemporaryPackageInfo?.comments !== undefined
+        ? testTemporaryPackageInfo?.comments[0]
+        : '';
+    expect(screen.getByDisplayValue(testComment));
     expect(screen.queryAllByText('Name'));
     expect(
       screen.getByDisplayValue(testTemporaryPackageInfo.packageName as string)

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/resource-details-attribution-column-helpers.ts
@@ -9,20 +9,20 @@ import { PanelPackage } from '../../types/types';
 
 export function getDisplayPackageInfo(
   selectedPackage: PanelPackage | null,
-  temporaryPackageInfo: PackageInfo,
+  packageInfo: PackageInfo,
   manualAttributions: Attributions
 ): PackageInfo {
   let displayPackageInfo = {};
 
   if (!selectedPackage) {
-    displayPackageInfo = temporaryPackageInfo;
+    displayPackageInfo = packageInfo;
   }
 
   switch (selectedPackage?.panel) {
     case PackagePanelTitle.ManualPackages:
     case PackagePanelTitle.ExternalPackages:
     case PackagePanelTitle.ContainedExternalPackages:
-      displayPackageInfo = temporaryPackageInfo;
+      displayPackageInfo = packageInfo;
       break;
     case PackagePanelTitle.ContainedManualPackages:
     case PackagePanelTitle.AllAttributions:

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -9,7 +9,7 @@ import MuiTab from '@mui/material/Tab';
 import { getManualData } from '../../state/selectors/all-views-resource-selectors';
 import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
 import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
-import { pick, remove } from 'lodash';
+import { remove } from 'lodash';
 import {
   getAttributionIdsOfSelectedResource,
   getDisplayedPackage,
@@ -27,6 +27,8 @@ import {
   toggleAccordionSearchField,
 } from '../../state/actions/resource-actions/audit-view-simple-actions';
 import { SearchTextField } from '../SearchTextField/SearchTextField';
+import { getDisplayAttributionWithCountFromAttributions } from '../../util/get-display-attributions-with-count-from-attributions';
+import { DisplayAttributionWithCount } from '../../types/types';
 
 const classes = {
   tabsRoot: {
@@ -106,10 +108,12 @@ export function ResourceDetailsTabs(
       !attributionIdsOfSelectedResource.includes(attributionId)
   );
 
-  const manualAttributionsToDisplay = pick(
-    manualData.attributions,
-    assignableAttributionIds
-  );
+  const displayAttributions: Array<DisplayAttributionWithCount> =
+    assignableAttributionIds.map((attributionId) =>
+      getDisplayAttributionWithCountFromAttributions([
+        [attributionId, manualData.attributions[attributionId], undefined],
+      ])
+    );
 
   const isAddToPackageEnabled: boolean =
     props.isGlobalTabEnabled && props.isAddToPackageEnabled;
@@ -182,7 +186,7 @@ export function ResourceDetailsTabs(
         aggregatedAttributionsPanel
       ) : (
         <AllAttributionsPanel
-          attributions={manualAttributionsToDisplay}
+          displayAttributions={displayAttributions}
           selectedAttributionId={
             selectedPackage && selectedPackage.attributionId
           }

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -29,6 +29,7 @@ import { getAttributionBreakpoints } from '../../state/selectors/all-views-resou
 import { isIdOfResourceWithChildren } from '../../util/can-resource-have-children';
 import { FolderProgressBar } from '../ProgressBar/FolderProgressBar';
 import MuiBox from '@mui/material/Box';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 
 const classes = {
   root: {
@@ -93,7 +94,7 @@ export function ResourceDetailsViewer(): ReactElement | null {
 
   function onOverrideParentClick(): void {
     setOverrideParentMode(true);
-    dispatch(setTemporaryPackageInfo({}));
+    dispatch(setTemporaryPackageInfo(EMPTY_DISPLAY_PACKAGE_INFO));
     dispatch(
       setDisplayedPackage({
         panel: PackagePanelTitle.ManualPackages,

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import {
   Attributions,
-  PackageInfo,
+  DisplayPackageInfo,
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
@@ -30,27 +30,32 @@ import {
 } from '../../../test-helpers/attribution-column-test-helpers';
 import { clickOnTab } from '../../../test-helpers/package-panel-helpers';
 import { act } from 'react-dom/test-utils';
-import { ADD_NEW_ATTRIBUTION_BUTTON_TEXT } from '../../../shared-constants';
+import {
+  ADD_NEW_ATTRIBUTION_BUTTON_TEXT,
+  EMPTY_DISPLAY_PACKAGE_INFO,
+} from '../../../shared-constants';
 
 const testExternalLicense = 'Computed attribution license.';
 const testExternalLicense2 = 'Other computed attribution license.';
 const testManualLicense = 'Manual attribution license.';
 const testManualLicense2 = 'Another manual attribution license.';
-const testTemporaryPackageInfo: PackageInfo = {
+const testTemporaryPackageInfo: DisplayPackageInfo = {
   packageName: 'jQuery',
   packageVersion: '16.5.0',
   licenseText: testManualLicense,
+  attributionIds: [],
 };
-const testTemporaryPackageInfo2: PackageInfo = {
+const testTemporaryPackageInfo2: DisplayPackageInfo = {
   packageName: 'Vue.js',
   packageVersion: '2.6.11',
   licenseText: testManualLicense2,
+  attributionIds: [],
 };
 
 function getTestTemporaryAndExternalStateWithParentAttribution(
   store: EnhancedTestStore,
   selectedResourceId: string,
-  temporaryPackageInfo: PackageInfo
+  temporaryPackageInfo: DisplayPackageInfo
 ): void {
   const manualAttributions: Attributions = {
     uuid_1: testTemporaryPackageInfo,
@@ -76,8 +81,9 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 
 describe('The ResourceDetailsViewer', () => {
   it('renders an Attribution column', () => {
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       packageName: 'jQuery',
+      attributionIds: [],
     };
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     act(() => {
@@ -164,7 +170,7 @@ describe('The ResourceDetailsViewer', () => {
       store.dispatch(
         setExternalData(externalAttributions, resourcesToExternalAttributions)
       );
-      store.dispatch(setTemporaryPackageInfo({}));
+      store.dispatch(setTemporaryPackageInfo(EMPTY_DISPLAY_PACKAGE_INFO));
     });
 
     expect(screen.getByText('Signals'));
@@ -197,7 +203,7 @@ describe('The ResourceDetailsViewer', () => {
         )
       );
       store.dispatch(setSelectedResourceId('/test_id/'));
-      store.dispatch(setTemporaryPackageInfo({}));
+      store.dispatch(setTemporaryPackageInfo(EMPTY_DISPLAY_PACKAGE_INFO));
     });
 
     expect(screen.getByText('Signals in Folder Content'));

--- a/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
+++ b/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
@@ -35,6 +35,7 @@ export function TextFieldStack(props: TextFieldStackProps): ReactElement {
   if (filteredComments.length == 0) {
     filteredComments.push('');
   }
+
   return props.isCollapsed ? (
     <MuiBox>
       <TextBox
@@ -44,7 +45,7 @@ export function TextFieldStack(props: TextFieldStackProps): ReactElement {
         text={''}
         minRows={1}
         maxRows={1}
-        handleChange={props.handleChange('comment')}
+        handleChange={props.handleChange('comments')}
       />
     </MuiBox>
   ) : (
@@ -61,7 +62,7 @@ export function TextFieldStack(props: TextFieldStackProps): ReactElement {
               minRows={numLines}
               maxRows={numLines}
               multiline={true}
-              handleChange={props.handleChange('comment')}
+              handleChange={props.handleChange('comments')}
             />
           </MuiBox>
         );

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/attribution-wizard-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/attribution-wizard-popup.test.tsx
@@ -24,6 +24,7 @@ import {
   createTestAppStore,
   renderComponentWithStore,
 } from '../../../test-helpers/render-component-with-store';
+import { convertPackageInfoToDisplayPackageInfo } from '../../../util/convert-package-info';
 
 const selectedResourceId = '/samplepath/';
 const testManualAttributions: Attributions = {
@@ -79,8 +80,15 @@ describe('AttributionWizardPopup', () => {
   });
 
   it('changes temporary package info', () => {
-    const initialTemporaryPackageInfo = testManualAttributions.uuid_0;
-    const expectedChangedTemporaryPackageInfo = testExternalAttributions.uuid_1;
+    const initialTemporaryPackageInfo = convertPackageInfoToDisplayPackageInfo(
+      testManualAttributions.uuid_0,
+      ['uuid_0']
+    );
+    const expectedChangedTemporaryPackageInfo =
+      convertPackageInfoToDisplayPackageInfo(
+        testExternalAttributions.uuid_1,
+        []
+      );
 
     const testStore = createTestAppStore();
     testStore.dispatch(setSelectedResourceId(selectedResourceId));

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -7,6 +7,7 @@ import {
   Attributions,
   AttributionsToResources,
   DiscreteConfidence,
+  DisplayPackageInfo,
   FrequentLicenses,
   PackageInfo,
   Resources,
@@ -84,10 +85,11 @@ const testResourcesToManualAttributions: ResourcesToAttributions = {
 describe('The load and navigation simple actions', () => {
   it('resets the state', () => {
     const testStore = createTestAppStore();
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       packageVersion: '1.1',
       packageName: 'test Package',
       licenseText: ' test License text',
+      attributionIds: [],
     };
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
@@ -252,15 +254,16 @@ describe('The load and navigation simple actions', () => {
   });
 
   it('sets and gets temporaryPackageInfo', () => {
-    const testPackageInfo: PackageInfo = {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
       packageName: 'test',
       packageVersion: '1.0',
       licenseText: 'License Text',
+      attributionIds: [],
     };
     const testStore = createTestAppStore();
-    testStore.dispatch(setTemporaryPackageInfo(testPackageInfo));
+    testStore.dispatch(setTemporaryPackageInfo(testDisplayPackageInfo));
     expect(getTemporaryPackageInfo(testStore.getState())).toMatchObject(
-      testPackageInfo
+      testDisplayPackageInfo
     );
   });
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/navigation-actions.test.ts
@@ -6,6 +6,7 @@
 import {
   Attributions,
   DiscreteConfidence,
+  DisplayPackageInfo,
   PackageInfo,
   Resources,
   ResourcesToAttributions,
@@ -45,17 +46,23 @@ import {
   getSelectedResourceId,
 } from '../../../selectors/audit-view-resource-selectors';
 import { getSelectedAttributionId } from '../../../selectors/attribution-view-resource-selectors';
+import { convertDisplayPackageInfoToPackageInfo } from '../../../../util/convert-package-info';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../../shared-constants';
 
 describe('resetTemporaryPackageInfo', () => {
   it('works correctly on audit view', () => {
-    const testReact: PackageInfo = {
+    const testPackageInfo: PackageInfo = {
       packageName: 'React',
+    };
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionIds: ['uuid1'],
     };
     const testResources: Resources = {
       file: 1,
     };
     const testManualAttributions: Attributions = {
-      uuid1: testReact,
+      uuid1: testPackageInfo,
     };
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       '/file': ['uuid1'],
@@ -64,8 +71,9 @@ describe('resetTemporaryPackageInfo', () => {
       panel: PackagePanelTitle.ManualPackages,
       attributionId: 'uuid1',
     };
-    const initialTemporaryPackageInfo: PackageInfo = {
+    const initialTemporaryPackageInfo: DisplayPackageInfo = {
       packageName: 'Vue',
+      attributionIds: [],
     };
 
     const testStore = createTestAppStore();
@@ -87,7 +95,9 @@ describe('resetTemporaryPackageInfo', () => {
     );
 
     testStore.dispatch(resetTemporaryPackageInfo());
-    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(testReact);
+    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(
+      testDisplayPackageInfo
+    );
   });
 
   it('works correctly on attribution view', () => {
@@ -97,8 +107,9 @@ describe('resetTemporaryPackageInfo', () => {
     const testManualAttributions: Attributions = {
       uuid1: testReact,
     };
-    const initialTemporaryPackageInfo: PackageInfo = {
+    const initialTemporaryPackageInfo: DisplayPackageInfo = {
       packageName: 'Vue',
+      attributionIds: [],
     };
 
     const testStore = createTestAppStore();
@@ -117,7 +128,11 @@ describe('resetTemporaryPackageInfo', () => {
     );
 
     testStore.dispatch(resetTemporaryPackageInfo());
-    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(testReact);
+    expect(
+      convertDisplayPackageInfoToPackageInfo(
+        getTemporaryPackageInfo(testStore.getState())
+      )
+    ).toEqual(testReact);
   });
 });
 
@@ -219,6 +234,10 @@ describe('setSelectedResourceIdAndExpand', () => {
 describe('setDisplayedPackageAndResetTemporaryPackageInfo', () => {
   it('sets the displayedPackage and loads the right initial temporaryPackageInfo', () => {
     const testPackageInfo: PackageInfo = { packageName: 'React' };
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionIds: ['uuid'],
+    };
     const testResources: Resources = {
       file1: 1,
     };
@@ -244,7 +263,9 @@ describe('setDisplayedPackageAndResetTemporaryPackageInfo', () => {
       )
     );
     expect(getDisplayedPackage(testStore.getState())).toBeNull();
-    expect(getTemporaryPackageInfo(testStore.getState())).toEqual({});
+    expect(getTemporaryPackageInfo(testStore.getState())).toEqual(
+      EMPTY_DISPLAY_PACKAGE_INFO
+    );
 
     testStore.dispatch(
       setDisplayedPackageAndResetTemporaryPackageInfo(expectedDisplayedPackage)
@@ -253,7 +274,7 @@ describe('setDisplayedPackageAndResetTemporaryPackageInfo', () => {
       expectedDisplayedPackage
     );
     expect(getTemporaryPackageInfo(testStore.getState())).toEqual(
-      testPackageInfo
+      testDisplayPackageInfo
     );
   });
 });

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -10,7 +10,6 @@ import {
   ExternalAttributionSources,
   FrequentLicenses,
   DisplayPackageInfo,
-  PackageInfo,
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
@@ -84,7 +83,7 @@ export function setFrequentLicenses(
 }
 
 export function setTemporaryPackageInfo(
-  packageInfo: PackageInfo | DisplayPackageInfo
+  packageInfo: DisplayPackageInfo
 ): SetTemporaryPackageInfoAction {
   return { type: ACTION_SET_TEMPORARY_PACKAGE_INFO, payload: packageInfo };
 }

--- a/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/attribution-wizard-actions.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfo } from '../../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../../shared/shared-types';
 import { PackageAttributeIds, PackageAttributes } from '../../../types/types';
 import {
   ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMES,
@@ -21,11 +21,11 @@ import {
 } from './types';
 
 export function setAttributionWizardOriginalAttribution(
-  originalAttribution: PackageInfo
+  originalDisplayPackageInfo: DisplayPackageInfo
 ): SetAttributionWizardOriginalAttribution {
   return {
     type: ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION,
-    payload: originalAttribution,
+    payload: originalDisplayPackageInfo,
   };
 }
 

--- a/src/Frontend/state/actions/resource-actions/navigation-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/navigation-actions.ts
@@ -13,7 +13,7 @@ import { PackagePanelTitle, View } from '../../../enums/enums';
 import { getSelectedView, getTargetView } from '../../selectors/view-selector';
 import {
   getManualData,
-  getPackageInfoOfSelectedAttribution,
+  getDisplayPackageInfoOfSelectedAttribution,
 } from '../../selectors/all-views-resource-selectors';
 import { doNothing } from '../../../util/do-nothing';
 import { getParents } from '../../helpers/get-parents';
@@ -31,13 +31,14 @@ import {
 } from './audit-view-simple-actions';
 import { setTemporaryPackageInfo } from './all-views-simple-actions';
 import {
-  getAttributionOfDisplayedPackageInManualPanel,
+  getDisplayPackageInfoOfDisplayedPackageInManualPanel,
   getDisplayedPackage,
   getSelectedResourceId,
   getTargetDisplayedPackage,
   getTargetSelectedResourceId,
 } from '../../selectors/audit-view-resource-selectors';
 import { getTargetSelectedAttributionId } from '../../selectors/attribution-view-resource-selectors';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 
 export function resetTemporaryPackageInfo(
   attribution?: DisplayPackageInfo
@@ -54,14 +55,16 @@ export function resetTemporaryPackageInfo(
       case View.Audit:
         dispatch(
           setTemporaryPackageInfo(
-            getAttributionOfDisplayedPackageInManualPanel(getState()) || {}
+            getDisplayPackageInfoOfDisplayedPackageInManualPanel(getState()) ||
+              EMPTY_DISPLAY_PACKAGE_INFO
           )
         );
         break;
       case View.Attribution:
         dispatch(
           setTemporaryPackageInfo(
-            getPackageInfoOfSelectedAttribution(getState()) || {}
+            getDisplayPackageInfoOfSelectedAttribution(getState()) ||
+              EMPTY_DISPLAY_PACKAGE_INFO
           )
         );
         break;

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -11,6 +11,7 @@ import {
   ExternalAttributionSources,
   FrequentLicenses,
   PackageInfo,
+  DisplayPackageInfo,
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
@@ -168,7 +169,7 @@ export interface SetProgressBarDataPayload {
 
 export interface SetTemporaryPackageInfoAction {
   type: typeof ACTION_SET_TEMPORARY_PACKAGE_INFO;
-  payload: PackageInfo;
+  payload: DisplayPackageInfo;
 }
 
 export interface SetSelectedResourceIdAction {
@@ -320,7 +321,7 @@ export interface SetPackageSearchTerm {
 
 export interface SetAttributionWizardOriginalAttribution {
   type: typeof ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION;
-  payload: PackageInfo;
+  payload: DisplayPackageInfo;
 }
 export interface SetAttributionWizardPackageNamespaces {
   type: typeof ACTION_SET_ATTRIBUTION_WIZARD_PACKAGE_NAMESPACES;

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -3,14 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfo } from '../../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../../shared/shared-types';
 import { FilterType, PopupType, View } from '../../../enums/enums';
 import { State } from '../../../types/types';
-import { getPackageInfoOfSelectedAttribution } from '../../selectors/all-views-resource-selectors';
+import { getDisplayPackageInfoOfSelectedAttribution } from '../../selectors/all-views-resource-selectors';
 import { getSelectedView } from '../../selectors/view-selector';
 import { AppThunkAction, AppThunkDispatch } from '../../types';
 import { setTemporaryPackageInfo } from '../resource-actions/all-views-simple-actions';
-import { getAttributionOfDisplayedPackageInManualPanel } from '../../selectors/audit-view-resource-selectors';
+import { getDisplayPackageInfoOfDisplayedPackageInManualPanel } from '../../selectors/audit-view-resource-selectors';
 import {
   ACTION_CLOSE_POPUP,
   ACTION_OPEN_POPUP,
@@ -28,6 +28,7 @@ import {
   UpdateActiveFilters,
 } from './types';
 import { setMultiSelectSelectedAttributionIds } from '../resource-actions/attribution-view-simple-actions';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 
 export function resetViewState(): ResetViewStateAction {
   return { type: ACTION_RESET_VIEW_STATE };
@@ -43,10 +44,11 @@ export function navigateToView(view: View): AppThunkAction {
     dispatch(setView(view));
     dispatch(setMultiSelectSelectedAttributionIds([]));
 
-    const updatedTemporaryPackageInfo: PackageInfo =
+    const updatedTemporaryPackageInfo: DisplayPackageInfo =
       (view === View.Audit
-        ? getAttributionOfDisplayedPackageInManualPanel(getState())
-        : getPackageInfoOfSelectedAttribution(getState())) || {};
+        ? getDisplayPackageInfoOfDisplayedPackageInManualPanel(getState())
+        : getDisplayPackageInfoOfSelectedAttribution(getState())) ||
+      EMPTY_DISPLAY_PACKAGE_INFO;
     dispatch(setTemporaryPackageInfo(updatedTemporaryPackageInfo));
   };
 }

--- a/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/open-attribution-wizard-popup-helpers.test.ts
@@ -3,7 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Attributions, PackageInfo } from '../../../../shared/shared-types';
+import {
+  Attributions,
+  DisplayPackageInfo,
+} from '../../../../shared/shared-types';
 import {
   AttributionIdWithCount,
   PackageAttributes,
@@ -154,10 +157,11 @@ describe('getPackageVersionsWithRelatedPackageNameIds', () => {
 
 describe('getPreSelectedPackageAttributeIds', () => {
   it('yields correct output', () => {
-    const testStartingAttribution: PackageInfo = {
+    const testStartingDisplayPackageInfo: DisplayPackageInfo = {
       packageNamespace: 'npm',
       packageName: 'buffer',
       packageVersion: '6.0.3',
+      attributionIds: [],
     };
     const testPackageNamespaces: PackageAttributes = {
       '1111': { text: 'npm' },
@@ -179,7 +183,7 @@ describe('getPreSelectedPackageAttributeIds', () => {
 
     const testPreSelectedPackageAttributeIds =
       getPreSelectedPackageAttributeIds(
-        testStartingAttribution,
+        testStartingDisplayPackageInfo,
         testPackageNamespaces,
         testPackageNames,
         testPackageVersions

--- a/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
+++ b/src/Frontend/state/helpers/open-attribution-wizard-popup-helpers.ts
@@ -5,9 +5,9 @@
 
 import {
   ResourcesToAttributions,
-  PackageInfo,
   Attributions,
   ResourcesWithAttributedChildren,
+  DisplayPackageInfo,
 } from '../../../shared/shared-types';
 import { getAttributedChildren } from '../../util/get-attributed-children';
 import { shouldNotBeCalled } from '../../util/should-not-be-called';
@@ -208,7 +208,7 @@ export function getPackageVersionsWithRelatedPackageNameIds(
 }
 
 export function getPreSelectedPackageAttributeIds(
-  originalAttribution: PackageInfo,
+  originalDisplayPackageInfo: DisplayPackageInfo,
   packageNamespaces: PackageAttributes,
   packageNames: PackageAttributes,
   packageVersions: PackageAttributes
@@ -217,9 +217,9 @@ export function getPreSelectedPackageAttributeIds(
   preSelectedPackageNameId: string;
   preSelectedPackageVersionId: string;
 } {
-  const namespace = originalAttribution.packageNamespace || '';
-  const name = originalAttribution.packageName || '';
-  const version = originalAttribution.packageVersion || '';
+  const namespace = originalDisplayPackageInfo.packageNamespace || '';
+  const name = originalDisplayPackageInfo.packageName || '';
+  const version = originalDisplayPackageInfo.packageVersion || '';
 
   const preSelectedPackageNamespaceId = Object.entries(
     packageNamespaces

--- a/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
@@ -6,7 +6,7 @@
 import {
   Attributions,
   DiscreteConfidence,
-  PackageInfo,
+  DisplayPackageInfo,
   ProjectMetadata,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
@@ -14,7 +14,7 @@ import { createTestAppStore } from '../../../test-helpers/render-component-with-
 import {
   getAttributionBreakpoints,
   getFilesWithChildren,
-  getPackageInfoOfSelectedAttribution,
+  getDisplayPackageInfoOfSelectedAttribution,
   getProjectMetadata,
 } from '../all-views-resource-selectors';
 import {
@@ -25,17 +25,21 @@ import {
 } from '../../actions/resource-actions/all-views-simple-actions';
 import { setSelectedAttributionId } from '../../actions/resource-actions/attribution-view-simple-actions';
 import { EMPTY_PROJECT_METADATA } from '../../../shared-constants';
+import { convertDisplayPackageInfoToPackageInfo } from '../../../util/convert-package-info';
 
 describe('getPackageInfoOfSelectedAttribution', () => {
   const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
-  const testTemporaryPackageInfo: PackageInfo = {
+  const testTemporaryPackageInfo: DisplayPackageInfo = {
     attributionConfidence: DiscreteConfidence.High,
     packageVersion: '1.0',
     packageName: 'test Package',
     licenseText: ' test License text',
+    attributionIds: [testManualAttributionUuid_1],
   };
   const testManualAttributions: Attributions = {
-    [testManualAttributionUuid_1]: testTemporaryPackageInfo,
+    [testManualAttributionUuid_1]: convertDisplayPackageInfoToPackageInfo(
+      testTemporaryPackageInfo
+    ),
   };
   const testResourcesToManualAttributions: ResourcesToAttributions = {
     '/root/src/something.js': [testManualAttributionUuid_1],
@@ -47,9 +51,9 @@ describe('getPackageInfoOfSelectedAttribution', () => {
       setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     testStore.dispatch(setSelectedAttributionId(testManualAttributionUuid_1));
-    expect(getPackageInfoOfSelectedAttribution(testStore.getState())).toBe(
-      testTemporaryPackageInfo
-    );
+    expect(
+      getDisplayPackageInfoOfSelectedAttribution(testStore.getState())
+    ).toEqual(testTemporaryPackageInfo);
   });
 
   it('returns empty temporary package info if no selected attribution', () => {
@@ -59,7 +63,7 @@ describe('getPackageInfoOfSelectedAttribution', () => {
     );
 
     expect(
-      getPackageInfoOfSelectedAttribution(testStore.getState())
+      getDisplayPackageInfoOfSelectedAttribution(testStore.getState())
     ).toBeNull();
   });
 });

--- a/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/audit-view-resource-selectors.test.ts
@@ -6,12 +6,13 @@
 import {
   Attributions,
   DiscreteConfidence,
+  DisplayPackageInfo,
   PackageInfo,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
 import { createTestAppStore } from '../../../test-helpers/render-component-with-store';
 import { PanelPackage } from '../../../types/types';
-import { getPackageInfoOfSelected } from '../all-views-resource-selectors';
+import { getDisplayPackageInfoOfSelected } from '../all-views-resource-selectors';
 import { setManualData } from '../../actions/resource-actions/all-views-simple-actions';
 import {
   setDisplayedPackage,
@@ -27,24 +28,31 @@ import {
   getResolvedExternalAttributions,
 } from '../audit-view-resource-selectors';
 import { PackagePanelTitle } from '../../../enums/enums';
+import { convertDisplayPackageInfoToPackageInfo } from '../../../util/convert-package-info';
 
 describe('The audit view resource selectors', () => {
   const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
   const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
-  const testTemporaryPackageInfo: PackageInfo = {
+  const testTemporaryPackageInfo: DisplayPackageInfo = {
     attributionConfidence: DiscreteConfidence.High,
     packageVersion: '1.0',
     packageName: 'test Package',
     licenseText: ' test License text',
+    attributionIds: [testManualAttributionUuid_1],
   };
-  const secondTestTemporaryPackageInfo: PackageInfo = {
+  const secondTestTemporaryPackageInfo: DisplayPackageInfo = {
     packageVersion: '2.0',
     packageName: 'not assigned test Package',
     licenseText: ' test not assigned License text',
+    attributionIds: [testManualAttributionUuid_2],
   };
   const testManualAttributions: Attributions = {
-    [testManualAttributionUuid_1]: testTemporaryPackageInfo,
-    [testManualAttributionUuid_2]: secondTestTemporaryPackageInfo,
+    [testManualAttributionUuid_1]: convertDisplayPackageInfoToPackageInfo(
+      testTemporaryPackageInfo
+    ),
+    [testManualAttributionUuid_2]: convertDisplayPackageInfoToPackageInfo(
+      secondTestTemporaryPackageInfo
+    ),
   };
   const testResourcesToManualAttributions: ResourcesToAttributions = {
     '/root/src/something.js': [testManualAttributionUuid_1],
@@ -52,20 +60,21 @@ describe('The audit view resource selectors', () => {
 
   it('sets Attributions and getsAttribution for a ResourceId', () => {
     const testStore = createTestAppStore();
-    const expectedPackageInfo: PackageInfo = {
+    const expectedDisplayPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
+      attributionIds: [testManualAttributionUuid_1],
     };
-    expect(getPackageInfoOfSelected(testStore.getState())).toBeNull();
+    expect(getDisplayPackageInfoOfSelected(testStore.getState())).toBeNull();
 
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
     );
     testStore.dispatch(setSelectedResourceId('/root/src/something.js'));
-    expect(getPackageInfoOfSelected(testStore.getState())).toEqual(
-      expectedPackageInfo
+    expect(getDisplayPackageInfoOfSelected(testStore.getState())).toEqual(
+      expectedDisplayPackageInfo
     );
   });
 

--- a/src/Frontend/state/selectors/__tests__/resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/resource-selectors.test.ts
@@ -6,7 +6,7 @@
 import {
   Attributions,
   DiscreteConfidence,
-  PackageInfo,
+  DisplayPackageInfo,
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
@@ -40,16 +40,18 @@ describe('getWerePackageInfoModified', () => {
 
   const testManualAttributionUuid_1 = '4d9f0b16-fbff-11ea-adc1-0242ac120002';
   const testManualAttributionUuid_2 = 'b5da73d4-f400-11ea-adc1-0242ac120002';
-  const testTemporaryPackageInfo: PackageInfo = {
+  const testTemporaryPackageInfo: DisplayPackageInfo = {
     attributionConfidence: DiscreteConfidence.High,
     packageVersion: '1.0',
     packageName: 'test Package',
     licenseText: ' test License text',
+    attributionIds: [],
   };
-  const secondTestTemporaryPackageInfo: PackageInfo = {
+  const secondTestTemporaryPackageInfo: DisplayPackageInfo = {
     packageVersion: '2.0',
     packageName: 'not assigned test Package',
     licenseText: ' test not assigned License text',
+    attributionIds: [],
   };
   const testManualAttributions: Attributions = {
     [testManualAttributionUuid_1]: testTemporaryPackageInfo,
@@ -61,10 +63,11 @@ describe('getWerePackageInfoModified', () => {
 
   it('returns true  when TemporaryPackageInfo have been modified', () => {
     const testStore = createTestAppStore();
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       packageVersion: '1.1',
       packageName: 'test Package',
       licenseText: ' test License text',
+      attributionIds: [],
     };
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
@@ -78,11 +81,12 @@ describe('getWerePackageInfoModified', () => {
 
   it('returns true  when confidence is changed', () => {
     const testStore = createTestAppStore();
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
+      attributionIds: [],
     };
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)
@@ -102,13 +106,17 @@ describe('getWerePackageInfoModified', () => {
     testStore.dispatch(setSelectedResourceId('/root/src/something.js'));
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
     testStore.dispatch(
-      setTemporaryPackageInfo({ attributionConfidence: DiscreteConfidence.Low })
+      setTemporaryPackageInfo({
+        attributionConfidence: DiscreteConfidence.Low,
+        attributionIds: [],
+      })
     );
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(false);
     testStore.dispatch(
       setTemporaryPackageInfo({
         attributionConfidence: DiscreteConfidence.Low,
         packageName: 'test Package',
+        attributionIds: [],
       })
     );
     expect(wereTemporaryPackageInfoModified(testStore.getState())).toBe(true);
@@ -116,11 +124,12 @@ describe('getWerePackageInfoModified', () => {
 
   it('returns false when TemporaryPackageInfo have not been modified', () => {
     const testStore = createTestAppStore();
-    const testTemporaryPackageInfo: PackageInfo = {
+    const testTemporaryPackageInfo: DisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       packageVersion: '1.0',
       packageName: 'test Package',
       licenseText: ' test License text',
+      attributionIds: [testManualAttributionUuid_1],
     };
     testStore.dispatch(
       setManualData(testManualAttributions, testResourcesToManualAttributions)

--- a/src/Frontend/state/selectors/attribution-wizard-selectors.ts
+++ b/src/Frontend/state/selectors/attribution-wizard-selectors.ts
@@ -3,17 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
 import {
   PackageAttributeIds,
   State,
   PackageAttributes,
 } from '../../types/types';
 
-export function getAttributionWizarOriginalAttribution(
+export function getAttributionWizarOriginalDisplayPackageInfo(
   state: State
-): PackageInfo {
-  return state.resourceState.attributionWizard.originalAttribution;
+): DisplayPackageInfo {
+  return state.resourceState.attributionWizard.originalDisplayPackageInfo;
 }
 
 export function getAttributionWizardPackageNamespaces(

--- a/src/Frontend/state/selectors/audit-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/audit-view-resource-selectors.ts
@@ -5,7 +5,7 @@
 
 import { PanelPackage, State } from '../../types/types';
 import { PackagePanelTitle } from '../../enums/enums';
-import { Attributions, PackageInfo } from '../../../shared/shared-types';
+import { Attributions, DisplayPackageInfo } from '../../../shared/shared-types';
 import { getFilteredAttributionsById } from '../../util/get-filtered-attributions-by-id';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import {
@@ -13,6 +13,7 @@ import {
   getResourcesToManualAttributions,
 } from './all-views-resource-selectors';
 import { getAttributionBreakpointCheckForState } from '../../util/is-attribution-breakpoint';
+import { convertPackageInfoToDisplayPackageInfo } from '../../util/convert-package-info';
 
 export function getSelectedResourceId(state: State): string {
   return state.resourceState.auditView.selectedResourceId;
@@ -106,16 +107,18 @@ export function getAttributionIdOfDisplayedPackageInManualPanel(
     : null;
 }
 
-export function getAttributionOfDisplayedPackageInManualPanel(
+export function getDisplayPackageInfoOfDisplayedPackageInManualPanel(
   state: State
-): PackageInfo | null {
+): DisplayPackageInfo | null {
   const attributionId: string | null =
     getAttributionIdOfDisplayedPackageInManualPanel(state);
   if (attributionId) {
     const manualAttributions: Attributions = getManualAttributions(state);
-    return manualAttributions[attributionId];
+    return convertPackageInfoToDisplayPackageInfo(
+      manualAttributions[attributionId],
+      [attributionId]
+    );
   }
-
   return null;
 }
 

--- a/src/Frontend/util/__tests__/convert-package-info-test.test.ts
+++ b/src/Frontend/util/__tests__/convert-package-info-test.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
+import {
+  convertDisplayPackageInfoToPackageInfo,
+  convertPackageInfoToDisplayPackageInfo,
+} from '../convert-package-info';
+
+describe('convertPackageInfoToDisplayPackageInfo', () => {
+  it('returns correct PackageInfo', () => {
+    const testPackageInfoA: PackageInfo = {
+      packageName: 'react',
+      comment: 'comment A',
+    };
+    const testPackageInfoB: PackageInfo = {
+      packageName: 'react',
+    };
+    const testPackageInfoC: PackageInfo = {
+      packageName: 'react',
+      comment: 'comment C',
+    };
+
+    const testAttributionIdsA = ['uuid_A'];
+    const testAttributionIdsB = ['uuid_B'];
+    const testAttributionIdsC = ['uuid_A', 'uuid_B'];
+
+    const expectedDisplayPackageInfoA: DisplayPackageInfo = {
+      packageName: 'react',
+      comments: ['comment A'],
+      attributionIds: ['uuid_A'],
+    };
+    const expectedDisplayPackageInfoB: DisplayPackageInfo = {
+      packageName: 'react',
+      attributionIds: ['uuid_B'],
+    };
+    const expectedDisplayPackageInfoC: DisplayPackageInfo = {
+      packageName: 'react',
+      comments: ['comment C'],
+      attributionIds: ['uuid_A', 'uuid_B'],
+    };
+
+    const testDisplayPackageInfoA = convertPackageInfoToDisplayPackageInfo(
+      testPackageInfoA,
+      testAttributionIdsA
+    );
+    const testDisplayPackageInfoB = convertPackageInfoToDisplayPackageInfo(
+      testPackageInfoB,
+      testAttributionIdsB
+    );
+    const testDisplayPackageInfoC = convertPackageInfoToDisplayPackageInfo(
+      testPackageInfoC,
+      testAttributionIdsC
+    );
+
+    expect(testDisplayPackageInfoA).toEqual(expectedDisplayPackageInfoA);
+    expect(testDisplayPackageInfoB).toEqual(expectedDisplayPackageInfoB);
+    expect(testDisplayPackageInfoC).toEqual(expectedDisplayPackageInfoC);
+  });
+});
+
+describe('convertDisplayPackageInfoToPackageInfo', () => {
+  it('returns correct PackageInfo', () => {
+    const testDisplayPackageInfoA: DisplayPackageInfo = {
+      packageName: 'react',
+      comments: ['comment A', 'comment B'],
+      attributionIds: ['123', '456'],
+    };
+    const testDisplayPackageInfoB: DisplayPackageInfo = {
+      packageName: 'react',
+      comments: ['comment'],
+      attributionIds: ['123'],
+    };
+    const testDisplayPackageInfoC: DisplayPackageInfo = {
+      packageName: 'react',
+      comments: ['comment'],
+      attributionIds: [],
+    };
+    const expectedPackageInfoA: PackageInfo = {
+      packageName: 'react',
+    };
+    const expectedPackageInfoBC: PackageInfo = {
+      packageName: 'react',
+      comment: 'comment',
+    };
+    const testPackageInfoA = convertDisplayPackageInfoToPackageInfo(
+      testDisplayPackageInfoA
+    );
+    const testPackageInfoB = convertDisplayPackageInfoToPackageInfo(
+      testDisplayPackageInfoB
+    );
+    const testPackageInfoC = convertDisplayPackageInfoToPackageInfo(
+      testDisplayPackageInfoC
+    );
+    expect(testPackageInfoA).toEqual(expectedPackageInfoA);
+    expect(testPackageInfoB).toEqual(expectedPackageInfoBC);
+    expect(testPackageInfoC).toEqual(expectedPackageInfoBC);
+  });
+});

--- a/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
+++ b/src/Frontend/util/__tests__/get-stripped-package-info.test.ts
@@ -3,8 +3,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Criticality, PackageInfo } from '../../../shared/shared-types';
-import { getStrippedPackageInfo } from '../get-stripped-package-info';
+import {
+  Criticality,
+  DisplayPackageInfo,
+  PackageInfo,
+} from '../../../shared/shared-types';
+import {
+  getStrippedDisplayPackageInfo,
+  getStrippedPackageInfo,
+} from '../get-stripped-package-info';
 
 describe('The getStrippedPackageInfo function', () => {
   it('strips falsy values', () => {
@@ -62,6 +69,76 @@ describe('The getStrippedPackageInfo function', () => {
 
     expect(getStrippedPackageInfo(testPackageInfo)).toEqual({
       packageName: 'React',
+    });
+  });
+});
+
+describe('The getStrippedDisplayPackageInfo function', () => {
+  it('strips falsy values', () => {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      packageVersion: '',
+      attributionIds: [],
+    };
+
+    expect(getStrippedDisplayPackageInfo(testDisplayPackageInfo)).toEqual({
+      packageName: 'React',
+      attributionIds: [],
+    });
+  });
+
+  it('strips source ', () => {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      source: {
+        name: 'HC',
+        documentConfidence: 10,
+      },
+      attributionIds: [],
+    };
+
+    expect(getStrippedDisplayPackageInfo(testDisplayPackageInfo)).toEqual({
+      packageName: 'React',
+      attributionIds: [],
+    });
+  });
+
+  it('strips preSelected ', () => {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      preSelected: true,
+      attributionIds: [],
+    };
+
+    expect(getStrippedDisplayPackageInfo(testDisplayPackageInfo)).toEqual({
+      packageName: 'React',
+      attributionIds: [],
+    });
+  });
+
+  it('strips criticality ', () => {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
+      packageName: 'React',
+      criticality: Criticality.High,
+      attributionIds: [],
+    };
+
+    expect(getStrippedDisplayPackageInfo(testDisplayPackageInfo)).toEqual({
+      packageName: 'React',
+      attributionIds: [],
+    });
+  });
+
+  it('strips excess values', () => {
+    const testDisplayPackageInfo = {
+      packageName: 'React',
+      count: 0,
+      attributionIds: [],
+    };
+
+    expect(getStrippedDisplayPackageInfo(testDisplayPackageInfo)).toEqual({
+      packageName: 'React',
+      attributionIds: [],
     });
   });
 });

--- a/src/Frontend/util/__tests__/handle-purl.test.ts
+++ b/src/Frontend/util/__tests__/handle-purl.test.ts
@@ -5,12 +5,12 @@
 
 import {
   generatePurlAppendix,
-  generatePurlFromPackageInfo,
+  generatePurlFromDisplayPackageInfo,
   ParsedPurl,
   parsePurl,
 } from '../handle-purl';
 import { PackageURL } from 'packageurl-js';
-import { PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
 
 describe('parsePurl', () => {
   it('returns false for an invalid purl', () => {
@@ -39,49 +39,59 @@ describe('parsePurl', () => {
 
 describe('generatePurlFromPackageInfo', () => {
   it('generates a valid Purl', () => {
-    const testPackageInfo: PackageInfo = {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
       packageType: 'type',
       packageVersion: 'version',
       packagePURLAppendix: '?appendix',
+      attributionIds: [],
     };
     const expectedPurl = 'pkg:type/namespace/name@version?appendix';
 
-    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
+    expect(generatePurlFromDisplayPackageInfo(testDisplayPackageInfo)).toBe(
+      expectedPurl
+    );
   });
 
   it('generates a valid Purl without appendix', () => {
-    const testPackageInfo: PackageInfo = {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
       packageType: 'type',
       packageVersion: 'version',
+      attributionIds: [],
     };
     const expectedPurl = 'pkg:type/namespace/name@version';
 
-    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
+    expect(generatePurlFromDisplayPackageInfo(testDisplayPackageInfo)).toBe(
+      expectedPurl
+    );
   });
 
   it('returns undefined when no packageName is given', () => {
-    const testPackageInfo: PackageInfo = {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
       packageNamespace: 'namespace',
       packageType: 'type',
       packageVersion: 'version',
+      attributionIds: [],
     };
 
-    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe('');
+    expect(generatePurlFromDisplayPackageInfo(testDisplayPackageInfo)).toBe('');
   });
 
   it('generates Purl with generic type when no packageType is given', () => {
-    const testPackageInfo: PackageInfo = {
+    const testDisplayPackageInfo: DisplayPackageInfo = {
       packageName: 'name',
       packageNamespace: 'namespace',
       packageVersion: 'version',
+      attributionIds: [],
     };
     const expectedPurl = 'pkg:generic/namespace/name@version';
 
-    expect(generatePurlFromPackageInfo(testPackageInfo)).toBe(expectedPurl);
+    expect(generatePurlFromDisplayPackageInfo(testDisplayPackageInfo)).toBe(
+      expectedPurl
+    );
   });
 });
 

--- a/src/Frontend/util/convert-package-info.ts
+++ b/src/Frontend/util/convert-package-info.ts
@@ -115,7 +115,7 @@ export function convertDisplayPackageInfoToPackageInfo(
       }
     }
     if (
-      displayPackageInfo.attributionIds.length === 1 &&
+      displayPackageInfo.attributionIds.length <= 1 &&
       displayPackageInfo.comments
     ) {
       packageInfo.comment = displayPackageInfo.comments[0];

--- a/src/Frontend/util/get-stripped-package-info.ts
+++ b/src/Frontend/util/get-stripped-package-info.ts
@@ -4,23 +4,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { pick, pickBy } from 'lodash';
-import { PackageInfo } from '../../shared/shared-types';
+import { DisplayPackageInfo, PackageInfo } from '../../shared/shared-types';
 import { getPackageInfoKeys } from '../../shared/shared-util';
+import { getDisplayPackageInfoKeys } from './get-display-package-info-keys';
 
 export function getStrippedPackageInfo(
   rawPackageInfo: PackageInfo
 ): PackageInfo {
-  const strippedTemporaryPackageInfo = pickBy(rawPackageInfo, (value) =>
-    Boolean(value)
-  );
-  delete strippedTemporaryPackageInfo.source;
-  delete strippedTemporaryPackageInfo.preSelected;
-  delete strippedTemporaryPackageInfo.criticality;
+  const strippedPackageInfo = pickBy(rawPackageInfo, (value) => Boolean(value));
+  delete strippedPackageInfo.source;
+  delete strippedPackageInfo.preSelected;
+  delete strippedPackageInfo.criticality;
 
-  return removeExcessProperties(strippedTemporaryPackageInfo);
+  return removeExcessProperties(strippedPackageInfo);
 }
 
 function removeExcessProperties(rawPackageInfo: PackageInfo): PackageInfo {
   const packageInfoKeys = getPackageInfoKeys();
   return pick(rawPackageInfo, packageInfoKeys);
+}
+
+export function getStrippedDisplayPackageInfo(
+  rawDisplayPackageInfo: DisplayPackageInfo
+): DisplayPackageInfo {
+  const strippedDisplayPackageInfo = pickBy(rawDisplayPackageInfo, (value) =>
+    Boolean(value)
+  );
+  delete strippedDisplayPackageInfo.source;
+  delete strippedDisplayPackageInfo.preSelected;
+  delete strippedDisplayPackageInfo.criticality;
+
+  return removeExcessPropertiesOfDisplayPackageInfo(
+    strippedDisplayPackageInfo as DisplayPackageInfo
+  );
+}
+
+function removeExcessPropertiesOfDisplayPackageInfo(
+  rawDisplayPackageInfo: DisplayPackageInfo
+): DisplayPackageInfo {
+  const displayPackageInfoKeys = getDisplayPackageInfoKeys();
+  return pick(rawDisplayPackageInfo, displayPackageInfoKeys);
 }

--- a/src/Frontend/util/handle-purl.ts
+++ b/src/Frontend/util/handle-purl.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PackageURL } from 'packageurl-js';
-import { PackageInfo } from '../../shared/shared-types';
+import { DisplayPackageInfo, PackageInfo } from '../../shared/shared-types';
 
 export interface ParsedPurl {
   isValid: boolean;
@@ -37,19 +37,23 @@ export function parsePurl(potentialPurl: string): ParsedPurl {
   }
 }
 
-export function generatePurlFromPackageInfo(packageInfo: PackageInfo): string {
-  return (packageInfo.packageNamespace ||
-    packageInfo.packageType ||
-    packageInfo.packagePURLAppendix) &&
-    packageInfo.packageName
+export function generatePurlFromDisplayPackageInfo(
+  displayPackageInfo: DisplayPackageInfo
+): string {
+  return (displayPackageInfo.packageNamespace ||
+    displayPackageInfo.packageType ||
+    displayPackageInfo.packagePURLAppendix) &&
+    displayPackageInfo.packageName
     ? new PackageURL(
-        packageInfo.packageType ? packageInfo.packageType : 'generic',
-        packageInfo?.packageNamespace,
-        packageInfo.packageName,
-        packageInfo?.packageVersion,
+        displayPackageInfo.packageType
+          ? displayPackageInfo.packageType
+          : 'generic',
+        displayPackageInfo?.packageNamespace,
+        displayPackageInfo.packageName,
+        displayPackageInfo?.packageVersion,
         undefined,
         undefined
-      ).toString() + (packageInfo.packagePURLAppendix || '')
+      ).toString() + (displayPackageInfo.packagePURLAppendix || '')
     : '';
 }
 

--- a/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
+++ b/src/Frontend/util/set-update-temporary-package-info-for-creator.ts
@@ -4,26 +4,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChangeEvent } from 'react';
-import { PackageInfo } from '../../shared/shared-types';
+import { DisplayPackageInfo } from '../../shared/shared-types';
 import { AppThunkDispatch } from '../state/types';
 import { setTemporaryPackageInfo } from '../state/actions/resource-actions/all-views-simple-actions';
 
 export function setUpdateTemporaryPackageInfoForCreator(
   dispatch: AppThunkDispatch,
-  temporaryPackageInfo: PackageInfo
+  temporaryPackageInfo: DisplayPackageInfo
 ) {
   return (propertyToUpdate: string) => {
     return (
       event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
     ): void => {
-      const newValue =
+      const newValueOfTemporaryPackageInfoProperty =
         event.target.type === 'number'
           ? parseInt(event.target.value)
+          : propertyToUpdate === 'comments'
+          ? [event.target.value]
           : event.target.value;
+
       dispatch(
         setTemporaryPackageInfo({
           ...temporaryPackageInfo,
-          [propertyToUpdate]: newValue,
+          [propertyToUpdate]: newValueOfTemporaryPackageInfoProperty,
         })
       );
     };


### PR DESCRIPTION
### Summary of changes

Apply the refactoring regarding `DisplayPackageInfo` to `temporaryPackageInfo`. This change entails changes to many components that get or set `temporaryPackageInfo`.

### Context and reason for change

Improve separation of display and business logic by introducing `DisplayPackageInfo` in all components that display attributions.
