### PR TITLE
DRAFT: Enable hiding attributed resources in resources browser

### DIFF
--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -20,7 +20,6 @@ import {
   OpossumColors,
 } from '../../shared-styles';
 import { topBarHeight } from '../TopBar/TopBar';
-import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import { IconButton } from '../IconButton/IconButton';
 import { getActiveFilters } from '../../state/selectors/view-selector';
@@ -28,6 +27,7 @@ import { AttributionCountsPanel } from '../AttributionCountsPanel/AttributionCou
 import { DisplayPackageInfos } from '../../types/types';
 import { convertPackageInfoToDisplayPackageInfo } from '../../util/convert-package-info';
 import { getAlphabeticalComparer } from '../../util/get-alphabetical-comparer';
+import { AttributionsFilter } from '../AttributionsFilter/AttributionsFilter';
 
 const classes = {
   root: {
@@ -102,7 +102,7 @@ export function AttributionView(): ReactElement {
           />
         }
         filterElement={
-          <FilterMultiSelect sx={showMultiSelect ? {} : { display: 'none' }} />
+          <AttributionsFilter sx={showMultiSelect ? {} : { display: 'none' }} />
         }
       />
       <AttributionDetailsViewer />

--- a/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
+++ b/src/Frontend/Components/AttributionView/__tests__/AttributionView.test.tsx
@@ -11,7 +11,7 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
-import { FilterType, View } from '../../../enums/enums';
+import { AttributionsFilterType, View } from '../../../enums/enums';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { navigateToView } from '../../../state/actions/view-actions/view-actions';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
@@ -96,7 +96,7 @@ describe('The Attribution View', () => {
     expect(screen.getByText('Test other package, 2.0'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
 
     expect(screen.getByText('Test other package, 2.0'));
     expect(screen.queryByText('Test package, 1.0')).not.toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('The Attribution View', () => {
     expect(screen.getByText('Test other package, 2.0'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
 
     expect(screen.getByText('Test package, 1.0'));
     expect(
@@ -150,15 +150,15 @@ describe('The Attribution View', () => {
     expect(screen.getByText('Test other package, 2.0'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
 
     expect(screen.queryByText('Test package, 1.0')).not.toBeInTheDocument();
     expect(
       screen.queryByText('Test other package, 2.0')
     ).not.toBeInTheDocument();
 
-    clickOnFilter(screen, FilterType.HideFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.HideFirstParty);
     expect(screen.getByText('Test other package, 2.0'));
     expect(screen.queryByText('Test package, 1.0')).not.toBeInTheDocument();
   });

--- a/src/Frontend/Components/AttributionsFilter/AttributionsFilter.tsx
+++ b/src/Frontend/Components/AttributionsFilter/AttributionsFilter.tsx
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { AttributionsFilterType } from '../../enums/enums';
+import { SxProps } from '@mui/material';
+import { updateActiveFilters } from '../../state/actions/view-actions/view-actions';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getActiveFilters } from '../../state/selectors/view-selector';
+import { FilterMultiSelect } from '../FilterMultiSelect/FilterMultiSelect';
+
+const FILTERS = [
+  AttributionsFilterType.OnlyFollowUp,
+  AttributionsFilterType.OnlyFirstParty,
+  AttributionsFilterType.HideFirstParty,
+  AttributionsFilterType.OnlyNeedsReview,
+];
+
+interface AttributionsFilterProps {
+  sx?: SxProps;
+}
+
+export function AttributionsFilter(
+  props: AttributionsFilterProps
+): ReactElement {
+  const dispatch = useAppDispatch();
+  const activeFilters = Array.from(useAppSelector(getActiveFilters));
+
+  const updateFilters = (filter: AttributionsFilterType): void => {
+    dispatch(updateActiveFilters(filter));
+  };
+
+  return (
+    <FilterMultiSelect
+      sx={props.sx}
+      allFilters={FILTERS}
+      activeFilters={activeFilters}
+      updateFilters={updateFilters}
+    />
+  );
+}

--- a/src/Frontend/Components/AttributionsFilter/__tests__/AttributionsFilter.test.tsx
+++ b/src/Frontend/Components/AttributionsFilter/__tests__/AttributionsFilter.test.tsx
@@ -3,28 +3,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterMultiSelect } from '../FilterMultiSelect';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
   expectFilterIsShown,
   openDropDown,
 } from '../../../test-helpers/general-test-helpers';
-import { FilterType } from '../../../enums/enums';
+import { AttributionsFilterType } from '../../../enums/enums';
 import { Provider } from 'react-redux';
 import { createAppStore } from '../../../state/configure-store';
+import { AttributionsFilter } from '../AttributionsFilter';
 
-describe('FilterMultiSelect', () => {
+describe('AttributionsFilter', () => {
   it('renders the filters in a dropdown', () => {
     const store = createAppStore();
     render(
       <Provider store={store}>
-        <FilterMultiSelect />
+        <AttributionsFilter />
       </Provider>
     );
     openDropDown(screen);
-    expectFilterIsShown(screen, FilterType.OnlyFirstParty);
-    expectFilterIsShown(screen, FilterType.OnlyFollowUp);
-    expectFilterIsShown(screen, FilterType.HideFirstParty);
+    expectFilterIsShown(screen, AttributionsFilterType.OnlyFirstParty);
+    expectFilterIsShown(screen, AttributionsFilterType.OnlyFollowUp);
+    expectFilterIsShown(screen, AttributionsFilterType.HideFirstParty);
+    expectFilterIsShown(screen, AttributionsFilterType.OnlyNeedsReview);
   });
 });

--- a/src/Frontend/Components/FilterMultiSelect/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/FilterMultiSelect/FilterMultiSelect.tsx
@@ -11,22 +11,13 @@ import MuiSelect from '@mui/material/Select';
 import MuiChip from '@mui/material/Chip';
 import MuiBox from '@mui/material/Box';
 import MuiOutlinedInput from '@mui/material/OutlinedInput';
-import { FilterType } from '../../enums/enums';
-import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { updateActiveFilters } from '../../state/actions/view-actions/view-actions';
-import { getActiveFilters } from '../../state/selectors/view-selector';
+import { AttributionsFilterType, ResourcesFilterType } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
 import { SxProps } from '@mui/material';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
-const FILTERS = [
-  FilterType.OnlyFollowUp,
-  FilterType.OnlyFirstParty,
-  FilterType.HideFirstParty,
-  FilterType.OnlyNeedsReview,
-];
 
 const classes = {
   dropDownForm: {
@@ -65,26 +56,26 @@ const classes = {
 };
 
 interface FilterMultiSelectProps {
+  allFilters: Array<AttributionsFilterType | ResourcesFilterType>;
+  activeFilters: Array<AttributionsFilterType | ResourcesFilterType>;
+  updateFilters(filter: AttributionsFilterType | ResourcesFilterType): void;
   sx?: SxProps;
 }
 
 export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
-  const dispatch = useAppDispatch();
-  const activeFilters = Array.from(useAppSelector(getActiveFilters));
-
-  const updateFilters = (filter: FilterType): void => {
-    dispatch(updateActiveFilters(filter));
-  };
-
   function getMenuItems(): Array<ReactElement> {
-    return FILTERS.map((filter) => (
+    return props.allFilters.map((filter) => (
       <MuiMenuItem
         dense
         aria-label={filter}
         key={filter}
         value={filter}
         onClick={(event): void => {
-          updateFilters(event.currentTarget.textContent as FilterType);
+          props.updateFilters(
+            event.currentTarget.textContent as
+              | AttributionsFilterType
+              | ResourcesFilterType
+          );
         }}
       >
         {filter}
@@ -106,7 +97,7 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
         sx={classes.dropDownSelect}
         data-testid="test-id-filter-multi-select"
         multiple
-        value={activeFilters}
+        value={props.activeFilters}
         input={<MuiOutlinedInput />}
         renderValue={(selectedFilters): ReactElement => (
           <MuiBox sx={classes.dropDownBox}>
@@ -121,7 +112,7 @@ export function FilterMultiSelect(props: FilterMultiSelectProps): ReactElement {
                   event.stopPropagation();
                 }}
                 onDelete={(): void => {
-                  updateFilters(filter);
+                  props.updateFilters(filter);
                 }}
               />
             ))}

--- a/src/Frontend/Components/ReportView/ReportView.tsx
+++ b/src/Frontend/Components/ReportView/ReportView.tsx
@@ -21,10 +21,10 @@ import { getAttributionsWithResources } from '../../util/get-attributions-with-r
 import { useFilters } from '../../util/use-filters';
 import { Table } from '../Table/Table';
 import { OpossumColors } from '../../shared-styles';
-import { FilterMultiSelect } from '../Filter/FilterMultiSelect';
 import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import MuiBox from '@mui/material/Box';
 import { AttributionCountsPanel } from '../AttributionCountsPanel/AttributionCountsPanel';
+import { AttributionsFilter } from '../AttributionsFilter/AttributionsFilter';
 
 const classes = {
   root: {
@@ -63,7 +63,7 @@ export function ReportView(): ReactElement {
         onIconClick={getOnIconClick()}
         topElement={
           <>
-            <FilterMultiSelect sx={{ maxWidth: '300px' }} />
+            <AttributionsFilter sx={{ maxWidth: '300px' }} />
             <AttributionCountsPanel
               sx={{ display: 'inline-block', margin: '20px' }}
             />

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -21,7 +21,7 @@ import {
 import { ReportView } from '../ReportView';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { setFrequentLicenses } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import { FilterType } from '../../../enums/enums';
+import { AttributionsFilterType } from '../../../enums/enums';
 
 describe('The ReportView', () => {
   const testResources: Resources = { ['test resource']: 1 };
@@ -102,7 +102,7 @@ describe('The ReportView', () => {
     expect(screen.getByText('Test other package'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
 
     expect(screen.getByText('Test other package'));
     expect(screen.queryByText('Test package')).not.toBeInTheDocument();
@@ -126,12 +126,12 @@ describe('The ReportView', () => {
     expect(screen.getByText('Test other package'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
 
     expect(screen.getByText('Test package'));
     expect(screen.queryByText('Test other package')).not.toBeInTheDocument();
 
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
     expect(screen.getByText('Test package'));
     expect(screen.getByText('Test other package'));
   });
@@ -154,13 +154,13 @@ describe('The ReportView', () => {
     expect(screen.getByText('Test other package'));
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
 
     expect(screen.queryByText('Test package')).not.toBeInTheDocument();
     expect(screen.queryByText('Test other package')).not.toBeInTheDocument();
 
-    clickOnFilter(screen, FilterType.HideFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.HideFirstParty);
 
     expect(screen.getByText('Test other package'));
     expect(screen.queryByText('Test package')).not.toBeInTheDocument();

--- a/src/Frontend/Components/ResourceBrowser/__tests__/resource-browser-helpers.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/resource-browser-helpers.test.ts
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Resources } from '../../../../shared/shared-types';
+import {
+  filterOutAttributedResourcesConsideringSiblings,
+  removePathFromResources,
+} from '../resource-browser-helpers';
+
+describe('filterOutAttributedResourcesConsideringSiblings', () => {
+  it('does not remove parent folder if children have unattributed sibling files', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1 },
+      folder2: { file3: 1 },
+    };
+    const testAttributedResourceIds = new Set(['/folder1/file1']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, file2: 1 },
+      folder2: { file3: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('does not remove parent folder if children have unattributed sibling folders', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+      folder3: { file3: 1 },
+    };
+    const testAttributedResourceIds = new Set(['/folder1/file1']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+      folder3: { file3: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes parent folder if children are all attributed', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1, folder2: { file3: 1 } },
+      folder3: { file4: 1 },
+    };
+    const testAttributedResourceIds = new Set([
+      '/folder1/file1',
+      '/folder1/file2',
+      '/folder1/folder2/file3',
+    ]);
+    const expectedFilteredResources: Resources = {
+      folder3: { file4: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes parent folder if single child is attributed', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1 },
+      folder2: { file3: 1 },
+    };
+    const testAttributedResourceIds = new Set(['/folder2/file3']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, file2: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes parent folder if all descendant files are attributed', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: {
+        file1: 1,
+        folder2: { folder3: { file2: 1, folder4: { folder5: { file3: 1 } } } },
+      },
+    };
+    const testAttributedResourceIds = new Set([
+      '/folder1/folder2/folder3/folder4/folder5/file3',
+    ]);
+    const expectedFilteredResources: Resources = {
+      folder1: {
+        file1: 1,
+        folder2: { folder3: { file2: 1 } },
+      },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes folder if it is attributed, even if sibling files are unattributed', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1, folder2: { file3: 1 } },
+    };
+    const testAttributedResourceIds = new Set(['/folder1/folder2/']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, file2: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes an attributed folder in root directory', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1 },
+      folder2: { file3: 1 },
+    };
+    const testAttributedResourceIds = new Set(['/folder2/']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, file2: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+
+  it('removes an attributed sibling folder if its children are attributed, even if other siblings are unattributed', () => {
+    const testResourcesToFilter: Resources = {
+      folder1: { file1: 1, file2: 1, folder2: { file3: 1 } },
+    };
+    const testAttributedResourceIds = new Set(['/folder1/folder2/file3']);
+    const expectedFilteredResources: Resources = {
+      folder1: { file1: 1, file2: 1 },
+    };
+    const testFilteredResources =
+      filterOutAttributedResourcesConsideringSiblings(
+        testResourcesToFilter,
+        testAttributedResourceIds
+      );
+    expect(testFilteredResources).toEqual(expectedFilteredResources);
+  });
+});
+
+describe('removePathFromResources', () => {
+  it('removes a non-empty folder', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    const testResourcePathToRemove = '/folder1/folder2/';
+    const expectedResourcesWithRemovedPath: Resources = {
+      folder1: { file1: 1 },
+    };
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+
+  it('removes an empty folder', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: {} },
+    };
+    const testResourcePathToRemove = '/folder1/folder2/';
+    const expectedResourcesWithRemovedPath: Resources = {
+      folder1: { file1: 1 },
+    };
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+
+  it('removes a folder in root direcotry', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    const testResourcePathToRemove = '/folder1/';
+    const expectedResourcesWithRemovedPath: Resources = {};
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+
+  it('removes a file', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    const testResourcePathToRemove = '/folder1/file1';
+    const expectedResourcesWithRemovedPath: Resources = {
+      folder1: { folder2: { file2: 1 } },
+    };
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+
+  it('removes nothing if resources do not contain the path to delete', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    const testResourcePathToRemove = '/folder3/file1';
+    const expectedResourcesWithRemovedPath: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+
+  it('removes nothing if path to delete is empty', () => {
+    const testResources: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    const testResourcePathToRemove = '';
+    const expectedResourcesWithRemovedPath: Resources = {
+      folder1: { file1: 1, folder2: { file2: 1 } },
+    };
+    removePathFromResources(testResourcePathToRemove, testResources);
+    expect(testResources).toEqual(expectedResourcesWithRemovedPath);
+  });
+});

--- a/src/Frontend/Components/ResourceBrowser/resource-browser-helpers.ts
+++ b/src/Frontend/Components/ResourceBrowser/resource-browser-helpers.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { isEmpty } from 'lodash';
+import { Resources } from '../../../shared/shared-types';
+
+export function filterOutAttributedResourcesConsideringSiblings(
+  resourcesToFilter: Resources,
+  attributedResourcesIds: Set<string>
+): Resources {
+  const [, filteredResources] = filterSubResources(
+    resourcesToFilter,
+    resourcesToFilter,
+    '/',
+    attributedResourcesIds
+  );
+
+  return filteredResources;
+}
+
+function filterSubResources(
+  partiallyFilteredResources: Resources,
+  currentResource: Resources,
+  currentRoot: string,
+  attributedResourceIds: Set<string>
+): [boolean, Resources] {
+  const childrenNames = Object.keys(currentResource);
+  let allChildrenAreAttributed = true;
+  for (const childName of childrenNames) {
+    const childResource = currentResource[childName];
+    if (childResource === 1) {
+      allChildrenAreAttributed = handleFile(
+        allChildrenAreAttributed,
+        currentRoot,
+        childName,
+        attributedResourceIds
+      );
+    } else if (isEmpty(childResource)) {
+      removePathFromResources(
+        currentRoot + childName + '/',
+        partiallyFilteredResources
+      );
+    } else {
+      ({ allChildrenAreAttributed, partiallyFilteredResources } =
+        handleFolderWithContent(
+          currentRoot,
+          childName,
+          attributedResourceIds,
+          allChildrenAreAttributed,
+          partiallyFilteredResources,
+          childResource
+        ));
+    }
+  }
+
+  if (allChildrenAreAttributed) {
+    removePathFromResources(currentRoot, partiallyFilteredResources);
+  }
+
+  return [allChildrenAreAttributed, partiallyFilteredResources];
+}
+
+function handleFolderWithContent(
+  currentRoot: string,
+  childName: string,
+  attributedResourceIds: Set<string>,
+  allChildrenAreAttributed: boolean,
+  partiallyFilteredResources: Resources,
+  childResource: Resources
+): {
+  allChildrenAreAttributed: boolean;
+  partiallyFilteredResources: Resources;
+} {
+  const folderResourceId = currentRoot + childName + '/';
+  if (resourceIsAttributed(folderResourceId, attributedResourceIds)) {
+    partiallyFilteredResources = handleAttributedFolder(
+      partiallyFilteredResources,
+      folderResourceId
+    );
+  } else {
+    allChildrenAreAttributed = handleUnattributedFolder(
+      partiallyFilteredResources,
+      childResource,
+      currentRoot,
+      childName,
+      attributedResourceIds,
+      allChildrenAreAttributed
+    );
+  }
+  return { allChildrenAreAttributed, partiallyFilteredResources };
+}
+
+function handleUnattributedFolder(
+  partiallyFilteredResources: Resources,
+  childResource: Resources,
+  currentRoot: string,
+  childName: string,
+  attributedResourceIds: Set<string>,
+  allChildrenAreAttributed: boolean
+): boolean {
+  let childsChildrenAreAttributed: boolean;
+  [childsChildrenAreAttributed, partiallyFilteredResources] =
+    filterSubResources(
+      partiallyFilteredResources,
+      childResource,
+      currentRoot + childName + '/',
+      attributedResourceIds
+    );
+  allChildrenAreAttributed =
+    allChildrenAreAttributed && childsChildrenAreAttributed;
+  return allChildrenAreAttributed;
+}
+
+function handleAttributedFolder(
+  partiallyFilteredResources: Resources,
+  folderResourceId: string
+): Resources {
+  removePathFromResources(folderResourceId, partiallyFilteredResources);
+  return partiallyFilteredResources;
+}
+
+export function removePathFromResources(
+  resourcePath: string,
+  resources: Resources
+): void {
+  const isFolder = resourcePath.endsWith('/');
+  const resourcePathSplit = isFolder
+    ? resourcePath.split('/').slice(1, -1)
+    : resourcePath.split('/').slice(1);
+  const pathTail = resourcePathSplit.pop() ?? '';
+  delete resourcePathSplit.reduce((parent: Resources, childName: string) => {
+    const returnValue = parent[childName] || {};
+    return returnValue !== 1 ? returnValue : {};
+  }, resources)[pathTail];
+}
+
+function handleFile(
+  allChildrenAreAttributed: boolean,
+  currentRoot: string,
+  childName: string,
+  attributedResourceIds: Set<string>
+): boolean {
+  return (
+    allChildrenAreAttributed &&
+    isFileAttributed(currentRoot, childName, attributedResourceIds)
+  );
+}
+
+function isFileAttributed(
+  currentRoot: string,
+  childName: string,
+  attributedResourceIds: Set<string>
+): boolean {
+  return resourceIsAttributed(currentRoot + childName, attributedResourceIds);
+}
+
+function resourceIsAttributed(
+  resourceId: string,
+  attributedResourceIds: Set<string>
+): boolean {
+  return attributedResourceIds.has(resourceId);
+}

--- a/src/Frontend/Components/ResourcesFilter/ResourcesFilter.tsx
+++ b/src/Frontend/Components/ResourcesFilter/ResourcesFilter.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { ResourcesFilterType } from '../../enums/enums';
+import { SxProps } from '@mui/material';
+import { FilterMultiSelect } from '../FilterMultiSelect/FilterMultiSelect';
+
+const FILTERS = [ResourcesFilterType.HideAttributed];
+
+interface ResourcesFilterProps {
+  activeFilters: Array<ResourcesFilterType>;
+  updateFilters(filter: ResourcesFilterType): void;
+  sx?: SxProps;
+}
+
+export function ResourcesFilter(props: ResourcesFilterProps): ReactElement {
+  return (
+    <FilterMultiSelect
+      sx={props.sx}
+      allFilters={FILTERS}
+      activeFilters={props.activeFilters}
+      updateFilters={props.updateFilters}
+    />
+  );
+}

--- a/src/Frontend/Components/ResourcesFilter/__tests__/ResourcesFilter.test.tsx
+++ b/src/Frontend/Components/ResourcesFilter/__tests__/ResourcesFilter.test.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  expectFilterIsShown,
+  openDropDown,
+} from '../../../test-helpers/general-test-helpers';
+import { ResourcesFilterType } from '../../../enums/enums';
+import { Provider } from 'react-redux';
+import { createAppStore } from '../../../state/configure-store';
+import { ResourcesFilter } from '../ResourcesFilter';
+import { doNothing } from '../../../util/do-nothing';
+
+describe('ResourcesFilter', () => {
+  it('renders the filters in a dropdown', () => {
+    const store = createAppStore();
+    render(
+      <Provider store={store}>
+        <ResourcesFilter activeFilters={[]} updateFilters={doNothing} />
+      </Provider>
+    );
+    openDropDown(screen);
+    expectFilterIsShown(screen, ResourcesFilterType.HideAttributed);
+  });
+});

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -74,11 +74,15 @@ export enum ButtonText {
   OpenDotOpossumFile = 'Open ".opossum" file',
 }
 
-export enum FilterType {
+export enum AttributionsFilterType {
   OnlyFirstParty = 'Only First Party',
   HideFirstParty = 'Hide First Party',
   OnlyFollowUp = 'Only Follow Up',
   OnlyNeedsReview = 'Only Needs Review',
+}
+
+export enum ResourcesFilterType {
+  HideAttributed = 'Hide Attributed',
 }
 
 export enum CheckboxLabel {

--- a/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests__/all-views.test.tsx
@@ -18,7 +18,7 @@ import { renderComponentWithStore } from '../../../test-helpers/render-component
 import {
   ButtonText,
   CheckboxLabel,
-  FilterType,
+  AttributionsFilterType,
   View,
 } from '../../../enums/enums';
 import { ParsedFileContent } from '../../../../shared/shared-types';
@@ -81,7 +81,7 @@ describe('The App integration', () => {
     clickOnButton(screen, ButtonText.Save);
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
     screen.getByText('JQuery');
     expect(screen.queryByText('Angular')).not.toBeInTheDocument();
     screen.getAllByText('Vue');
@@ -92,12 +92,12 @@ describe('The App integration', () => {
     screen.getByText('Vue');
 
     openDropDown(screen);
-    clickOnFilter(screen, FilterType.OnlyFollowUp);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFollowUp);
     screen.getByText('JQuery');
     screen.getByText('Angular');
     screen.getByText('Vue');
 
-    clickOnFilter(screen, FilterType.OnlyFirstParty);
+    clickOnFilter(screen, AttributionsFilterType.OnlyFirstParty);
     expect(screen.queryByText('JQuery')).not.toBeInTheDocument();
     expect(screen.queryByText('Angular')).not.toBeInTheDocument();
     screen.getByText('Vue');

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -4,7 +4,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType, PopupType, View } from '../../../../enums/enums';
+import {
+  AttributionsFilterType,
+  PopupType,
+  View,
+} from '../../../../enums/enums';
 import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
 import {
   getActiveFilters,
@@ -102,13 +106,17 @@ describe('view actions', () => {
     testStore.dispatch(navigateToView(View.Attribution));
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(setTargetView(View.Audit));
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFollowUp)
+    );
 
     expect(isAttributionViewSelected(testStore.getState())).toBe(true);
     expect(getTargetView(testStore.getState())).toBe(View.Audit);
     expect(getOpenPopup(testStore.getState())).toBe(PopupType.NotSavedPopup);
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFollowUp
+      )
     ).toBe(true);
 
     testStore.dispatch(resetViewState());
@@ -116,38 +124,64 @@ describe('view actions', () => {
     expect(getTargetView(testStore.getState())).toBe(null);
     expect(getOpenPopup(testStore.getState())).toBe(null);
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFollowUp
+      )
     ).toBe(false);
   });
 
   it('sets filters correctly', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFirstParty)
+    );
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFirstParty
+      )
     ).toBe(true);
 
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFirstParty)
+    );
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFirstParty
+      )
     ).toBe(false);
 
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
-    testStore.dispatch(updateActiveFilters(FilterType.HideFirstParty));
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFirstParty)
+    );
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.HideFirstParty)
+    );
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFirstParty
+      )
     ).toBe(false);
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.HideFirstParty)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.HideFirstParty
+      )
     ).toBe(true);
 
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
-    testStore.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFirstParty)
+    );
+    testStore.dispatch(
+      updateActiveFilters(AttributionsFilterType.OnlyFollowUp)
+    );
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFirstParty)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFirstParty
+      )
     ).toBe(true);
     expect(
-      getActiveFilters(testStore.getState()).has(FilterType.OnlyFollowUp)
+      getActiveFilters(testStore.getState()).has(
+        AttributionsFilterType.OnlyFollowUp
+      )
     ).toBe(true);
   });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType, View } from '../../../enums/enums';
+import { AttributionsFilterType, View } from '../../../enums/enums';
 import { PopupInfo } from '../../../types/types';
 
 export const ACTION_SET_TARGET_VIEW = 'ACTION_SET_TARGET_VIEW';
@@ -48,7 +48,7 @@ export interface OpenPopupAction {
 
 export interface UpdateActiveFilters {
   type: typeof ACTION_UPDATE_ACTIVE_FILTERS;
-  payload: FilterType;
+  payload: AttributionsFilterType;
 }
 
 export interface SetIsLoadingAction {

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DisplayPackageInfo } from '../../../../shared/shared-types';
-import { FilterType, PopupType, View } from '../../../enums/enums';
+import { AttributionsFilterType, PopupType, View } from '../../../enums/enums';
 import { State } from '../../../types/types';
 import { getDisplayPackageInfoOfSelectedAttributionInAttributionView } from '../../selectors/all-views-resource-selectors';
 import { getSelectedView } from '../../selectors/view-selector';
@@ -88,7 +88,7 @@ export function closePopup(): ClosePopupAction {
 }
 
 export function updateActiveFilters(
-  filterType: FilterType
+  filterType: AttributionsFilterType
 ): UpdateActiveFilters {
   return {
     type: ACTION_UPDATE_ACTIVE_FILTERS,

--- a/src/Frontend/state/helpers/__tests__/set-filters.test.ts
+++ b/src/Frontend/state/helpers/__tests__/set-filters.test.ts
@@ -3,51 +3,51 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType } from '../../../enums/enums';
+import { AttributionsFilterType } from '../../../enums/enums';
 import { getFiltersToRemove, getUpdatedFilters } from '../set-filters';
 
 describe('The getUpdatedFilters function', () => {
   it('adds non-existing filter', () => {
-    const activeFilters = new Set([FilterType.OnlyFollowUp]);
+    const activeFilters = new Set([AttributionsFilterType.OnlyFollowUp]);
     const expectedFilters = new Set([
-      FilterType.OnlyFollowUp,
-      FilterType.HideFirstParty,
+      AttributionsFilterType.OnlyFollowUp,
+      AttributionsFilterType.HideFirstParty,
     ]);
-    expect(getUpdatedFilters(activeFilters, FilterType.HideFirstParty)).toEqual(
-      expectedFilters
-    );
+    expect(
+      getUpdatedFilters(activeFilters, AttributionsFilterType.HideFirstParty)
+    ).toEqual(expectedFilters);
   });
 
   it('remove existing filter', () => {
     const activeFilters = new Set([
-      FilterType.OnlyFollowUp,
-      FilterType.HideFirstParty,
+      AttributionsFilterType.OnlyFollowUp,
+      AttributionsFilterType.HideFirstParty,
     ]);
-    const expectedFilters = new Set([FilterType.OnlyFollowUp]);
-    expect(getUpdatedFilters(activeFilters, FilterType.HideFirstParty)).toEqual(
-      expectedFilters
-    );
+    const expectedFilters = new Set([AttributionsFilterType.OnlyFollowUp]);
+    expect(
+      getUpdatedFilters(activeFilters, AttributionsFilterType.HideFirstParty)
+    ).toEqual(expectedFilters);
   });
 });
 
 describe('The getFiltersToRemove function', () => {
   it('returns only first party filter when the new filter is hide first party', () => {
-    const filtersToRemove = new Set([FilterType.OnlyFirstParty]);
-    expect(getFiltersToRemove(FilterType.HideFirstParty)).toEqual(
+    const filtersToRemove = new Set([AttributionsFilterType.OnlyFirstParty]);
+    expect(getFiltersToRemove(AttributionsFilterType.HideFirstParty)).toEqual(
       filtersToRemove
     );
   });
 
   it('returns hide first party filter when the new filter is only first party', () => {
-    const filtersToRemove = new Set([FilterType.HideFirstParty]);
-    expect(getFiltersToRemove(FilterType.OnlyFirstParty)).toEqual(
+    const filtersToRemove = new Set([AttributionsFilterType.HideFirstParty]);
+    expect(getFiltersToRemove(AttributionsFilterType.OnlyFirstParty)).toEqual(
       filtersToRemove
     );
   });
 
   it('returns no filter when the new filter is only follow up', () => {
     const filtersToRemove = new Set();
-    expect(getFiltersToRemove(FilterType.OnlyFollowUp)).toEqual(
+    expect(getFiltersToRemove(AttributionsFilterType.OnlyFollowUp)).toEqual(
       filtersToRemove
     );
   });

--- a/src/Frontend/state/helpers/set-filters.ts
+++ b/src/Frontend/state/helpers/set-filters.ts
@@ -3,16 +3,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType } from '../../enums/enums';
+import { AttributionsFilterType } from '../../enums/enums';
 
 const mutuallyExclusiveFilters = [
-  [FilterType.OnlyFirstParty, FilterType.HideFirstParty],
+  [
+    AttributionsFilterType.OnlyFirstParty,
+    AttributionsFilterType.HideFirstParty,
+  ],
 ];
 
 export function getUpdatedFilters(
-  activeFilters: Set<FilterType>,
-  newFilter: FilterType
-): Set<FilterType> {
+  activeFilters: Set<AttributionsFilterType>,
+  newFilter: AttributionsFilterType
+): Set<AttributionsFilterType> {
   const currentFilters = new Set(activeFilters);
   if (currentFilters.has(newFilter)) {
     currentFilters.delete(newFilter);
@@ -26,7 +29,9 @@ export function getUpdatedFilters(
   return currentFilters;
 }
 
-export function getFiltersToRemove(newFilter: FilterType): Set<FilterType> {
+export function getFiltersToRemove(
+  newFilter: AttributionsFilterType
+): Set<AttributionsFilterType> {
   return new Set(
     mutuallyExclusiveFilters
       .filter((filterPair) => filterPair.includes(newFilter))

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType, View } from '../../enums/enums';
+import { AttributionsFilterType, View } from '../../enums/enums';
 import { PopupInfo } from '../../types/types';
 import {
   ACTION_CLOSE_POPUP,
@@ -22,7 +22,7 @@ export interface ViewState {
   view: View;
   targetView: View | null;
   popupInfo: Array<PopupInfo>;
-  activeFilters: Set<FilterType>;
+  activeFilters: Set<AttributionsFilterType>;
   isLoading: boolean;
 }
 
@@ -30,7 +30,7 @@ export const initialViewState: ViewState = {
   view: View.Audit,
   targetView: null,
   popupInfo: [],
-  activeFilters: new Set<FilterType>(),
+  activeFilters: new Set<AttributionsFilterType>(),
   isLoading: false,
 };
 

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterType, PopupType, View } from '../../enums/enums';
+import { AttributionsFilterType, PopupType, View } from '../../enums/enums';
 import { State } from '../../types/types';
 
 export function isAttributionViewSelected(state: State): boolean {
@@ -33,7 +33,7 @@ export function getOpenPopup(state: State): null | PopupType {
   return popup.length === 1 ? popup[0].popup : null;
 }
 
-export function getActiveFilters(state: State): Set<FilterType> {
+export function getActiveFilters(state: State): Set<AttributionsFilterType> {
   return state.viewState.activeFilters;
 }
 

--- a/src/Frontend/util/__tests__/use-filters.test.tsx
+++ b/src/Frontend/util/__tests__/use-filters.test.tsx
@@ -11,7 +11,7 @@ import {
   renderComponentWithStore,
 } from '../../test-helpers/render-component-with-store';
 import { updateActiveFilters } from '../../state/actions/view-actions/view-actions';
-import { FilterType } from '../../enums/enums';
+import { AttributionsFilterType } from '../../enums/enums';
 
 let filteredAttributions: Attributions;
 
@@ -48,7 +48,7 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with follow-up filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyFollowUp));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }
@@ -69,7 +69,7 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with only first party filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyFirstParty));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }
@@ -81,7 +81,7 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with hide first party filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.HideFirstParty));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }
@@ -93,8 +93,8 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with only first party and follow up filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.OnlyFirstParty));
-    store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyFirstParty));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyFollowUp));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }
@@ -104,8 +104,8 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with hide first party and follow up filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.HideFirstParty));
-    store.dispatch(updateActiveFilters(FilterType.OnlyFollowUp));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.HideFirstParty));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyFollowUp));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }
@@ -117,7 +117,7 @@ describe('useFollowUpFilter', () => {
 
   it('returns working getFilteredAttributions with only needs review filter', () => {
     const store = createTestAppStore();
-    store.dispatch(updateActiveFilters(FilterType.OnlyNeedsReview));
+    store.dispatch(updateActiveFilters(AttributionsFilterType.OnlyNeedsReview));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store }

--- a/src/Frontend/util/use-filters.ts
+++ b/src/Frontend/util/use-filters.ts
@@ -9,7 +9,7 @@ import {
   AttributionsWithResources,
   PackageInfo,
 } from '../../shared/shared-types';
-import { FilterType } from '../enums/enums';
+import { AttributionsFilterType } from '../enums/enums';
 import { useAppSelector } from '../state/hooks';
 import { getActiveFilters } from '../state/selectors/view-selector';
 
@@ -22,16 +22,16 @@ export function useFilters(
 ): AttributionsWithResources | Attributions {
   const activeFilters = useAppSelector(getActiveFilters);
 
-  attributions = activeFilters.has(FilterType.OnlyFollowUp)
+  attributions = activeFilters.has(AttributionsFilterType.OnlyFollowUp)
     ? pickBy(attributions, (value: PackageInfo) => value.followUp)
     : attributions;
-  attributions = activeFilters.has(FilterType.OnlyFirstParty)
+  attributions = activeFilters.has(AttributionsFilterType.OnlyFirstParty)
     ? pickBy(attributions, (value: PackageInfo) => value.firstParty)
     : attributions;
-  attributions = activeFilters.has(FilterType.HideFirstParty)
+  attributions = activeFilters.has(AttributionsFilterType.HideFirstParty)
     ? pickBy(attributions, (value: PackageInfo) => !value.firstParty)
     : attributions;
-  attributions = activeFilters.has(FilterType.OnlyNeedsReview)
+  attributions = activeFilters.has(AttributionsFilterType.OnlyNeedsReview)
     ? pickBy(attributions, (value: PackageInfo) => value.needsReview)
     : attributions;
   return attributions;


### PR DESCRIPTION
### Summary of changes

Add filter section to resources browser. Allow the user to filter out attributed resources such that only unattributed resources remain. To provide context to the user, do not hide attributed files that are siblings to unattributed ones.

### Context and reason for change

Simplify finding unattributed resources to improve focus and efficacy of the user.

### How can the changes be tested

Run tests in `...\ResourceBrowser\__tests__\resource-browser-helpers.test.ts` or use test files and do it manually.

### Additional comments

Loggings for measuring filter speed are removed before merging the code and can be used to assess filter performance with different input files. The filter section is adopted from the one in the attribution view (multi select) as it is planned to add more filters. Additionally, some refactoring was performed to account for having multiple types of filters now (resources and attributions).

Unfiltered resource browser:
![Screenshot 2023-07-10 095337](https://github.com/opossum-tool/OpossumUI/assets/83081698/0b036fc0-1b2a-4d75-85fe-21863d064044)

Filtered resource browser:
![Screenshot 2023-07-10 095406](https://github.com/opossum-tool/OpossumUI/assets/83081698/75c44142-f175-4c7b-aed5-5921226e5741)


Fix: #1479 
