### PR TITLE
Add LocatorPopup to find signals

### DIFF
--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -24,6 +24,7 @@ import { AttributionWizardPopup } from '../AttributionWizardPopup/AttributionWiz
 import { FileSupportPopup } from '../FileSupportPopup/FileSupportPopup';
 import { FileSupportDotOpossumAlreadyExistsPopup } from '../FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup';
 import { UpdateAppPopup } from '../UpdateAppPopup/UpdateAppPopup';
+import { LocatorPopup } from '../LocatorPopup/LocatorPopup';
 
 function getPopupComponent(popupType: PopupType | null): ReactElement | null {
   switch (popupType) {
@@ -61,6 +62,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <FileSupportDotOpossumAlreadyExistsPopup />;
     case PopupType.UpdateAppPopup:
       return <UpdateAppPopup />;
+    case PopupType.LocatorPopup:
+      return <LocatorPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { ReactElement } from 'react';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { closePopup } from '../../state/actions/view-actions/view-actions';
+import { ButtonText } from '../../enums/enums';
+import { useAppDispatch } from '../../state/hooks';
+
+export function LocatorPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+  function close(): void {
+    dispatch(closePopup());
+  }
+
+  const content = <></>;
+
+  return (
+    <NotificationPopup
+      content={content}
+      header={'Locate Signals'}
+      isOpen={true}
+      fullWidth={true}
+      leftButtonConfig={{
+        onClick: (): void => {},
+        buttonText: ButtonText.Clear,
+      }}
+      centerLeftButtonConfig={{
+        onClick: (): void => {},
+        buttonText: ButtonText.Apply,
+      }}
+      rightButtonConfig={{
+        onClick: close,
+        buttonText: ButtonText.Cancel,
+      }}
+      onBackdropClick={close}
+      onEscapeKeyDown={close}
+    />
+  );
+}

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { LocatorPopup } from '../LocatorPopup';
+
+describe('Locator popup ', () => {
+  jest.useFakeTimers();
+
+  it('renders', () => {
+    renderComponentWithStore(<LocatorPopup />);
+    expect(
+      screen.getByText('Locate Signals', { exact: true }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -28,6 +28,7 @@ export enum PopupType {
   FileSupportPopup = 'FileSupportPopup',
   FileSupportDotOpossumAlreadyExistsPopup = 'FileSupportDotOpossumAlreadyExistsPopup',
   UpdateAppPopup = 'UpdateAppPopup',
+  LocatorPopup = 'LocatorPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -51,6 +52,7 @@ export enum ButtonText {
   Back = 'Back',
   Close = 'Close',
   Cancel = 'Cancel',
+  Clear = 'Clear',
   Confirm = 'Confirm',
   ConfirmGlobally = 'Confirm globally',
   ConfirmSelectedGlobally = 'Confirm selected globally',


### PR DESCRIPTION
### Summary of changes

This diff adds the skeleton for a locator popup. 

### Context and reason for change

We want to introduce a new feature which enables the user to search for signals based on criticality and licenses.

### How can the changes be tested

See the unit tests. We have a different ticket to make the popup appear with a shortcut, once this is implemented one can see the actual popup. 

Issue: #1938 