### PR TITLE
Update Tooltip text of the criticality bar.

### DIFF
--- a/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
@@ -226,11 +226,14 @@ describe('TopProgressBar', () => {
     act(() => {
       jest.runAllTimers();
     });
-    expect(screen.getByText(/Files with only signals: 3/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Files with only highly critical signals: 1/) &&
-        screen.getByText(/Files with only medium critical signals: 1/) &&
-        screen.getByText(/Files with only non-critical signals: 1/),
+      screen.getByText(/Files without attributions but/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/with signals: 3/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/with highly-critical signals: 1/) &&
+        screen.getByText(/with medium-critical signals: 1/) &&
+        screen.getByText(/with non-critical signals: 1/),
     ).toBeDefined();
   });
 });

--- a/src/Frontend/Components/ProgressBar/progress-bar-helpers.tsx
+++ b/src/Frontend/Components/ProgressBar/progress-bar-helpers.tsx
@@ -58,17 +58,16 @@ export function getCriticalityBarTooltipText(
     progressBarData.filesWithMediumCriticalExternalAttributionsCount;
   return (
     <MuiBox>
-      Files with only signals:{' '}
-      {progressBarData.filesWithOnlyExternalAttributionCount}
+      Files without attributions but <br />
+      with signals: {progressBarData.filesWithOnlyExternalAttributionCount}
       <br />
-      Files with only highly critical signals:{' '}
+      with highly-critical signals:{' '}
       {progressBarData.filesWithHighlyCriticalExternalAttributionsCount}
       <br />
-      Files with only medium critical signals:{' '}
+      with medium-critical signals:{' '}
       {progressBarData.filesWithMediumCriticalExternalAttributionsCount}
       <br />
-      Files with only non-critical signals:{' '}
-      {filesWithNonCriticalExternalAttributions}
+      with non-critical signals: {filesWithNonCriticalExternalAttributions}
     </MuiBox>
   );
 }


### PR DESCRIPTION
### Summary of changes

- Updated tooltip text of criticality bar.

![OpossumUI_CriticallityBarToolTip](https://github.com/opossum-tool/OpossumUI/assets/89708272/d03c853e-42cb-4ab5-bdb2-325e8d41006e)

### Context and reason for change
The previous tooltip text was missleading as it was not clear what the "only" related to, e.g., "Files with only highly critical signals". Therefore, the tooltip was updated. The new headline makes it clear, that only resources without attributions but with signals only are considered.
The logic used to calculate the numbers did not have to be changed, as it already implements the behaviour requested in the Issue #1986.

### How can the changes be tested

- Checkout the commit
- run `yarn start`
- open the example file `opossum_ui_scan_input.opossum`
- use the toggle on the right hand side of the progress bar in order to switch to the criticallity bar
- Move cursor over the criticallity bar in order to see the updated tooltip text

Issue: #1986
Fix: #1986
