### PR TITLE
Add search icons to `CriticalLicensesTable` in `ProjectStatisticsPopup`

### DIFF
--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -7,6 +7,9 @@ import React, { ReactElement } from 'react';
 import { Criticality } from '../../../shared/shared-types';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
 import { LicenseNamesWithCriticality } from '../../types/types';
+import { IconButton } from '../IconButton/IconButton';
+import { LocateAttributionsIcon } from '../Icons/Icons';
+import { clickableIcon } from '../../shared-styles';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
 const COUNT_COLUMN_NAME_IN_TABLE = 'Count';
@@ -21,6 +24,10 @@ const classes = {
     maxHeight: '400px',
     maxWidth: '500px',
     marginBottom: '3px',
+  },
+  clickableIcon,
+  iconButton: {
+    marginLeft: '8px',
   },
 };
 
@@ -70,6 +77,12 @@ export function CriticalLicensesTable(
       containerStyle={classes.container}
       columnHeaders={TABLE_COLUMN_NAMES}
       columnNames={TABLE_COLUMN_NAMES}
+      firstColumnIconButtons={Object.fromEntries(
+        criticalLicensesTotalAttributions.map(({ licenseName }) => [
+          licenseName,
+          getLocateAttributionIconButton(licenseName),
+        ]),
+      )}
       rowNames={criticalLicensesTotalAttributions.map(
         (attribution) => attribution.licenseName,
       )}
@@ -77,7 +90,9 @@ export function CriticalLicensesTable(
         criticalLicensesTotalAttributions.map(
           ({ licenseName, totalNumberOfAttributions }) => [
             licenseName,
-            { [COUNT_COLUMN_NAME_IN_TABLE]: totalNumberOfAttributions },
+            {
+              [COUNT_COLUMN_NAME_IN_TABLE]: totalNumberOfAttributions,
+            },
           ],
         ),
       )}
@@ -135,4 +150,19 @@ function getTotalNumberOfAttributions(
         licenseNameAndTotalAttributions.totalNumberOfAttributions,
     )
     .reduce((total, value) => total + value, 0);
+}
+
+function getLocateAttributionIconButton(licenseName: string): ReactElement {
+  const onLocateAttributionButtonClick = function (): void {
+    // TODO: dispatch license locator actions in next ticket
+  };
+  return (
+    <IconButton
+      tooltipTitle={`locate attributions with "${licenseName}"`}
+      tooltipPlacement="right"
+      onClick={onLocateAttributionButtonClick}
+      iconSx={classes.iconButton}
+      icon={<LocateAttributionsIcon sx={classes.clickableIcon} />}
+    />
+  );
 }

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -17,6 +17,7 @@ import LocalParkingIcon from '@mui/icons-material/LocalParking';
 import SearchIcon from '@mui/icons-material/Search';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
+import MyLocationIcon from '@mui/icons-material/MyLocation';
 import React, { ReactElement } from 'react';
 import {
   baseIcon,
@@ -279,5 +280,11 @@ export function MissingPackageNameIcon(props: IconProps): ReactElement {
         })}
       />
     </MuiTooltip>
+  );
+}
+
+export function LocateAttributionsIcon(props: IconProps): ReactElement {
+  return (
+    <MyLocationIcon arial-abel={'locate attributions icon'} sx={props.sx} />
   );
 }

--- a/src/Frontend/Components/ProjectLicensesTable/ProjectLicensesTable.tsx
+++ b/src/Frontend/Components/ProjectLicensesTable/ProjectLicensesTable.tsx
@@ -29,6 +29,7 @@ interface ProjectLicensesTableProps {
   columnHeaders: Array<string>;
   columnNames: Array<string>;
   rowNames: Array<string>;
+  firstColumnIconButtons?: { [rowName: string]: ReactElement };
   tableContent: TableContent;
   tableFooter?: Array<string>;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
@@ -75,10 +76,16 @@ export function ProjectLicensesTable(
                     key={columnIndex}
                     align={columnIndex === 0 ? 'left' : 'center'}
                   >
-                    {columnIndex === 0
-                      ? rowName
-                      : props.tableContent[rowName][columnName] ||
-                        PLACEHOLDER_ATTRIBUTION_COUNT}
+                    {columnIndex === 0 ? (
+                      <>
+                        <span>{rowName}</span>
+                        {props.firstColumnIconButtons &&
+                          props.firstColumnIconButtons[rowName]}
+                      </>
+                    ) : (
+                      props.tableContent[rowName][columnName] ||
+                      PLACEHOLDER_ATTRIBUTION_COUNT
+                    )}
                   </MuiTableCell>
                 ))}
               </MuiTableRow>

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -9,10 +9,11 @@ import {
 } from '../../../test-helpers/render-component-with-store';
 import React from 'react';
 import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup';
