### PR TITLE
Introduce icon indicating that there are filters selected

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -91,17 +91,17 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
             isEditable={props.isEditable}
             title={'Confidence'}
             handleChange={props.discreteConfidenceChangeHandler}
-            value={
+            value={(
               props.displayPackageInfo.attributionConfidence ||
               DiscreteConfidence.High
-            }
+            ).toString()}
             menuItems={[
               {
-                value: DiscreteConfidence.High,
+                value: DiscreteConfidence.High.toString(),
                 name: `High (${DiscreteConfidence.High})`,
               },
               {
-                value: DiscreteConfidence.Low,
+                value: DiscreteConfidence.Low.toString(),
                 name: `Low (${DiscreteConfidence.Low})`,
               },
             ]}

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -11,12 +11,12 @@ import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 
 interface DropdownProps extends InputElementProps {
-  value: number;
+  value: string;
   menuItems: Array<menuItem>;
 }
 
 interface menuItem {
-  value: number;
+  value: string;
   name: string;
 }
 

--- a/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
@@ -15,14 +15,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={DiscreteConfidence.High}
+        value={DiscreteConfidence.High.toString()}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}
@@ -42,14 +42,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={10}
+        value={'10'}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -3,11 +3,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
-import { ButtonText } from '../../enums/enums';
-import { useAppDispatch } from '../../state/hooks';
+import { ButtonText, CriticalityTypes } from '../../enums/enums';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { Dropdown } from '../InputElements/Dropdown';
+import { SelectedCriticality } from '../../types/types';
+import { getLocatePopupSelectedCriticality } from '../../state/selectors/locate-popup-selectors';
+import { setLocatePopupSelectedCriticality } from '../../state/actions/resource-actions/locate-popup-actions';
+
+const classes = {
+  dropdown: {
+    marginTop: '8px',
+  },
+};
 
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
@@ -15,20 +25,55 @@ export function LocatorPopup(): ReactElement {
     dispatch(closePopup());
   }
 
-  const content = <></>;
+  const selectedCriticality = useAppSelector(getLocatePopupSelectedCriticality);
+  const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
+    useState<SelectedCriticality>(selectedCriticality);
 
   return (
     <NotificationPopup
-      content={content}
+      content={
+        <Dropdown
+          sx={classes.dropdown}
+          isEditable={true}
+          title={'Criticality'}
+          value={criticalityDropDownChoice}
+          menuItems={[
+            {
+              value: SelectedCriticality.High,
+              name: CriticalityTypes.HighCriticality,
+            },
+            {
+              value: SelectedCriticality.Medium,
+              name: CriticalityTypes.MediumCriticality,
+            },
+            {
+              value: SelectedCriticality.Any,
+              name: CriticalityTypes.AnyCriticality,
+            },
+          ]}
+          handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
+            setCriticalityDropDownChoice(
+              event.target.value as SelectedCriticality,
+            );
+          }}
+        />
+      }
       header={'Locate Signals'}
       isOpen={true}
-      fullWidth={true}
+      fullWidth={false}
       leftButtonConfig={{
-        onClick: (): void => {},
+        onClick: (): void => {
+          setCriticalityDropDownChoice(SelectedCriticality.Any);
+          dispatch(setLocatePopupSelectedCriticality(SelectedCriticality.Any));
+        },
         buttonText: ButtonText.Clear,
       }}
       centerLeftButtonConfig={{
-        onClick: (): void => {},
+        onClick: (): void => {
+          dispatch(
+            setLocatePopupSelectedCriticality(criticalityDropDownChoice),
+          );
+        },
         buttonText: ButtonText.Apply,
       }}
       rightButtonConfig={{

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -3,10 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import { screen } from '@testing-library/react';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { LocatorPopup } from '../LocatorPopup';
+import { getLocatePopupSelectedCriticality } from '../../../state/selectors/locate-popup-selectors';
+import { SelectedCriticality } from '../../../types/types';
+import { clickOnButton } from '../../../test-helpers/general-test-helpers';
+import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -16,5 +23,48 @@ describe('Locator popup ', () => {
     expect(
       screen.getByText('Locate Signals', { exact: true }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
+    expect(screen.getByText('Any')).toBeInTheDocument();
+  });
+
+  it('selects criticality values using the dropdown', () => {
+    const testStore = createTestAppStore();
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    fireEvent.mouseDown(screen.getByText('Any').childNodes[0] as Element);
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('High').parentNode as Element);
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
+
+    clickOnButton(screen, 'Apply');
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.High,
+    );
+  });
+
+  it('resets criticality using the Clear button', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupSelectedCriticality(SelectedCriticality.Medium),
+    );
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+
+    clickOnButton(screen, 'Clear');
+
+    expect(screen.getByText('Any')).toBeInTheDocument();
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
   });
 });

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -8,7 +8,7 @@ import MuiToggleButton from '@mui/material/ToggleButton';
 import MuiToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { View } from '../../enums/enums';
