### PR TITLE
Fix tooltip

### DIFF
--- a/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/FetchLicenseInformationButton.tsx
@@ -53,8 +53,10 @@ const classes = {
 };
 
 export const FETCH_DATA_TOOLTIP = 'Fetch data';
-export const FETCH_DATA_BUTTON_DISABLED_TOOLTIP =
+export const FETCH_DATA_INVALID_DOMAIN_TOOLTIP =
   'Fetching data is not possible. Please enter a URL with one of the following domains: pypi.org, npmjs.com, github.com.';
+export const FETCH_DATA_FOR_SIGNALS_TOOLTIP =
+  'Fetching data is not possible. Signals cannot be modified.';
 
 export enum FetchStatus {
   Idle = 'Idle',
@@ -126,10 +128,15 @@ export function useFetchPackageInfo(props: LicenseFetchingInformation): {
   };
 }
 
-function DisabledFetchLicenseInformationButton(): ReactElement {
+interface DisabledFetchLicenseInformationButtonProps {
+  tooltipText: string;
+}
+function DisabledFetchLicenseInformationButton(
+  props: DisabledFetchLicenseInformationButtonProps,
+): ReactElement {
   return (
     <IconButton
-      tooltipTitle={FETCH_DATA_BUTTON_DISABLED_TOOLTIP}
+      tooltipTitle={props.tooltipText}
       tooltipPlacement="right"
       disabled={true}
       onClick={doNothing}
@@ -200,6 +207,12 @@ export function FetchLicenseInformationButton(props: {
       convertPayload={licenseFetchingInformation.convertPayload}
     />
   ) : (
-    <DisabledFetchLicenseInformationButton />
+    <DisabledFetchLicenseInformationButton
+      tooltipText={
+        props.disabled
+          ? FETCH_DATA_FOR_SIGNALS_TOOLTIP
+          : FETCH_DATA_INVALID_DOMAIN_TOOLTIP
+      }
+    />
   );
 }

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -6,7 +6,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { ReactElement, ReactNode } from 'react';
 import {
-  FETCH_DATA_BUTTON_DISABLED_TOOLTIP,
+  FETCH_DATA_FOR_SIGNALS_TOOLTIP,
+  FETCH_DATA_INVALID_DOMAIN_TOOLTIP,
   FETCH_DATA_TOOLTIP,
   FetchLicenseInformationButton,
   FetchStatus,
@@ -29,9 +30,23 @@ const axiosMock = new MockAdapter(axios);
 
 describe('FetchLicenseInformationButton', () => {
   it('renders disabled button', () => {
-    render(<FetchLicenseInformationButton disabled={true} url={''} />);
+    render(
+      <FetchLicenseInformationButton
+        disabled={true}
+        url={'https://github.com/reactchartjs/react-chartjs-2/tree/d8c'}
+      />,
+    );
     expect(
-      screen.getByLabelText(FETCH_DATA_BUTTON_DISABLED_TOOLTIP),
+      screen.getByLabelText(FETCH_DATA_FOR_SIGNALS_TOOLTIP),
+    ).toBeInTheDocument();
+  });
+
+  it('renders tooltip vor invalid domain', () => {
+    render(
+      <FetchLicenseInformationButton disabled={false} url={'invalid url'} />,
+    );
+    expect(
+      screen.getByLabelText(FETCH_DATA_INVALID_DOMAIN_TOOLTIP),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
### Summary of changes

Introduce new tooltip for fetch data button in order to inform the user that fetching data is not possible for signals.

### Context and reason for change

Fix: #1821

### How can the changes be tested

Observe correct tooltips in OpossumUI.
