### PR TITLE
Needs review icon

### DIFF
--- a/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
@@ -12,6 +12,7 @@ import {
   FollowUpIcon,
   IncompleteAttributionsIcon,
   MissingPackageNameIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import pickBy from 'lodash/pickBy';
@@ -28,8 +29,11 @@ const classes = {
     width: '13px',
     height: '13px',
   },
-  titleFollowUpIcon: {
+  titleNeedsReviewIcon: {
     color: OpossumColors.orange,
+  },
+  titleFollowUpIcon: {
+    color: OpossumColors.red,
   },
   preselectedAttributionIcon: {
     color: OpossumColors.darkBlue,
@@ -51,6 +55,9 @@ export function AttributionCountsPanel(
 ): ReactElement {
   const attributions: Attributions = useAppSelector(getManualAttributions);
   const numberOfAttributions = Object.keys(attributions).length;
+  const numberOfAttributionsThatNeedReview = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.needsReview)
+  ).length;
   const numberOfFollowUps = Object.keys(
     pickBy(attributions, (value: PackageInfo) => value.followUp)
   ).length;
@@ -73,7 +80,14 @@ export function AttributionCountsPanel(
         sxProps: props.sx,
       })}
     >
-      {`Attributions (${numberOfAttributions} total, ${numberOfFollowUps}`}
+      {`Attributions (${numberOfAttributions} total, ${numberOfAttributionsThatNeedReview}`}
+      <NeedsReviewIcon
+        sx={{
+          ...classes.titleNeedsReviewIcon,
+          ...classes.icons,
+        }}
+      />
+      {`, ${numberOfFollowUps}`}
       <FollowUpIcon
         sx={{
           ...classes.titleFollowUpIcon,

--- a/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
@@ -61,7 +61,9 @@ describe('The Attribution Counts Panel', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
     expect(
-      screen.getByText(/Attributions \(2 total, 1, 0, 1, 1\)/, { exact: true })
+      screen.getByText(/Attributions \(2 total, 0, 1, 0, 1, 1\)/, {
+        exact: true,
+      })
     );
   });
 });

