### PR TITLE
Handle unsaved changes when locating attributions

### DIFF
--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -23,6 +23,8 @@ import {
 } from '../../view-actions/view-actions';
 import {
   changeSelectedAttributionIdOrOpenUnsavedPopup,
+  locateSignalsFromLocatorPopup,
+  locateSignalsFromProjectStatisticsPopup,
   navigateToSelectedPathOrOpenUnsavedPopup,
   navigateToTargetResourceOrAttribution,
   openAttributionWizardPopup,
@@ -37,11 +39,13 @@ import { getParsedInputFileEnrichedWithTestData } from '../../../../test-helpers
 import {
   AttributionData,
   Attributions,
+  Criticality,
   DiscreteConfidence,
   DisplayPackageInfo,
   PackageInfo,
   Resources,
   ResourcesToAttributions,
+  SelectedCriticality,
 } from '../../../../../shared/shared-types';
 import { savePackageInfo } from '../../resource-actions/save-actions';
 import { setSelectedAttributionId } from '../../resource-actions/attribution-view-simple-actions';
@@ -78,6 +82,7 @@ import {
 } from '../../../selectors/attribution-wizard-selectors';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../../shared-constants';
 import { convertDisplayPackageInfoToPackageInfo } from '../../../../util/convert-package-info';
+import { getShowNoSignalsLocatedMessage } from '../../../selectors/locate-popup-selectors';
 
 describe('The actions checking for unsaved changes', () => {
   describe('navigateToSelectedPathOrOpenUnsavedPopup', () => {
@@ -98,6 +103,61 @@ describe('The actions checking for unsaved changes', () => {
         '/folder1/folder2/test_file',
       ]);
       expect(getSelectedView(testStore.getState())).toBe(View.Audit);
+    });
+
+    it('closes an open popup if dispatched from an open popup', () => {
+      const testStore = createTestAppStore();
+      testStore.dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+
+      expect(getOpenPopup(testStore.getState())).toBe(
+        PopupType.ProjectStatisticsPopup,
+      );
+
+      testStore.dispatch(
+        navigateToSelectedPathOrOpenUnsavedPopup('/folder/file', true),
+      );
+
+      expect(getOpenPopup(testStore.getState())).toBeNull();
+    });
+
+    it('does not navigate to another resource if dispatched from an open popup and there are unsaved changes', () => {
+      const testStore = createTestAppStore();
+      const testInitalPackageInfo: PackageInfo = {
+        packageName: 'react',
+        packageVersion: '18',
+      };
+      const testManualAttributions: Attributions = {
+        uuid: testInitalPackageInfo,
+      };
+      const changedDisplayPackageInfo: DisplayPackageInfo = {
+        packageName: 'react',
+        packageVersion: '19',
+        attributionIds: ['uuid'],
+      };
+      testStore.dispatch(
+        loadFromFile(
+          getParsedInputFileEnrichedWithTestData({
+            manualAttributions: testManualAttributions,
+          }),
+        ),
+      );
+
+      testStore.dispatch(navigateToView(View.Attribution));
+      testStore.dispatch(openPopup(PopupType.ProjectStatisticsPopup));
+      testStore.dispatch(setSelectedAttributionId('uuid'));
+      testStore.dispatch(
+        setTemporaryDisplayPackageInfo(changedDisplayPackageInfo),
+      );
+      testStore.dispatch(
+        navigateToSelectedPathOrOpenUnsavedPopup('/folder/file', true),
+      );
+      expect(getOpenPopup(testStore.getState())).toBe(PopupType.NotSavedPopup);
+      testStore.dispatch(
+        unlinkAttributionAndSavePackageInfoAndNavigateToTargetView(),
+      );
+      expect(getOpenPopup(testStore.getState())).toBe(
+        PopupType.ProjectStatisticsPopup,
+      );
     });
   });
 
@@ -713,5 +773,99 @@ describe('openAttributionWizardPopup', () => {
     expect(getOpenPopup(testStore.getState())).toBe(
       PopupType.AttributionWizardPopup,
     );
+  });
+});
+
+describe('locateSignalsFromLocatorPopup', () => {
+  it('sets showNoSignalsLocatedMessage and does not navigate if no resources are found', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(navigateToView(View.Attribution));
+
+    expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(false);
+    expect(getSelectedView(testStore.getState())).toBe(View.Attribution);
+    expect(getSelectedResourceId(testStore.getState())).toBe('');
+
+    testStore.dispatch(
+      locateSignalsFromLocatorPopup(
+        SelectedCriticality.High,
+        new Set<string>(['GPL-2.0']),
+      ),
+    );
+
+    expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(true);
+    expect(getSelectedView(testStore.getState())).toBe(View.Attribution);
+    expect(getSelectedResourceId(testStore.getState())).toBe('');
+  });
+
+  it('navigates to a located resource', () => {
+    const testStore = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid1: {
+        packageName: 'react',
+        criticality: Criticality.High,
+        licenseName: 'GPL-2.0',
+      },
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/folder/file': ['uuid1'],
+    };
+
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+          resourcesToExternalAttributions: testResourcesToExternalAttributions,
+        }),
+      ),
+    );
+    testStore.dispatch(navigateToView(View.Attribution));
+
+    expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(false);
+    expect(getSelectedView(testStore.getState())).toBe(View.Attribution);
+    expect(getSelectedResourceId(testStore.getState())).toBe('');
+    testStore.dispatch(
+      locateSignalsFromLocatorPopup(
+        SelectedCriticality.High,
+        new Set<string>(['GPL-2.0']),
+      ),
+    );
+    expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(false);
+    expect(getSelectedView(testStore.getState())).toBe(View.Audit);
+    expect(getSelectedResourceId(testStore.getState())).toBe('/folder/file');
+  });
+});
+
+describe('locateSignalsFromProjectStatisticsPopup', () => {
+  it('navigates to a located resource independent of criticality', () => {
+    const testStore = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid1: {
+        packageName: 'react',
+        criticality: Criticality.High,
+        licenseName: 'GPL-2.0',
+      },
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/folder/file': ['uuid1'],
+    };
+
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+          resourcesToExternalAttributions: testResourcesToExternalAttributions,
+        }),
+      ),
+    );
+    testStore.dispatch(navigateToView(View.Attribution));
+
+    expect(getSelectedView(testStore.getState())).toBe(View.Attribution);
+    expect(getSelectedResourceId(testStore.getState())).toBe('');
+
+    testStore.dispatch(locateSignalsFromProjectStatisticsPopup('GPL-2.0'));
+
+    expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(false);
+    expect(getSelectedView(testStore.getState())).toBe(View.Audit);
+    expect(getSelectedResourceId(testStore.getState())).toBe('/folder/file');
   });
 });

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -74,14 +74,20 @@ import { setLocatePopupFilters } from '../resource-actions/locate-popup-actions'
 
 export function navigateToSelectedPathOrOpenUnsavedPopup(
   resourcePath: string,
+  fromPopup?: boolean,
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryDisplayPackageInfoModified(getState())) {
-      dispatch(setTargetSelectedResourceId(resourcePath));
-      dispatch(setTargetView(View.Audit));
+      if (!fromPopup) {
+        dispatch(setTargetSelectedResourceId(resourcePath));
+        dispatch(setTargetView(View.Audit));
+      }
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
       dispatch(openResourceInResourceBrowser(resourcePath));
+      if (fromPopup) {
+        dispatch(closePopup());
+      }
     }
   };
 }
