### PR TITLE
Remove preferred icon from signals

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -137,7 +137,9 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       excludeFromNotice: props.displayPackageInfo.excludeFromNotice,
       needsReview: Boolean(props.displayPackageInfo.needsReview),
       followUp: Boolean(props.displayPackageInfo.followUp),
-      isPreferred: Boolean(props.displayPackageInfo.preferred),
+      isPreferred: props.cardConfig.isExternalAttribution
+        ? false
+        : Boolean(props.displayPackageInfo.preferred),
       isContextMenuOpen,
       criticality: props.cardConfig.isExternalAttribution
         ? props.displayPackageInfo.criticality


### PR DESCRIPTION
### Summary of changes

Only manual attributions get a preferred star icon.

### Context and reason for change

For now, signals should not be marked with a star as preferred.
How it looks like now:
![image](https://github.com/opossum-tool/OpossumUI/assets/85183359/c9400074-3cc8-44e6-9544-eb980d16f4da)


### How can the changes be tested

Open opossum_input file and check signals