### PR TITLE
Highlight located resources

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import WestRoundedIcon from '@mui/icons-material/WestRounded';
 import MyLocationIcon from '@mui/icons-material/MyLocation';
 import remove from 'lodash/remove';
 import React, { ReactElement } from 'react';
@@ -16,6 +17,7 @@ import {
   getResourcesToExternalAttributions,
   getResourcesToManualAttributions,
   getResourcesWithExternalAttributedChildren,
+  getResourcesWithLocatedAttributions,
   getResourcesWithManualAttributedChildren,
 } from '../../state/selectors/all-views-resource-selectors';
 import { setSelectedResourceIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -57,6 +59,11 @@ const classes = {
     '&:hover': {
       background: OpossumColors.middleBlue,
     },
+  },
+  locatedResourceIcon: {
+    marginTop: '-2px',
+    marginLeft: '10px',
+    stroke: OpossumColors.darkBlue,
   },
 };
 
@@ -132,8 +139,8 @@ export function ResourceBrowser(): ReactElement | null {
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   const maxTreeHeight: number = useWindowHeight() - topBarHeight - 4;
 
-  const showLocatorIcon = useAppSelector(isLocateSignalActive);
-  const locatorIcon = showLocatorIcon ? (
+  const locateSignalActive = useAppSelector(isLocateSignalActive);
+  const locatorIcon = locateSignalActive ? (
     <IconButton
       iconSx={classes.locatorIcon}
       containerSx={classes.locatorIconContainer}
@@ -145,6 +152,22 @@ export function ResourceBrowser(): ReactElement | null {
       icon={<MyLocationIcon aria-label={'locate attributions'} />}
     />
   ) : undefined;
+  const resourcesWithLocatedAttributions = useAppSelector(
+    getResourcesWithLocatedAttributions,
+  );
+  const locatedResources = locateSignalActive
+    ? resourcesWithLocatedAttributions.locatedResources
+    : undefined;
+  const resourcesWithLocatedChildren = locateSignalActive
+    ? resourcesWithLocatedAttributions.resourcesWithLocatedChildren.paths
+    : undefined;
+
+  const locatedResourceIcon = (
+    <WestRoundedIcon
+      sx={classes.locatedResourceIcon}
+      aria-label={'located attribution'}
+    />
+  );
 
   return resources ? (
     <VirtualizedTree
@@ -168,6 +191,9 @@ export function ResourceBrowser(): ReactElement | null {
         treeExpandIcon: treeClasses.treeExpandIcon,
       }}
       locatorIcon={locatorIcon}
+      locatedResourceIcon={locatedResourceIcon}
+      locatedResources={locatedResources}
+      resourcesWithLocatedChildren={resourcesWithLocatedChildren}
     />
   ) : null;
 }

--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
@@ -51,6 +51,9 @@ interface VirtualizedTreeProps {
   alwaysShowHorizontalScrollBar?: boolean;
   breakpoints?: Set<string>;
   locatorIcon?: ReactElement;
+  locatedResourceIcon?: ReactElement;
+  locatedResources?: Set<string>;
+  resourcesWithLocatedChildren?: Array<string>;
 }
 
 export function VirtualizedTree(
@@ -67,6 +70,8 @@ export function VirtualizedTree(
     props.onToggle,
     props.getTreeNodeLabel,
     props.cardHeight,
+    props.locatedResources,
+    props.resourcesWithLocatedChildren,
     props.breakpoints,
   );
 
@@ -98,6 +103,7 @@ export function VirtualizedTree(
                 ...treeNodeProps[index],
                 expandedNodeIcon: props.expandedNodeIcon,
                 nonExpandedNodeIcon: props.nonExpandedNodeIcon,
+                locatedResourceIcon: props.locatedResourceIcon,
                 treeNodeStyle: props.treeNodeStyle,
               }}
             />

--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTreeNode.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTreeNode.tsx
@@ -54,6 +54,8 @@ export interface VirtualizedTreeNodeData {
   treeNodeStyle?: TreeNodeStyle;
   nodeHeight: number;
   breakpoints?: Set<string>;
+  isLocatedNode: boolean;
+  locatedResourceIcon?: ReactElement;
 }
 
 export function VirtualizedTreeNode(
@@ -98,6 +100,8 @@ export function VirtualizedTreeNode(
       >
         {props.getTreeNodeLabel(props.nodeName, props.node, props.nodeId)}
       </MuiBox>
+      <MuiBox />
+      {props.isLocatedNode ? props.locatedResourceIcon : null}
     </MuiBox>
   );
 }

--- a/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
+++ b/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
@@ -7,6 +7,7 @@ import {
   getNodeIdsToExpand,
   isBreakpointOrChildOfBreakpoint,
   isChildOfSelected,
+  isLocated,
   isSelected,
 } from '../utils/get-tree-node-props';
 import { NodesForTree } from '../types';
@@ -81,5 +82,40 @@ describe('renderTree', () => {
     ];
 
     expect(getNodeIdsToExpand(nodeId, node)).toEqual(expectedNodeIdsToExpand);
+  });
+
+  it('isLocatedSelected highlights selected resources', () => {
+    const locatedNodeId = '/located.js';
+    const notLocatedNodeId = '/notLocated.js';
+    const locatedResources = new Set<string>(['/located.js']);
+
+    expect(isLocated(locatedNodeId, false, locatedResources)).toBe(true);
+    expect(isLocated(notLocatedNodeId, false, locatedResources)).toBe(false);
+  });
+
+  it('isLocatedSelected highlights unexpanded resources with located children', () => {
+    const locatedParentId = '/locatedParent/';
+    const notLocatedParentId = '/notLocatedParent/';
+    const resourcesWithLocatedChildren = ['/locatedParent/'];
+
+    expect(
+      isLocated(
+        locatedParentId,
+        false,
+        undefined,
+        resourcesWithLocatedChildren,
+      ),
+    ).toBe(true);
+    expect(
+      isLocated(locatedParentId, true, undefined, resourcesWithLocatedChildren),
+    ).toBe(false);
+    expect(
+      isLocated(
+        notLocatedParentId,
+        false,
+        undefined,
+        resourcesWithLocatedChildren,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
@@ -23,6 +23,8 @@ export function getTreeNodeProps(
     nodeId: string,
   ) => ReactElement,
   cardHeight: number,
+  locatedResources?: Set<string>,
+  resourcesWithLocatedChildren?: Array<string>,
   breakpoints?: Set<string>,
 ): Array<VirtualizedTreeNodeData> {
   const sortedNodeNames: Array<string> = Object.keys(nodes).sort(
@@ -38,6 +40,12 @@ export function getTreeNodeProps(
       canNodeHaveChildren(node) && Object.keys(node).length !== 0;
     const nodeId = getNodeId(nodeName, parentPath, canNodeHaveChildren(node));
     const isExpandedNode = isExpanded(nodeId, expandedNodes);
+    const isLocatedNode = isLocated(
+      nodeId,
+      isExpandedNode,
+      locatedResources,
+      resourcesWithLocatedChildren,
+    );
 
     const nodeIdsToExpand: Array<string> = getNodeIdsToExpand(nodeId, node);
 
@@ -65,6 +73,7 @@ export function getTreeNodeProps(
       selected,
       nodeHeight,
       breakpoints,
+      isLocatedNode,
     });
 
     if (isExpandedNode) {
@@ -79,6 +88,8 @@ export function getTreeNodeProps(
           onToggle,
           getTreeNodeLabel,
           nodeHeight,
+          locatedResources,
+          resourcesWithLocatedChildren,
           breakpoints,
         ),
       );
@@ -86,6 +97,25 @@ export function getTreeNodeProps(
   }
 
   return treeNodes;
+}
+
+export function isLocated(
+  nodeId: string,
+  isExpandedNode: boolean,
+  locatedResources?: Set<string>,
+  resourcesWithLocatedChildren?: Array<string>,
+): boolean {
+  if (locatedResources && locatedResources.has(nodeId)) {
+    return true;
+  }
+  if (
+    resourcesWithLocatedChildren &&
+    resourcesWithLocatedChildren.includes(nodeId) &&
+    !isExpandedNode
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function getNodeIdsToExpand(


### PR DESCRIPTION
### Summary of changes

Display an arrow on the virtualized tree pointing to located resources.
![image](https://github.com/opossum-tool/OpossumUI/assets/107913663/c098f906-0ab7-4814-b21c-70a9e8581387)
This will highlight resources satisfying one of the following conditions:
1. The resource is located
2. The resource contains located children, and the resource is not expanded.

### Context and reason for change

This allows a user to find located resources, which satisfy the filters chosen in the locator popup (Ctrl+L).

### How can the changes be tested

See unit tests.
The locator popup does not yet set any state, so testing it normally is not possible (See #1944). To try it in the app, I hardcoded some located resources in `ResourceBrowser.tsx`:
```
  // const locatedResources = locateSignalActive
  //   ? resourcesWithLocatedAttributions.locatedResources
  //   : undefined;
  // const resourcesWithLocatedChildren = locateSignalActive
  //   ? resourcesWithLocatedAttributions.resourcesWithLocatedChildren.paths
  //   : undefined;
  const locatedResources = new Set<string>(['/Frontend/shared-styles.ts', '/index.tsx']);
  const resourcesWithLocatedChildren = ['/', '/Frontend/'];
```
