### PR TITLE
Fix incorrect count of merged hhc signals

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/accordion-panel-helper.test.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/accordion-panel-helper.test.ts
@@ -41,7 +41,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
     const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
       [expectedPackageCardIds[0]]: {
-        count: 5,
+        count: 3,
         displayPackageInfo: {
           attributionIds: ['uuid1', 'uuid2'],
           packageName: 'Typescript',
@@ -109,7 +109,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
     const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
       [expectedPackageCardIds[0]]: {
-        count: 5,
+        count: 3,
         displayPackageInfo: {
           attributionIds: ['uuid1', 'uuid2'],
           attributionConfidence: 20,
@@ -179,7 +179,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
     const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
       [expectedPackageCardIds[0]]: {
-        count: 5,
+        count: 3,
         displayPackageInfo: {
           attributionIds: ['uuid1', 'uuid2'],
           originIds: ['uuid3', 'uuid4', 'uuid5'],
@@ -220,7 +220,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
 
     const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
       [expectedPackageCardIds[0]]: {
-        count: 5,
+        count: 3,
         displayPackageInfo: {
           attributionIds: ['uuidToMerge1', 'uuidToMerge2'],
           packageName: 'Typescript',

--- a/src/Frontend/util/__tests__/get-display-attributions-with-count-from-attributions.test.ts
+++ b/src/Frontend/util/__tests__/get-display-attributions-with-count-from-attributions.test.ts
@@ -35,7 +35,7 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         comments: ['comment A'],
         attributionIds: ['uuid_1', 'uuid_2'],
       },
-      count: 3,
+      count: 2,
     };
     const testDisplayAttributionWithCount =
       getDisplayPackageInfoWithCountFromAttributions(
@@ -74,7 +74,7 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         attributionConfidence: 20,
         attributionIds: ['uuid_1', 'uuid_2'],
       },
-      count: 3,
+      count: 2,
     };
     const testDisplayAttributionWithCount =
       getDisplayPackageInfoWithCountFromAttributions(
@@ -113,7 +113,7 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         attributionIds: ['uuid_1', 'uuid_2'],
         originIds: ['id_1', 'id_2', 'id_3'],
       },
-      count: 3,
+      count: 2,
     };
     const testDisplayAttributionWithCount =
       getDisplayPackageInfoWithCountFromAttributions(
@@ -179,7 +179,7 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         packageName: 'React',
         attributionIds: ['uuid_1', 'uuid_2'],
       },
-      count: 3,
+      count: 2,
     };
     const testDisplayAttributionWithCount =
       getDisplayPackageInfoWithCountFromAttributions(
@@ -225,7 +225,7 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         attributionIds: ['uuid_1', 'uuid_2', 'uuid_3'],
         originIds: ['id_1', 'id_2', 'id_3'],
       },
-      count: 3,
+      count: 2,
     };
     const testDisplayAttributionWithCount =
       getDisplayPackageInfoWithCountFromAttributions(

--- a/src/Frontend/util/get-display-attributions-with-count-from-attributions.ts
+++ b/src/Frontend/util/get-display-attributions-with-count-from-attributions.ts
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { sum } from 'lodash';
 import { DisplayPackageInfo, PackageInfo } from '../../shared/shared-types';
 import { DisplayPackageInfoWithCount } from '../types/types';
 
@@ -82,7 +81,7 @@ export function getDisplayPackageInfoWithCountFromAttributions(
   }
 
   return {
-    count: sum(counts),
+    count: Math.max(...counts, 0),
     displayPackageInfo: attributionToShow,
   };
 }


### PR DESCRIPTION
### Summary of changes

Instead of summarizing of all the similar hhc signals, now we just take the max value. I decided to go easy way (not adding a lot of extra logic of deduplication of resources) as the metrics is not the most important and accurate anyway.

### Context and reason for change

For merged hhc signals (where only comments are different ) there is incorrect count of signals (just a sum of all of them) which is not realistic, e.g.
<img width="210" alt="Screenshot 2023-09-21 at 14 09 53" src="https://github.com/opossum-tool/OpossumUI/assets/85183359/a5083fc5-9e66-4ddf-98f3-5d7ce62c8a44">

### How can the changes be tested

Run tests.
Open any project with merged signals and see that the number is more real now, e.g.
<img width="210" alt="Screenshot 2023-09-21 at 14 07 41" src="https://github.com/opossum-tool/OpossumUI/assets/85183359/4fe4cd8f-00b2-49d6-949b-bfe1d9edfa38">


Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
