### PR TITLE
Add logic to license locator icons in `ProjectStatisticsPopup`

### DIFF
--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -8,8 +8,11 @@ import { Criticality } from '../../../shared/shared-types';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
 import { LicenseNamesWithCriticality } from '../../types/types';
 import { IconButton } from '../IconButton/IconButton';
-import { LocateAttributionsIcon } from '../Icons/Icons';
+import { LocateSignalsIcon } from '../Icons/Icons';
 import { clickableIcon } from '../../shared-styles';
+import { useAppDispatch } from '../../state/hooks';
+import { AppThunkDispatch } from '../../state/types';
+import { locateSignalsFromProjectStatisticsPopup } from '../../state/actions/popup-actions/popup-actions';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
 const COUNT_COLUMN_NAME_IN_TABLE = 'Count';
@@ -40,6 +43,7 @@ interface CriticalLicensesTableProps {
 export function CriticalLicensesTable(
   props: CriticalLicensesTableProps,
 ): ReactElement {
+  const dispatch = useAppDispatch();
   const allLicensesWithCriticality = Object.entries(
     props.licenseNamesWithCriticality,
   ).map((licenseNameAndCriticality) => {
@@ -80,7 +84,7 @@ export function CriticalLicensesTable(
       firstColumnIconButtons={Object.fromEntries(
         criticalLicensesTotalAttributions.map(({ licenseName }) => [
           licenseName,
-          getLocateAttributionIconButton(licenseName),
+          getLocateSignalsIconButton(licenseName, dispatch),
         ]),
       )}
       rowNames={criticalLicensesTotalAttributions.map(
@@ -152,17 +156,20 @@ function getTotalNumberOfAttributions(
     .reduce((total, value) => total + value, 0);
 }
 
-function getLocateAttributionIconButton(licenseName: string): ReactElement {
-  const onLocateAttributionButtonClick = function (): void {
-    // TODO: dispatch license locator actions in next ticket
+function getLocateSignalsIconButton(
+  licenseName: string,
+  dispatch: AppThunkDispatch,
+): ReactElement {
+  const onLocateSignalButtonClick = function (): void {
+    dispatch(locateSignalsFromProjectStatisticsPopup(licenseName));
   };
   return (
     <IconButton
-      tooltipTitle={`locate attributions with "${licenseName}"`}
+      tooltipTitle={`locate signals with "${licenseName}"`}
       tooltipPlacement="right"
-      onClick={onLocateAttributionButtonClick}
+      onClick={onLocateSignalButtonClick}
       iconSx={classes.iconButton}
-      icon={<LocateAttributionsIcon sx={classes.clickableIcon} />}
+      icon={<LocateSignalsIcon sx={classes.clickableIcon} />}
     />
   );
 }

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -282,10 +282,8 @@ export function MissingPackageNameIcon(props: IconProps): ReactElement {
   );
 }
 
-export function LocateAttributionsIcon(props: IconProps): ReactElement {
-  return (
-    <MyLocationIcon arial-abel={'locate attributions icon'} sx={props.sx} />
-  );
+export function LocateSignalsIcon(props: IconProps): ReactElement {
+  return <MyLocationIcon arial-abel={'locate signals icon'} sx={props.sx} />;
 }
 
 export function PreferredIcon(props: IconProps): ReactElement {

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -43,7 +43,7 @@ import { isLocateSignalActive } from '../../state/selectors/locate-popup-selecto
 import { IconButton } from '../IconButton/IconButton';
 import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { PopupType } from '../../enums/enums';
-import { LocateAttributionsIcon } from '../Icons/Icons';
+import { LocateSignalsIcon } from '../Icons/Icons';
 
 const classes = {
   locatorIconContainer: {
@@ -149,18 +149,12 @@ export function ResourceBrowser(): ReactElement | null {
       onClick={(): void => {
         dispatch(openPopup(PopupType.LocatorPopup));
       }}
-      icon={<LocateAttributionsIcon />}
+      icon={<LocateSignalsIcon />}
     />
   ) : undefined;
   const resourcesWithLocatedAttributions = useAppSelector(
     getResourcesWithLocatedAttributions,
   );
-  const locatedResources = locateSignalActive
-    ? resourcesWithLocatedAttributions.locatedResources
-    : undefined;
-  const resourcesWithLocatedChildren = locateSignalActive
-    ? resourcesWithLocatedAttributions.resourcesWithLocatedChildren
-    : undefined;
 
   const locatedResourceIcon = (
     <WestRoundedIcon
@@ -192,8 +186,10 @@ export function ResourceBrowser(): ReactElement | null {
       }}
       locatorIcon={locatorIcon}
       locatedResourceIcon={locatedResourceIcon}
-      locatedResources={locatedResources}
-      resourcesWithLocatedChildren={resourcesWithLocatedChildren}
+      locatedResources={resourcesWithLocatedAttributions.locatedResources}
+      resourcesWithLocatedChildren={
+        resourcesWithLocatedAttributions.resourcesWithLocatedChildren
+      }
     />
   ) : null;
 }

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { NIL as uuidNil } from 'uuid';
 import {
   Attributions,
+  Criticality,
   Resources,
   ResourcesToAttributions,
   SelectedCriticality,
@@ -26,13 +27,12 @@ import {
   setFilesWithChildren,
   setManualData,
   setResources,
-  setResourcesWithLocatedAttributions,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { getSelectedResourceId } from '../../../state/selectors/audit-view-resource-selectors';
 import { isEqual } from 'lodash';
 import { addResolvedExternalAttribution } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { collapseFolderByClickingOnIcon } from '../../../test-helpers/resource-browser-test-helpers';
-import { setLocatePopupSelectedCriticality } from '../../../state/actions/resource-actions/locate-popup-actions';
+import { setLocatePopupFilters } from '../../../state/actions/resource-actions/locate-popup-actions';
 import { getOpenPopup } from '../../../state/selectors/view-selector';
 import { PopupType } from '../../../enums/enums';
 
@@ -147,15 +147,13 @@ describe('ResourceBrowser', () => {
     const testManualAttributions: Attributions = {};
     const testResourcesToManualAttributions: ResourcesToAttributions = {};
     const testExternalAttributions: Attributions = {
-      [testUuid]: { packageName: 'jquery' },
+      [testUuid]: { packageName: 'jquery', criticality: Criticality.High },
     };
     const testResourcesToExternalAttributions: ResourcesToAttributions = {
       '/root/src/': [testUuid],
     };
 
     const testLocatePopupSelectedCriticality = SelectedCriticality.High;
-    const testResourcesWithLocatedChildren = new Set<string>(['/', '/root/']);
-    const testLocatedResources = new Set<string>(['/root/src/']);
 
     const { store } = renderComponentWithStore(<ResourceBrowser />);
     act(() => {
@@ -173,13 +171,10 @@ describe('ResourceBrowser', () => {
         ),
       );
       store.dispatch(
-        setResourcesWithLocatedAttributions(
-          testResourcesWithLocatedChildren,
-          testLocatedResources,
-        ),
-      );
-      store.dispatch(
-        setLocatePopupSelectedCriticality(testLocatePopupSelectedCriticality),
+        setLocatePopupFilters({
+          selectedCriticality: testLocatePopupSelectedCriticality,
+          selectedLicenses: new Set<string>(),
+        }),
       );
     });
 
@@ -334,7 +329,10 @@ describe('ResourceBrowser', () => {
     act(() => {
       store.dispatch(setResources({}));
       store.dispatch(
-        setLocatePopupSelectedCriticality(SelectedCriticality.High),
+        setLocatePopupFilters({
+          selectedCriticality: SelectedCriticality.High,
+          selectedLicenses: new Set<string>(),
+        }),
       );
     });
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -33,7 +33,6 @@ import {
   getResourcesToExternalAttributions,
   getResourcesToManualAttributions,
   getResourcesWithExternalAttributedChildren,
-  getResourcesWithLocatedAttributions,
   getResourcesWithManualAttributedChildren,
   getTemporaryDisplayPackageInfo,
 } from '../../../selectors/all-views-resource-selectors';
@@ -47,7 +46,6 @@ import {
   setIsPreferenceFeatureEnabled,
   setManualData,
   setResources,
-  setResourcesWithLocatedAttributions,
   setTemporaryDisplayPackageInfo,
 } from '../all-views-simple-actions';
 import { setSelectedResourceId } from '../audit-view-simple-actions';
@@ -331,29 +329,6 @@ describe('The load and navigation simple actions', () => {
     expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
       testExternalAttributionsToHashes,
     );
-  });
-
-  it('sets and gets resourcesWithLocatedAttributions', () => {
-    const testStore = createTestAppStore();
-    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
-      resourcesWithLocatedChildren: new Set(),
-      locatedResources: new Set(),
-    });
-
-    const testResourcesWithLocatedChildren = new Set<string>([
-      'test resource with located children',
-    ]);
-    const testLocatedResources = new Set<string>(['test resource']);
-    testStore.dispatch(
-      setResourcesWithLocatedAttributions(
-        testResourcesWithLocatedChildren,
-        testLocatedResources,
-      ),
-    );
-    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
-      resourcesWithLocatedChildren: testResourcesWithLocatedChildren,
-      locatedResources: testLocatedResources,
-    });
   });
 
   it('sets and gets isPreferenceFeatureEnabled', () => {

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -40,8 +40,6 @@ import {
   SetProjectMetadata,
   SetResourcesAction,
   SetTemporaryDisplayPackageInfoAction,
-  SetResourcesWithLocatedAttributions,
-  ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS,
   ACTION_SET_ENABLE_PREFERENCE_FEATURE,
   SetIsPreferenceFeatureEnabled,
 } from './types';
@@ -143,19 +141,6 @@ export function setExternalAttributionsToHashes(
   return {
     type: ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES,
     payload: externalAttributionsToHashes,
-  };
-}
-
-export function setResourcesWithLocatedAttributions(
-  resourcesWithLocatedChildren: Set<string>,
-  locatedResources: Set<string>,
-): SetResourcesWithLocatedAttributions {
-  return {
-    type: ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS,
-    payload: {
-      resourcesWithLocatedChildren,
-      locatedResources,
-    },
   };
 }
 

--- a/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/locate-popup-actions.ts
@@ -3,28 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedCriticality } from '../../../../shared/shared-types';
+import { LocatePopupFilters } from '../../../types/types';
 import {
-  SetLocatePopupSelectedCriticality,
-  ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
-  SetLocatePopupSelectedLicenses,
-  ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
+  SetLocatePopupFilters,
+  ACTION_SET_LOCATE_POPUP_FILTERS,
 } from './types';
 
-export function setLocatePopupSelectedCriticality(
-  selectedCriticality: SelectedCriticality,
-): SetLocatePopupSelectedCriticality {
+export function setLocatePopupFilters(
+  locatePopupFilters: LocatePopupFilters,
+): SetLocatePopupFilters {
   return {
-    type: ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY,
-    payload: selectedCriticality,
-  };
-}
-
-export function setLocatePopupSelectedLicenses(
-  selectedLicenses: Set<string>,
-): SetLocatePopupSelectedLicenses {
-  return {
-    type: ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES,
-    payload: selectedLicenses,
+    type: ACTION_SET_LOCATE_POPUP_FILTERS,
+    payload: locatePopupFilters,
   };
 }

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -15,12 +15,12 @@ import {
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
-  SelectedCriticality,
 } from '../../../../shared/shared-types';
 import {
   PanelPackage,
   PackageAttributeIds,
   PackageAttributes,
+  LocatePopupFilters,
 } from '../../../types/types';
 import { AllowedSaveOperations } from '../../../enums/enums';
 
@@ -95,14 +95,12 @@ export const ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT =
   'ACTION_SET_ATTRIBUTION_WIZARD_TOTAL_ATTRIBUTION_COUNT';
 export const ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES =
   'ACTION_SET_EXTERNAL_ATTRIBUTIONS_TO_HASHES';
-export const ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY =
-  'ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY';
-export const ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES =
-  'ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES';
 export const ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS =
   'ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS';
 export const ACTION_SET_ENABLE_PREFERENCE_FEATURE =
   'ACTION_SET_ENABLE_PREFERENCE_FEATURE';
+export const ACTION_SET_LOCATE_POPUP_FILTERS =
+  'ACTION_SET_LOCATE_POPUP_FILTERS';
 
 export type ResourceAction =
   | ResetResourceStateAction
@@ -145,10 +143,8 @@ export type ResourceAction =
   | SetAttributionWizardSelectedPackageIds
   | SetAttributionWizardTotalAttributionCount
   | SetExternalAttributionsToHashes
-  | SetLocatePopupSelectedCriticality
-  | SetLocatePopupSelectedLicenses
-  | SetResourcesWithLocatedAttributions
-  | SetIsPreferenceFeatureEnabled;
+  | SetIsPreferenceFeatureEnabled
+  | SetLocatePopupFilters;
 
 export interface ResetResourceStateAction {
   type: typeof ACTION_RESET_RESOURCE_STATE;
@@ -368,25 +364,12 @@ export interface SetExternalAttributionsToHashes {
   payload: AttributionsToHashes;
 }
 
-export interface SetLocatePopupSelectedCriticality {
-  type: typeof ACTION_SET_LOCATE_POPUP_SELECTED_CRITICALITY;
-  payload: SelectedCriticality;
-}
-
-export interface SetLocatePopupSelectedLicenses {
-  type: typeof ACTION_SET_LOCATE_POPUP_SELECTED_LICENSES;
-  payload: Set<string>;
-}
-
-export interface SetResourcesWithLocatedAttributions {
-  type: typeof ACTION_SET_RESOURCES_WITH_LOCATED_ATTRIBUTIONS;
-  payload: {
-    resourcesWithLocatedChildren: Set<string>;
-    locatedResources: Set<string>;
-  };
-}
-
 export interface SetIsPreferenceFeatureEnabled {
   type: typeof ACTION_SET_ENABLE_PREFERENCE_FEATURE;
   payload: boolean;
+}
+
+export interface SetLocatePopupFilters {
+  type: typeof ACTION_SET_LOCATE_POPUP_FILTERS;
+  payload: LocatePopupFilters;
 }

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -13,6 +13,8 @@ export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
 export const ACTION_UPDATE_ACTIVE_FILTERS = 'ACTION_UPDATE_ACTIVE_FILTERS';
 export const ACTION_SET_IS_LOADING = 'ACTION_SET_IS_LOADING';
+export const ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE =
+  'ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE';
 
 export type ViewAction =
   | SetView
@@ -21,7 +23,8 @@ export type ViewAction =
   | ResetViewStateAction
   | OpenPopupAction
   | UpdateActiveFilters
-  | SetIsLoadingAction;
+  | SetIsLoadingAction
+  | SetShowNoSignalsLocatedMessage;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -53,5 +56,10 @@ export interface UpdateActiveFilters {
 
 export interface SetIsLoadingAction {
   type: typeof ACTION_SET_IS_LOADING;
+  payload: boolean;
+}
+
+export interface SetShowNoSignalsLocatedMessage {
+  type: typeof ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE;
   payload: boolean;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -16,6 +16,7 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_IS_LOADING,
+  ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
@@ -23,6 +24,7 @@ import {
   OpenPopupAction,
   ResetViewStateAction,
   SetIsLoadingAction,
+  SetShowNoSignalsLocatedMessage,
   SetTargetView,
   SetView,
   UpdateActiveFilters,
@@ -98,4 +100,13 @@ export function updateActiveFilters(
 
 export function setIsLoading(isLoading: boolean): SetIsLoadingAction {
   return { type: ACTION_SET_IS_LOADING, payload: isLoading };
+}
+
+export function setShowNoSignalsLocatedMessage(
+  showMessage: boolean,
+): SetShowNoSignalsLocatedMessage {
+  return {
+    type: ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
+    payload: showMessage,
+  };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -11,6 +11,7 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_IS_LOADING,
+  ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   ACTION_UPDATE_ACTIVE_FILTERS,
@@ -24,6 +25,7 @@ export interface ViewState {
   popupInfo: Array<PopupInfo>;
   activeFilters: Set<FilterType>;
   isLoading: boolean;
+  showNoSignalsLocatedMessage: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -32,6 +34,7 @@ export const initialViewState: ViewState = {
   popupInfo: [],
   activeFilters: new Set<FilterType>(),
   isLoading: false,
+  showNoSignalsLocatedMessage: false,
 };
 
 export function viewState(
@@ -74,6 +77,11 @@ export function viewState(
       return {
         ...state,
         isLoading: action.payload,
+      };
+    case ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE:
+      return {
+        ...state,
+        showNoSignalsLocatedMessage: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
@@ -3,12 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Criticality } from '../../../../shared/shared-types';
+import { SelectedCriticality } from '../../../../shared/shared-types';
 import { createTestAppStore } from '../../../test-helpers/render-component-with-store';
-import {
-  setLocatePopupSelectedCriticality,
-  setLocatePopupSelectedLicenses,
-} from '../../actions/resource-actions/locate-popup-actions';
+import { setLocatePopupFilters } from '../../actions/resource-actions/locate-popup-actions';
 import { isLocateSignalActive } from '../locate-popup-selectors';
 
 describe('isLocateSignalActive', () => {
@@ -19,7 +16,12 @@ describe('isLocateSignalActive', () => {
 
   it('returns true if the selected criticality is not the default', () => {
     const testStore = createTestAppStore();
-    testStore.dispatch(setLocatePopupSelectedCriticality(Criticality.High));
+    testStore.dispatch(
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.High,
+        selectedLicenses: new Set<string>(),
+      }),
+    );
 
     expect(isLocateSignalActive(testStore.getState()));
   });
@@ -27,7 +29,10 @@ describe('isLocateSignalActive', () => {
   it('returns true if there are selected licenses', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
-      setLocatePopupSelectedLicenses(new Set<string>(['testLicenseId'])),
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.Any,
+        selectedLicenses: new Set<string>(['testLicenseId']),
+      }),
     );
     expect(isLocateSignalActive(testStore.getState()));
   });

--- a/src/Frontend/state/selectors/locate-popup-selectors.ts
+++ b/src/Frontend/state/selectors/locate-popup-selectors.ts
@@ -3,27 +3,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedCriticality } from '../../../shared/shared-types';
-import { State } from '../../types/types';
+import { LocatePopupFilters, State } from '../../types/types';
 import { initialResourceState } from '../reducers/resource-reducer';
 
-export function getLocatePopupSelectedCriticality(
-  state: State,
-): SelectedCriticality {
-  return state.resourceState.locatePopup.selectedCriticality;
-}
-
-export function getLocatePopupSelectedLicenses(state: State): Set<string> {
-  return state.resourceState.locatePopup.selectedLicenses;
+export function getLocatePopupFilters(state: State): LocatePopupFilters {
+  return state.resourceState.locatePopup;
 }
 
 export function isLocateSignalActive(state: State): boolean {
-  const locatePopupSelectedCriticality =
-    getLocatePopupSelectedCriticality(state);
-  const locatePopupSelectedLicenses = getLocatePopupSelectedLicenses(state);
+  const locatePopupFilters = getLocatePopupFilters(state);
+
   return (
-    locatePopupSelectedCriticality !==
+    locatePopupFilters.selectedCriticality !==
       initialResourceState.locatePopup.selectedCriticality ||
-    locatePopupSelectedLicenses.size > 0
+    locatePopupFilters.selectedLicenses.size > 0
   );
+}
+
+export function getShowNoSignalsLocatedMessage(state: State): boolean {
+  return state.viewState.showNoSignalsLocatedMessage;
 }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -14,6 +14,7 @@ import {
   PackageInfo,
   Resources,
   ResourcesToAttributions,
+  SelectedCriticality,
 } from '../../shared/shared-types';
 
 export type State = {
@@ -190,4 +191,9 @@ export interface DisplayPackageInfos {
 
 export interface DisplayPackageInfosWithCount {
   [packageCardId: string]: DisplayPackageInfoWithCount;
+}
+
+export interface LocatePopupFilters {
+  selectedCriticality: SelectedCriticality;
+  selectedLicenses: Set<string>;
 }


### PR DESCRIPTION
### Summary of changes

Clicking on an icon initiates the location process. All attributions that contain the underlying license are highlighted in the resource browser. The view changes to Audit View and the resource browser navigates to a resource with a located attribution.

### Context and reason for change

The new search icons allow for searching licenses in the `ResourceBrowser` according to the functionality of the `LocatorPopup`. 

### How can the changes be tested

Manually by using a test file.

### Comment
Meanwhile, this PR has accumulated some refactorings.

Fix: #1985
