### PR TITLE
Extend packageinfo and schema for preferred attributions

### DIFF
--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -149,6 +149,17 @@
             "items": {
               "type": "string"
             }
+          },
+          "preferred":{
+            "type": "boolean",
+            "description": "Indicates that the attribution has been marked as preferred by a user."
+          },
+          "preferredOverOriginIds": {
+            "type": "array",
+            "description": "OriginIds of all attributions this one is preferred over.",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": ["source"],

--- a/src/ElectronBackend/input/OpossumOutputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumOutputFileSchema.json
@@ -109,6 +109,17 @@
           "needsReview": {
             "type": "boolean",
             "description": "Indicates that the information in an attribution needs further review."
+          },
+          "preferred":{
+            "type": "boolean",
+            "description": "Indicates that the attribution has been marked as preferred by a user."
+          },
+          "preferredOverOriginIds": {
+            "type": "array",
+            "description": "OriginIds of all attributions this one is preferred over.",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [],

--- a/src/ElectronBackend/input/__tests__/parseFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseFile.test.ts
@@ -122,6 +122,8 @@ const correctOutput: OpossumOutputFile = {
       packageVersion: '16.0.1',
       licenseText: '',
       needsReview: true,
+      preferred: true,
+      preferredOverOriginIds: ['test-id'],
     },
   },
   resourcesToAttributions: {

--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -19,7 +19,7 @@ import { createTempFolder, deleteFolder } from '../../test-helpers';
 const testCsvHeader =
   '"Index";"Confidence";"Comment";"Package Name";"Package Version";"Package Namespace";' +
   '"Package Type";"PURL Appendix";"URL";"Copyright";"License Name";"License Text (truncated)";"Source";"First Party";' +
-  '"Follow-up";"Origin Attribution IDs";"pre-selected";"exclude-from-notice";"criticality";"needs-review";"Resources"';
+  '"Follow-up";"Origin Attribution IDs";"pre-selected";"exclude-from-notice";"criticality";"needs-review";"preferred";"preferred-over-origin-ids";"Resources"';
 
 describe('writeCsvToFile', () => {
   it('writeCsvToFile short', async () => {
@@ -46,13 +46,13 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"',
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"";"";"/test.file"',
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"',
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm"',
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/b"',
     );
     deleteFolder(temporaryPath);
   });
@@ -117,10 +117,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"',
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"";"";"/test.file"',
     );
     expect(content).toContain(
-      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
+      '"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/c/bla.mm\n' +
         '/b"',
     );
     deleteFolder(temporaryPath);
@@ -163,10 +163,10 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"',
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"";"";"/test.file"',
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`,
+      `"2";"";"";"Fancy name,: tt";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"${expectedResources}"`,
     );
     deleteFolder(temporaryPath);
   });
@@ -453,25 +453,25 @@ describe('writeCsvToFile', () => {
     const content = await fs.promises.readFile(csvPath, 'utf8');
     expect(content).toContain(testCsvHeader);
     expect(content).toContain(
-      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"/test.file"',
+      '"1";"";"";"";"";"";"";"";"";"";"";"license text, with; commas";"";"true";"";"";"";"";"";"";"";"";"/test.file"',
     );
     expect(content).toContain(
-      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"";"";"/a"`,
+      `"2";"";"";"Fancy name with long license";"";"";"";"";"";"";"";"${expectedLicenseText}";"";"";"";"";"";"";"";"";"";"";"/a"`,
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b"',
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c"',
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.bla"',
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/a/b/c/testi.blub"',
     );
     expect(content).toContain(
-      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"',
+      '"2";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"";"/other"',
     );
     deleteFolder(temporaryPath);
   });

--- a/src/ElectronBackend/output/writeCsvToFile.ts
+++ b/src/ElectronBackend/output/writeCsvToFile.ts
@@ -91,6 +91,8 @@ export function getHeadersFromColumns(columns: Array<KeysOfAttributionInfo>): {
     excludeFromNotice: 'exclude-from-notice',
     criticality: 'criticality',
     needsReview: 'needs-review',
+    preferred: 'preferred',
+    preferredOverOriginIds: 'preferred-over-origin-ids',
   };
 
   const headers: { [key: string]: string } = {};

--- a/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
+++ b/src/Frontend/Components/ReportTableItem/report-table-item-helpers.ts
@@ -30,6 +30,7 @@ export function getFormattedCellData(
     case 'preSelected':
     case 'needsReview':
     case 'excludeFromNotice':
+    case 'preferred':
       cellData = attributionInfo[config.attributionProperty] ? 'Yes' : 'No';
       break;
     case 'icons':
@@ -39,6 +40,7 @@ export function getFormattedCellData(
       cellData = attributionInfo[config.attributionProperty]?.name.trim() || '';
       break;
     case 'originIds':
+    case 'preferredOverOriginIds':
       cellData = '';
       break;
     default:

--- a/src/Frontend/util/__tests__/convert-package-info.test.ts
+++ b/src/Frontend/util/__tests__/convert-package-info.test.ts
@@ -53,6 +53,8 @@ describe('convertPackageInfoToDisplayPackageInfo', () => {
       'excludeFromNotice',
       'criticality',
       'needsReview',
+      'preferred',
+      'preferredOverOriginIds',
     ];
     expect(testKeysOfPackageInfo).toEqual(expectedKeysOfPackageInfo);
   });
@@ -133,6 +135,8 @@ describe('convertDisplayPackageInfoToPackageInfo', () => {
       'criticality',
       'comments',
       'attributionIds',
+      'preferred',
+      'preferredOverOriginIds',
     ];
     expect(testKeysOfDisplayPackageInfo).toEqual(
       expectedKeysOfDisplayPackageInfo,

--- a/src/Frontend/util/get-display-package-info-keys.ts
+++ b/src/Frontend/util/get-display-package-info-keys.ts
@@ -29,6 +29,8 @@ export function getDisplayPackageInfoKeys(): Array<KeysOfDisplayPackageInfo> {
     criticality: true,
     comments: true,
     attributionIds: true,
+    preferred: true,
+    preferredOverOriginIds: true,
   };
   return Object.keys(
     displayPackageInfoKeysObject,

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -55,6 +55,8 @@ interface PackageInfoCore {
   excludeFromNotice?: boolean;
   criticality?: Criticality;
   needsReview?: boolean;
+  preferred?: boolean;
+  preferredOverOriginIds?: Array<string>;
 }
 
 export interface PackageInfo extends PackageInfoCore {

--- a/src/shared/shared-util.ts
+++ b/src/shared/shared-util.ts
@@ -28,6 +28,8 @@ export function getPackageInfoKeys(): Array<KeysOfPackageInfo> {
     excludeFromNotice: true,
     criticality: true,
     needsReview: true,
+    preferred: true,
+    preferredOverOriginIds: true,
   };
   return Object.keys(packageInfoKeysObject) as Array<KeysOfPackageInfo>;
 }


### PR DESCRIPTION
### Summary of changes

We add two new fields "preferred" and "prefferedOverOriginIds" to the PackageInfo and the manual attributions in the schema for the output file.

### Context and reason for change

We want to support preferred attributions marked as such by the user. For this, the two new fields are necessary.

### How can the changes be tested

Run the updated unit tests.

Fixes #1988