### PR TITLE
Introduce new locatePopup filter state

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Criticality } from '../../../../../shared/shared-types';
+import { createTestAppStore } from '../../../../test-helpers/render-component-with-store';
+import {
+  getLocatePopupSelectedCriticality,
+  getLocatePopupSelectedLicenses,
+} from '../../../selectors/locate-popup-selectors';
+import {
+  setLocatePopupSelectedCriticality,
+  setLocatePopupSelectedLicenses,
+} from '../locate-popup-actions';
+
+describe('The locatePopup actions', () => {
+  it('sets and gets selected criticality', () => {
+    const testStore = createTestAppStore();
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe('any');
+
+    testStore.dispatch(setLocatePopupSelectedCriticality(Criticality.High));
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      Criticality.High,
+    );
+  });
+
+  it('sets and gets selected licenses', () => {
+    const testStore = createTestAppStore();
+    expect(getLocatePopupSelectedLicenses(testStore.getState()).size).toBe(0);
+
+    testStore.dispatch(
+      setLocatePopupSelectedLicenses(new Set<string>(['testLicenseId'])),
+    );
+    expect(getLocatePopupSelectedLicenses(testStore.getState())).toEqual(
+      new Set<string>(['testLicenseId']),
+    );
+  });
+});

--- a/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SelectedCriticality } from '../../../types/types';
+import {
+  SetLocatePopupSelectedCriticality,
+  ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
+  SetLocatePopupSelectedLicenses,
+  ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
+} from './types';
+
+export function setLocatePopupSelectedCriticality(
+  selectedCriticality: SelectedCriticality,
+): SetLocatePopupSelectedCriticality {
+  return {
+    type: ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
+    payload: selectedCriticality,
+  };
+}
+
+export function setLocatePopupSelectedLicenses(
+  selectedLicenses: Set<string>,
+): SetLocatePopupSelectedLicenses {
+  return {
+    type: ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
+    payload: selectedLicenses,
+  };
+}

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -20,6 +20,7 @@ import {
   PanelPackage,
   PackageAttributeIds,
   PackageAttributes,
+  SelectedCriticality,
 } from '../../../types/types';
 
 export const ACTION_SET_SELECTED_ATTRIBUTION_ID =
@@ -92,6 +93,10 @@ export const ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT =
   'ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT';
 export const ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES =
   'ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES';
+export const ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY =
+  'ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY';
+export const ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES =
+  'ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -133,7 +138,9 @@ export type ResourceAction =
   | SetAttributionWizardPackageVersions
   | SetAttributionWizardSelectedPackageIds
   | SetAttributionWizardTotalAttributionCount
-  | SetExternalAttributionsToHashes;
+  | SetExternalAttributionsToHashes
+  | SetLocatePopupSelectedCriticality
+  | SetLocatePopupSelectedLicenses;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -351,4 +358,14 @@ export interface SetAttributionWizardTotalAttributionCount {
 export interface SetExternalAttributionsToHashes {
   type: typeof ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES;
   payload: AttributionsToHashes;
+}
+
+export interface SetLocatePopupSelectedCriticality {
+  type: typeof ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY;
+  payload: SelectedCriticality;
+}
+
+export interface SetLocatePopupSelectedLicenses {
+  type: typeof ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES;
+  payload: Set<string>;
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import {
+  SelectedCriticality,
   PackageAttributeIds,
   PackageAttributes,
   PanelPackage,
@@ -68,6 +69,8 @@ import {
   ACTION_UNLINK_RESOURCE_FROM_ATTRIBUTION,
   ACTION_UPDATE_ATTRIBUTION,
   ResourceAction,
+  ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
+  ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
 } from '../actions/resource-actions/types';
 import {
   createManualAttribution,
@@ -136,6 +139,10 @@ export const initialResourceState: ResourceState = {
     },
     totalAttributionCount: null,
   },
+  locatePopup: {
+    selectedCriticality: 'any',
+    selectedLicenses: new Set(),
+  },
 };
 
 export type ResourceState = {
@@ -181,6 +188,10 @@ export type ResourceState = {
     packageVersions: PackageAttributes;
     selectedPackageAttributeIds: PackageAttributeIds;
     totalAttributionCount: number | null;
+  };
+  locatePopup: {
+    selectedCriticality: SelectedCriticality;
+    selectedLicenses: Set<string>;
   };
 };
 
@@ -823,6 +834,22 @@ export const resourceState = (
         allViews: {
           ...state.allViews,
           externalAttributionsToHashes: action.payload,
+        },
+      };
+    case ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY:
+      return {
+        ...state,
+        locatePopup: {
+          ...state.locatePopup,
+          selectedCriticality: action.payload,
+        },
+      };
+    case ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES:
+      return {
+        ...state,
+        locatePopup: {
+          ...state.locatePopup,
+          selectedLicenses: action.payload,
         },
       };
     default:

--- a/src/Frontend/state/selectors/locate-popup-selectors.ts
+++ b/src/Frontend/state/selectors/locate-popup-selectors.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SelectedCriticality, State } from '../../types/types';
+
+export function getLocatePopupSelectedCriticality(
+  state: State,
+): SelectedCriticality {
+  return state.resourceState.locatePopup.selectedCriticality;
+}
+
+export function getLocatePopupSelectedLicenses(state: State): Set<string> {
+  return state.resourceState.locatePopup.selectedLicenses;
+}

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -190,3 +190,5 @@ export interface DisplayPackageInfos {
 export interface DisplayPackageInfosWithCount {
   [packageCardId: string]: DisplayPackageInfoWithCount;
 }
+
+export type SelectedCriticality = Criticality | 'any';


### PR DESCRIPTION
Issue: #1939

### Summary of changes

Introduce a new filter state in resource state:

```
locatePopup: {
 selectedCriticality: Criticality | "any"   (introduce new type for this one),
 selectedLicenses: Set<string>;
}
```

as well as getters and setters.

### Context and reason for change

This state is intended to be used by a new locate popup, that will make is possible to search for attributions by criticality and/or by licenses.

### How can the changes be tested

See unit tests