### PR TITLE
Remove unnecessary columns from report view

### DIFF
--- a/src/Frontend/Components/ReportTableHeader/__tests__/ReportTableHeader.test.tsx
+++ b/src/Frontend/Components/ReportTableHeader/__tests__/ReportTableHeader.test.tsx
@@ -20,9 +20,6 @@ describe('The report view table header', () => {
     expect(screen.getByText('Confidence'));
     expect(screen.getByText('Comment'));
     expect(screen.getByText('URL'));
-    expect(screen.getByText('First Party'));
-    expect(screen.getByText('Follow-up'));
     expect(screen.getByText('Resources'));
-    expect(screen.getByText('Excluded'));
   });
 });

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -54,10 +54,6 @@ describe('The ReportTableItem', () => {
 
     expect(screen.getByText('packageWebsite'));
 
-    expect(screen.getByText('Yes'));
-
-    expect(screen.getAllByText('No')).toHaveLength(2);
-
     expect(screen.getByText('/'));
   });
 

--- a/src/Frontend/Components/Table/Table.tsx
+++ b/src/Frontend/Components/Table/Table.tsx
@@ -90,21 +90,6 @@ export const tableConfigs: Array<TableConfig> = [
     width: 'small',
   },
   { attributionProperty: 'comment', displayName: 'Comment', width: 'small' },
-  {
-    attributionProperty: 'followUp',
-    displayName: 'Follow-up',
-    width: 'small',
-  },
-  {
-    attributionProperty: 'excludeFromNotice',
-    displayName: 'Excluded',
-    width: 'small',
-  },
-  {
-    attributionProperty: 'firstParty',
-    displayName: 'First Party',
-    width: 'small',
-  },
 ];
 
 interface TableProps {

--- a/src/Frontend/Components/Table/__tests__/Table.test.tsx
+++ b/src/Frontend/Components/Table/__tests__/Table.test.tsx
@@ -68,12 +68,6 @@ describe('The Table', () => {
     expect(screen.getByText('URL'));
     expect(screen.getByText('packageWebsite'));
 
-    expect(screen.getByText('First Party'));
-    expect(screen.getByText('Yes'));
-
-    expect(screen.getByText('Follow-up'));
-    expect(screen.getAllByText('No'));
-
     expect(screen.getByText('Resources'));
     expect(screen.getByText('/'));
 


### PR DESCRIPTION
### Summary of changes

Remove follow-up, first party and excluded column from report view.

### Context and reason for change

These columns are no longer needed as we instead display icons in the first column of the table.

### How can the changes be tested

Open report view in OpossumUI
