### PR TITLE
Follow up checkbox

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -278,7 +278,8 @@ IMPORTANT: Some fields in the column have special meanings/behaviors:
   - it was globally decided that this attribution does not need attribution (e.g. it is proprietary but bought for the
     whole company).
 - _Comment / Comments_: In the case of an ordinary signal or an attribution, the comment textbox is displaying a single comment. In the case of a merged signal, the comment textbox is displaying multiple comments according to the comments of the individual merged signals.
-- _Needs Review Checkbox_: Checking this checkbox does not have any effect on the overall workflow. The state of the checkbox is however persisted when saving the attribution.
+- _Needs Review Checkbox_: This checkbox can be used to signal to another OpossumUI user that an attribution needs further review.
+  The state of the checkbox is persisted when saving the attribution, so it can e.g. be used for a typical QA workflow.
 
 The `Attribution Details Column`, if editable, shows the following buttons:
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -266,18 +266,19 @@ attribution information and signals cannot be edited.
 
 IMPORTANT: Some fields in the column have special meanings/behaviors:
 
-- _PURL_: if provided, package name and version are extracted from it, and the corresponding fields are not editable. A
+- _PURL_: If provided, package name and version are extracted from it, and the corresponding fields are not editable. A
   basic validity check is done on the purl: if the purl text is red it means it is invalid and saving is prevented.
-- _License Text_: it will appear in the attributions document. It will be automatically filled in for licenses suggested
+- _License Text_: It will appear in the attributions document. It will be automatically filled in for licenses suggested
   in the license name dropdown.
-- _Exclude From Notice Checkbox_: if checked, the relative attribution will not be shown in the notice document.
-  In the case of first party code the respective flag should be preferred.
+- _Exclude From Notice Checkbox_: If checked, the relative attribution will not be shown in the notice document.
+  In the case of first party code, the respective flag should be preferred.
   _Exclude From Notice Checkbox_ should be used only if:
   - the content of the attribution does not need attribution or
   - the attribution isn't an actual attribution or
   - it was globally decided that this attribution does not need attribution (e.g. it is proprietary but bought for the
     whole company).
 - _Comment / Comments_: In the case of an ordinary signal or an attribution, the comment textbox is displaying a single comment. In the case of a merged signal, the comment textbox is displaying multiple comments according to the comments of the individual merged signals.
+- _Needs Review Checkbox_: Checking this checkbox does not have any effect on the overall workflow. The state of the checkbox is however persisted when saving the attribution.
 
 The `Attribution Details Column`, if editable, shows the following buttons:
 

