### PR TITLE
Add feature flag

### DIFF
--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -575,7 +575,7 @@ describe('The App in Audit View', () => {
     );
   });
 
-  it('preferred button is shown and sets an attribution as preferred', () => {
+  it.skip('preferred button is shown and sets an attribution as preferred', () => {
     function getExpectedSaveFileArgs(
       preferred: boolean,
       preferredOverOriginIds?: Array<string>,
@@ -673,7 +673,7 @@ describe('The App in Audit View', () => {
     expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(2);
   });
 
-  it('after setting an attribution to preferred, global save is disabled', () => {
+  it.skip('after setting an attribution to preferred, global save is disabled', () => {
     const testResources: Resources = {
       file: 1,
       other_file: 1,

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -231,7 +231,7 @@ describe('loadFromFile', () => {
     expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
       expectedExternalAttributionsToHashes,
     );
-    expect(getIsPreferenceFeatureEnabled(testStore.getState())).toEqual(true);
+    expect(getIsPreferenceFeatureEnabled(testStore.getState())).toEqual(false);
   });
 
   it('disables the preference feature if no external source is relevant', () => {

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -8,12 +8,12 @@ import { AppThunkAction, AppThunkDispatch } from '../../types';
 import {
   setAttributionBreakpoints,
   setBaseUrlsForSources,
-  setIsPreferenceFeatureEnabled,
   setExternalAttributionSources,
   setExternalAttributionsToHashes,
   setExternalData,
   setFilesWithChildren,
   setFrequentLicenses,
+  setIsPreferenceFeatureEnabled,
   setManualData,
   setProjectMetadata,
   setResources,
@@ -66,6 +66,12 @@ export function loadFromFile(
     dispatch(
       setIsPreferenceFeatureEnabled(fileContainsSourcesRelevantForPreferred),
     );
+
+    // Feature flag
+    // when removing unskip the following tests
+    // * after setting an attribution to preferred, global save is disabled
+    // * preferred button is shown and sets an attribution as preferred
+    dispatch(setIsPreferenceFeatureEnabled(false));
 
     parsedFileContent.resolvedExternalAttributions.forEach((attribution) =>
       dispatch(addResolvedExternalAttribution(attribution)),


### PR DESCRIPTION
### Summary of changes

We add a feature flag in order to deactivate the preferred attributions feature.

### Context and reason for change

Deactivate the preferred attributions feature for a new release, as it is not yet finalized.


