### PR TITLE
Introduce icon indicating that there are filters selected

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -91,17 +91,17 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
             isEditable={props.isEditable}
             title={'Confidence'}
             handleChange={props.discreteConfidenceChangeHandler}
-            value={
+            value={(
               props.displayPackageInfo.attributionConfidence ||
               DiscreteConfidence.High
-            }
+            ).toString()}
             menuItems={[
               {
-                value: DiscreteConfidence.High,
+                value: DiscreteConfidence.High.toString(),
                 name: `High (${DiscreteConfidence.High})`,
               },
               {
-                value: DiscreteConfidence.Low,
+                value: DiscreteConfidence.Low.toString(),
                 name: `Low (${DiscreteConfidence.Low})`,
               },
             ]}

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -11,12 +11,12 @@ import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 
 interface DropdownProps extends InputElementProps {
-  value: number;
+  value: string;
   menuItems: Array<menuItem>;
 }
 
 interface menuItem {
-  value: number;
+  value: string;
   name: string;
 }
 

--- a/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
@@ -15,14 +15,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={DiscreteConfidence.High}
+        value={DiscreteConfidence.High.toString()}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}
@@ -42,14 +42,14 @@ describe('The Dropdown', () => {
       <Dropdown
         isEditable={true}
         title={'Confidence'}
-        value={10}
+        value={'10'}
         menuItems={[
           {
-            value: DiscreteConfidence.High,
+            value: DiscreteConfidence.High.toString(),
             name: `High (${DiscreteConfidence.High})`,
           },
           {
-            value: DiscreteConfidence.Low,
+            value: DiscreteConfidence.Low.toString(),
             name: `Low (${DiscreteConfidence.Low})`,
           },
         ]}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -3,11 +3,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { ReactElement } from 'react';
+import React, { ChangeEvent, ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
-import { ButtonText } from '../../enums/enums';
-import { useAppDispatch } from '../../state/hooks';
+import { ButtonText, CriticalityTypes } from '../../enums/enums';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { Dropdown } from '../InputElements/Dropdown';
+import { SelectedCriticality } from '../../types/types';
+import { getLocatePopupSelectedCriticality } from '../../state/selectors/locate-popup-selectors';
+import { setLocatePopupSelectedCriticality } from '../../state/actions/resource-actions/locate-popup-actions';
+
+const classes = {
+  dropdown: {
+    marginTop: '8px',
+  },
+};
 
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
@@ -15,20 +25,55 @@ export function LocatorPopup(): ReactElement {
     dispatch(closePopup());
   }
 
-  const content = <></>;
+  const selectedCriticality = useAppSelector(getLocatePopupSelectedCriticality);
+  const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
+    useState<SelectedCriticality>(selectedCriticality);
 
   return (
     <NotificationPopup
-      content={content}
+      content={
+        <Dropdown
+          sx={classes.dropdown}
+          isEditable={true}
+          title={'Criticality'}
+          value={criticalityDropDownChoice}
+          menuItems={[
+            {
+              value: SelectedCriticality.High,
+              name: CriticalityTypes.HighCriticality,
+            },
+            {
+              value: SelectedCriticality.Medium,
+              name: CriticalityTypes.MediumCriticality,
+            },
+            {
+              value: SelectedCriticality.Any,
+              name: CriticalityTypes.AnyCriticality,
+            },
+          ]}
+          handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
+            setCriticalityDropDownChoice(
+              event.target.value as SelectedCriticality,
+            );
+          }}
+        />
+      }
       header={'Locate Signals'}
       isOpen={true}
-      fullWidth={true}
+      fullWidth={false}
       leftButtonConfig={{
-        onClick: (): void => {},
+        onClick: (): void => {
+          setCriticalityDropDownChoice(SelectedCriticality.Any);
+          dispatch(setLocatePopupSelectedCriticality(SelectedCriticality.Any));
+        },
         buttonText: ButtonText.Clear,
       }}
       centerLeftButtonConfig={{
-        onClick: (): void => {},
+        onClick: (): void => {
+          dispatch(
+            setLocatePopupSelectedCriticality(criticalityDropDownChoice),
+          );
+        },
         buttonText: ButtonText.Apply,
       }}
       rightButtonConfig={{

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -3,10 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
-import { screen } from '@testing-library/react';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { LocatorPopup } from '../LocatorPopup';
+import { getLocatePopupSelectedCriticality } from '../../../state/selectors/locate-popup-selectors';
+import { SelectedCriticality } from '../../../types/types';
+import { clickOnButton } from '../../../test-helpers/general-test-helpers';
+import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -16,5 +23,48 @@ describe('Locator popup ', () => {
     expect(
       screen.getByText('Locate Signals', { exact: true }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
+    expect(screen.getByText('Any')).toBeInTheDocument();
+  });
+
+  it('selects criticality values using the dropdown', () => {
+    const testStore = createTestAppStore();
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    fireEvent.mouseDown(screen.getByText('Any').childNodes[0] as Element);
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('High').parentNode as Element);
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
+
+    clickOnButton(screen, 'Apply');
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.High,
+    );
+  });
+
+  it('resets criticality using the Clear button', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupSelectedCriticality(SelectedCriticality.Medium),
+    );
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+
+    clickOnButton(screen, 'Clear');
+
+    expect(screen.getByText('Any')).toBeInTheDocument();
+    expect(screen.queryByText('Medium')).not.toBeInTheDocument();
+
+    expect(getLocatePopupSelectedCriticality(testStore.getState())).toBe(
+      SelectedCriticality.Any,
+    );
   });
 });

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -104,6 +104,7 @@ export enum CriticalityTypes {
   HighCriticality = 'High',
   MediumCriticality = 'Medium',
   NoCriticality = 'Not critical',
+  AnyCriticality = 'Any',
 }
 
 export enum HighlightingColor {

--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
@@ -20,10 +20,33 @@ import {
 import { getTreeNodeProps } from './utils/get-tree-node-props';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
+import { IconButton } from '../../Components/IconButton/IconButton';
+import MyLocationIcon from '@mui/icons-material/MyLocation';
+import { OpossumColors } from '../../shared-styles';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import {
+  getLocatePopupSelectedCriticality,
+  getLocatePopupSelectedLicenses,
+} from '../../state/selectors/locate-popup-selectors';
+import { initialResourceState } from '../../state/reducers/resource-reducer';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
+import { PopupType } from '../../enums/enums';
 
 const classes = {
   content: {
     height: '100%',
+  },
+  filterIcon: {
+    margin: '4px',
+    padding: '2px',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    zIndex: 1,
+    color: OpossumColors.darkBlue,
+    '&:hover': {
+      background: OpossumColors.middleBlue,
+    },
   },
 };
 
@@ -55,6 +78,8 @@ interface VirtualizedTreeProps {
 export function VirtualizedTree(
   props: VirtualizedTreeProps,
 ): ReactElement | null {
+  const dispatch = useAppDispatch();
+
   // eslint-disable-next-line testing-library/render-result-naming-convention
   const treeNodeProps: Array<VirtualizedTreeNodeData> = getTreeNodeProps(
     props.nodes,
@@ -83,8 +108,31 @@ export function VirtualizedTree(
     (itemData) => itemData.nodeId === props.selectedNodeId,
   );
 
+  const locatePopupSelectedCriticality = useAppSelector(
+    getLocatePopupSelectedCriticality,
+  );
+  const locatePopupSelectedLicenses = useAppSelector(
+    getLocatePopupSelectedLicenses,
+  );
+  const showFilterIcon =
+    locatePopupSelectedCriticality !==
+      initialResourceState.locatePopup.selectedCriticality ||
+    locatePopupSelectedLicenses.size > 0;
+
   return props.nodes ? (
     <MuiBox aria-label={props.ariaLabel} sx={props.sx}>
+      {showFilterIcon ? (
+        <IconButton
+          sx={classes.filterIcon}
+          // TODO figure out how to place the tooltip correctly
+          tooltipTitle=""
+          tooltipPlacement="right"
+          onClick={(): void => {
+            dispatch(openPopup(PopupType.LocatorPopup));
+          }}
+          icon={<MyLocationIcon aria-label={'filter attributions'} />}
+        />
+      ) : null}
       <MuiBox sx={classes.content}>
         <List
           length={treeNodeProps.length}

--- a/src/Frontend/extracted/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/__tests__/VirtualizedTree.test.tsx
@@ -5,8 +5,15 @@
 
 import React, { ReactElement } from 'react';
 import { VirtualizedTree } from '../VirtualizedTree';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { NodesForTree } from '../types';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
+import { SelectedCriticality } from '../../../types/types';
+import { getOpenPopup } from '../../../state/selectors/view-selector';
 
 describe('The VirtualizedTree', () => {
   const testNodes: NodesForTree = {
@@ -25,24 +32,26 @@ describe('The VirtualizedTree', () => {
     docs: { 'readme.md': 1 },
   };
 
+  const testVirtualizedTree = (
+    <VirtualizedTree
+      expandedIds={['/', '/thirdParty/', '/root/', '/root/src/', 'docs/']}
+      isFakeNonExpandableNode={(path: string): boolean => Boolean(path)}
+      onSelect={(): void => {}}
+      onToggle={(): void => {}}
+      nodes={testNodes}
+      selectedNodeId={'/thirdParty/'}
+      getTreeNodeLabel={
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        (nodeName, node, nodeId): ReactElement => <div>{nodeName || '/'}</div>
+      }
+      breakpoints={new Set()}
+      cardHeight={20}
+      maxHeight={5000}
+    />
+  );
+
   it('renders VirtualizedTree', () => {
-    render(
-      <VirtualizedTree
-        expandedIds={['/', '/thirdParty/', '/root/', '/root/src/', 'docs/']}
-        isFakeNonExpandableNode={(path: string): boolean => Boolean(path)}
-        onSelect={(): void => {}}
-        onToggle={(): void => {}}
-        nodes={testNodes}
-        selectedNodeId={'/thirdParty/'}
-        getTreeNodeLabel={
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          (nodeName, node, nodeId): ReactElement => <div>{nodeName || '/'}</div>
-        }
-        breakpoints={new Set()}
-        cardHeight={20}
-        maxHeight={5000}
-      />,
-    );
+    renderComponentWithStore(testVirtualizedTree);
 
     for (const label of [
       '/',
@@ -58,5 +67,26 @@ describe('The VirtualizedTree', () => {
     ]) {
       expect(screen.getByText(label));
     }
+  });
+
+  it('does not display the filter icon when no resources have been filtered', () => {
+    renderComponentWithStore(testVirtualizedTree);
+    expect(
+      screen.queryByLabelText('filter attributions'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays the filter icon after resources have been filtered', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupSelectedCriticality(SelectedCriticality.Medium),
+    );
+    renderComponentWithStore(testVirtualizedTree, { store: testStore });
+
+    expect(screen.getByLabelText('filter attributions')).toBeInTheDocument();
+
+    fireEvent.click(screen.queryByLabelText('filter attributions') as Element);
+
+    expect(getOpenPopup(testStore.getState())).toBe('LocatorPopup');
   });
 });

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -144,6 +144,7 @@ export const treeClasses = {
         return {
           background: OpossumColors.white,
           height: '100%',
+          position: 'relative',
         };
       }
       case 'browser': {
@@ -152,6 +153,7 @@ export const treeClasses = {
           padding: '4px 0',
           background: OpossumColors.white,
           height: '100%',
+          position: 'relative',
         };
       }
       case 'popup': {
@@ -165,6 +167,7 @@ export const treeClasses = {
             width: `calc(100vw - ${horizontalSpaceBetweenTreeAndViewportEdges}px)`,
             maxWidth: `calc(${popupMaxWidth}px - ${popupContentPadding}px)`,
             background: OpossumColors.white,
+            position: 'relative',
           };
         } else {
           throw Error(

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -150,7 +150,7 @@ export const initialResourceState: ResourceState = {
     totalAttributionCount: null,
   },
   locatePopup: {
-    selectedCriticality: 'any',
+    selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set(),
   },
 };

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -191,4 +191,11 @@ export interface DisplayPackageInfosWithCount {
   [packageCardId: string]: DisplayPackageInfoWithCount;
 }
 
-export type SelectedCriticality = Criticality | 'any';
+enum AnyCriticality {
+  Any = 'any',
+}
+export type SelectedCriticality = Criticality | AnyCriticality;
+export const SelectedCriticality = {
+  ...Criticality,
+  ...AnyCriticality,
+};


### PR DESCRIPTION
### Summary of changes

Display a target icon on the virtualized tree whenever locator popup filters are active. Clicking on it opens the locator popup.
![image](https://github.com/opossum-tool/OpossumUI/assets/107913663/4d6fa015-11ee-4f57-9a3d-2539818d1e58)

### Context and reason for change

This allows a user to see that they have filters active, and gives another way to open the popup.

### How can the changes be tested

Open the popup with Ctrl+L, then select some filters.