--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -32,6 +32,7 @@ import {
   getExcludeFromNoticeChangeHandler,
   getFirstPartyChangeHandler,
   getFollowUpChangeHandler,
+  getNeedsReviewChangeHandler,
   getMergeButtonsDisplayState,
   getResolvedToggleHandler,
   selectedPackagesAreResolved,
@@ -78,6 +79,7 @@ interface AttributionColumnProps {
   saveFileRequestListener(): void;
   setTemporaryPackageInfo(packageInfo: PackageInfo): void;
   smallerLicenseTextOrCommentField?: boolean;
+  addMarginForNeedsReviewCheckbox?: boolean;
 }
 
 export function AttributionColumn(props: AttributionColumnProps): ReactElement {
@@ -333,6 +335,13 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         mainButtonConfigs={mainButtonConfigs}
         hamburgerMenuButtonConfigs={hamburgerMenuButtonConfigs}
         displayTexts={displayTexts}
+        isEditable={props.isEditable}
+        displayPackageInfo={props.displayPackageInfo}
+        needsReviewChangeHandler={getNeedsReviewChangeHandler(
+          temporaryPackageInfo,
+          dispatch
+        )}
+        addMarginForNeedsReviewCheckbox={props.addMarginForNeedsReviewCheckbox}
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionColumn/ButtonRow.tsx
@@ -7,16 +7,22 @@ import React, { ReactElement } from 'react';
 import { ToggleButton } from '../ToggleButton/ToggleButton';
 import { ButtonGroup, MainButtonConfig } from '../ButtonGroup/ButtonGroup';
 import MuiTypography from '@mui/material/Typography';
-import { ButtonText } from '../../enums/enums';
+import { ButtonText, CheckboxLabel } from '../../enums/enums';
 import { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import MuiBox from '@mui/material/Box';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { checkboxClass } from '../../shared-styles';
+import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
 
 const classes = {
+  ...checkboxClass,
   root: {
     marginLeft: '10px',
     marginTop: '5px',
   },
   buttonRow: {
+    display: 'flex',
+    alignItems: 'center',
     position: 'absolute',
     bottom: '0px',
     right: '0px',
@@ -28,6 +34,10 @@ const classes = {
     marginTop: '0px',
     marginRight: '0px',
   },
+  checkboxForPopUp: {
+    marginRight: '190px',
+    marginBottom: '-8px',
+  },
 };
 
 interface ButtonRowProps {
@@ -38,9 +48,17 @@ interface ButtonRowProps {
   displayTexts: Array<string>;
   mainButtonConfigs: Array<MainButtonConfig>;
   hamburgerMenuButtonConfigs?: Array<ContextMenuItem>;
+  isEditable: boolean;
+  displayPackageInfo: PackageInfo | DisplayPackageInfo;
+  needsReviewChangeHandler(event: React.ChangeEvent<HTMLInputElement>): void;
+  addMarginForNeedsReviewCheckbox?: boolean;
 }
 
 export function ButtonRow(props: ButtonRowProps): ReactElement {
+  const marginForNeedsReviewCheckbox = props.addMarginForNeedsReviewCheckbox
+    ? classes.checkboxForPopUp
+    : {};
+
   return (
     <MuiBox sx={classes.root}>
       {props.displayTexts.map((text, index) => (
@@ -50,11 +68,23 @@ export function ButtonRow(props: ButtonRowProps): ReactElement {
       ))}
       <MuiBox sx={classes.buttonRow}>
         {props.showButtonGroup ? (
-          <ButtonGroup
-            isHidden={props.areButtonsHidden}
-            mainButtonConfigs={props.mainButtonConfigs}
-            hamburgerMenuButtonConfigs={props.hamburgerMenuButtonConfigs}
-          />
+          <>
+            <Checkbox
+              sx={{
+                ...classes.checkBox,
+                ...marginForNeedsReviewCheckbox,
+              }}
+              label={CheckboxLabel.NeedsReview}
+              disabled={!props.isEditable}
+              checked={Boolean(props.displayPackageInfo.needsReview)}
+              onChange={props.needsReviewChangeHandler}
+            />
+            <ButtonGroup
+              isHidden={props.areButtonsHidden}
+              mainButtonConfigs={props.mainButtonConfigs}
+              hamburgerMenuButtonConfigs={props.hamburgerMenuButtonConfigs}
+            />
+          </>
         ) : (
           <ToggleButton
             buttonText={

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -336,6 +336,36 @@ describe('The AttributionColumn', () => {
     );
   });
 
+  it('renders a checkbox for needs review', () => {
+    const testTemporaryPackageInfo: PackageInfo = {
+      attributionConfidence: DiscreteConfidence.High,
+    };
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        displayPackageInfo={testTemporaryPackageInfo}
+        setUpdateTemporaryPackageInfoFor={(): (() => void) => doNothing}
+        onSaveButtonClick={doNothing}
+        setTemporaryPackageInfo={(): (() => void) => doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />
+    );
+    act(() => {
+      store.dispatch(setTemporaryPackageInfo(testTemporaryPackageInfo));
+    });
+
+    expect(
+      getTemporaryPackageInfo(store.getState()).needsReview
+    ).toBeUndefined();
+
+    clickOnCheckbox(screen, CheckboxLabel.NeedsReview);
+    expect(getTemporaryPackageInfo(store.getState()).needsReview).toBe(true);
+  });
+
   it('renders an url icon and opens a link in browser', () => {
     const testTemporaryPackageInfo: PackageInfo = {
       url: 'https://www.testurl.com/',

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -139,6 +139,20 @@ export function getResolvedToggleHandler(
   };
 }
 
+export function getNeedsReviewChangeHandler(
+  temporaryPackageInfo: PackageInfo,
+  dispatch: AppThunkDispatch
+): (event: React.ChangeEvent<HTMLInputElement>) => void {
+  return (event): void => {
+    dispatch(
+      setTemporaryPackageInfo({
+        ...temporaryPackageInfo,
+        needsReview: event.target.checked,
+      })
+    );
+  };
+}
+
 export function selectedPackagesAreResolved(
   attributionIds: Array<string>,
   resolvedExternalAttributions: Set<string>

--- a/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/AttributionCountsPanel.tsx
@@ -12,6 +12,7 @@ import {
   FollowUpIcon,
   IncompleteAttributionsIcon,
   MissingPackageNameIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import pickBy from 'lodash/pickBy';
@@ -28,8 +29,11 @@ const classes = {
     width: '13px',
     height: '13px',
   },
-  titleFollowUpIcon: {
+  titleNeedsReviewIcon: {
     color: OpossumColors.orange,
+  },
+  titleFollowUpIcon: {
+    color: OpossumColors.red,
   },
   preselectedAttributionIcon: {
     color: OpossumColors.darkBlue,
@@ -51,6 +55,9 @@ export function AttributionCountsPanel(
 ): ReactElement {
   const attributions: Attributions = useAppSelector(getManualAttributions);
   const numberOfAttributions = Object.keys(attributions).length;
+  const numberOfAttributionsThatNeedReview = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.needsReview)
+  ).length;
   const numberOfFollowUps = Object.keys(
     pickBy(attributions, (value: PackageInfo) => value.followUp)
   ).length;
@@ -73,7 +80,14 @@ export function AttributionCountsPanel(
         sxProps: props.sx,
       })}
     >
-      {`Attributions (${numberOfAttributions} total, ${numberOfFollowUps}`}
+      {`Attributions (${numberOfAttributions} total, ${numberOfAttributionsThatNeedReview}`}
+      <NeedsReviewIcon
+        sx={{
+          ...classes.titleNeedsReviewIcon,
+          ...classes.icons,
+        }}
+      />
+      {`, ${numberOfFollowUps}`}
       <FollowUpIcon
         sx={{
           ...classes.titleFollowUpIcon,

--- a/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
@@ -61,7 +61,9 @@ describe('The Attribution Counts Panel', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
     expect(
-      screen.getByText(/Attributions \(2 total, 1, 0, 1, 1\)/, { exact: true })
+      screen.getByText(/Attributions \(2 total, 0, 1, 0, 1, 1\)/, {
+        exact: true,
+      })
     );
   });
 });

--- a/src/Frontend/Components/AttributionPropertyCountTable/AttributionPropertyCountTable.tsx
+++ b/src/Frontend/Components/AttributionPropertyCountTable/AttributionPropertyCountTable.tsx
@@ -17,6 +17,7 @@ import { tableClasses } from '../../shared-styles';
 const ATTRIBUTION_PROPERTIES_ID_TO_DISPLAY_NAME: {
   [attributionProperty: string]: string;
 } = {
+  needsReview: 'Needs review',
   followUp: 'Follow up',
   firstParty: 'First party',
   incomplete: 'Incomplete Attributions',

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -65,7 +65,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -90,7 +90,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -116,7 +116,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 
@@ -144,7 +144,7 @@ describe('The Attribution View', () => {
       store.dispatch(navigateToView(View.Attribution));
     });
 
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 1/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 1/));
     expect(screen.getByText('Test package, 1.0'));
     expect(screen.getByText('Test other package, 2.0'));
 

--- a/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
+++ b/src/Frontend/Components/ButtonGroup/ButtonGroup.tsx
@@ -15,7 +15,6 @@ import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-class
 
 const classes = {
   root: {
-    marginTop: '10px',
     justifyContent: 'space-evenly',
     display: 'flex',
   },

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -68,6 +68,7 @@ export function EditAttributionPopup(): ReactElement {
           }}
           saveFileRequestListener={saveFileRequestListener}
           smallerLicenseTextOrCommentField
+          addMarginForNeedsReviewCheckbox
         />
       }
       header={'Edit Attribution'}

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -25,6 +25,7 @@ const FILTERS = [
   FilterType.OnlyFollowUp,
   FilterType.OnlyFirstParty,
   FilterType.HideFirstParty,
+  FilterType.OnlyNeedsReview,
 ];
 
 const classes = {

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -16,6 +16,7 @@ import ReplayIcon from '@mui/icons-material/Replay';
 import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import SearchIcon from '@mui/icons-material/Search';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import React, { ReactElement } from 'react';
 import {
   baseIcon,
@@ -119,6 +120,20 @@ export function FollowUpIcon(props: IconProps): ReactElement {
     <MuiTooltip sx={classes.tooltip} title="has follow-up">
       <ReplayIcon
         aria-label={'Follow-up icon'}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
+      />
+    </MuiTooltip>
+  );
+}
+
+export function NeedsReviewIcon(props: IconProps): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="needs review">
+      <QuestionMarkIcon
+        aria-label={'Needs-review icon'}
         sx={getSxFromPropsAndClasses({
           styleClass: classes.nonClickableIcon,
           sxProps: props.sx,

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -15,6 +15,7 @@ import {
   FirstPartyIcon,
   FollowUpIcon,
   IncompleteAttributionsIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
   SearchPackagesIcon,
   SignalIcon,
@@ -37,6 +38,12 @@ describe('The Icons', () => {
     render(<FollowUpIcon />);
 
     expect(screen.getByLabelText('Follow-up icon'));
+  });
+
+  it('renders NeedsReviewIcon', () => {
+    render(<NeedsReviewIcon />);
+
+    expect(screen.getByLabelText('Needs-review icon'));
   });
 
   it('renders FirstPartyIcon', () => {

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -134,6 +134,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
     ...props.cardConfig,
     firstParty: props.packageInfo.firstParty,
     excludeFromNotice: props.packageInfo.excludeFromNotice,
+    needsReview: Boolean(props.packageInfo.needsReview),
     followUp: Boolean(props.packageInfo.followUp),
     isContextMenuOpen,
     isMarkedForReplacement:

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -9,6 +9,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
@@ -21,8 +22,11 @@ export function getKey(prefix: string, cardId: string): string {
 }
 
 const classes = {
-  followUpIcon: {
+  needsReviewIcon: {
     color: OpossumColors.orange,
+  },
+  followUpIcon: {
+    color: OpossumColors.red,
   },
   excludeFromNoticeIcon: {
     color: OpossumColors.grey,
@@ -40,6 +44,22 @@ export function getRightIcons(
     rightIcons.push(openResourcesIcon);
   }
 
+  if (cardConfig.needsReview) {
+    rightIcons.push(
+      <NeedsReviewIcon
+        key={getKey('needs-review-icon', cardId)}
+        sx={classes.needsReviewIcon}
+      />
+    );
+  }
+  if (cardConfig.followUp) {
+    rightIcons.push(
+      <FollowUpIcon
+        key={getKey('follow-up-icon', cardId)}
+        sx={classes.followUpIcon}
+      />
+    );
+  }
   if (cardConfig.firstParty) {
     rightIcons.push(
       <FirstPartyIcon key={getKey('first-party-icon', cardId)} />
@@ -50,14 +70,6 @@ export function getRightIcons(
       <ExcludeFromNoticeIcon
         key={getKey('exclude-icon', cardId)}
         sx={classes.excludeFromNoticeIcon}
-      />
-    );
-  }
-  if (cardConfig.followUp) {
-    rightIcons.push(
-      <FollowUpIcon
-        key={getKey('follow-up-icon', cardId)}
-        sx={classes.followUpIcon}
       />
     );
   }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -34,6 +34,7 @@ const testAttributions_1: Attributions = {
     criticality: Criticality.Medium,
     licenseName: 'Apache License Version 2.0',
     firstParty: true,
+    needsReview: true,
   },
   uuid2: {
     source: {
@@ -50,6 +51,7 @@ const testAttributions_1: Attributions = {
     },
     licenseName: ' Apache license version-2.0 ',
     followUp: FollowUp,
+    needsReview: true,
   },
   uuid4: {
     source: {
@@ -202,6 +204,7 @@ describe('aggregateAttributionPropertiesFromAttributions', () => {
     const expectedAttributionPropertyCounts: {
       [attributionPropertyOrTotal: string]: number;
     } = {
+      needsReview: 2,
       followUp: 1,
       firstParty: 2,
       incomplete: 4,
@@ -227,6 +230,7 @@ describe('aggregateAttributionPropertiesFromAttributions', () => {
     const expectedAttributionPropertyCounts: {
       [attributionPropertyOrTotal: string]: number;
     } = {
+      needsReview: 0,
       followUp: 0,
       firstParty: 0,
       incomplete: 5,

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -23,6 +23,7 @@ interface UniqueLicenseNameToAttributions {
   [strippedLicenseName: string]: Array<string>;
 }
 
+const ATTRIBUTION_PROPERTY_NEEDS_REVIEW = 'needsReview';
 const ATTRIBUTION_PROPERTY_FOLLOW_UP = 'followUp';
 const ATTRIBUTION_PROPERTY_FIRST_PARTY = 'firstParty';
 const ATTRIBUTION_PROPERTY_INCOMPLETE = 'incomplete';
@@ -207,6 +208,9 @@ export function aggregateAttributionPropertiesFromAttributions(
   const attributionPropertyCounts: {
     [attributionPropertyOrTotal: string]: number;
   } = {};
+  attributionPropertyCounts[ATTRIBUTION_PROPERTY_NEEDS_REVIEW] = Object.keys(
+    pickBy(attributions, (value: PackageInfo) => value.needsReview)
+  ).length;
   attributionPropertyCounts[ATTRIBUTION_PROPERTY_FOLLOW_UP] = Object.keys(
     pickBy(attributions, (value: PackageInfo) => value.followUp)
   ).length;

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -11,6 +11,7 @@ import {
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
   FollowUpIcon,
+  NeedsReviewIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { TableConfig, tableConfigs } from '../Table/Table';
@@ -96,6 +97,10 @@ const classes = {
   followUpIcon: {
     border: `2px ${OpossumColors.red} solid`,
     color: OpossumColors.red,
+  },
+  needsReviewIcon: {
+    border: `2px ${OpossumColors.orange} solid`,
+    color: OpossumColors.orange,
   },
   excludeFromNoticeIcon: {
     border: `2px ${OpossumColors.grey} solid`,
@@ -298,6 +303,17 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
           />
           <br />
         </>
+        {attributionInfo.needsReview && (
+          <>
+            <NeedsReviewIcon
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.needsReviewIcon,
+              }}
+            />{' '}
+            <br />
+          </>
+        )}
         {attributionInfo.followUp && (
           <>
             <FollowUpIcon

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -74,6 +74,7 @@ describe('The ReportTableItem', () => {
         url: 'packageWebsite',
         firstParty: true,
         resources: ['/'],
+        needsReview: true,
       },
       uuid2: {
         packageName: 'Redux',
@@ -107,5 +108,6 @@ describe('The ReportTableItem', () => {
     expect(screen.getByLabelText('First party icon'));
     expect(screen.getByLabelText('Follow-up icon'));
     expect(screen.getByLabelText('Exclude from notice icon'));
+    expect(screen.getByLabelText('Needs-review icon'));
   });
 });

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -77,7 +77,7 @@ describe('The ReportView', () => {
       );
       store.dispatch(setFrequentLicenses(testFrequentLicenses));
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('MIT text'));
     expect(screen.getByText('Test other package'));
@@ -97,7 +97,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -121,7 +121,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 
@@ -149,7 +149,7 @@ describe('The ReportView', () => {
         )
       );
     });
-    expect(screen.getByText(/Attributions \(2 total, 1, 0, 0/));
+    expect(screen.getByText(/Attributions \(2 total, 0, 1, 0, 0/));
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
 

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -78,6 +78,7 @@ export enum FilterType {
   OnlyFirstParty = 'Only First Party',
   HideFirstParty = 'Hide First Party',
   OnlyFollowUp = 'Only Follow Up',
+  OnlyNeedsReview = 'Only Needs Review',
 }
 
 export enum CheckboxLabel {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -84,6 +84,7 @@ export enum CheckboxLabel {
   FirstParty = '1st Party',
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',
+  NeedsReview = 'Needs Review',
 }
 
 export enum ProjectStatisticsPopupTitle {

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -64,6 +64,7 @@ export interface ListCardConfig {
   isPreSelected?: boolean;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
+  needsReview?: boolean;
   followUp?: boolean;
   isHeader?: boolean;
   isContextMenuOpen?: boolean;

--- a/src/Frontend/util/__tests__/use-filters.test.tsx
+++ b/src/Frontend/util/__tests__/use-filters.test.tsx
@@ -43,6 +43,7 @@ describe('useFollowUpFilter', () => {
     copyright: 'other Copyright John Doe',
     licenseText: 'Some other license text',
     followUp: FollowUp,
+    needsReview: true,
   };
 
   it('returns working getFilteredAttributions with follow-up filter', () => {
@@ -105,6 +106,18 @@ describe('useFollowUpFilter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
     store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    renderComponentWithStore(
+      <TestComponent manualAttributions={testManualAttributions} />,
+      { store }
+    );
+    expect(filteredAttributions).toEqual({
+      [testOtherManualUuid]: testManualAttributions[testOtherManualUuid],
+    });
+  });
+
+  it('returns working getFilteredAttributions with only needs review filter', () => {
+    const store = createTestAppStore();
+    store.dispatch(updateActiveFilters(FilterType.OnlyNeedsReview));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }

--- a/src/Frontend/util/use-filters.ts
+++ b/src/Frontend/util/use-filters.ts
@@ -31,5 +31,8 @@ export function useFilters(
   attributions = activeFilters.has(FilterType.HideFirstParty)
     ? pickBy(attributions, (value: PackageInfo) => !value.firstParty)
     : attributions;
+  attributions = activeFilters.has(FilterType.OnlyNeedsReview)
+    ? pickBy(attributions, (value: PackageInfo) => value.needsReview)
+    : attributions;
   return attributions;
 }

--- a/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
@@ -36,18 +36,6 @@ test.describe('Open outdated .json file via command line', () => {
     }
   });
 
-  test('should open FileSupportPopup when .json file is provided as command line arg', async () => {
-    const header = 'Warning: Outdated input file format';
-    const fileSupportPopupEntry = await getElementWithText(window, header);
-    await expect(fileSupportPopupEntry).toBeVisible({
-      timeout: EXPECT_TIMEOUT,
-    });
-    const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
-    await expect(keepOldFileFormatButton).toBeVisible({
-      timeout: EXPECT_TIMEOUT,
-    });
-  });
-
   test('should open file when provided as command line arg', async () => {
     const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
     await keepOldFileFormatButton.click();

--- a/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
@@ -28,6 +28,7 @@ test.describe('Open outdated .json file via command line', () => {
     app = await getApp('src/e2e-tests/test-resources/opossum_input_e2e.json');
     window = await app.firstWindow();
     await window.waitForLoadState('networkidle', { timeout: LOAD_TIMEOUT });
+    await window.title();
   });
 
   test.afterEach(async () => {

--- a/src/e2e-tests/__tests__/e2e-dot-opossum-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-dot-opossum-file-format.test.ts
@@ -25,6 +25,7 @@ test.describe('Open .opossum file via command line', () => {
     );
     window = await app.firstWindow();
     await window.waitForLoadState('networkidle', { timeout: LOAD_TIMEOUT });
+    await window.title();
   });
 
   test.afterEach(async () => {

--- a/src/e2e-tests/__tests__/e2e-without-file.test.ts
+++ b/src/e2e-tests/__tests__/e2e-without-file.test.ts
@@ -22,6 +22,7 @@ test.describe('The OpossumUI', () => {
     app = await getApp();
     window = await app.firstWindow();
     await window.waitForLoadState('networkidle', { timeout: LOAD_TIMEOUT });
+    await window.title();
   });
 
   test.afterEach(async () => {

--- a/src/e2e-tests/test-helpers/test-helpers.ts
+++ b/src/e2e-tests/test-helpers/test-helpers.ts
@@ -19,7 +19,7 @@ import {
 
 const ELECTRON_LAUNCH_TEST_TIMEOUT = 75000;
 export const E2E_TEST_TIMEOUT = 120000;
-export const EXPECT_TIMEOUT = 30000;
+export const EXPECT_TIMEOUT = 50000;
 export const LOAD_TIMEOUT = 100000;
 
 export async function getApp(


### PR DESCRIPTION
### Summary of changes

In this branch we are adding a feature to signal that an attribution needs review.

### Context and reason for change

In order to improve the workflow of a typical QA process, we add this feature to provide a way for an OpossumUI user to signal to QA that an attribution needs special attention.

replaces:  #1651

### How can the changes be tested

Open a file in OpossumUI and use the checkbox for a manual attribution. Check also that the statistics popup is updated accordingly.
