### PR TITLE
Add checkbox for needsReview

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -32,6 +32,7 @@ import {
   getExcludeFromNoticeChangeHandler,
   getFirstPartyChangeHandler,
   getFollowUpChangeHandler,
+  getNeedsReviewChangeHandler,
   getMergeButtonsDisplayState,
   getResolvedToggleHandler,
   selectedPackagesAreResolved,
@@ -78,6 +79,7 @@ interface AttributionColumnProps {
   saveFileRequestListener(): void;
   setTemporaryPackageInfo(packageInfo: PackageInfo): void;
   smallerLicenseTextOrCommentField?: boolean;
+  addMarginForNeedsReviewCheckbox?: boolean;
 }
 
 export function AttributionColumn(props: AttributionColumnProps): ReactElement {
@@ -333,6 +335,13 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         mainButtonConfigs={mainButtonConfigs}
         hamburgerMenuButtonConfigs={hamburgerMenuButtonConfigs}
         displayTexts={displayTexts}
+        isEditable={props.isEditable}
+        displayPackageInfo={props.displayPackageInfo}
+        needsReviewChangeHandler={getNeedsReviewChangeHandler(
+          temporaryPackageInfo,
+          dispatch
+        )}
+        addMarginForNeedsReviewCheckbox={props.addMarginForNeedsReviewCheckbox}
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -7,16 +7,22 @@ import React, { ReactElement } from 'react';
 import { ToggleButton } from '../ToggleButton/ToggleButton';
 import { ButtonGroup, MainButtonConfig } from '../ButtonGroup/ButtonGroup';
 import MuiTypography from '@mui/material/Typography';
-import { ButtonText } from '../../enums/enums';
+import { ButtonText, CheckboxLabel } from '../../enums/enums';
 import { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import MuiBox from '@mui/material/Box';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { checkboxClass } from '../../shared-styles';
+import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
 
 const classes = {
+  ...checkboxClass,
   root: {
     marginLeft: '10px',
     marginTop: '5px',
   },
   buttonRow: {
+    display: 'flex',
+    alignItems: 'center',
     position: 'absolute',
     bottom: '0px',
     right: '0px',
@@ -28,6 +34,10 @@ const classes = {
     marginTop: '0px',
     marginRight: '0px',
   },
+  checkboxForPopUp: {
+    marginRight: '190px',
+    marginBottom: '-8px',
+  },
 };
 
 interface ButtonRowProps {
@@ -38,9 +48,17 @@ interface ButtonRowProps {
   displayTexts: Array<string>;
   mainButtonConfigs: Array<MainButtonConfig>;
   hamburgerMenuButtonConfigs?: Array<ContextMenuItem>;
+  isEditable: boolean;
+  displayPackageInfo: PackageInfo | DisplayPackageInfo;
+  needsReviewChangeHandler(event: React.ChangeEvent<HTMLInputElement>): void;
+  addMarginForNeedsReviewCheckbox?: boolean;
 }
 
 export function ButtonRow(props: ButtonRowProps): ReactElement {
+  const marginForNeedsReviewCheckbox = props.addMarginForNeedsReviewCheckbox
+    ? classes.checkboxForPopUp
+    : {};
+
   return (
     <MuiBox sx={classes.root}>
       {props.displayTexts.map((text, index) => (
@@ -50,11 +68,23 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
       ))}
       <MuiBox sx={classes.buttonRow}>
         {props.showButtonGroup ? (
-          <ButtonGroup
-            isHidden={props.areButtonsHidden}
-            mainButtonConfigs={props.mainButtonConfigs}
-            hamburgerMenuButtonConfigs={props.hamburgerMenuButtonConfigs}
-          />
+          <>
+            <Checkbox
+              sx={{
+                ...classes.checkBox,
+                ...marginForNeedsReviewCheckbox,
+              }}
+              label={CheckboxLabel.NeedsReview}
+              disabled={!props.isEditable}
+              checked={Boolean(props.displayPackageInfo.needsReview)}
+              onChange={props.needsReviewChangeHandler}
+            />
+            <ButtonGroup
+              isHidden={props.areButtonsHidden}
+              mainButtonConfigs={props.mainButtonConfigs}
+              hamburgerMenuButtonConfigs={props.hamburgerMenuButtonConfigs}
+            />
+          </>
         ) : (
           <ToggleButton
             buttonText={

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -336,6 +336,36 @@ describe('The AttributionColumn', () => {
     );
   });
 
+  it('renders a checkbox for needs review', () => {
+    const testTemporaryPackageInfo: PackageInfo = {
+      attributionConfidence: DiscreteConfidence.High,
+    };
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        displayPackageInfo={testTemporaryPackageInfo}
+        setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
+        onSaveButtonClick={doNothing}
+        setTemporaryPackageInfo={(): (() => void) => doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />
+    );
+    act(() => {
+      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    });
+
+    expect(
+      getTemporaryPackageInfo(store.getState()).needsReview
+    ).toBeUndefined();
+
+    clickOnCheckbox(screen, CheckboxLabel.NeedsReview);
+    expect(getTemporaryPackageInfo(store.getState()).needsReview).toBe(true);
+  });
+
   it('renders an url icon and opens a link in browser', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       url: 'https://www.testurl.com/',

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -139,6 +139,20 @@ export function getResolvedToggleHandler(
   };
 }
 
+export function getNeedsReviewChangeHandler(
+  temporaryPackageInfo: PackageInfo,
+  dispatch: AppThunkDispatch
+): (event: React.ChangeEvent<HTMLInputElement>) => void {
+  return (event): void => {
+    dispatch(
+      setTemporaryPackageInfo({
+        ...temporaryPackageInfo,
+        needsReview: event.target.checked,
+      })
+    );
+  };
+}
+
 export function selectedPackagesAreResolved(
   attributionIds: Array<string>,
   resolvedExternalAttributions: Set<string>

--- a/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
+++ b/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
@@ -15,7 +15,6 @@ import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-class
 
 const classes = {
   root: {
-    marginTop: '10px',
     justifyContent: 'space-evenly',
     display: 'flex',
   },

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -68,6 +68,7 @@ export function EditAttributionPopup(): ReactElement {
           }}
           saveFileRequestListener={saveFileRequestListener}
           smallerLicenseTextOrCommentField
+          addMarginForNeedsReviewCheckbox
         />
       }
       header={'Edit Attribution'}

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -84,6 +84,7 @@ export enum CheckboxLabel {
   FirstParty = '1st Party',
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',
+  NeedsReview = 'Needs Review',
 }
 
 export enum ProjectStatisticsPopupTitle {


### PR DESCRIPTION
### Summary of changes

This adds a checkbox next to the buttons on the attribution view to signal that an attribution needs further review.

### Context and reason for change

We are adding a checkbox to OpossumUI to signal if a review is required for an attribution.

### How can the changes be tested

- Run the tests in `AttributionColumn.test.tsx`.
- Open a file in OpossumUI and verify that the new checkbox shows up and works.