### PR TITLE
Add logic to calculate located resources

### DIFF
--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -23,6 +23,8 @@ import {
 } from '../../../shared/shared-types';
 import { getExternalAttributions } from '../../state/selectors/all-views-resource-selectors';
 import { AutoComplete } from '../InputElements/AutoComplete';
+import { locateResourcesByCriticalityAndLicense } from '../../state/helpers/action-and-reducer-helpers';
+import { setResourcesWithLocatedAttributions } from '../../state/actions/resource-actions/all-views-simple-actions';
 
 const classes = {
   dropdown: {
@@ -80,6 +82,12 @@ export function LocatorPopup(): ReactElement {
   function handleApplyClick(): void {
     dispatch(setLocatePopupSelectedCriticality(criticalityDropDownChoice));
     dispatch(setLocatePopupSelectedLicenses(new Set([searchedLicense])));
+    dispatch(
+      locateResourcesByCriticalityAndLicense(
+        criticalityDropDownChoice,
+        new Set([searchedLicense]),
+      ),
+    );
   }
 
   function handleClearClick(): void {
@@ -87,6 +95,16 @@ export function LocatorPopup(): ReactElement {
     dispatch(setLocatePopupSelectedCriticality(SelectedCriticality.Any));
     setSearchedLicense('');
     dispatch(setLocatePopupSelectedLicenses(new Set()));
+    dispatch(
+      setResourcesWithLocatedAttributions(
+        {
+          paths: [],
+          pathsToIndices: {},
+          attributedChildren: {},
+        },
+        new Set(),
+      ),
+    );
   }
   function close(): void {
     dispatch(closePopup());

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -23,6 +23,7 @@ import {
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
 import { setLocatePopupSelectedLicenses } from '../../../state/actions/resource-actions/locate-popup-actions';
+import { getResourcesWithLocatedAttributions } from '../../../state/selectors/all-views-resource-selectors';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -103,6 +104,17 @@ describe('Locator popup ', () => {
       ),
     );
     const licenseSet = new Set(['MIT']);
+    const expectedLocatedResources = {
+      resourcesWithLocatedChildren: {
+        attributedChildren: { 1: new Set([0]) },
+        paths: ['/root/', '/'],
+        pathsToIndices: {
+          '/root/': 0,
+          '/': 1,
+        },
+      },
+      locatedResources: new Set(['/root/']),
+    };
 
     renderComponentWithStore(<LocatorPopup />, { store: testStore });
 
@@ -110,6 +122,9 @@ describe('Locator popup ', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }) as Element);
     expect(getLocatePopupSelectedLicenses(testStore.getState())).toEqual(
       licenseSet,
+    );
+    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual(
+      expectedLocatedResources,
     );
   });
 
@@ -125,6 +140,14 @@ describe('Locator popup ', () => {
     expect(getLocatePopupSelectedLicenses(testStore.getState())).toEqual(
       new Set(),
     );
+    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
+      resourcesWithLocatedChildren: {
+        attributedChildren: {},
+        paths: [],
+        pathsToIndices: {},
+      },
+      locatedResources: new Set(),
+    });
   });
 
   it('shows license if selected beforehand', () => {


### PR DESCRIPTION
### Summary of changes

This commit adds new logic to calculate all resources that should be highlighted when we filter for signals with certain licenses or criticality. Fixes #1944.

### Context and reason for change

We want to imlement a new feature to be able to locate signals based on criticality and certain licenses. 

### How can the changes be tested

Checkout the commit, open a file and select a criticality and or license name. Observe the new state of resourcesWithLocatedAttributions in the redux dev tools browser. Make sure that there exists at least one resource with a signal of the selected type. 
