### PR TITLE
Don't create an empty attribution if only 'Needs Review' is checked

### DIFF
--- a/src/Frontend/util/__tests__/package-info-has-no-significant-fields.test.ts
+++ b/src/Frontend/util/__tests__/package-info-has-no-significant-fields.test.ts
@@ -20,6 +20,7 @@ describe('The test package', () => {
     { followUp: FollowUp },
     { excludeFromNotice: true },
     { criticality: Criticality.Medium },
+    { needsReview: true },
     {
       source: {
         name: 'test name',

--- a/src/Frontend/util/package-info-has-no-significant-fields.ts
+++ b/src/Frontend/util/package-info-has-no-significant-fields.ts
@@ -17,5 +17,6 @@ export function packageInfoHasNoSignificantFields(
   delete packageInfoWithSignificantFields.excludeFromNotice;
   delete packageInfoWithSignificantFields.criticality;
   delete packageInfoWithSignificantFields.source;
+  delete packageInfoWithSignificantFields.needsReview;
   return isEmpty(packageInfoWithSignificantFields);
 }


### PR DESCRIPTION
### Summary of changes

This PR adds the field needsReview to the list of insignificant fields, so that there is no attribution created if only "Needs Review" is checked.

### Context and reason for change

Fix: #1686 