--- a/src/Frontend/Components/AttributionPropertyCountTable/AttributionPropertyCountTable.tsx
+++ b/src/Frontend/Components/AttributionPropertyCountTable/AttributionPropertyCountTable.tsx
@@ -17,6 +17,7 @@ import { tableClasses } from '../../shared-styles';
 const ATTRIBUTION_PROPERTIES_ID_TO_DISPLAY_NAME: {
   [attributionProperty: string]: string;
 } = {
+  needsReview: 'Needs review',
   followUp: 'Follow up',
   firstParty: 'First party',
   incomplete: 'Incomplete Attributions',

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -65,7 +65,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -90,7 +90,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -116,7 +116,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -144,7 +144,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -16,6 +16,7 @@ import ReplayIcon from '@mui/icons-material/Replay';
 import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import SearchIcon from '@mui/icons-material/Search';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import React, { ReactElement } from 'react';
 import {
   baseIcon,
@@ -119,6 +120,20 @@ export function FollowUpIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="has follow-up">
       <ReplayIcon
         aria-label={'Follow-up icon'}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
+      />
+    </MuiTooltip>
+  );
+}
+
+export function NeedsReviewIcon(props: IconProps): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="needs review">
+      <QuestionMarkIcon
+        aria-label={'Needs-review icon'}
         sx={getSxFromPropsAndClasses({
           styleClass: classes.nonClickableIcon,
           sxProps: props.sx,

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -15,6 +15,7 @@ import {
   FirstPartyIcon,
   FollowUpIcon,
   IncompleteAttributionsIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
   SearchPackagesIcon,
   SignalIcon,
@@ -37,6 +38,12 @@ describe('The Icons', () => {
     render(<FollowUpIcon />);
 
     expect(screen.getByLabelText('Follow-up icon'));
+  });
+
+  it('renders NeedsReviewIcon', () => {
+    render(<NeedsReviewIcon />);
+
+    expect(screen.getByLabelText('Needs-review icon'));
   });
 
   it('renders FirstPartyIcon', () => {

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -134,6 +134,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     ...props.cardConfig,
     firstParty: props.packageInfo.firstParty,
     excludeFromNotice: props.packageInfo.excludeFromNotice,
+    needsReview: Boolean(props.packageInfo.needsReview),
     followUp: Boolean(props.packageInfo.followUp),
     isContextMenuOpen,
     isMarkedForReplacement:

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -9,6 +9,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
@@ -21,8 +22,11 @@ export function getKey(prefix: string, cardId: string): string {
 }
 
 const classes = {
-  followUpIcon: {
+  needsReviewIcon: {
     color: OpossumColors.orange,
+  },
+  followUpIcon: {
+    color: OpossumColors.red,
   },
   excludeFromNoticeIcon: {
     color: OpossumColors.grey,
@@ -40,6 +44,22 @@ export function getRightIcons(
     rightIcons.push(openResourcesIcon);
   }
 
+  if (cardConfig.needsReview) {
+    rightIcons.push(
+      <NeedsReviewIcon
+        key={getKey('needs-review-icon', cardId)}
+        sx={classes.needsReviewIcon}
+      />
+    );
+  }
+  if (cardConfig.followUp) {
+    rightIcons.push(
+      <FollowUpIcon
+        key={getKey('follow-up-icon', cardId)}
+        sx={classes.followUpIcon}
+      />
+    );
+  }
   if (cardConfig.firstParty) {
     rightIcons.push(
       <FirstPartyIcon key={getKey('first-party-icon', cardId)} />
@@ -50,14 +70,6 @@ export function getRightIcons(
       <ExcludeFromNoticeIcon
         key={getKey('exclude-icon', cardId)}
         sx={classes.excludeFromNoticeIcon}
-      />
-    );
-  }
-  if (cardConfig.followUp) {
-    rightIcons.push(
-      <FollowUpIcon
-        key={getKey('follow-up-icon', cardId)}
-        sx={classes.followUpIcon}
       />
     );
   }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -34,6 +34,7 @@ const testAttributions_1: Attributions = {
     criticality: Criticality.Medium,
     licenseName: 'Apache License Version 2.0',
     firstParty: true,
+    needsReview: true,
   },
   uuid2: {
     source: {
@@ -50,6 +51,7 @@ const testAttributions_1: Attributions = {
     },
     licenseName: ' Apache license version-2.0 ',
     followUp: FollowUp,
+    needsReview: true,
   },
   uuid4: {
     source: {
@@ -202,6 +204,7 @@ describe('aggregateAttributionPropertiesFromAttributions', () => {
     const expectedAttributionPropertyCounts: {
       [attributionPropertyOrTotal: string]: number;
     } = {
+      needsReview: 2,
       followUp: 1,
       firstParty: 2,
       incomplete: 4,
@@ -227,6 +230,7 @@ describe('aggregateAttributionPropertiesFromAttributions', () => {
     const expectedAttributionPropertyCounts: {
       [attributionPropertyOrTotal: string]: number;
     } = {
+      needsReview: 0,
       followUp: 0,
       firstParty: 0,
       incomplete: 5,

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -23,6 +23,7 @@ interface UniqueLicenseNameToAttributions {
   [strippedLicenseName: string]: Array<string>;
 }
 
+const ATTRIBUTION_PROPERTY_NEEDS_REVIEW = 'needsReview';
 const ATTRIBUTION_PROPERTY_FOLLOW_UP = 'followUp';
 const ATTRIBUTION_PROPERTY_FIRST_PARTY = 'firstParty';
 const ATTRIBUTION_PROPERTY_INCOMPLETE = 'incomplete';
@@ -207,6 +208,9 @@ export function aggregateAttributionPropertiesFromAttributions(
   const attributionPropertyCounts: {
     [attributionPropertyOrTotal: string]: number;
   } = {};
+  attributionPropertyCounts[ATTRIBUTION_PROPERTY_NEEDS_REVIEW] = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.needsReview)
+  ).length;
   attributionPropertyCounts[ATTRIBUTION_PROPERTY_FOLLOW_UP] = Object.keys(
     pickBy(attributions, (value: PackageInfo) => value.followUp)
   ).length;

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -11,6 +11,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { TableConfig, tableConfigs } from '../Table/Table';
@@ -96,6 +97,10 @@ const classes = {
   followUpIcon: {
     border: `2px ${OpossumColors.red} solid`,
     color: OpossumColors.red,
+  },
+  needsReviewIcon: {
+    border: `2px ${OpossumColors.orange} solid`,
+    color: OpossumColors.orange,
   },
   excludeFromNoticeIcon: {
     border: `2px ${OpossumColors.grey} solid`,
@@ -298,6 +303,17 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
           />
           <br />
         </>
+        {attributionInfo.needsReview && (
+          <>
+            <NeedsReviewIcon
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.needsReviewIcon,
+              }}
+            />{' '}
+            <br />
+          </>
+        )}
         {attributionInfo.followUp && (
           <>
             <FollowUpIcon

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -74,6 +74,7 @@ describe('The ReportTableItem', () => {
         url: 'packageWebsite',
         firstParty: true,
         resources: ['/'],
+        needsReview: true,
       },
       uuid2: {
         packageName: 'Redux',
@@ -107,5 +108,6 @@ describe('The ReportTableItem', () => {
     expect(screen.getByLabelText('First party icon'));
     expect(screen.getByLabelText('Follow-up icon'));
     expect(screen.getByLabelText('Exclude from notice icon'));
+    expect(screen.getByLabelText('Needs-review icon'));
   });
 });

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -77,7 +77,7 @@ describe('The ReportView', () => {
       );
       store.dispatch(setFrequentLicenses(testFrequentLicenses));
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('MIT text'));
     expect(screen.getByText('Test other package'));
@@ -97,7 +97,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -121,7 +121,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -149,7 +149,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -64,6 +64,7 @@ export interface ListCardConfig {
   isPreSelected?: boolean;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
+  needsReview?: boolean;
   followUp?: boolean;
   isHeader?: boolean;
   isContextMenuOpen?: boolean;

--- a/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
@@ -36,18 +36,6 @@ test.describe('Open outdated .json file via command line', () => {
     }
   });
 
-  test('should open FileSupportPopup when .json file is provided as command line arg', async () => {
-    const header = 'Warning: Outdated input file format';
-    const fileSupportPopupEntry = await getElementWithText(window, header);
-    await expect(fileSupportPopupEntry).toBeVisible({
-      timeout: EXPECT_TIMEOUT,
-    });
-    const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
-    await expect(keepOldFileFormatButton).toBeVisible({
-      timeout: EXPECT_TIMEOUT,
-    });
-  });
-
   test('should open file when provided as command line arg', async () => {
     const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
     await keepOldFileFormatButton.click();

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -19,7 +19,7 @@ import {
 
 const ELECTRON_LAUNCH_TEST_TIMEOUT = 75000;
 export const E2E_TEST_TIMEOUT = 120000;
-export const EXPECT_TIMEOUT = 30000;
+export const EXPECT_TIMEOUT = 50000;
 export const LOAD_TIMEOUT = 100000;
 
 export async function getApp(


### PR DESCRIPTION
### Summary of changes

Adds a new icon to signal that an attribution needs review.
Note that in the cards in attribution view, there should be a maximum of 4 icons shown at the same time, since pre-selected attributions cannot have the needs-preview attribute.
Also, the color of the follow-up icon was adjusted in the attribution view to make it consistent with the report view.

### Context and reason for change

We are adding a checkbox to OpossumUI to signal if a review is required for an attribution.

### How can the changes be tested

- Run the tests in `Icons.test.tsx` and `ReportTableItem.test.tsx`
- Open a file in OpossumUI and verify that the new icon shows up in the report- and attribution view (twice).
