### PR TITLE
Fix computation of "files with only external attribution count"

### DIFF
--- a/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/progress-bar-data-helpers.test.ts
@@ -21,6 +21,11 @@ describe('The getUpdatedProgressBarData function', () => {
   it('gets updated progress data', () => {
     const testResources: Resources = {
       thirdParty: {
+        package: {
+          contents: {
+            'readme.txt': 1,
+          },
+        },
         'package_1.tr.gz': 1,
         'package_2.tr.gz': 1,
       },
@@ -89,6 +94,7 @@ describe('The getUpdatedProgressBarData function', () => {
       '/thirdParty/package_2.tr.gz': [
         testMediumCriticalExternalAttributionUuid,
       ],
+      '/thirdParty/package/': [testMediumCriticalExternalAttributionUuid],
     };
 
     const progressBarData = getUpdatedProgressBarData({
@@ -102,13 +108,20 @@ describe('The getUpdatedProgressBarData function', () => {
       attributionBreakpoints: new Set<string>(),
       filesWithChildren: new Set<string>(),
     });
-    const expectedNumberOfFiles = 4;
+    const expectedNumberOfFiles = 5;
+    const expectedNumberOfFilesWithOnlyExternalAttribution = 3;
     expect(progressBarData.fileCount).toEqual(expectedNumberOfFiles);
     expect(progressBarData.filesWithManualAttributionCount).toEqual(1);
-    expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(2);
+    expect(progressBarData.filesWithOnlyExternalAttributionCount).toEqual(
+      expectedNumberOfFilesWithOnlyExternalAttribution,
+    );
     expect(
       progressBarData.resourcesWithNonInheritedExternalAttributionOnly,
-    ).toEqual(['/thirdParty/package_1.tr.gz', '/thirdParty/package_2.tr.gz']);
+    ).toEqual([
+      '/thirdParty/package/',
+      '/thirdParty/package_1.tr.gz',
+      '/thirdParty/package_2.tr.gz',
+    ]);
     expect(
       progressBarData.filesWithHighlyCriticalExternalAttributionsCount,
     ).toEqual(1);
@@ -120,7 +133,7 @@ describe('The getUpdatedProgressBarData function', () => {
     ).toEqual(1);
     expect(
       progressBarData.resourcesWithMediumCriticalExternalAttributions,
-    ).toEqual(['/thirdParty/package_2.tr.gz']);
+    ).toEqual(['/thirdParty/package/', '/thirdParty/package_2.tr.gz']);
   });
 
   it('gets updated progress data without resolved external attributions', () => {

--- a/src/Frontend/state/helpers/progress-bar-data-helpers.ts
+++ b/src/Frontend/state/helpers/progress-bar-data-helpers.ts
@@ -149,7 +149,8 @@ function updateProgressBarDataForResources(
         path,
         hasManualAttribution && !isBreakpoint,
         hasOnlyPreselectedAttribution && !isBreakpoint,
-        hasNonInheritedExternalAttributions && !isBreakpoint,
+        (hasNonInheritedExternalAttributions || hasParentExternalAttribution) &&
+          !isBreakpoint,
       );
     }
   }


### PR DESCRIPTION
### Summary of changes

Fix computation of "files with only external attribution count"

### Context and reason for change

When calculating the number of "Files with only signals" for the tooltip of the progress bar, we want to sum up all files that only have a signal and all files that only have a parent which only has a signal. Before this fix, the logic was such that only files with a direct parent with signal were counted, but not files with a parent higher up the tree, that has a signal.

### How can the changes be tested

For one example Opossum input file, we calculated the number that should be shown in the metrics by hand and compared it to the displayed number. We also used a console log to verify that the correct paths were counted.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
