### PR TITLE
Show preferred attribution icon at package cards

### DIFF
--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -48,11 +48,9 @@ const classes = {
     color: OpossumColors.middleBlue,
   },
   tooltip: tooltipStyle,
-  openCloseFolderIcons: {
-    margin: '0px',
-    padding: '0px',
-    width: '16px',
-    height: '20px',
+  preferredIcon: {
+    ...baseIcon,
+    color: OpossumColors.mediumOrange,
   },
 };
 
@@ -296,7 +294,7 @@ export function PreferredIcon(props: IconProps): ReactElement {
       <StarIcon
         aria-label={'Preferred icon'}
         sx={getSxFromPropsAndClasses({
-          styleClass: classes.nonClickableIcon,
+          styleClass: classes.preferredIcon,
           sxProps: props.sx,
         })}
       />

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -137,6 +137,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       excludeFromNotice: props.displayPackageInfo.excludeFromNotice,
       needsReview: Boolean(props.displayPackageInfo.needsReview),
       followUp: Boolean(props.displayPackageInfo.followUp),
+      isPreferred: Boolean(props.displayPackageInfo.preferred),
       isContextMenuOpen,
       criticality: props.cardConfig.isExternalAttribution
         ? props.displayPackageInfo.criticality

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -11,6 +11,7 @@ import {
   FollowUpIcon,
   NeedsReviewIcon,
   PreSelectedIcon,
+  PreferredIcon,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
 import { DisplayPackageInfo } from '../../../shared/shared-types';
@@ -77,6 +78,9 @@ export function getRightIcons(
     rightIcons.push(
       <PreSelectedIcon key={getKey('pre-selected-icon', cardId)} />,
     );
+  }
+  if (cardConfig.isPreferred) {
+    rightIcons.push(<PreferredIcon key={getKey('preferred-icon', cardId)} />);
   }
 
   return rightIcons;

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -65,6 +65,7 @@ export interface ListCardConfig {
   isMarkedForReplacement?: boolean;
   isResolved?: boolean;
   isPreSelected?: boolean;
+  isPreferred?: boolean;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
   needsReview?: boolean;


### PR DESCRIPTION
### Summary of changes

Now package cards with preferred attributions are with preferred icon (star)

### Context and reason for change

Fix #2037 

### How can the changes be tested
Mark some attribution as preferred and check Audit and Attribution views.
![image](https://github.com/opossum-tool/OpossumUI/assets/85183359/54b80229-5536-494e-afe6-1cb17eac649c)
