### PR TITLE
Add criticality selector to locate popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -91,17 +91,17 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
             isEditable={props.isEditable}
             title={'Confidence'}
             handleChange={props.discreteConfidenceChangeHandler}
-            value={
+            value={(
               props.displayPackageInfo.attributionConfidence ||
               DiscreteConfidence.High
-            }
+            ).toString()}
             menuItems={[
               {
-                value: DiscreteConfidence.High,
+                value: DiscreteConfidence.High.toString(),
                 name: `High (${DiscreteConfidence.High})`,
               },
               {
-                value: DiscreteConfidence.Low,
+                value: DiscreteConfidence.Low.toString(),
                 name: `Low (${DiscreteConfidence.Low})`,
               },
             ]}

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -11,12 +11,12 @@ import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 
 interface DropdownProps extends InputElementProps {
-  value: number;
+  value: string;
   menuItems: Array<menuItem>;
 }
 
-interface menuItem {
-  value: number;
+export interface menuItem {
+  value: string;
   name: string;
 }
 

--- a/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
@@ -15,14 +15,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={DiscreteConfidence.High}
+        value={DiscreteConfidence.High.toString()}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}
@@ -42,14 +42,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={10}
+        value={'10'}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -3,11 +3,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
-import { ButtonText } from '../../enums/enums';
-import { useAppDispatch } from '../../state/hooks';
+import { ButtonText, CriticalityTypes } from '../../enums/enums';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { Dropdown, menuItem } from '../InputElements/Dropdown';
+import { getLocatePopupSelectedCriticality } from '../../state/selectors/locate-popup-selectors';
+import { setLocatePopupSelectedCriticality } from '../../state/actions/resource-actions/locate-popup-actions';
+import { SelectedCriticality } from '../../../shared/shared-types';
+
+const classes = {
+  dropdown: {
+    marginTop: '8px',
+  },
+};
+
+const criticalityMenuItems: Array<menuItem> = [
+  {
+    value: SelectedCriticality.High,
+    name: CriticalityTypes.HighCriticality,
+  },
+  {
+    value: SelectedCriticality.Medium,
+    name: CriticalityTypes.MediumCriticality,
+  },
+  {
+    value: SelectedCriticality.Any,
+    name: CriticalityTypes.AnyCriticality,
+  },
+];
 
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
@@ -15,20 +40,46 @@ export function LocatorPopup(): ReactElement {
     dispatch(closePopup());
   }
 
