### PR TITLE
Introduce resourcesWithLocatedAttributions state

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -32,6 +32,7 @@ import {
   getResourcesToManualAttributions,
   getResourcesWithExternalAttributedChildren,
   getResourcesWithManualAttributedChildren,
+  getResourcesWithLocatedAttributions,
   getTemporaryDisplayPackageInfo,
 } from '../../../selectors/all-views-resource-selectors';
 import {
@@ -43,6 +44,7 @@ import {
   setFrequentLicenses,
   setManualData,
   setResources,
+  setResourcesWithLocatedAttributions,
   setTemporaryDisplayPackageInfo,
 } from '../all-views-simple-actions';
 import { setSelectedResourceId } from '../audit-view-simple-actions';
@@ -307,5 +309,35 @@ describe('The load and navigation simple actions', () => {
     expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
       testExternalAttributionsToHashes,
     );
+  });
+
+  it('sets and gets resourcesWithLocatedAttributions', () => {
+    const testStore = createTestAppStore();
+    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
+      resourcesWithLocatedChildren: {
+        attributedChildren: {},
+        paths: [],
+        pathsToIndices: {},
+      },
+      locatedResources: new Set(),
+    });
+
+    const testResourcesWithLocatedChildren = {
+      paths: Array<string>('path/to/resource/1'),
+      pathsToIndices: { 'path/to/resource/1': 1 },
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      attributedChildren: { 1: new Set<number>([10, 11, 12]) },
+    };
+    const testLocatedResources = new Set<string>(['test resource']);
+    testStore.dispatch(
+      setResourcesWithLocatedAttributions(
+        testResourcesWithLocatedChildren,
+        testLocatedResources,
+      ),
+    );
+    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
+      resourcesWithLocatedChildren: testResourcesWithLocatedChildren,
+      locatedResources: testLocatedResources,
+    });
   });
 });

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -13,6 +13,7 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
+  ResourcesWithAttributedChildren,
 } from '../../../../shared/shared-types';
 import { getAttributionDataFromSetAttributionDataPayload } from '../../helpers/action-and-reducer-helpers';
 import {
@@ -40,6 +41,8 @@ import {
   SetProjectMetadata,
   SetResourcesAction,
   SetTemporaryDisplayPackageInfoAction,
+  SetResourcesWithLocatedAttributions,
+  ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS,
 } from './types';
 
 export function resetResourceState(): ResetResourceStateAction {
@@ -139,5 +142,18 @@ export function setExternalAttributionsToHashes(
   return {
     type: ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES,
     payload: externalAttributionsToHashes,
+  };
+}
+
+export function setResourcesWithLocatedAttributions(
+  resourcesWithLocatedChildren: ResourcesWithAttributedChildren,
+  locatedResources: Set<string>,
+): SetResourcesWithLocatedAttributions {
+  return {
+    type: ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS,
+    payload: {
+      resourcesWithLocatedChildren,
+      locatedResources,
+    },
   };
 }

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -15,6 +15,7 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
+  ResourcesWithAttributedChildren,
 } from '../../../../shared/shared-types';
 import {
   PanelPackage,
@@ -97,6 +98,8 @@ export const ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY =
   'ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY';
 export const ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES =
   'ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES';
+export const ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS =
+  'ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -140,7 +143,8 @@ export type ResourceAction =
   | SetAttributionWizardTotalAttributionCount
   | SetExternalAttributionsToHashes
   | SetLocatePopupSelectedCriticality
-  | SetLocatePopupSelectedLicenses;
+  | SetLocatePopupSelectedLicenses
+  | SetResourcesWithLocatedAttributions;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -368,4 +372,12 @@ export interface SetLocatePopupSelectedCriticality {
 export interface SetLocatePopupSelectedLicenses {
   type: typeof ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES;
   payload: Set<string>;
+}
+
+export interface SetResourcesWithLocatedAttributions {
+  type: typeof ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS;
+  payload: {
+    resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+    locatedResources: Set<string>;
+  };
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -12,6 +12,7 @@ import {
   FrequentLicenses,
   ProjectMetadata,
   Resources,
+  ResourcesWithAttributedChildren,
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import {
@@ -71,6 +72,7 @@ import {
   ResourceAction,
   ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
   ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
+  ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS,
 } from '../actions/resource-actions/types';
 import {
   createManualAttribution,
@@ -106,6 +108,14 @@ export const initialResourceState: ResourceState = {
     externalAttributionSources: {},
     attributionIdMarkedForReplacement: '',
     externalAttributionsToHashes: {},
+    resourcesWithLocatedAttributions: {
+      resourcesWithLocatedChildren: {
+        paths: [],
+        pathsToIndices: {},
+        attributedChildren: {},
+      },
+      locatedResources: new Set(),
+    },
   },
   auditView: {
     selectedResourceId: '',
@@ -160,6 +170,10 @@ export type ResourceState = {
     externalAttributionSources: ExternalAttributionSources;
     attributionIdMarkedForReplacement: string;
     externalAttributionsToHashes: AttributionsToHashes;
+    resourcesWithLocatedAttributions: {
+      resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+      locatedResources: Set<string>;
+    };
   };
   auditView: {
     selectedResourceId: string;
@@ -850,6 +864,14 @@ export const resourceState = (
         locatePopup: {
           ...state.locatePopup,
           selectedLicenses: action.payload,
+        },
+      };
+    case ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS:
+      return {
+        ...state,
+        allViews: {
+          ...state.allViews,
+          resourcesWithLocatedAttributions: action.payload,
         },
       };
     default:

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -229,3 +229,10 @@ export function getExternalAttributionsToHashes(
 ): AttributionsToHashes {
   return state.resourceState.allViews.externalAttributionsToHashes;
 }
+
+export function getResourcesWithLocatedAttributions(state: State): {
+  resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+  locatedResources: Set<string>;
+} {
+  return state.resourceState.allViews.resourcesWithLocatedAttributions;
+}


### PR DESCRIPTION
Issue: #1943

### Summary of changes

Introduce new filter state in resource state in allViews:

```
resourcesWithLocatedAttributions: {
 resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
 locatedResources: Set<string>;
};
```

### Context and reason for change

This state is intended to be used by a new locate popup, to store the resources that match the filters.

### How can the changes be tested

See new unit test
