### PR TITLE
Add button to mark attribution as preferred

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -19,6 +19,7 @@ import { getSelectedView } from '../../state/selectors/view-selector';
 import {
   getDisplayedPackage,
   getResolvedExternalAttributions,
+  getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
 import { IpcRendererEvent } from 'electron';
 import { useIpcRenderer } from '../../util/use-ipc-renderer';
@@ -52,6 +53,8 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import MuiBox from '@mui/material/Box';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 import { isEqual } from 'lodash';
+import { PanelPackage } from '../../types/types';
+import { savePackageInfo } from '../../state/actions/resource-actions/save-actions';
 
 const classes = {
   root: {
@@ -104,6 +107,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     getAttributionIdMarkedForReplacement,
   );
   const view = useAppSelector(getSelectedView);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
 
   const {
     isLicenseTextShown,
@@ -139,9 +143,22 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       temporaryDisplayPackageInfo.preSelected,
     ),
     targetAttributionIsExternalAttribution: false,
+    attributionIsPreferred:
+      selectedPackage?.displayPackageInfo.preferred ?? false,
+    view,
   });
 
   const mainButtonConfigs: Array<MainButtonConfig> = [];
+
+  function toggleIsSelectedPackagePreferred(
+    resourceId: string,
+    attributionId: string,
+    selectedPackage: PanelPackage,
+  ): void {
+    const packageInfo = selectedPackage.displayPackageInfo;
+    packageInfo.preferred = !packageInfo.preferred;
+    dispatch(savePackageInfo(resourceId, attributionId, packageInfo));
+  }
 
   if (props.onSaveButtonClick) {
     mainButtonConfigs.push({
@@ -212,6 +229,32 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         );
       },
       hidden: mergeButtonDisplayState.hideReplaceMarkedByButton,
+    },
+    {
+      buttonText: ButtonText.MarkAsPreferred,
+      onClick: (): void => {
+        if (selectedPackage) {
+          toggleIsSelectedPackagePreferred(
+            selectedResourceId,
+            selectedManualAttributionIdInCurrentView,
+            selectedPackage,
+          );
+        }
+      },
+      hidden: mergeButtonDisplayState.hideMarkAsPreferredButton,
+    },
+    {
+      buttonText: ButtonText.UnmarkAsPreferred,
+      onClick: (): void => {
+        if (selectedPackage) {
+          toggleIsSelectedPackagePreferred(
+            selectedResourceId,
+            selectedManualAttributionIdInCurrentView,
+            selectedPackage,
+          );
+        }
+      },
+      hidden: mergeButtonDisplayState.hideUnmarkAsPreferredButton,
     },
   ];
 

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -68,6 +68,8 @@ describe('getMergeButtonsDisplayState', () => {
         attributionIdMarkedForReplacement: '',
         targetAttributionId: 'attr',
         selectedAttributionId: '',
+        attributionIsPreferred: false,
+        view: View.Audit,
         packageInfoWereModified: false,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: true,
@@ -77,6 +79,8 @@ describe('getMergeButtonsDisplayState', () => {
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
+      hideMarkAsPreferredButton: true,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -89,12 +93,16 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: false,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: false,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -107,12 +115,16 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: false,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: true,
       hideUnmarkForReplacementButton: false,
       hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -125,12 +137,16 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: false,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: true,
       deactivateReplaceMarkedByButton: false,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -143,12 +159,16 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: true,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: true,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -161,12 +181,16 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: true,
         targetAttributionIsPreSelected: false,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: false,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 
@@ -179,12 +203,60 @@ describe('getMergeButtonsDisplayState', () => {
         packageInfoWereModified: false,
         targetAttributionIsPreSelected: true,
         targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Audit,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,
       hideUnmarkForReplacementButton: true,
       hideReplaceMarkedByButton: false,
       deactivateReplaceMarkedByButton: true,
+      hideMarkAsPreferredButton: false,
+      hideUnmarkAsPreferredButton: true,
+    });
+  });
+
+  it('activates UnmarkAsPreferredButton when attribution is preferred', () => {
+    expect(
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: true,
+        targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: true,
+        view: View.Audit,
+      }),
+    ).toStrictEqual({
+      hideMarkForReplacementButton: false,
+      hideUnmarkForReplacementButton: true,
+      hideReplaceMarkedByButton: false,
+      deactivateReplaceMarkedByButton: true,
+      hideMarkAsPreferredButton: true,
+      hideUnmarkAsPreferredButton: false,
+    });
+  });
+
+  it('hides MarkAsPreferredButton & UnmarkAsPreferredButton in the attribution view', () => {
+    expect(
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: true,
+        targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: false,
+        view: View.Attribution,
+      }),
+    ).toStrictEqual({
+      hideMarkForReplacementButton: false,
+      hideUnmarkForReplacementButton: true,
+      hideReplaceMarkedByButton: false,
+      deactivateReplaceMarkedByButton: true,
+      hideMarkAsPreferredButton: true,
+      hideUnmarkAsPreferredButton: true,
     });
   });
 });

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -193,6 +193,8 @@ export interface MergeButtonDisplayState {
   hideUnmarkForReplacementButton: boolean;
   hideReplaceMarkedByButton: boolean;
   deactivateReplaceMarkedByButton: boolean;
+  hideMarkAsPreferredButton: boolean;
+  hideUnmarkAsPreferredButton: boolean;
 }
 
 export function getMergeButtonsDisplayState(currentState: {
@@ -202,6 +204,8 @@ export function getMergeButtonsDisplayState(currentState: {
   packageInfoWereModified: boolean;
   targetAttributionIsPreSelected: boolean;
   targetAttributionIsExternalAttribution: boolean;
+  attributionIsPreferred?: boolean;
+  view?: View;
 }): MergeButtonDisplayState {
   const anyAttributionMarkedForReplacement =
     currentState.attributionIdMarkedForReplacement !== '';
@@ -229,6 +233,14 @@ export function getMergeButtonsDisplayState(currentState: {
       (selectedAttributionIsPartOfMerge &&
         currentState.packageInfoWereModified) ||
       currentState.targetAttributionIsPreSelected,
+    hideMarkAsPreferredButton:
+      !currentState.selectedAttributionId ||
+      currentState.view !== View.Audit ||
+      Boolean(currentState.attributionIsPreferred),
+    hideUnmarkAsPreferredButton:
+      !currentState.selectedAttributionId ||
+      currentState.view !== View.Audit ||
+      !currentState.attributionIsPreferred,
   };
 }
 

--- a/src/Frontend/Components/ContextMenu/ContextMenu.tsx
+++ b/src/Frontend/Components/ContextMenu/ContextMenu.tsx
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import StarOutlineIcon from '@mui/icons-material/StarOutline';
+import StarIcon from '@mui/icons-material/Star';
 import React, { ReactElement, useState } from 'react';
 import MuiMenu from '@mui/material/Menu';
 import MuiMenuItem from '@mui/material/MenuItem';
@@ -56,6 +58,8 @@ const BUTTON_TITLE_TO_ICON_MAP: {
   [ButtonText.Hide]: <VisibilityOffIcon fontSize="small" />,
   [ButtonText.Unhide]: <VisibilityIcon fontSize="small" />,
   [ButtonText.OpenAttributionWizardPopup]: <AutoFixHighIcon fontSize="small" />,
+  [ButtonText.MarkAsPreferred]: <StarOutlineIcon fontSize="small" />,
+  [ButtonText.UnmarkAsPreferred]: <StarIcon fontSize="small" />,
 };
 
 export interface ContextMenuItem {

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import StarIcon from '@mui/icons-material/Star';
 import MuiTooltip from '@mui/material/Tooltip';
 import Filter1Icon from '@mui/icons-material/Filter1';
 import InsertCommentIcon from '@mui/icons-material/InsertComment';
@@ -286,5 +287,19 @@ export function MissingPackageNameIcon(props: IconProps): ReactElement {
 export function LocateAttributionsIcon(props: IconProps): ReactElement {
   return (
     <MyLocationIcon arial-abel={'locate attributions icon'} sx={props.sx} />
+  );
+}
+
+export function PreferredIcon(props: IconProps): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="is preferred">
+      <StarIcon
+        aria-label={'Preferred icon'}
+        sx={getSxFromPropsAndClasses({
+          styleClass: classes.nonClickableIcon,
+          sxProps: props.sx,
+        })}
+      />
+    </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -338,6 +338,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           },
         ];
   }
+
   function getContextMenuItemsForExternalAttributions(): Array<ContextMenuItem> {
     return props.hideContextMenuAndMultiSelect
       ? []

--- a/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
+++ b/src/Frontend/Components/ReportTableItem/ReportTableItem.tsx
@@ -12,6 +12,7 @@ import {
   FirstPartyIcon,
   FollowUpIcon,
   NeedsReviewIcon,
+  PreferredIcon,
   PreSelectedIcon,
 } from '../Icons/Icons';
 import { TableConfig, tableConfigs } from '../Table/Table';
@@ -109,6 +110,10 @@ const classes = {
   preSelectedIcon: {
     border: `2px ${OpossumColors.darkBlue} solid`,
     color: OpossumColors.darkBlue,
+  },
+  preferredIcon: {
+    border: `2px ${OpossumColors.mediumOrange} solid`,
+    color: OpossumColors.mediumOrange,
   },
   markedTableCell: {
     backgroundColor: OpossumColors.lightOrange,
@@ -364,6 +369,17 @@ export function ReportTableItem(props: ReportTableItemProps): ReactElement {
               sx={{
                 ...reportTableItemClasses.icon,
                 ...reportTableItemClasses.preSelectedIcon,
+              }}
+            />{' '}
+            <br />
+          </>
+        )}
+        {attributionInfo.preferred && (
+          <>
+            <PreferredIcon
+              sx={{
+                ...reportTableItemClasses.icon,
+                ...reportTableItemClasses.preferredIcon,
               }}
             />{' '}
             <br />

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -71,6 +71,7 @@ describe('The ReportTableItem', () => {
         firstParty: true,
         resources: ['/'],
         needsReview: true,
+        preferred: true,
       },
       uuid2: {
         packageName: 'Redux',
@@ -105,5 +106,6 @@ describe('The ReportTableItem', () => {
     expect(screen.getByLabelText('Follow-up icon'));
     expect(screen.getByLabelText('Exclude from notice icon'));
     expect(screen.getByLabelText('Needs-review icon'));
+    expect(screen.getByLabelText('Preferred icon'));
   });
 });

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -74,6 +74,8 @@ export enum ButtonText {
   UnmarkForReplacement = 'Unmark for replacement',
   Unhide = 'Unhide',
   OpenDotOpossumFile = 'Open ".opossum" file',
+  MarkAsPreferred = 'Mark as preferred',
+  UnmarkAsPreferred = 'Unmark as preferred',
 }
 
 export enum FilterType {


### PR DESCRIPTION
### Summary of changes

Add a button to the ... menu in the audit view, to mark an attribution as preferred.
![image](https://github.com/opossum-tool/OpossumUI/assets/107913663/6805d20d-c6f6-4a6d-81a0-cc237fc5882c)
This option is not present in the attribution view, because on that view, you don't see which attributions you prefer this one over. The icon is also added to the report view.
![image](https://github.com/opossum-tool/OpossumUI/assets/107913663/ea726c22-67f1-48a5-8617-ac8bd78d3d12)

### Context and reason for change

We are implementing a new feature to mark attributions as 'preferred'. Preferred attributions give new information which we can use in internal tools to produce higher quality input files.

### How can the changes be tested

Open your favorite input file, and mark an attribution as preferred.
