### PR TITLE
Disallow adding a preferred attribution

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -7,7 +7,7 @@ import React, { ReactElement, useState } from 'react';
 import { ListCard } from '../ListCard/ListCard';
 import { getCardLabels } from '../../util/get-card-labels';
 import { ListCardConfig, PackageCardConfig } from '../../types/types';
-import { clickableIcon } from '../../shared-styles';
+import { clickableIcon, disabledIcon } from '../../shared-styles';
 import { IconButton } from '../IconButton/IconButton';
 import PlusIcon from '@mui/icons-material/Add';
 import { ContextMenu, ContextMenuItem } from '../ContextMenu/ContextMenu';
@@ -65,6 +65,7 @@ const classes = {
     visibility: 'hidden',
   },
   clickableIcon,
+  disabledIcon,
   multiSelectCheckbox: {
     height: '40px',
     marginTop: '1px',
@@ -74,6 +75,9 @@ const classes = {
     minWidth: '0px',
   },
 };
+
+export const CANNOT_ADD_PREFERRED_ATTRIBUTION_TOOLTIP =
+  'A preferred attribution cannot be added';
 
 interface PackageCardProps {
   cardId: string;
@@ -402,15 +406,22 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
 
   const leftIcon = props.onIconClick ? (
     <IconButton
-      tooltipTitle="add"
+      tooltipTitle={
+        props.displayPackageInfo.preferred
+          ? CANNOT_ADD_PREFERRED_ATTRIBUTION_TOOLTIP
+          : 'add'
+      }
       tooltipPlacement="left"
+      disabled={props.displayPackageInfo.preferred}
       onClick={props.onIconClick}
       key={getKey('add-icon', props.cardId)}
       icon={
         <PlusIcon
           sx={{
             ...(props.cardConfig.isResolved ? classes.hiddenIcon : {}),
-            ...classes.clickableIcon,
+            ...(props.displayPackageInfo.preferred
+              ? classes.disabledIcon
+              : classes.clickableIcon),
           }}
           aria-label={`add ${packageLabels[0] || ''}`}
         />

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -6,7 +6,10 @@
 import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { doNothing } from '../../../util/do-nothing';
-import { PackageCard } from '../PackageCard';
+import {
+  PackageCard,
+  CANNOT_ADD_PREFERRED_ATTRIBUTION_TOOLTIP,
+} from '../PackageCard';
 import {
   createTestAppStore,
   renderComponentWithStore,
@@ -327,5 +330,42 @@ describe('The PackageCard', () => {
     expect(getOpenPopup(testStore.getState())).toBe(
       PopupType.AttributionWizardPopup,
     );
+  });
+
+  it('add button for preferred attribution is disabled', () => {
+    const testResourcesToManualAttributions: ResourcesToAttributions = {
+      'package_1.tr.gz': [testAttributionId],
+    };
+
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: testResources,
+          manualAttributions: testAttributions,
+          resourcesToManualAttributions: testResourcesToManualAttributions,
+        }),
+      ),
+    );
+    renderComponentWithStore(
+      <PackageCard
+        cardConfig={{ isExternalAttribution: false, isPreSelected: true }}
+        cardId={'some_id'}
+        displayPackageInfo={{
+          packageName: 'packageName',
+          attributionIds: [testAttributionId],
+          preferred: true,
+        }}
+        onClick={doNothing}
+        onIconClick={doNothing}
+        showCheckBox={true}
+      />,
+      { store: testStore },
+    );
+
+    const addButton = screen.getByLabelText(
+      CANNOT_ADD_PREFERRED_ATTRIBUTION_TOOLTIP,
+    );
+    expect(addButton.attributes.getNamedItem('disabled')).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Summary of changes

In Audit View, we disable the button to add an attribution to a resource if this attribution is preferred.

### Context and reason for change

We want to make it possible that an attribution can be marked as preferred by the user. In this case, this attribution should not be added to another resource afterwards as it is not necessarily also preferred for the other resource.

### How can the changes be tested

Run the new unit test in src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx

Open the file example.opossum from the example-files folder. In audit view, select the file ElectronBackend/menu.ts and mark the TypeScript attribution there as preferred. Then select the file ElectronBackend/main.ts, go to the GLOBAL tab and check that for this TypeScript attribution the + button on the left is disabled and shows the correct tooltip when hovering over it.

Fix: #1992