### PR TITLE
[merge after 2033] Save list of 'preferred over' origin IDs

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -53,7 +53,8 @@ import { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import MuiBox from '@mui/material/Box';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
-import { cloneDeep, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
+import { toggleIsSelectedPackagePreferred } from '../../state/actions/resource-actions/preference-actions';
 
 const classes = {
   root: {
@@ -156,15 +157,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
 
   const mainButtonConfigs: Array<MainButtonConfig> = [];
 
-  function toggleIsSelectedPackagePreferred(): void {
-    const newTemporaryDisplayPackageInfo = cloneDeep(
-      temporaryDisplayPackageInfo,
-    );
-    newTemporaryDisplayPackageInfo.preferred =
-      !newTemporaryDisplayPackageInfo.preferred;
-    dispatch(setTemporaryDisplayPackageInfo(newTemporaryDisplayPackageInfo));
-  }
-
   if (props.onSaveButtonClick) {
     mainButtonConfigs.push({
       buttonText: temporaryDisplayPackageInfo.preSelected
@@ -239,7 +231,9 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       buttonText: ButtonText.MarkAsPreferred,
       onClick: (): void => {
         if (selectedPackage) {
-          toggleIsSelectedPackagePreferred();
+          dispatch(
+            toggleIsSelectedPackagePreferred(temporaryDisplayPackageInfo),
+          );
         }
       },
       hidden: mergeButtonDisplayState.hideMarkAsPreferredButton,
@@ -248,7 +242,9 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       buttonText: ButtonText.UnmarkAsPreferred,
       onClick: (): void => {
         if (selectedPackage) {
-          toggleIsSelectedPackagePreferred();
+          dispatch(
+            toggleIsSelectedPackagePreferred(temporaryDisplayPackageInfo),
+          );
         }
       },
       hidden: mergeButtonDisplayState.hideUnmarkAsPreferredButton,

--- a/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Resources } from '../../../../../shared/shared-types';
+import { _getOriginIdsToPreferOver } from '../preference-actions';
+
+describe('_getOriginIdsToPreferOver', () => {
+  it('finds all external attributions in the subtree', () => {
+    const testSource = { name: 'testSource', documentConfidence: 100 };
+    const resources: Resources = {
+      folder: { subfolder: { file1: 1 }, file2: 1 },
+    };
+    const pathToRootResource = '/folder/';
+    const resourcesToExternalAttributions = {
+      '/folder/': ['uuid0'],
+      '/folder/subfolder/file1': ['uuid1'],
+      '/folder/file2': ['uuid2'],
+      '/': ['uuid3'],
+    };
+    const resourcesToManualAttributions = {};
+    const externalAttributions = {
+      uuid0: { originIds: ['originUuid0'], source: testSource },
+      uuid1: { originIds: ['originUuid1'], source: testSource },
+      uuid2: { originIds: ['originUuid2'], source: testSource },
+      uuid3: { originIds: ['originUuid3'], source: testSource },
+    };
+    const externalAttributionsSources = {
+      testSource: {
+        name: 'Test Source',
+        priority: 0,
+        isRelevantForPreferred: true,
+      },
+    };
+
+    const actualOriginUuids = _getOriginIdsToPreferOver(
+      pathToRootResource,
+      resources,
+      resourcesToExternalAttributions,
+      resourcesToManualAttributions,
+      externalAttributions,
+      externalAttributionsSources,
+    );
+
+    const expectedOriginUuids = ['originUuid0', 'originUuid1', 'originUuid2'];
+    expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+
+  it('combines and deduplicates origin ids', () => {
+    const testSource = { name: 'testSource', documentConfidence: 100 };
+    const resources: Resources = { file1: 1, file2: 1 };
+    const pathToRootResource = '/';
+    const resourcesToExternalAttributions = {
+      '/file1': ['uuid1', 'uuid2'],
+      '/file2': ['uuid2', 'uuid3'],
+    };
+    const resourcesToManualAttributions = {};
+    const externalAttributions = {
+      uuid1: { originIds: ['originUuid1'], source: testSource },
+      uuid2: { originIds: ['originUuid2', 'originUuid3'], source: testSource },
+      uuid3: { originIds: ['originUuid3', 'originUuid4'], source: testSource },
+    };
+    const externalAttributionsSources = {
+      testSource: {
+        name: 'Test Source',
+        priority: 0,
+        isRelevantForPreferred: true,
+      },
+    };
+
+    const actualOriginUuids = _getOriginIdsToPreferOver(
+      pathToRootResource,
+      resources,
+      resourcesToExternalAttributions,
+      resourcesToManualAttributions,
+      externalAttributions,
+      externalAttributionsSources,
+    );
+
+    const expectedOriginUuids = [
+      'originUuid1',
+      'originUuid2',
+      'originUuid3',
+      'originUuid4',
+    ];
+    expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+
+  it('breaks on manual attributions', () => {
+    const testSource = { name: 'testSource', documentConfidence: 100 };
+    const resources: Resources = { folder: { file1: 1 } };
+    const pathToRootResource = '/';
+    const resourcesToExternalAttributions = {
+      '/folder/': ['uuid0'],
+      '/folder/file1': ['uuid1'],
+    };
+    const resourcesToManualAttributions = { '/folder/file1': ['uuid2'] };
+    const externalAttributions = {
+      uuid0: { originIds: ['originUuid0'], source: testSource },
+      uuid1: { originIds: ['originUuid1'], source: testSource },
+    };
+    const externalAttributionsSources = {
+      testSource: {
+        name: 'Test Source',
+        priority: 0,
+        isRelevantForPreferred: true,
+      },
+    };
+
+    const actualOriginUuids = _getOriginIdsToPreferOver(
+      pathToRootResource,
+      resources,
+      resourcesToExternalAttributions,
+      resourcesToManualAttributions,
+      externalAttributions,
+      externalAttributionsSources,
+    );
+
+    const expectedOriginUuids = ['originUuid0'];
+    expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+
+  it('only returns origin ids with sources relevant for preferred', () => {
+    const relevantSource = { name: 'relevantSource', documentConfidence: 100 };
+    const otherSource = { name: 'otherSource', documentConfidence: 100 };
+    const resources: Resources = { file1: 1, file2: 1 };
+    const pathToRootResource = '/';
+    const resourcesToExternalAttributions = {
+      '/file1': ['uuid1'],
+      '/file2': ['uuid2'],
+    };
+    const resourcesToManualAttributions = {};
+    const externalAttributions = {
+      uuid1: { originIds: ['originUuid1'], source: relevantSource },
+      uuid2: { originIds: ['originUuid2'], source: otherSource },
+    };
+    const externalAttributionsSources = {
+      relevantSource: {
+        name: 'Relevant Source',
+        priority: 0,
+        isRelevantForPreferred: true,
+      },
+      otherSource: { name: 'Other Source', priority: 0 },
+    };
+
+    const actualOriginUuids = _getOriginIdsToPreferOver(
+      pathToRootResource,
+      resources,
+      resourcesToExternalAttributions,
+      resourcesToManualAttributions,
+      externalAttributions,
+      externalAttributionsSources,
+    );
+
+    const expectedOriginUuids = ['originUuid1'];
+    expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+});

--- a/src/Frontend/state/actions/resource-actions/preference-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/preference-actions.ts
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { cloneDeep } from 'lodash';
+import {
+  Resources,
+  ResourcesToAttributions,
+  Attributions,
+  ExternalAttributionSources,
+  PackageInfo,
+  DisplayPackageInfo,
+} from '../../../../shared/shared-types';
+import { PathPredicate, State } from '../../../types/types';
+import { getSubtree } from '../../../util/get-attributions-with-resources';
+import {
+  getResources,
+  getExternalAttributions,
+  getExternalAttributionSources,
+  getResourcesToExternalAttributions,
+  getResourcesToManualAttributions,
+} from '../../selectors/all-views-resource-selectors';
+import { getSelectedResourceId } from '../../selectors/audit-view-resource-selectors';
+import { AppThunkAction, AppThunkDispatch } from '../../types';
+import { setTemporaryDisplayPackageInfo } from './all-views-simple-actions';
+
+export function toggleIsSelectedPackagePreferred(
+  packageInfo: DisplayPackageInfo,
+): AppThunkAction {
+  return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const state = getState();
+
+    const newTemporaryDisplayPackageInfo = cloneDeep(packageInfo);
+    newTemporaryDisplayPackageInfo.preferred =
+      !newTemporaryDisplayPackageInfo.preferred;
+
+    if (newTemporaryDisplayPackageInfo.preferred) {
+      newTemporaryDisplayPackageInfo.preferredOverOriginIds =
+        _getOriginIdsToPreferOver(
+          getSelectedResourceId(state),
+          getResources(state) ?? {},
+          getResourcesToExternalAttributions(state),
+          getResourcesToManualAttributions(state),
+          getExternalAttributions(state),
+          getExternalAttributionSources(state),
+        );
+    } else {
+      newTemporaryDisplayPackageInfo.preferredOverOriginIds = undefined;
+    }
+
+    dispatch(setTemporaryDisplayPackageInfo(newTemporaryDisplayPackageInfo));
+  };
+}
+
+export function _getOriginIdsToPreferOver(
+  pathToRootResource: string,
+  resources: Resources,
+  resourcesToExternalAttributions: ResourcesToAttributions,
+  resourcesToManualAttributions: ResourcesToAttributions,
+  externalAttributions: Attributions,
+  externalAttributionSources: ExternalAttributionSources,
+): Array<string> {
+  const rootResource = getSubtree(resources, pathToRootResource);
+
+  const isBreakpoint: PathPredicate = (path: string) =>
+    path in resourcesToManualAttributions;
+
+  const subtreeResourcesIds = getResourceIdsInSubtreeWithBreakpoints(
+    pathToRootResource,
+    rootResource,
+    isBreakpoint,
+  );
+
+  const packageInfos = getPackageInfosFromResources(
+    subtreeResourcesIds,
+    resourcesToExternalAttributions,
+    externalAttributions,
+  );
+
+  const originIds = getOriginIdsToPreferOverFromPackageInfos(
+    packageInfos,
+    externalAttributionSources,
+  );
+
+  return originIds;
+}
+
+function getPackageInfosFromResources(
+  resourceIds: Array<string>,
+  resourcesToAttributions: ResourcesToAttributions,
+  attributions: Attributions,
+): Array<PackageInfo> {
+  const attributionIds = resourceIds.flatMap(
+    (resourceId) => resourcesToAttributions[resourceId] ?? [],
+  );
+  const deduplicatedAttributionIds = Array.from(new Set(attributionIds));
+  const packageInfos = deduplicatedAttributionIds.flatMap(
+    (attributionId) => attributions[attributionId],
+  );
+  return packageInfos;
+}
+
+function getResourceIdsInSubtreeWithBreakpoints(
+  pathToRootResource: string,
+  rootResource: Resources,
+  isBreakpoint: PathPredicate,
+): Array<string> {
+  const resources: Array<string> = [pathToRootResource];
+
+  for (const [childResourceName, childResource] of Object.entries(
+    rootResource,
+  )) {
+    const pathToChildResource = pathToRootResource + childResourceName;
+    if (isBreakpoint(pathToChildResource)) {
+      continue;
+    }
+    if (childResource === 1) {
+      resources.push(pathToChildResource);
+    } else {
+      resources.push(
+        ...getResourceIdsInSubtreeWithBreakpoints(
+          pathToChildResource + '/',
+          childResource,
+          isBreakpoint,
+        ),
+      );
+    }
+  }
+
+  return resources;
+}
+
+function getOriginIdsToPreferOverFromPackageInfos(
+  packageInfos: Array<PackageInfo>,
+  externalAttributionSources: ExternalAttributionSources,
+): Array<string> {
+  const originIds: Array<string> = [];
+
+  packageInfos.forEach((packageInfo) => {
+    const isRelevantForPreferred =
+      externalAttributionSources[packageInfo.source?.name ?? '']
+        ?.isRelevantForPreferred;
+    if (isRelevantForPreferred && packageInfo.originIds) {
+      originIds.push(...packageInfo.originIds);
+    }
+  });
+
+  return Array.from(new Set(originIds));
+}

--- a/src/Frontend/util/get-attributions-with-resources.ts
+++ b/src/Frontend/util/get-attributions-with-resources.ts
@@ -111,7 +111,10 @@ function getResourcesRecursively(
   });
 }
 
-function getSubtree(resourceTree: Resources, folderPath: string): Resources {
+export function getSubtree(
+  resourceTree: Resources,
+  folderPath: string,
+): Resources {
   if (folderPath === '/') {
     return resourceTree;
   }


### PR DESCRIPTION
### Summary of changes

When marking an attribution as preferred, save a list of signals that it is preferred over. This list contains all signals in subfolders from sources relevant for preference. As an exception, resources with different manual attributions act as breakpoints.

### Context and reason for change

We are implementing a new feature to mark attributions as 'preferred'. Preferred attributions give new information which we can use in internal tools to produce higher quality input files.

### How can the changes be tested

First, make sure you have a sensible choice for "signals relevant for preference" in your input file. Mark an attribution as preferred. Check that the corresponding attribution in the input file is updated.
