### PR TITLE
Preferred flag is dropped for pre-selected attributions

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -92,6 +92,8 @@ const inputFileContent: ParsedOpossumInputFile = {
       firstParty: true,
       excludeFromNotice: true,
       criticality: Criticality.High,
+      preferred: true,
+      preferredOverOriginIds: ['test-id'],
     },
   },
   frequentLicenses: [
@@ -138,6 +140,8 @@ const expectedFileContent: ParsedFileContent = {
         excludeFromNotice: true,
         firstParty: true,
         criticality: Criticality.High,
+        preferred: true,
+        preferredOverOriginIds: ['test-id'],
       },
     },
     resourcesToAttributions: {
@@ -394,6 +398,8 @@ describe('Test of loading function', () => {
               preSelected: true,
               attributionConfidence: 17,
               comment: 'some comment',
+              preferred: true,
+              preferredOverOriginIds: ['test-id'],
             },
           },
           frequentLicenses: [
@@ -466,6 +472,8 @@ describe('Test of loading function', () => {
               preSelected: true,
               attributionConfidence: 17,
               comment: 'some comment',
+              preferred: true,
+              preferredOverOriginIds: ['test-id'],
             },
           },
           resourcesToAttributions: {

--- a/src/ElectronBackend/input/__tests__/parseFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseFile.test.ts
@@ -190,7 +190,7 @@ describe('parseOpossumFile', () => {
     const opossumFilePath = path.join(
       upath.toUnix(temporaryPath),
       'test.opossum',
-    ); //test
+    );
 
     await writeOpossumFile(
       opossumFilePath,

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -267,6 +267,8 @@ function createJsonOutputFile(
     const packageInfo = externalAttributionsCopy[attributionId];
     if (packageInfo.preSelected) {
       delete packageInfo.source;
+      delete packageInfo.preferred;
+      delete packageInfo.preferredOverOriginIds;
       if (packageInfo.attributionConfidence !== undefined) {
         packageInfo.attributionConfidence =
           packageInfo.attributionConfidence >= DiscreteConfidence.High

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -61,6 +61,8 @@ interface RawPackageInfo {
   excludeFromNotice?: boolean;
   criticality?: Criticality;
   needsReview?: boolean;
+  preferred?: boolean;
+  preferredOverOriginIds?: Array<string>;
 }
 
 export interface RawAttributions {


### PR DESCRIPTION
### Summary of changes

When creating a manual attribution from a pre-selected external attribution the preferred flag and the list of preferredOverOriginIds are deleted. 

### Context and reason for change

We do not want that new preferred attributions are created automatically via pre-selection.

### How can the changes be tested

Run tests in 'importFromFile.test.ts'.

Issue: #2007
Fix: #2007
