### PR TITLE
Remove unnecessary function

### DIFF
--- a/src/Frontend/util/__tests__/get-card-labels-test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels-test.ts
@@ -9,59 +9,69 @@ import {
   addSecondLineOfPackageLabelFromAttribute,
   getCardLabels,
 } from '../get-card-labels';
-import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
+import { DisplayPackageInfo } from '../../../shared/shared-types';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 
 describe('Test getPackageLabel', () => {
-  const testProps: PackageInfo = {
+  const testProps: DisplayPackageInfo = {
     packageName: 'Test package name',
     packageVersion: '1.2',
     copyright: '(c) Test copyright',
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
+    attributionIds: [],
   };
-  const testPropsWithoutVersion: PackageInfo = {
+  const testPropsWithoutVersion: DisplayPackageInfo = {
     packageName: 'Test package name',
     copyright: 'Test copyright',
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
+    attributionIds: [],
   };
-  const testPropsWithUndefinedName: PackageInfo = {
+  const testPropsWithUndefinedName: DisplayPackageInfo = {
     packageName: undefined,
     copyright: 'Test copyright',
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
+    attributionIds: [],
   };
-  const testPropsWithoutName: PackageInfo = {
+  const testPropsWithoutName: DisplayPackageInfo = {
     copyright: 'Test copyright',
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
     url: 'Test url',
     licenseName: 'Test license name',
+    attributionIds: [],
   };
-  const testPropsCopyrightLicenseTextAndComment: PackageInfo = {
+  const testPropsCopyrightLicenseTextAndComment: DisplayPackageInfo = {
     copyright: 'Test copyright',
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
+    attributionIds: [],
   };
-  const testPropsWithLicenseTextAndComment: PackageInfo = {
+  const testPropsWithLicenseTextAndComment: DisplayPackageInfo = {
     licenseText: 'Test license text',
-    comment: 'Test comment',
+    comments: ['Test comment'],
+    attributionIds: [],
   };
-  const testPropsJustComment: PackageInfo = {
-    comment: 'Test comment',
+  const testPropsJustComment: DisplayPackageInfo = {
+    comments: ['Test comment'],
+    attributionIds: [],
   };
-  const testPropsJustUrlAndCopyright: PackageInfo = {
+  const testPropsJustUrlAndCopyright: DisplayPackageInfo = {
     copyright: 'Test copyright',
     url: 'Test url',
+    attributionIds: [],
   };
-  const testPropsJustFirstParty: PackageInfo = {
+  const testPropsJustFirstParty: DisplayPackageInfo = {
     firstParty: true,
+    attributionIds: [],
   };
 
   it('finds label for package', () => {
@@ -104,7 +114,7 @@ describe('Test getPackageLabel', () => {
     expect(getCardLabels(testPropsJustComment)).toEqual(['Test comment']);
   });
   it('finds label for empty package', () => {
-    expect(getCardLabels({})).toEqual([]);
+    expect(getCardLabels(EMPTY_DISPLAY_PACKAGE_INFO)).toEqual([]);
   });
   it('finds label for package with just url and copyright', () => {
     expect(getCardLabels(testPropsJustUrlAndCopyright)).toEqual([

--- a/src/Frontend/util/get-alphabetical-comparer.ts
+++ b/src/Frontend/util/get-alphabetical-comparer.ts
@@ -5,6 +5,7 @@
 
 import { Attributions } from '../../shared/shared-types';
 import { getCardLabels } from './get-card-labels';
+import { convertPackageInfoToDisplayPackageInfo } from './convert-package-info';
 
 export function getAlphabeticalComparer(attributions: Attributions) {
   return function compareFunction(
@@ -13,20 +14,30 @@ export function getAlphabeticalComparer(attributions: Attributions) {
   ): number {
     const defaultName = '\u10FFFF'; // largest unicode character
 
-    const elementCardLabels = getCardLabels({
-      packageName: attributions[element].packageName,
-      ...attributions[element],
-    });
+    const elementCardLabels = getCardLabels(
+      convertPackageInfoToDisplayPackageInfo(
+        {
+          packageName: attributions[element].packageName,
+          ...attributions[element],
+        },
+        []
+      )
+    );
     const elementTitle = getElementTitle(elementCardLabels, defaultName);
     const elementTitleIsAlphabetical = isElementTitleAlphabetical(
       elementTitle,
       defaultName
     );
 
-    const otherElementCardLabels = getCardLabels({
-      packageName: attributions[otherElement].packageName,
-      ...attributions[otherElement],
-    });
+    const otherElementCardLabels = getCardLabels(
+      convertPackageInfoToDisplayPackageInfo(
+        {
+          packageName: attributions[otherElement].packageName,
+          ...attributions[otherElement],
+        },
+        []
+      )
+    );
     const otherElementTitle = getElementTitle(
       otherElementCardLabels,
       defaultName

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -3,12 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  DisplayPackageInfo,
-  PackageInfo,
-  isDisplayPackageInfo,
-} from '../../shared/shared-types';
-import { convertPackageInfoToDisplayPackageInfo } from './convert-package-info';
+import { DisplayPackageInfo } from '../../shared/shared-types';
 
 type RelevantDisplayPackageInfoAttributes =
   | 'packageName'
@@ -24,11 +19,8 @@ const PRIORITIZED_DISPLAY_PACKAGE_INFO_ATTRIBUTES: Array<RelevantDisplayPackageI
 const FIRST_PARTY_TEXT = 'First party';
 
 export function getCardLabels(
-  packageInfo: PackageInfo | DisplayPackageInfo
+  displayPackageInfo: DisplayPackageInfo
 ): Array<string> {
-  const displayPackageInfo = isDisplayPackageInfo(packageInfo)
-    ? packageInfo
-    : convertPackageInfoToDisplayPackageInfo(packageInfo, ['']);
   const packageLabels: Array<string> = [];
 
   for (const attribute of PRIORITIZED_DISPLAY_PACKAGE_INFO_ATTRIBUTES) {

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -57,12 +57,6 @@ export interface DisplayPackageInfo extends PackageInfoCore {
   attributionIds: Array<string>;
 }
 
-export function isDisplayPackageInfo(
-  packageInfoOrDisplayPackageInfo: PackageInfo | DisplayPackageInfo
-): packageInfoOrDisplayPackageInfo is DisplayPackageInfo {
-  return 'attributionIds' in packageInfoOrDisplayPackageInfo;
-}
-
 export interface Source {
   name: string;
   documentConfidence: number;


### PR DESCRIPTION
### Summary of changes

Remove unnecessary function `isDisplayPackageInfo`.

### Context and reason for change

Function `isDisplayPackageInfo` is not needed anymore.


