### PR TITLE
Added NeedsReview filter

### DIFF
--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -25,6 +25,7 @@ const FILTERS = [
   FilterType.OnlyFollowUp,
   FilterType.OnlyFirstParty,
   FilterType.HideFirstParty,
+  FilterType.OnlyNeedsReview,
 ];
 
 const classes = {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -78,6 +78,7 @@ export enum FilterType {
   OnlyFirstParty = 'Only First Party',
   HideFirstParty = 'Hide First Party',
   OnlyFollowUp = 'Only Follow Up',
+  OnlyNeedsReview = 'Only Needs Review',
 }
 
 export enum CheckboxLabel {

--- a/src/Frontend/util/__tests__/use-filters.test.tsx
+++ b/src/Frontend/util/__tests__/use-filters.test.tsx
@@ -43,6 +43,7 @@ describe('useFollowUpFilter', () => {
     copyright: 'other Copyright John Doe',
     licenseText: 'Some other license text',
     followUp: FollowUp,
+    needsReview: true,
   };
 
   it('returns working getFilteredAttributions with follow-up filter', () => {
@@ -105,6 +106,18 @@ describe('useFollowUpFilter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
     store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    renderComponentWithStore(
+      <TestComponent manualAttributions={testManualAttributions} />,
+      { store }
+    );
+    expect(filteredAttributions).toEqual({
+      [testOtherManualUuid]: testManualAttributions[testOtherManualUuid],
+    });
+  });
+
+  it('returns working getFilteredAttributions with only needs review filter', () => {
+    const store = createTestAppStore();
+    store.dispatch(updateActiveFilters(FilterType.OnlyNeedsReview));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }

--- a/src/Frontend/util/use-filters.ts
+++ b/src/Frontend/util/use-filters.ts
@@ -31,5 +31,8 @@ export function useFilters(
   attributions = activeFilters.has(FilterType.HideFirstParty)
     ? pickBy(attributions, (value: PackageInfo) => !value.firstParty)
     : attributions;
+  attributions = activeFilters.has(FilterType.OnlyNeedsReview)
+    ? pickBy(attributions, (value: PackageInfo) => value.needsReview)
+    : attributions;
   return attributions;
 }


### PR DESCRIPTION
### Summary of changes

Added filter item "Needs Review" to Attribution and Report Views.

### Context and reason for change

We are adding a checkbox to OpossumUI to signal if a review is required for an attribution.

### How can the changes be tested

use-filters.test.tsx

Mark some attributions "needs review" and see filters in Attribution and Report Views.

![image](https://user-images.githubusercontent.com/85183359/235903122-0c75ad65-e650-4d19-8b7d-ebc08364bee0.png)