@@ -377,7 +383,12 @@ export function locateSignalsFromLocatorPopup(
     dispatch(setShowNoSignalsLocatedMessage(showNoSignalsLocatedMessage));
 
     if (!showNoSignalsLocatedMessage) {
-      dispatch(closePopup());
+      dispatch(
+        navigateToSelectedPathOrOpenUnsavedPopup(
+          locatedResources.values().next().value,
+          true,
+        ),
+      );
     }
   };
 }
@@ -396,10 +407,11 @@ export function locateSignalsFromProjectStatisticsPopup(
       getState(),
     );
 
-    dispatch(navigateToView(View.Audit));
     dispatch(
-      openResourceInResourceBrowser(locatedResources.values().next().value),
+      navigateToSelectedPathOrOpenUnsavedPopup(
+        locatedResources.values().next().value,
+        true,
+      ),
     );
-    dispatch(closePopup());
   };
 }

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -74,20 +74,14 @@ import { setLocatePopupFilters } from '../resource-actions/locate-popup-actions'
 
 export function navigateToSelectedPathOrOpenUnsavedPopup(
   resourcePath: string,
-  fromPopup?: boolean,
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     if (wereTemporaryDisplayPackageInfoModified(getState())) {
-      if (!fromPopup) {
-        dispatch(setTargetSelectedResourceId(resourcePath));
-        dispatch(setTargetView(View.Audit));
-      }
+      dispatch(setTargetSelectedResourceId(resourcePath));
+      dispatch(setTargetView(View.Audit));
       dispatch(openPopup(PopupType.NotSavedPopup));
     } else {
       dispatch(openResourceInResourceBrowser(resourcePath));
-      if (fromPopup) {
-        dispatch(closePopup());
-      }
     }
   };
 }
