### PR TITLE
Resource icon is grey after deletion of all manual attribution

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/__tests__/get-resource-browser-tree-item-label.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/get-resource-browser-tree-item-label.test.ts
@@ -3,8 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Criticality } from '../../../../shared/shared-types';
-import { getCriticality } from '../get-resource-browser-tree-item-label';
+import {
+  Criticality,
+  ResourcesWithAttributedChildren,
+} from '../../../../shared/shared-types';
+import {
+  containsManualAttribution,
+  getCriticality,
+} from '../get-resource-browser-tree-item-label';
 
 describe('Tree item labels', () => {
   it('checks resource getCriticality', () => {
@@ -35,4 +41,27 @@ describe('Tree item labels', () => {
       expect(criticality).toEqual(expectedCriticalities[nodeId]);
     }
   });
+});
+
+describe('Manual attributions', () => {
+  it.each`
+    nodeId     | expectedReturn
+    ${'path1'} | ${true}
+    ${'path2'} | ${true}
+    ${'path3'} | ${false}
+    ${'path4'} | ${false}
+  `(
+    'checks if $nodeId containsManualAttribution: $expectedReturn',
+    ({ nodeId, expectedReturn }) => {
+      const resourcesWithManualAttributedChildren: ResourcesWithAttributedChildren =
+        {
+          paths: ['path1', 'path2'],
+          pathsToIndices: { path1: 1, path3: 3 },
+          attributedChildren: { 1: new Set([]) },
+        };
+      expect(
+        containsManualAttribution(nodeId, resourcesWithManualAttributedChildren)
+      ).toEqual(expectedReturn);
+    }
+  );
 });

--- a/src/Frontend/Components/ResourceBrowser/get-resource-browser-tree-item-label.tsx
+++ b/src/Frontend/Components/ResourceBrowser/get-resource-browser-tree-item-label.tsx
@@ -159,13 +159,13 @@ function containsExternalAttribution(
   );
 }
 
-function containsManualAttribution(
+export function containsManualAttribution(
   nodeId: string,
   resourcesWithManualAttributedChildren: ResourcesWithAttributedChildren
 ): boolean {
   return (
     resourcesWithManualAttributedChildren &&
-    nodeId in resourcesWithManualAttributedChildren.pathsToIndices
+    resourcesWithManualAttributedChildren.paths.includes(nodeId)
   );
 }
 


### PR DESCRIPTION
### Summary of changes

resourcesWithManualAttributedChildren.pathToIndices is not updated once attribution is deleted. Paths is the correct list which is updated.

### Context and reason for change

Fix #1685

### How can the changes be tested

Start the app, find any resource without attributions (resource with grey icon), create a new attribution for the resource, delete it and check the color of resource icon (it has to be in the same state as it was at the beginning - grey)
