### PR TITLE
Update preferences when an attribution is created, deleted, linked or unlinked

### DIFF
--- a/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
@@ -4,9 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Resources } from '../../../../../shared/shared-types';
-import { _getOriginIdsToPreferOver } from '../preference-actions';
+import { getOriginIdsToPreferOver } from '../preference-actions';
 
-describe('_getOriginIdsToPreferOver', () => {
+describe('getOriginIdsToPreferOver', () => {
   it('finds all external attributions in the subtree', () => {
     const testSource = { name: 'testSource', documentConfidence: 100 };
     const resources: Resources = {
@@ -34,7 +34,7 @@ describe('_getOriginIdsToPreferOver', () => {
       },
     };
 
-    const actualOriginUuids = _getOriginIdsToPreferOver(
+    const actualOriginUuids = getOriginIdsToPreferOver(
       pathToRootResource,
       resources,
       resourcesToExternalAttributions,
@@ -69,7 +69,7 @@ describe('_getOriginIdsToPreferOver', () => {
       },
     };
 
-    const actualOriginUuids = _getOriginIdsToPreferOver(
+    const actualOriginUuids = getOriginIdsToPreferOver(
       pathToRootResource,
       resources,
       resourcesToExternalAttributions,
@@ -108,7 +108,7 @@ describe('_getOriginIdsToPreferOver', () => {
       },
     };
 
-    const actualOriginUuids = _getOriginIdsToPreferOver(
+    const actualOriginUuids = getOriginIdsToPreferOver(
       pathToRootResource,
       resources,
       resourcesToExternalAttributions,
@@ -144,7 +144,7 @@ describe('_getOriginIdsToPreferOver', () => {
       otherSource: { name: 'Other Source', priority: 0 },
     };
 
-    const actualOriginUuids = _getOriginIdsToPreferOver(
+    const actualOriginUuids = getOriginIdsToPreferOver(
       pathToRootResource,
       resources,
       resourcesToExternalAttributions,

--- a/src/Frontend/state/actions/resource-actions/preference-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/preference-actions.ts
@@ -38,7 +38,7 @@ export function toggleIsSelectedPackagePreferred(
 
     if (newTemporaryDisplayPackageInfo.preferred) {
       newTemporaryDisplayPackageInfo.preferredOverOriginIds =
-        _getOriginIdsToPreferOver(
+        getOriginIdsToPreferOver(
           getSelectedResourceId(state),
           getResources(state) ?? {},
           getResourcesToExternalAttributions(state),
@@ -54,7 +54,7 @@ export function toggleIsSelectedPackagePreferred(
   };
 }
 
-export function _getOriginIdsToPreferOver(
+export function getOriginIdsToPreferOver(
   pathToRootResource: string,
   resources: Resources,
   resourcesToExternalAttributions: ResourcesToAttributions,

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -77,6 +77,7 @@ import {
 import {
   createManualAttribution,
   deleteManualAttribution,
+  getCalculatePreferredOverOriginIds,
   linkToAttributionManualData,
   replaceAttributionWithMatchingAttributionId,
   unlinkResourceFromAttributionId,
@@ -390,6 +391,7 @@ export const resourceState = (
         state.allViews.manualData,
         selectedResourceId,
         action.payload.strippedPackageInfo,
+        getCalculatePreferredOverOriginIds(state),
       );
 
       const packageCardIndex = getIndexOfAttributionInManualPackagePanel(
@@ -492,6 +494,7 @@ export const resourceState = (
         state.allViews.manualData,
         attributionToDeleteId,
         getAttributionBreakpointCheckForResourceState(state),
+        getCalculatePreferredOverOriginIds(state),
       );
 
       const displayedDisplayPackageInfo =
@@ -622,6 +625,7 @@ export const resourceState = (
           action.payload.resourceId,
           matchingAttributionIdForLinking,
           getAttributionBreakpointCheckForResourceState(state),
+          getCalculatePreferredOverOriginIds(state),
         );
 
       const packageCardIndexOfLinkingAttribution =
@@ -665,6 +669,7 @@ export const resourceState = (
           state.allViews.manualData,
           action.payload.resourceId,
           action.payload.attributionId,
+          getCalculatePreferredOverOriginIds(state),
         );
 
       return {


### PR DESCRIPTION
### Summary of changes

Whenever an attribution is created, deleted, linked or unlinked, recalculate the preferences of its parents.

### Context and reason for change

Manual attributions act as break points for preference calculations. Therefore, any time we change an attribution placement in the resource tree, we need to update the preference calculations of its parents. Only the parents are relevant, because the 'prefered over' calculation travels down the resource tree only.

We have 6 save operations for attributions:

- Create
- Replace
- Update
- Delete
- Link
- Unlink

Replace & update don't require any recalculations, because they don't change any breakpoint locations. The other four operations do.

Recalculating preferences requires some external attribution data from the state. I wasn't totally sure how best to pass this around. I didn't want to pass the entire state to the helper functions. Passing the params needed for recalculations was possible too, but passing the function around instead made more sense to me.

### How can the changes be tested

See unit tests.
Play around with it in OpossumUI with the output json open, and check that it is updated as expected.