### PR TITLE
Cache PanelAttributionData in the manual progress bar worker

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/AggregatedAttributionsPanel.tsx
@@ -68,15 +68,9 @@ export function AggregatedAttributionsPanel(
     ],
   );
 
-  const manualPanelData: PanelAttributionData = {
-    attributions: manualData.attributions,
-    resourcesToAttributions: manualData.resourcesToAttributions,
-    resourcesWithAttributedChildren: manualData.resourcesWithAttributedChildren,
-  };
   const containedManualPackagesWorkerArgs = useMemo(
     () => ({
       selectedResourceId,
-      manualData: manualPanelData,
       panelTitle: PackagePanelTitle.ContainedManualPackages,
     }),
 
@@ -89,6 +83,22 @@ export function AggregatedAttributionsPanel(
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedResourceId, manualData.resourcesToAttributions],
+  );
+
+  const manualPanelData: PanelAttributionData = {
+    attributions: manualData.attributions,
+    resourcesToAttributions: manualData.resourcesToAttributions,
+    resourcesWithAttributedChildren: manualData.resourcesWithAttributedChildren,
+  };
+  const containedManualPackagesSyncFallbackArgs = useMemo(
+    () => ({
+      selectedResourceId,
+      manualData: manualPanelData,
+      panelTitle: PackagePanelTitle.ContainedManualPackages,
+    }),
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedResourceId, manualData],
   );
 
   return (
@@ -118,6 +128,7 @@ export function AggregatedAttributionsPanel(
           <WorkerAccordionPanel
             title={PackagePanelTitle.ContainedManualPackages}
             workerArgs={containedManualPackagesWorkerArgs}
+            syncFallbackArgs={containedManualPackagesSyncFallbackArgs}
             getDisplayPackageInfosWithCount={
               getContainedManualDisplayPackageInfosWithCount
             }

--- a/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/WorkerAccordionPanel.tsx
@@ -35,7 +35,7 @@ interface ContainedExternalAttributionsAccordionWorkerArgs {
 
 interface ContainedManualAttributionsAccordionWorkerArgs {
   selectedResourceId: string;
-  manualData: PanelAttributionData;
+  manualData?: PanelAttributionData;
   panelTitle: PackagePanelTitle;
 }
 
@@ -44,7 +44,7 @@ interface WorkerAccordionPanelProps {
     | PackagePanelTitle.ContainedExternalPackages
     | PackagePanelTitle.ContainedManualPackages;
   workerArgs: ContainedAttributionsAccordionWorkerArgs;
-  syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs;
+  syncFallbackArgs: ContainedAttributionsAccordionWorkerArgs;
   getDisplayPackageInfosWithCount(
     workerArgs: ContainedAttributionsAccordionWorkerArgs,
   ): [Array<string>, DisplayPackageInfosWithCount];
@@ -125,7 +125,7 @@ async function loadDisplayPackageInfosWithCount(
   getDisplayPackageInfosWithCount: (
     workerArgs: ContainedAttributionsAccordionWorkerArgs,
   ) => [Array<string>, DisplayPackageInfosWithCount],
-  syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs,
+  syncFallbackArgs: ContainedAttributionsAccordionWorkerArgs,
 ): Promise<void> {
   setDisplayPackageInfosWithCountAndResourceId(
     EMPTY_DISPLAY_PACKAGE_INFOS_WITH_COUNT_AND_RESOURCE_ID,
@@ -145,7 +145,6 @@ async function loadDisplayPackageInfosWithCount(
           Error('Web Worker execution error.'),
           setDisplayPackageInfosWithCountAndResourceId,
           getDisplayPackageInfosWithCount,
-          workerArgs,
           syncFallbackArgs,
         );
       } else {
@@ -158,7 +157,6 @@ async function loadDisplayPackageInfosWithCount(
       error,
       setDisplayPackageInfosWithCountAndResourceId,
       getDisplayPackageInfosWithCount,
-      workerArgs,
       syncFallbackArgs,
     );
   }
@@ -171,18 +169,17 @@ function logErrorAndComputeInMainProcess(
     displayPackageInfosWithCountAndResourceId: DisplayPackageInfosWithCountAndResourceId,
   ) => void,
   getDisplayPackageInfosWithCount: (
-    workerArgs: ContainedAttributionsAccordionWorkerArgs,
+    syncFallbackArgs: ContainedAttributionsAccordionWorkerArgs,
   ) => [Array<string>, DisplayPackageInfosWithCount],
-  workerArgs: ContainedAttributionsAccordionWorkerArgs,
-  syncFallbackArgs?: ContainedAttributionsAccordionWorkerArgs,
+  syncFallbackArgs: ContainedAttributionsAccordionWorkerArgs,
 ): void {
   console.info(`Error in ResourceDetailsTab ${panelTitle}: `, error);
 
   const [sortedPackageCardIds, displayAttributionIdsWithCount] =
-    getDisplayPackageInfosWithCount(syncFallbackArgs || workerArgs);
+    getDisplayPackageInfosWithCount(syncFallbackArgs);
 
   setDisplayPackageInfosWithCountAndResourceId({
-    resourceId: workerArgs.selectedResourceId,
+    resourceId: syncFallbackArgs.selectedResourceId,
     sortedPackageCardIds,
     displayPackageInfosWithCount: displayAttributionIdsWithCount,
   });

--- a/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
+++ b/src/Frontend/Components/WorkersContextProvider/WorkersContextProvider.tsx
@@ -10,6 +10,7 @@ import {
   getExternalAttributionsToHashes,
   getExternalData,
   getFilesWithChildren,
+  getManualData,
   getResources,
   getResourcesToExternalAttributions,
 } from '../../state/selectors/all-views-resource-selectors';
@@ -28,6 +29,7 @@ export const AccordionWorkersContextProvider: FC<{
 }> = ({ children }) => {
   const externalAttributionData = useAppSelector(getExternalData);
   const attributionsToHashes = useAppSelector(getExternalAttributionsToHashes);
+  const manualAttributionData = useAppSelector(getManualData);
 
   const externalData: PanelAttributionData = useMemo(
     () => ({
@@ -37,6 +39,16 @@ export const AccordionWorkersContextProvider: FC<{
         externalAttributionData.resourcesWithAttributedChildren,
     }),
     [externalAttributionData],
+  );
+
+  const manualData: PanelAttributionData = useMemo(
+    () => ({
+      attributions: manualAttributionData.attributions,
+      resourcesToAttributions: manualAttributionData.resourcesToAttributions,
+      resourcesWithAttributedChildren:
+        manualAttributionData.resourcesWithAttributedChildren,
+    }),
+    [manualAttributionData],
   );
 
   useMemo(() => {
@@ -52,6 +64,20 @@ export const AccordionWorkersContextProvider: FC<{
       console.info('Web worker error in workers context provider: ', error);
     }
   }, [externalData, attributionsToHashes]);
+
+  useMemo(() => {
+    try {
+      // remove data from previous file or empty data from app just opened
+      resourceDetailsTabsWorkers.containedManualAttributionsAccordionWorker.postMessage(
+        { manualData: null },
+      );
+      resourceDetailsTabsWorkers.containedManualAttributionsAccordionWorker.postMessage(
+        { manualData },
+      );
+    } catch (error) {
+      console.info('Web worker error in workers context provider: ', error);
+    }
+  }, [manualData]);
 
   return (
     <AccordionWorkersContext.Provider value={resourceDetailsTabsWorkers}>

--- a/src/Frontend/web-workers/contained-manual-attributions-accordion-worker.ts
+++ b/src/Frontend/web-workers/contained-manual-attributions-accordion-worker.ts
@@ -4,23 +4,38 @@
 
 import { DisplayPackageInfosWithCountAndResourceId } from '../types/types';
 import { getContainedManualDisplayPackageInfosWithCount } from '../Components/AggregatedAttributionsPanel/accordion-panel-helpers';
+import { PanelAttributionData } from '../util/get-contained-packages';
+
+let cachedManualData: PanelAttributionData | null = null;
 
 self.onmessage = ({
   data: { selectedResourceId, manualData, panelTitle },
 }): void => {
-  const [sortedPackageCardIds, displayPackageInfosWithCount] =
-    getContainedManualDisplayPackageInfosWithCount({
-      selectedResourceId,
-      manualData,
-      panelTitle,
-    });
-  const output: DisplayPackageInfosWithCountAndResourceId = {
-    resourceId: selectedResourceId,
-    sortedPackageCardIds,
-    displayPackageInfosWithCount,
-  };
+  if (manualData !== undefined) {
+    cachedManualData = manualData;
+  }
 
-  self.postMessage({
-    output,
-  });
+  if (selectedResourceId) {
+    if (cachedManualData) {
+      const [sortedPackageCardIds, displayPackageInfosWithCount] =
+        getContainedManualDisplayPackageInfosWithCount({
+          selectedResourceId,
+          manualData: cachedManualData,
+          panelTitle,
+        });
+      const output: DisplayPackageInfosWithCountAndResourceId = {
+        resourceId: selectedResourceId,
+        sortedPackageCardIds,
+        displayPackageInfosWithCount,
+      };
+
+      self.postMessage({
+        output,
+      });
+    } else {
+      self.postMessage({
+        output: null,
+      });
+    }
+  }
 };


### PR DESCRIPTION
### Summary of changes

Cache PanelAttributionData in the manual progress bar worker. Then, instead of re-sending it every time we click on a resource, we only re-send it when we save.

### Context and reason for change

Sending this data takes up a significant amount of time when clicking on a folder. By caching the data, navigation speed is improved, at the cost of slower loads.

### How can the changes be tested

Open a large file, and measure how long it takes to load a large directory.

We tried it on the biggest file we have and got the following results:
Before: 7 seconds
After: 4 seconds