+import { PopupType, View } from '../../enums/enums';
 import { setViewOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import { CommitInfoDisplay } from '../CommitInfoDisplay/CommitInfoDisplay';
@@ -19,6 +19,13 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import { BackendCommunication } from '../BackendCommunication/BackendCommunication';
 import MuiBox from '@mui/material/Box';
 import { getResources } from '../../state/selectors/all-views-resource-selectors';
+import { FilterAlt } from '@mui/icons-material';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
+import {
+  getLocatePopupSelectedCriticality,
+  getLocatePopupSelectedLicenses,
+} from '../../state/selectors/locate-popup-selectors';
+import { initialResourceState } from '../../state/reducers/resource-reducer';
 
 export const topBarHeight = 36;
 
@@ -32,6 +39,16 @@ const classes = {
     margin: '8px',
     width: '18px',
     height: '18px',
+    padding: '2px',
+    color: OpossumColors.white,
+    '&:hover': {
+      background: OpossumColors.middleBlue,
+    },
+  },
+  filterIcon: {
+    margin: '4px',
+    width: '24px',
+    height: '24px',
     padding: '2px',
     color: OpossumColors.white,
     '&:hover': {
@@ -62,6 +79,18 @@ const classes = {
 export function TopBar(): ReactElement {
   const selectedView = useAppSelector(getSelectedView);
   const showTopProgressBar = useAppSelector(getResources) !== null;
+
+  const locatePopupSelectedCriticality = useAppSelector(
+    getLocatePopupSelectedCriticality,
+  );
+  const locatePopupSelectedLicenses = useAppSelector(
+    getLocatePopupSelectedLicenses,
+  );
+  const showFilterIcon =
+    locatePopupSelectedCriticality !==
+      initialResourceState.locatePopup.selectedCriticality ||
+    locatePopupSelectedLicenses.size > 0;
+
   const dispatch = useAppDispatch();
 
   function handleClick(
@@ -88,6 +117,18 @@ export function TopBar(): ReactElement {
         }
       />
       {showTopProgressBar ? <TopProgressBar /> : <MuiBox flex={1} />}
+      {showFilterIcon ? (
+        <IconButton
+          tooltipTitle="filter attributions"
+          tooltipPlacement="right"
+          onClick={(): void => {
+            dispatch(openPopup(PopupType.LocatorPopup));
+          }}
+          icon={
+            <FilterAlt sx={classes.filterIcon} aria-label={'open file icon'} />
+          }
+        />
+      ) : null}
       <MuiToggleButtonGroup
         size="small"
         value={selectedView}

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -8,6 +8,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { initialResourceState } from '../../../state/reducers/resource-reducer';
 import {
+  getOpenPopup,
   isAttributionViewSelected,
   isAuditViewSelected,
   isReportViewSelected,
@@ -19,6 +20,8 @@ import {
 import { TopBar } from '../TopBar';
 import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { setResources } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
+import { SelectedCriticality } from '../../../types/types';
 
 describe('TopBar', () => {
   it('renders an Open file icon', () => {
@@ -104,5 +107,26 @@ describe('TopBar', () => {
     testStore.dispatch(setResources({ '': 1 }));
     renderComponentWithStore(<TopBar />, { store: testStore });
     expect(screen.getByLabelText('TopProgressBar')).toBeInTheDocument();
+  });
+
+  it('does not display the filter icon when no resources have been filtered', () => {
+    renderComponentWithStore(<TopBar />);
+    expect(
+      screen.queryByLabelText('filter attributions'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays the filter icon after resources have been filtered', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupSelectedCriticality(SelectedCriticality.Medium),
+    );
+    renderComponentWithStore(<TopBar />, { store: testStore });
+
+    expect(screen.getByLabelText('filter attributions')).toBeInTheDocument();
+
+    fireEvent.click(screen.queryByLabelText('filter attributions') as Element);
+
+    expect(getOpenPopup(testStore.getState())).toBe('LocatorPopup');
   });
 });

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -104,6 +104,7 @@ export enum CriticalityTypes {
   HighCriticality = 'High',
   MediumCriticality = 'Medium',
   NoCriticality = 'Not critical',
+  AnyCriticality = 'Any',
 }
 
 export enum HighlightingColor {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -150,7 +150,7 @@ export const initialResourceState: ResourceState = {
     totalAttributionCount: null,
   },
   locatePopup: {
-    selectedCriticality: 'any',
+    selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set(),
   },
 };

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -191,4 +191,11 @@ export interface DisplayPackageInfosWithCount {
   [packageCardId: string]: DisplayPackageInfoWithCount;
 }
 
-export type SelectedCriticality = Criticality | 'any';
+enum AnyCriticality {
+  Any = 'any',
+}
+export type SelectedCriticality = Criticality | AnyCriticality;
+export const SelectedCriticality = {
+  ...Criticality,
+  ...AnyCriticality,
+};


### PR DESCRIPTION
### Summary of changes

Display a filter icon on the top bar whenever locator popup filters are active. Clicking on it opens the locator popup.
![image](https://github.com/opossum-tool/OpossumUI/assets/107913663/004899d5-4c01-423f-81b3-e38b9e864449)

### Context and reason for change

This allows a user to see that they have filters active, and gives another way to open the popup.

### How can the changes be tested

Open the popup with Ctrl+L, then select some filters.