-import { Attributions } from '../../../../shared/shared-types';
+import { Attributions, Criticality } from '../../../../shared/shared-types';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { screen } from '@testing-library/react';
+import { ProjectStatisticsPopupTitle } from '../../../enums/enums';
 
 describe('The ProjectStatisticsPopup', () => {
   it('displays license names and source names', () => {
@@ -46,6 +47,40 @@ describe('The ProjectStatisticsPopup', () => {
     expect(screen.getByText('The MIT License (MIT)')).toBeInTheDocument();
     expect(screen.getByText('Scancode')).toBeInTheDocument();
     expect(screen.getByText('Reuser')).toBeInTheDocument();
+  });
+
+  it('renders search icons in CriticalLicensesTable', () => {
+    const store = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        licenseName: 'GNU General Public License v2.0',
+        criticality: Criticality.High,
+      },
+      uuid_2: {
+        licenseName: 'The MIT License (MIT)',
+        criticality: Criticality.Medium,
+      },
+    };
+    store.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+        }),
+      ),
+    );
+    renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+
+    expect(
+      screen.getByText(ProjectStatisticsPopupTitle.CriticalLicensesTable),
+    ).toBeInTheDocument();
+    const iconButtonGPL = screen.getByRole('button', {
+      name: 'locate attributions with "GNU General Public License v2.0"',
+    });
+    const iconButtonMIT = screen.getByRole('button', {
+      name: 'locate attributions with "The MIT License (MIT)"',
+    });
+    expect(iconButtonGPL).toBeEnabled();
+    expect(iconButtonMIT).toBeEnabled();
   });
 
   it('renders pie charts when there are attributions', () => {
@@ -93,6 +128,7 @@ describe('The ProjectStatisticsPopup', () => {
     );
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
+
     expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
     expect(screen.getByText('Critical Signals')).toBeInTheDocument();
     expect(screen.getAllByText('Incomplete Attributions')).toHaveLength(2);

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import WestRoundedIcon from '@mui/icons-material/WestRounded';
-import MyLocationIcon from '@mui/icons-material/MyLocation';
 import remove from 'lodash/remove';
 import React, { ReactElement } from 'react';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
@@ -44,6 +43,7 @@ import { isLocateSignalActive } from '../../state/selectors/locate-popup-selecto
 import { IconButton } from '../IconButton/IconButton';
 import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { PopupType } from '../../enums/enums';
+import { LocateAttributionsIcon } from '../Icons/Icons';
 
 const classes = {
   locatorIconContainer: {
@@ -149,7 +149,7 @@ export function ResourceBrowser(): ReactElement | null {
       onClick={(): void => {
         dispatch(openPopup(PopupType.LocatorPopup));
       }}
-      icon={<MyLocationIcon aria-label={'locate attributions'} />}
+      icon={<LocateAttributionsIcon />}
     />
   ) : undefined;
   const resourcesWithLocatedAttributions = useAppSelector(

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -338,9 +338,9 @@ describe('ResourceBrowser', () => {
       );
     });
 
-    expect(screen.getByLabelText('locate attributions')).toBeInTheDocument();
+    expect(screen.getByLabelText('filters active')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('locate attributions'));
+    fireEvent.click(screen.getByLabelText('filters active'));
 
     expect(getOpenPopup(store.getState())).toBe(PopupType.LocatorPopup);
   });


### PR DESCRIPTION
### Summary of changes
This commit adds icons for searching licenses to the `CriticalLicensesTable` in `ProjectStatisticsPopup`. The logic is implemented in an upcoming PR.

### Context and reason for change
We want the user to be able to search for resources with specific licenses via the `ProjectStatisticsPopup`. The new search icons allow for searching licenses in the `ResourceBrowser` according to the functionality of the `LocatorPopup`.

### How can the changes be tested
**Automatic testing:**
Run `ProjectStatisticsPopup.test.tsx`.
**Manual testing:**
Load test file, open `ProjectStatisticsPopup`, and hover over the icons in the third column of the `CriticalLicensesTable`.


Fix: #1984