### PR TITLE
Disable deps optimization

### DIFF
--- a/src/e2e-tests/vite-e2e-config.ts
+++ b/src/e2e-tests/vite-e2e-config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
   build: {
     outDir: '../build',
   },
+  optimizeDeps: {
+    disabled: true,
+  },
 });


### PR DESCRIPTION

### Summary of changes

For the e2e tests deps optimization is disabled.

### Context and reason for change

For the e2e tests deps optimization is disabled as it seems to occasionally lead to timeouts in e2e tests if node modules are cached.

### How can the changes be tested

`yarn test:e2e`