-  const content = <></>;
+  const selectedCriticality = useAppSelector(getLocatePopupSelectedCriticality);
+  const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
+    useState<SelectedCriticality>(selectedCriticality);
+
+  function handleApplyClick(): void {
+    dispatch(setLocatePopupSelectedCriticality(criticalityDropDownChoice));
+  }
+
+  function handleClearClick(): void {
+    setCriticalityDropDownChoice(SelectedCriticality.Any);
+    dispatch(setLocatePopupSelectedCriticality(SelectedCriticality.Any));
+  }
+
+  function updateCritialityDropdownChoice(
+    event: ChangeEvent<HTMLInputElement>,
+  ): void {
+    setCriticalityDropDownChoice(event.target.value as SelectedCriticality);
+  }
 
   return (
     <NotificationPopup
-      content={content}
+      content={
+        <Dropdown
+          sx={classes.dropdown}
+          isEditable={true}
+          title={'Criticality'}
+          value={criticalityDropDownChoice}
+          menuItems={criticalityMenuItems}
+          handleChange={updateCritialityDropdownChoice}
+        />
+      }
       header={'Locate Signals'}
       isOpen={true}
-      fullWidth={true}
+      fullWidth={false}
       leftButtonConfig={{
-        onClick: (): void => {},
+        onClick: handleClearClick,
         buttonText: ButtonText.Clear,
       }}
       centerLeftButtonConfig={{
-        onClick: (): void => {},
+        onClick: handleApplyClick,
         buttonText: ButtonText.Apply,
       }}
       rightButtonConfig={{

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -3,10 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import { screen } from '@testing-library/react';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { LocatorPopup } from '../LocatorPopup';
+import { getLocatePopupSelectedCriticality } from '../../../state/selectors/locate-popup-selectors';
+import { clickOnButton } from '../../../test-helpers/general-test-helpers';
+import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
+import { SelectedCriticality } from '../../../../shared/shared-types';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -16,5 +23,48 @@ describe('Locator popup ', () => {
     expect(
       screen.getByText('Locate Signals', { exact: true }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
+    expect(screen.getByText('Any')).toBeInTheDocument();
+  });
+
+  it('selects criticality values using the dropdown', () => {
+    const testStore = createTestAppStore();
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    fireEvent.mouseDown(screen.getByText('Any').childNodes[0] as Element);
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('High').parentNode as Element);
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
+
+    clickOnButton(screen, 'Apply');
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.High,
+    );
+  });
+
+  it('resets criticality using the Clear button', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupSelectedCriticality(SelectedCriticality.Medium),
+    );
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+
+    clickOnButton(screen, 'Clear');
+
+    expect(screen.getByText('Any')).toBeInTheDocument();
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
   });
 });

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -104,6 +104,7 @@ export enum CriticalityTypes {
   HighCriticality = 'High',
   MediumCriticality = 'Medium',
   NoCriticality = 'Not critical',
+  AnyCriticality = 'Any',
 }
 
 export enum HighlightingColor {

--- a/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedCriticality } from '../../../types/types';
+import { SelectedCriticality } from '../../../../shared/shared-types';
 import {
   SetLocatePopupSelectedCriticality,
   ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -16,12 +16,12 @@ import {
   Resources,
   ResourcesToAttributions,
   ResourcesWithAttributedChildren,
+  SelectedCriticality,
 } from '../../../../shared/shared-types';
 import {
   PanelPackage,
   PackageAttributeIds,
   PackageAttributes,
-  SelectedCriticality,
 } from '../../../types/types';
 
 export const ACTION_SET_SELECTED_ATTRIBUTION_ID =

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -13,10 +13,10 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesWithAttributedChildren,
+  SelectedCriticality,
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
 import {
-  SelectedCriticality,
   PackageAttributeIds,
   PackageAttributes,
   PanelPackage,
@@ -150,7 +150,7 @@ export const initialResourceState: ResourceState = {
     totalAttributionCount: null,
   },
   locatePopup: {
-    selectedCriticality: 'any',
+    selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set(),
   },
 };

--- a/src/Frontend/state/selectors/locate-popup-selectors.ts
+++ b/src/Frontend/state/selectors/locate-popup-selectors.ts
@@ -3,7 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedCriticality, State } from '../../types/types';
+import { SelectedCriticality } from '../../../shared/shared-types';
+import { State } from '../../types/types';
 
 export function getLocatePopupSelectedCriticality(
   state: State,

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -190,5 +190,3 @@ export interface DisplayPackageInfos {
 export interface DisplayPackageInfosWithCount {
   [packageCardId: string]: DisplayPackageInfoWithCount;
 }
-
-export type SelectedCriticality = Criticality | 'any';

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -20,6 +20,15 @@ export enum Criticality {
   Medium = 'medium',
 }
 
+enum AnyCriticality {
+  Any = 'any',
+}
+export type SelectedCriticality = Criticality | AnyCriticality;
+export const SelectedCriticality = {
+  ...Criticality,
+  ...AnyCriticality,
+};
+
 export enum DiscreteConfidence {
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   High = 80,


### PR DESCRIPTION
### Summary of changes

Adds a criticality selector to locate popup, allowing the user to choose between 'High', 'Medium', and 'Any' criticality. The choice is stored in the frontend state.

### Context and reason for change

This allows the user to choose what level of criticality to locate in the locate popup. When filtering is implemented, it will highlight all resources with attributions matching the selected criticality.

### How can the changes be tested

See unit tests.

Open a file with OpossumUI, open the popup with Ctrl+L, and use the selector.