### PR TITLE
Add license selector to popup

### DIFF
--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -9,14 +9,26 @@ import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { ButtonText, CriticalityTypes } from '../../enums/enums';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Dropdown, menuItem } from '../InputElements/Dropdown';
-import { getLocatePopupSelectedCriticality } from '../../state/selectors/locate-popup-selectors';
-import { setLocatePopupSelectedCriticality } from '../../state/actions/resource-actions/locate-popup-actions';
-import { SelectedCriticality } from '../../../shared/shared-types';
+import {
+  getLocatePopupSelectedCriticality,
+  getLocatePopupSelectedLicenses,
+} from '../../state/selectors/locate-popup-selectors';
+import {
+  setLocatePopupSelectedCriticality,
+  setLocatePopupSelectedLicenses,
+} from '../../state/actions/resource-actions/locate-popup-actions';
+import {
+  Attributions,
+  SelectedCriticality,
+} from '../../../shared/shared-types';
+import { getExternalAttributions } from '../../state/selectors/all-views-resource-selectors';
+import { AutoComplete } from '../InputElements/AutoComplete';
 
 const classes = {
   dropdown: {
     marginTop: '8px',
   },
+  autocomplete: { marginTop: '8px' },
 };
 
 const criticalityMenuItems: Array<menuItem> = [
@@ -34,43 +46,79 @@ const criticalityMenuItems: Array<menuItem> = [
   },
 ];
 
+// exported for testing
+export function getLicenseNames(attributions: Attributions): Array<string> {
+  const licenseNames: Set<string> = new Set();
+  for (const attribution of Object.values(attributions)) {
+    const licenseName = attribution.licenseName;
+    if (licenseName) {
+      licenseNames.add(licenseName);
+    }
+  }
+  return Array.from(licenseNames.values());
+}
+
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
-  function close(): void {
-    dispatch(closePopup());
-  }
-
   const selectedCriticality = useAppSelector(getLocatePopupSelectedCriticality);
   const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
     useState<SelectedCriticality>(selectedCriticality);
+  function updateCriticalityDropdownChoice(
+    event: ChangeEvent<HTMLInputElement>,
+  ): void {
+    setCriticalityDropDownChoice(event.target.value as SelectedCriticality);
+  }
+  const externalAttributions = useAppSelector(getExternalAttributions);
+  const licenseNameOptions = getLicenseNames(externalAttributions);
+  const selectedLicenses = useAppSelector(getLocatePopupSelectedLicenses);
+  // currently we only support sets with one element
+  // once we support multiple elements we will have to adapt the logic to not take one arbitrary element of the set
+  const selectedLicense =
+    selectedLicenses.size == 0 ? '' : selectedLicenses.values().next().value;
+  const [searchedLicense, setSearchedLicense] = useState(selectedLicense);
 
   function handleApplyClick(): void {
     dispatch(setLocatePopupSelectedCriticality(criticalityDropDownChoice));
+    dispatch(setLocatePopupSelectedLicenses(new Set([searchedLicense])));
   }
 
   function handleClearClick(): void {
     setCriticalityDropDownChoice(SelectedCriticality.Any);
     dispatch(setLocatePopupSelectedCriticality(SelectedCriticality.Any));
+    setSearchedLicense('');
+    dispatch(setLocatePopupSelectedLicenses(new Set()));
   }
