### PR TITLE
Add filter for preferred attributions

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -151,7 +151,8 @@
       "packageType": "maven",
       "copyright": "(c) John Doe",
       "licenseText": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
-      "followUp": "FOLLOW_UP"
+      "followUp": "FOLLOW_UP",
+      "preferred": true
     },
     "bb61b094-b5ba-4bd0-b218-8ec96b7c5ae0": {
       "source": {

--- a/src/Frontend/Components/Filter/FilterMultiSelect.tsx
+++ b/src/Frontend/Components/Filter/FilterMultiSelect.tsx
@@ -26,6 +26,7 @@ const FILTERS = [
   FilterType.OnlyFirstParty,
   FilterType.HideFirstParty,
   FilterType.OnlyNeedsReview,
+  FilterType.OnlyPreferred,
 ];
 
 const classes = {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -81,6 +81,7 @@ export enum FilterType {
   HideFirstParty = 'Hide First Party',
   OnlyFollowUp = 'Only Follow Up',
   OnlyNeedsReview = 'Only Needs Review',
+  OnlyPreferred = 'Only Preferred',
 }
 
 export enum CheckboxLabel {

--- a/src/Frontend/util/__tests__/use-filters.test.tsx
+++ b/src/Frontend/util/__tests__/use-filters.test.tsx
@@ -44,6 +44,7 @@ describe('useFollowUpFilter', () => {
     licenseText: 'Some other license text',
     followUp: FollowUp,
     needsReview: true,
+    preferred: true,
   };
 
   it('returns working getFilteredAttributions with follow-up filter', () => {
@@ -118,6 +119,18 @@ describe('useFollowUpFilter', () => {
   it('returns working getFilteredAttributions with only needs review filter', () => {
     const store = createTestAppStore();
     store.dispatch(updateActiveFilters(FilterType.OnlyNeedsReview));
+    renderComponentWithStore(
+      <TestComponent manualAttributions={testManualAttributions} />,
+      { store },
+    );
+    expect(filteredAttributions).toEqual({
+      [testOtherManualUuid]: testManualAttributions[testOtherManualUuid],
+    });
+  });
+
+  it('returns working getFilteredAttributions with only preferred filter', () => {
+    const store = createTestAppStore();
+    store.dispatch(updateActiveFilters(FilterType.OnlyPreferred));
     renderComponentWithStore(
       <TestComponent manualAttributions={testManualAttributions} />,
       { store },

--- a/src/Frontend/util/use-filters.ts
+++ b/src/Frontend/util/use-filters.ts
@@ -34,5 +34,8 @@ export function useFilters(
   attributions = activeFilters.has(FilterType.OnlyNeedsReview)
     ? pickBy(attributions, (value: PackageInfo) => value.needsReview)
     : attributions;
+  attributions = activeFilters.has(FilterType.OnlyPreferred)
+    ? pickBy(attributions, (value: PackageInfo) => value.preferred)
+    : attributions;
   return attributions;
 }


### PR DESCRIPTION
### Summary of changes

We add a new filter to attribution view and audit view to filter for preferred attributions.

### Context and reason for change

We want to make it possible for users to mark attributiions as preferred. Therefore we also want a filter for these attributions.

### How can the changes be tested

Run the new unit test in src/Frontend/util/__tests__/use-filters.test.tsx.
Open the updated file opossum_input.json from the example-files folder in OpossumUI. Go to attribution view and select the new filter. There should be exactly one attribution in the filtered list.

Fix: #1990 