### PR TITLE
Locator popup does not fail when a signal is not linked to any resource

### DIFF
--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -33,21 +33,28 @@ import {
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 
-const testResources: Resources = {
-  thirdParty: {
-    'package_1.tr.gz': 1,
-    'package_2.tr.gz': 1,
-    'jQuery.js': 1,
-  },
-};
-const testAttributionId = 'attributionId';
-const anotherAttributionId = 'another_id';
-const testAttributions: Attributions = {
-  [testAttributionId]: { packageName: 'pkg', preSelected: true },
-  [anotherAttributionId]: { packageName: 'pkg2', preSelected: true },
-};
+let testResources: Resources;
+let testAttributionId: string;
+let anotherAttributionId: string;
+let testAttributions: Attributions;
 
 describe('The PackageCard', () => {
+  beforeEach(() => {
+    testResources = {
+      thirdParty: {
+        'package_1.tr.gz': 1,
+        'package_2.tr.gz': 1,
+        'jQuery.js': 1,
+      },
+    };
+    testAttributionId = 'attributionId';
+    anotherAttributionId = 'another_id';
+    testAttributions = {
+      [testAttributionId]: { packageName: 'pkg', preSelected: true },
+      [anotherAttributionId]: { packageName: 'pkg2', preSelected: true },
+    };
+  });
+
   it('has working confirm button', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
@@ -75,7 +82,6 @@ describe('The PackageCard', () => {
       />,
       { store: testStore },
     );
-
     expect(screen.getByText('packageName'));
 
     expect(
@@ -155,6 +161,7 @@ describe('The PackageCard', () => {
     const testResourcesToManualAttributions: ResourcesToAttributions = {
       'package_1.tr.gz': [testAttributionId],
       'package_2.tr.gz': [testAttributionId],
+      'jQuery.js': [anotherAttributionId],
     };
 
     const testStore = createTestAppStore();

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -97,7 +97,11 @@ describe('loadFromFile', () => {
     };
     const testResourcesToExternalAttributions: ResourcesToAttributions = {
       '/root/src/something.js': ['uuid'],
-      '/thirdParty/package_1.tr.gz': ['test_id'],
+      '/thirdParty/package_1.tr.gz': [
+        'test_id',
+        'doNotChangeMe1',
+        'doNotChangeMe2',
+      ],
     };
     const testFrequentLicenses: FrequentLicenses = {
       nameOrder: [{ shortName: 'MIT', fullName: 'MIT license' }],
@@ -158,12 +162,17 @@ describe('loadFromFile', () => {
       attributionsToResources: {
         uuid: ['/root/src/something.js'],
         test_id: ['/thirdParty/package_1.tr.gz'],
+        doNotChangeMe1: ['/thirdParty/package_1.tr.gz'],
+        doNotChangeMe2: ['/thirdParty/package_1.tr.gz'],
       },
       resourcesWithAttributedChildren: {
         attributedChildren: {
-          '1': new Set<number>().add(0),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '1': new Set<number>().add(0).add(4),
           '2': new Set<number>().add(0),
           '3': new Set<number>().add(0),
+          // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+          '5': new Set<number>().add(4),
         },
         pathsToIndices: {
           '/': 1,

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -980,33 +980,10 @@ describe('The unlinkAttributionAndSavePackageInfo action', () => {
     };
     const testInitialManualAttributions: Attributions = {
       reactUuid: testReact,
-      vueUuid: testVue,
     };
     const testInitialResourcesToManualAttributions: ResourcesToAttributions = {
       '/something.js': ['reactUuid'],
       '/somethingElse.js': ['reactUuid'],
-    };
-    const expectedManualData: AttributionData = {
-      attributions: testInitialManualAttributions,
-      resourcesToAttributions: {
-        '/something.js': ['vueUuid'],
-        '/somethingElse.js': ['reactUuid'],
-      },
-      attributionsToResources: {
-        reactUuid: ['/somethingElse.js'],
-        vueUuid: ['/something.js'],
-      },
-      resourcesWithAttributedChildren: {
-        attributedChildren: {
-          '1': new Set<number>().add(0).add(2),
-        },
-        pathsToIndices: {
-          '/': 1,
-          '/something.js': 0,
-          '/somethingElse.js': 2,
-        },
-        paths: ['/something.js', '/', '/somethingElse.js'],
-      },
     };
 
     const testStore = createTestAppStore();
@@ -1020,6 +997,16 @@ describe('The unlinkAttributionAndSavePackageInfo action', () => {
         }),
       ),
     );
+    const startingManualAttributions = getManualAttributions(
+      testStore.getState(),
+    );
+    expect(Object.keys(startingManualAttributions).length).toEqual(1);
+    const startingManualAttributionsToResources =
+      getManualAttributionsToResources(testStore.getState());
+    expect(startingManualAttributionsToResources.reactUuid).toEqual([
+      '/something.js',
+      '/somethingElse.js',
+    ]);
 
     testStore.dispatch(
       unlinkAttributionAndSavePackageInfo(
@@ -1028,7 +1015,14 @@ describe('The unlinkAttributionAndSavePackageInfo action', () => {
         testVue,
       ),
     );
-    expect(getManualData(testStore.getState())).toEqual(expectedManualData);
+    const finalManualAttributions = getManualAttributions(testStore.getState());
+    expect(Object.keys(finalManualAttributions).length).toEqual(2);
+    const finalManualAttributionsToResources = getManualAttributionsToResources(
+      testStore.getState(),
+    );
+    expect(finalManualAttributionsToResources.reactUuid).toEqual([
+      '/somethingElse.js',
+    ]);
   });
 });
 

--- a/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
@@ -18,6 +18,7 @@ import { NIL as uuidNil } from 'uuid';
 import {
   computeChildrenWithAttributions,
   createExternalAttributionsToHashes,
+  getAttributionDataFromSetAttributionDataPayload,
   getAttributionIdOfFirstPackageCardInManualPackagePanel,
   getIndexOfAttributionInManualPackagePanel,
 } from '../action-and-reducer-helpers';
@@ -342,5 +343,20 @@ describe('getIndexOfAttributionInManualPackagePanel', () => {
       testManualData,
     );
     expect(testIndex).toEqual(expectedIndex);
+  });
+});
+
+describe('getAttributionDataFromSetAttributionDataPayload', () => {
+  it('prunes attributions without linked resources', () => {
+    const expectedAttributionData: AttributionData = EMPTY_ATTRIBUTION_DATA;
+
+    const testAttributions: Attributions = { uuid_0: { packageName: 'Vue' } };
+    const testResourcesToAttributions: ResourcesToAttributions = {};
+    const attributionData = getAttributionDataFromSetAttributionDataPayload({
+      attributions: testAttributions,
+      resourcesToAttributions: testResourcesToAttributions,
+    });
+
+    expect(attributionData).toEqual(expectedAttributionData);
   });
 });

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -98,16 +98,34 @@ export function getAttributionDataFromSetAttributionDataPayload(payload: {
   attributions: Attributions;
   resourcesToAttributions: ResourcesToAttributions;
 }): AttributionData {
+  const attributionsToResources = getAttributionsToResources(
+    payload.resourcesToAttributions,
+  );
+
+  pruneAttributionsWithoutResources(
+    payload.attributions,
+    attributionsToResources,
+  );
+
   return {
     attributions: payload.attributions,
     resourcesToAttributions: payload.resourcesToAttributions,
-    attributionsToResources: getAttributionsToResources(
-      payload.resourcesToAttributions,
-    ),
+    attributionsToResources,
     resourcesWithAttributedChildren: computeChildrenWithAttributions(
       payload.resourcesToAttributions,
     ),
   };
+}
+
+export function pruneAttributionsWithoutResources(
+  attributions: Attributions,
+  attributionsToResources: AttributionsToResources,
+): void {
+  Object.keys(attributions).forEach((attributionId) => {
+    if (!attributionsToResources[attributionId]) {
+      delete attributions[attributionId];
+    }
+  });
 }
 
 function getAttributionsToResources(


### PR DESCRIPTION
### Summary of changes

When loading an input file into the state, external attributions without linked resources are pruned. The goas is, as they are unreachable, thei should not be present in the state.  The pruning is done in the FE as attributionsToResources are needed to do the search. The attribution without linked resources has been kept in the input file, as a test for this feature.

### Context and reason for change

See linked issue.

### How can the changes be tested

Test that the bug does not exist any longer: build the app and try to reproduce the bug, using the opossum_input.json file.