-
-  function updateCritialityDropdownChoice(
-    event: ChangeEvent<HTMLInputElement>,
-  ): void {
-    setCriticalityDropDownChoice(event.target.value as SelectedCriticality);
+  function close(): void {
+    dispatch(closePopup());
   }
-
+  const content = (
+    <>
+      <Dropdown
+        sx={classes.dropdown}
+        isEditable={true}
+        title={'Criticality'}
+        value={criticalityDropDownChoice}
+        menuItems={criticalityMenuItems}
+        handleChange={updateCriticalityDropdownChoice}
+      />
+      <AutoComplete
+        isEditable={true}
+        sx={classes.autocomplete}
+        title={'License'}
+        handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
+          setSearchedLicense(event.target.value);
+        }}
+        isHighlighted={false}
+        options={licenseNameOptions}
+        inputValue={searchedLicense}
+        showTextBold={false}
+        formatOptionForDisplay={(option: string): string => option}
+      />
+    </>
+  );
   return (
     <NotificationPopup
-      content={
-        <Dropdown
-          sx={classes.dropdown}
-          isEditable={true}
-          title={'Criticality'}
-          value={criticalityDropDownChoice}
-          menuItems={criticalityMenuItems}
-          handleChange={updateCritialityDropdownChoice}
-        />
-      }
+      content={content}
       header={'Locate Signals'}
       isOpen={true}
       fullWidth={false}

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -9,11 +9,20 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-import { LocatorPopup } from '../LocatorPopup';
 import { getLocatePopupSelectedCriticality } from '../../../state/selectors/locate-popup-selectors';
 import { clickOnButton } from '../../../test-helpers/general-test-helpers';
 import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
 import { SelectedCriticality } from '../../../../shared/shared-types';
+import { getLicenseNames, LocatorPopup } from '../LocatorPopup';
+import { getLocatePopupSelectedLicenses } from '../../../state/selectors/locate-popup-selectors';
+import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
+import { setExternalData } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  Attributions,
+  PackageInfo,
+  ResourcesToAttributions,
+} from '../../../../shared/shared-types';
+import { setLocatePopupSelectedLicenses } from '../../../state/actions/resource-actions/locate-popup-actions';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -25,6 +34,9 @@ describe('Locator popup ', () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
     expect(screen.getByText('Any')).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', { name: 'License' }),
+    ).toBeInTheDocument();
   });
 
   it('selects criticality values using the dropdown', () => {
@@ -66,5 +78,82 @@ describe('Locator popup ', () => {
     expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
       SelectedCriticality.Any,
     );
+  });
+
+  it('sets state if license selected', () => {
+    const testStore = createTestAppStore();
+    // add external attribution with license MIT to see it
+    const testExternalAttribution: PackageInfo = {
+      packageName: 'jQuery',
+      packageVersion: '16.0.0',
+      licenseName: 'MIT',
+      comment: 'ManualPackage',
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_1: testExternalAttribution,
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/root/': ['uuid_1'],
+    };
+
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testResourcesToExternalAttributions,
+      ),
+    );
+    const licenseSet = new Set(['MIT']);
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT']);
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }) as Element);
+    expect(getLocatePopupSelectedLicenses(testStore.getState())).toEqual(
+      licenseSet,
+    );
+  });
+
+  it('clears license field if clear button pressed', () => {
+    const testStore = createTestAppStore();
+
+    const licenseSet = new Set(['MIT']);
+    testStore.dispatch(setLocatePopupSelectedLicenses(licenseSet));
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }) as Element);
+    expect(getLocatePopupSelectedLicenses(testStore.getState())).toEqual(
+      new Set(),
+    );
+  });
+
+  it('shows license if selected beforehand', () => {
+    const testStore = createTestAppStore();
+
+    const licenseSet = new Set(['MIT']);
+    testStore.dispatch(setLocatePopupSelectedLicenses(licenseSet));
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+    expect(screen.getByDisplayValue('MIT')).toBeInTheDocument();
+  });
+});
+
+describe('getLicenseNamesFromExternalAttributions', () => {
+  it('collects the correct license names', () => {
+    const testExternalMITAttribution: PackageInfo = {
+      licenseName: 'MIT',
+    };
+    const testExternalApacheAttribution: PackageInfo = {
+      licenseName: 'Apache-2.0',
+    };
+
+    const testExternalAttributions: Attributions = {
+      uuid_1: testExternalMITAttribution,
+      uuid_2: testExternalApacheAttribution,
+    };
+
+    const licenseNames = getLicenseNames(testExternalAttributions);
+    const expectedLicenseNames = ['MIT', 'Apache-2.0'];
+    expect(licenseNames).toEqual(expectedLicenseNames);
   });
 });


### PR DESCRIPTION
### Summary of changes

This commit adds an auto-completion input field with a dropdown to the locator popup. The dropdown contains all licenses found in any external attribution and does not aggregate licenses. If a license is selected and the apply button is pressed the corresponding state is set. If the clear button is pressed the state will be reset. Fixes #1941.
### Context and reason for change
We want to imlement a new feature to be able to locate signals based on criticality and certain licenses.
### How can the changes be tested
Check out the commit, open an .opossum file and open the popup. Observe the license field and the dropdown when clicking into the field, the dropdown should contain all license names of all external attributions (see the screenshot below).
If you start to type anything the dropdown will filter for those licenses matching your text. Click apply to set the state for this selected license. If you close the popup and reopen it your selected license will be shown in the corresponding field.
If you click the clean button the field will be cleared and the state is reset.

![Screenshot from 2023-09-12 16-09-44](https://github.com/opossum-tool/OpossumUI/assets/50019307/e6691f9f-932b-4408-9f84-53c3e53f9ed0)

