### PR TITLE
Show project statistics popup after new file was loaded. Fix: 1711

### DIFF
--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -60,6 +60,7 @@ export function BackendCommunication(): ReactElement | null {
     parsedFileContent: ParsedFileContent,
   ): void {
     dispatch(loadFromFile(parsedFileContent));
+    dispatch(openPopup(PopupType.ProjectStatisticsPopup));
   }
 
   function getExportFileRequestListener(

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -13,9 +13,6 @@ import { Attributions } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { screen } from '@testing-library/react';
-import { mockResizeObserver } from '../../../test-helpers/popup-test-helpers';
-
-mockResizeObserver();
 
 describe('The ProjectStatisticsPopup', () => {
   it('displays license names and source names', () => {

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -7,6 +7,7 @@
 import { App } from '../../../Components/App/App';
 import {
   clickOnButton,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   expectButton,
   getOpenResourcesButtonForPackagePanel,
@@ -81,6 +82,7 @@ describe('Other popups of the app', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectButton(screen, ButtonText.Save, true);
@@ -137,6 +139,7 @@ describe('Other popups of the app', () => {
 
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', testInitialPackageName);
@@ -198,6 +201,7 @@ describe('Other popups of the app', () => {
 
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', testInitialPackageName);
@@ -268,6 +272,7 @@ describe('Other popups of the app', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, '/');
 
@@ -297,6 +302,7 @@ describe('Other popups of the app', () => {
 
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
 

--- a/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
@@ -8,6 +8,7 @@ import {
   clickOnButton,
   clickOnCheckbox,
   clickOnFilter,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   goToView,
   mockElectronBackend,
@@ -70,7 +71,7 @@ describe('The App integration', () => {
     mockElectronBackend(mockChannelReturn);
 
     renderComponentWithStore(<App />);
-
+    closeProjectStatisticsPopup(screen);
     goToView(screen, View.Attribution);
     screen.getByText('JQuery');
     screen.getByText('Angular');

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -38,6 +38,7 @@ import { clickOnCardInAttributionList } from '../../../test-helpers/package-pane
 import {
   clickOnButton,
   clickOnMultiSelectCheckboxInPackageCard,
+  closeProjectStatisticsPopup,
   expectSelectCheckboxInPackageCardIsChecked,
   getParsedInputFileEnrichedWithTestData,
   goToView,
@@ -238,6 +239,7 @@ describe('In Attribution View the ContextMenu', () => {
       }),
     );
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     goToView(screen, View.Attribution);
     expectGlobalOnlyContextMenuForPreselectedAttribution(

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -8,6 +8,7 @@ import { App } from '../../../Components/App/App';
 import {
   clickOnButton,
   clickOnOpenFileIcon,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   expectButton,
   goToView,
@@ -169,6 +170,7 @@ describe('The App in attribution view', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnOpenFileIcon(screen);
     goToView(screen, View.Attribution);
@@ -309,6 +311,7 @@ describe('The App in attribution view', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnOpenFileIcon(screen);
     goToView(screen, View.Attribution);
@@ -379,6 +382,7 @@ describe('The App in attribution view', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnOpenFileIcon(screen);
     goToView(screen, View.Attribution);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -5,6 +5,7 @@
 
 import {
   clickOnButton,
+  closeProjectStatisticsPopup,
   getParsedInputFileEnrichedWithTestData,
   mockElectronBackend,
 } from '../../../test-helpers/general-test-helpers';
@@ -79,6 +80,7 @@ describe('Add to attribution', () => {
       );
 
       renderComponentWithStore(<App />);
+      closeProjectStatisticsPopup(screen);
 
       clickOnElementInResourceBrowser(screen, 'folder1');
       clickOnElementInResourceBrowser(screen, 'firstResource.js');
@@ -216,6 +218,7 @@ describe('Add to attribution', () => {
     );
 
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
     clickOnTab(screen, 'Global Tab');

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -7,6 +7,7 @@
 import { App } from '../../../Components/App/App';
 import {
   clickOnButton,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   expectButton,
   expectButtonIsNotShown,
@@ -77,6 +78,7 @@ describe('The App in Audit View', () => {
 
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'something.js');
     expectValueInTextBox(screen, 'Name', 'InitialPackageName');
@@ -157,6 +159,7 @@ describe('The App in Audit View', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');
@@ -239,6 +242,7 @@ describe('The App in Audit View', () => {
 
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectValueInTextBox(screen, 'Name', 'React');

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -7,6 +7,7 @@
 import {
   clickOnButton,
   clickOnTopProgressBar,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   getOpenFileIcon,
   getParsedInputFileEnrichedWithTestData,
@@ -138,6 +139,7 @@ describe('The App in Audit View', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     getElementInResourceBrowser(screen, 'root');
     expectPackagePanelNotShown(screen, 'Signals in Folder Content');
@@ -213,6 +215,7 @@ describe('The App in Audit View', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'withExternalAttribution.js');
     expectValueNotInConfidenceField(screen, '10');
@@ -346,6 +349,7 @@ describe('The App in Audit View', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
     expectPackageInPackagePanel(
@@ -431,6 +435,7 @@ describe('The App in Audit View', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'folder1');
     expectPackageInPackagePanel(

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -8,6 +8,7 @@ import {
   clickOnButton,
   clickOnEditIconForElement,
   clickOnOpenFileIcon,
+  closeProjectStatisticsPopup,
   EMPTY_PARSED_FILE_CONTENT,
   goToView,
   mockElectronBackend,
@@ -113,6 +114,7 @@ describe('The report view', () => {
     };
     mockElectronBackend(mockChannelReturn);
     renderComponentWithStore(<App />);
+    closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'something.js');
 

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -250,6 +250,11 @@ export function clickOnFilter(screen: Screen, label: string): void {
   fireEvent.click(screen.getByLabelText(label) as Element);
 }
 
+export function closeProjectStatisticsPopup(screen: Screen): void {
+  expect(screen.getByText('Project Statistics')).toBeInTheDocument();
+  fireEvent.click(getButton(screen, ButtonText.Close));
+}
+
 export function expectElementsInAutoCompleteAndSelectFirst(
   screen: Screen,
   elements: Array<string>,

--- a/src/Frontend/test-helpers/popup-test-helpers.ts
+++ b/src/Frontend/test-helpers/popup-test-helpers.ts
@@ -74,20 +74,3 @@ export function expectConfirmMultiSelectDeletionPopupNotVisible(
 ): void {
   expect(screen.queryByText('Confirm Deletion')).not.toBeInTheDocument();
 }
-
-export function mockResizeObserver(): void {
-  const originalResizeObserver = window.ResizeObserver;
-
-  beforeEach(() => {
-    window.ResizeObserver = jest.fn().mockImplementation(() => ({
-      observe: jest.fn(),
-      unobserve: jest.fn(),
-      disconnect: jest.fn(),
-    }));
-  });
-
-  afterEach(() => {
-    window.ResizeObserver = originalResizeObserver;
-    jest.restoreAllMocks();
-  });
-}

--- a/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-deprecated-file-format.test.ts
@@ -42,6 +42,12 @@ test.describe('Open outdated .json file via command line', () => {
 
     await getElementWithText(window, 'Frontend');
 
+    const closeProjectStatisticsPopupButton = await getElementWithText(
+      window,
+      'Close',
+    );
+    await closeProjectStatisticsPopupButton.click();
+
     const electronBackendEntry = await getElementWithText(
       window,
       'ElectronBackend',
@@ -56,6 +62,12 @@ test.describe('Open outdated .json file via command line', () => {
   test('should show signals and attributions in accordions', async () => {
     const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
     await keepOldFileFormatButton.click();
+
+    const closeProjectStatisticsPopupButton = await getElementWithText(
+      window,
+      'Close',
+    );
+    await closeProjectStatisticsPopupButton.click();
 
     const electronBackendEntry = await getElementWithText(
       window,
@@ -91,6 +103,12 @@ test.describe('Open outdated .json file via command line', () => {
     async () => {
       const keepOldFileFormatButton = await getButtonWithName(window, 'Keep');
       await keepOldFileFormatButton.click();
+
+      const closeProjectStatisticsPopupButton = await getElementWithText(
+        window,
+        'Close',
+      );
+      await closeProjectStatisticsPopupButton.click();
 
       const electronBackendEntry = await getElementWithText(
         window,

--- a/src/e2e-tests/__tests__/e2e-dot-opossum-file-format.test.ts
+++ b/src/e2e-tests/__tests__/e2e-dot-opossum-file-format.test.ts
@@ -36,6 +36,12 @@ test.describe('Open .opossum file via command line', () => {
   test('should open file when provided as command line arg', async () => {
     await getElementWithText(window, 'Frontend');
 
+    const closeProjectStatisticsPopupButton = await getElementWithText(
+      window,
+      'Close',
+    );
+    await closeProjectStatisticsPopupButton.click();
+
     const electronBackendEntry = await getElementWithText(
       window,
       'ElectronBackend',
@@ -44,6 +50,12 @@ test.describe('Open .opossum file via command line', () => {
   });
 
   test('should show signals and attributions in accordions', async () => {
+    const closeProjectStatisticsPopupButton = await getElementWithText(
+      window,
+      'Close',
+    );
+    await closeProjectStatisticsPopupButton.click();
+
     const electronBackendEntry = await getElementWithText(
       window,
       'ElectronBackend',


### PR DESCRIPTION
### Summary of changes

In `src\Frontend\Components\BackendCommunication\BackendCommunication.tsx` in `fileLoadedListener()`  the `ProjectStatisticsPopup` is now dispatched right after the `parsedFileContent`. Thus, the `ProjectStatisticsPopup` will open once a new file is loaded.
Some tests had to be addapted.

### Context and reason for change

As an OpossumUI user, I want to get a quick overview of the project when opening a new file.
In order to achieve this the project statistics popup should automatically open when a new file is opened.

Fix: #1711 

### How can the changes be tested
Start OpossumUI and open a non empty opossum file. 

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
