### PR TITLE
Calculate located resources

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -159,7 +159,7 @@ export function ResourceBrowser(): ReactElement | null {
     ? resourcesWithLocatedAttributions.locatedResources
     : undefined;
   const resourcesWithLocatedChildren = locateSignalActive
-    ? resourcesWithLocatedAttributions.resourcesWithLocatedChildren.paths
+    ? resourcesWithLocatedAttributions.resourcesWithLocatedChildren
     : undefined;
 
   const locatedResourceIcon = (

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -154,11 +154,7 @@ describe('ResourceBrowser', () => {
     };
 
     const testLocatePopupSelectedCriticality = SelectedCriticality.High;
-    const testResourcesWithLocatedChildren = {
-      paths: ['/', '/root/'],
-      pathsToIndices: {},
-      attributedChildren: {},
-    };
+    const testResourcesWithLocatedChildren = new Set<string>(['/', '/root/']);
     const testLocatedResources = new Set<string>(['/root/src/']);
 
     const { store } = renderComponentWithStore(<ResourceBrowser />);

--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
@@ -53,7 +53,7 @@ interface VirtualizedTreeProps {
   locatorIcon?: ReactElement;
   locatedResourceIcon?: ReactElement;
   locatedResources?: Set<string>;
-  resourcesWithLocatedChildren?: Array<string>;
+  resourcesWithLocatedChildren?: Set<string>;
 }
 
 export function VirtualizedTree(

--- a/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
+++ b/src/Frontend/extracted/VirtualisedTree/__tests__/get-tree-node-props.test.ts
@@ -96,7 +96,7 @@ describe('renderTree', () => {
   it('isLocatedSelected highlights unexpanded resources with located children', () => {
     const locatedParentId = '/locatedParent/';
     const notLocatedParentId = '/notLocatedParent/';
-    const resourcesWithLocatedChildren = ['/locatedParent/'];
+    const resourcesWithLocatedChildren = new Set(['/locatedParent/']);
 
     expect(
       isLocated(

--- a/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/utils/get-tree-node-props.tsx
@@ -24,7 +24,7 @@ export function getTreeNodeProps(
   ) => ReactElement,
   cardHeight: number,
   locatedResources?: Set<string>,
-  resourcesWithLocatedChildren?: Array<string>,
+  resourcesWithLocatedChildren?: Set<string>,
   breakpoints?: Set<string>,
 ): Array<VirtualizedTreeNodeData> {
   const sortedNodeNames: Array<string> = Object.keys(nodes).sort(
@@ -103,19 +103,16 @@ export function isLocated(
   nodeId: string,
   isExpandedNode: boolean,
   locatedResources?: Set<string>,
-  resourcesWithLocatedChildren?: Array<string>,
+  resourcesWithLocatedChildren?: Set<string>,
 ): boolean {
   if (locatedResources && locatedResources.has(nodeId)) {
     return true;
   }
-  if (
+  return !!(
     resourcesWithLocatedChildren &&
-    resourcesWithLocatedChildren.includes(nodeId) &&
+    resourcesWithLocatedChildren.has(nodeId) &&
     !isExpandedNode
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 export function getNodeIdsToExpand(

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -314,20 +314,13 @@ describe('The load and navigation simple actions', () => {
   it('sets and gets resourcesWithLocatedAttributions', () => {
     const testStore = createTestAppStore();
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
-      resourcesWithLocatedChildren: {
-        attributedChildren: {},
-        paths: [],
-        pathsToIndices: {},
-      },
+      resourcesWithLocatedChildren: new Set(),
       locatedResources: new Set(),
     });
 
-    const testResourcesWithLocatedChildren = {
-      paths: Array<string>('path/to/resource/1'),
-      pathsToIndices: { 'path/to/resource/1': 1 },
-      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      attributedChildren: { 1: new Set<number>([10, 11, 12]) },
-    };
+    const testResourcesWithLocatedChildren = new Set<string>([
+      'test resource with located children',
+    ]);
     const testLocatedResources = new Set<string>(['test resource']);
     testStore.dispatch(
       setResourcesWithLocatedAttributions(

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -13,7 +13,6 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
-  ResourcesWithAttributedChildren,
 } from '../../../../shared/shared-types';
 import { getAttributionDataFromSetAttributionDataPayload } from '../../helpers/action-and-reducer-helpers';
 import {
@@ -146,7 +145,7 @@ export function setExternalAttributionsToHashes(
 }
 
 export function setResourcesWithLocatedAttributions(
-  resourcesWithLocatedChildren: ResourcesWithAttributedChildren,
+  resourcesWithLocatedChildren: Set<string>,
   locatedResources: Set<string>,
 ): SetResourcesWithLocatedAttributions {
   return {

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -15,7 +15,6 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
-  ResourcesWithAttributedChildren,
   SelectedCriticality,
 } from '../../../../shared/shared-types';
 import {
@@ -377,7 +376,7 @@ export interface SetLocatePopupSelectedLicenses {
 export interface SetResourcesWithLocatedAttributions {
   type: typeof ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS;
   payload: {
-    resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+    resourcesWithLocatedChildren: Set<string>;
     locatedResources: Set<string>;
   };
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -12,7 +12,6 @@ import {
   FrequentLicenses,
   ProjectMetadata,
   Resources,
-  ResourcesWithAttributedChildren,
   SelectedCriticality,
 } from '../../../shared/shared-types';
 import { PackagePanelTitle } from '../../enums/enums';
@@ -109,11 +108,7 @@ export const initialResourceState: ResourceState = {
     attributionIdMarkedForReplacement: '',
     externalAttributionsToHashes: {},
     resourcesWithLocatedAttributions: {
-      resourcesWithLocatedChildren: {
-        paths: [],
-        pathsToIndices: {},
-        attributedChildren: {},
-      },
+      resourcesWithLocatedChildren: new Set(),
       locatedResources: new Set(),
     },
   },
@@ -171,7 +166,7 @@ export type ResourceState = {
     attributionIdMarkedForReplacement: string;
     externalAttributionsToHashes: AttributionsToHashes;
     resourcesWithLocatedAttributions: {
-      resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+      resourcesWithLocatedChildren: Set<string>;
       locatedResources: Set<string>;
     };
   };

--- a/src/Frontend/state/selectors/all-views-resource-selectors.ts
+++ b/src/Frontend/state/selectors/all-views-resource-selectors.ts
@@ -231,7 +231,7 @@ export function getExternalAttributionsToHashes(
 }
 
 export function getResourcesWithLocatedAttributions(state: State): {
-  resourcesWithLocatedChildren: ResourcesWithAttributedChildren;
+  resourcesWithLocatedChildren: Set<string>;
   locatedResources: Set<string>;
 } {
   return state.resourceState.allViews.resourcesWithLocatedAttributions;


### PR DESCRIPTION
### Summary of changes

Calculate located resources and resources with located children
- Introduce conditions to check the entries in the locate popup
- Adjust the state to only store paths for resources with located children
- Consider short- and full names of frequent licenses
- Fix and add tests
- code style improvements

### Context and reason for change

We are introducing a feature to "locate" resources that have or contain attributions with criteria that can be set in a new popup.

### How can the changes be tested

Run the tests

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