@@ -383,10 +377,10 @@ export function locateSignalsFromLocatorPopup(
     dispatch(setShowNoSignalsLocatedMessage(showNoSignalsLocatedMessage));
 
     if (!showNoSignalsLocatedMessage) {
+      dispatch(closePopup());
       dispatch(
         navigateToSelectedPathOrOpenUnsavedPopup(
           locatedResources.values().next().value,
-          true,
         ),
       );
     }
@@ -406,11 +400,10 @@ export function locateSignalsFromProjectStatisticsPopup(
     const { locatedResources } = getResourcesWithLocatedAttributions(
       getState(),
     );
-
+    dispatch(closePopup());
     dispatch(
       navigateToSelectedPathOrOpenUnsavedPopup(
         locatedResources.values().next().value,
-        true,
       ),
     );
   };

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -20,7 +20,7 @@ export enum Criticality {
   Medium = 'medium',
 }
 
-enum AnyCriticality {
+export enum AnyCriticality {
   Any = 'any',
 }
 export type SelectedCriticality = Criticality | AnyCriticality;

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -20,7 +20,7 @@ export enum Criticality {
   Medium = 'medium',
 }
 
-export enum AnyCriticality {
+enum AnyCriticality {
   Any = 'any',
 }
 export type SelectedCriticality = Criticality | AnyCriticality;


### PR DESCRIPTION
### Summary of changes

It is possible to open the `ProjectStatisticsPopup` or the `LocatorPopup` while having unsaved changes of an attribution. If the user then locates attributions, the `NotSavedPopup` appears. After the user has decided to save or undo the changes (or cancelled), the `ProjectStatisticsPopup` or `LocatorPopup` is shown again. From here, the user can again initialize the location process.

### Context and reason for change

We introduced signal location that can currently be initiated via the ' LocatorPopup'  or the `ProjectStatisticsPopup`. However, so far, we do not consider the possibility of unsaved changes of the `temporaryDisplayPackageInfo` when starting the location process.

### How can the changes be tested

1. Open an example file
2. Select a manual attribution (either in audit or attribution view)
3. Change the content of a textbox in the attribution column
4. Open  ' LocatorPopup'  or  `ProjectStatisticsPopup` (via main menu)
5. Start the location process
6. Choose to undo or save the changes
7. See that the   ' LocatorPopup'  or  `ProjectStatisticsPopup` appears again
8. Start the location process

Fix: #2020
