### PR TITLE
Remove feature flag

### DIFF
--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -575,7 +575,7 @@ describe('The App in Audit View', () => {
     );
   });
 
-  it.skip('preferred button is shown and sets an attribution as preferred', () => {
+  it('preferred button is shown and sets an attribution as preferred', () => {
     function getExpectedSaveFileArgs(
       preferred: boolean,
       preferredOverOriginIds?: Array<string>,
@@ -673,7 +673,7 @@ describe('The App in Audit View', () => {
     expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(2);
   });
 
-  it.skip('after setting an attribution to preferred, global save is disabled', () => {
+  it('after setting an attribution to preferred, global save is disabled', () => {
     const testResources: Resources = {
       file: 1,
       other_file: 1,

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -231,7 +231,7 @@ describe('loadFromFile', () => {
     expect(getExternalAttributionsToHashes(testStore.getState())).toEqual(
       expectedExternalAttributionsToHashes,
     );
-    expect(getIsPreferenceFeatureEnabled(testStore.getState())).toEqual(false);
+    expect(getIsPreferenceFeatureEnabled(testStore.getState())).toEqual(true);
   });
 
   it('disables the preference feature if no external source is relevant', () => {

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -67,12 +67,6 @@ export function loadFromFile(
       setIsPreferenceFeatureEnabled(fileContainsSourcesRelevantForPreferred),
     );
 
-    // Feature flag
-    // when removing unskip the following tests
-    // * after setting an attribution to preferred, global save is disabled
-    // * preferred button is shown and sets an attribution as preferred
-    dispatch(setIsPreferenceFeatureEnabled(false));
-
     parsedFileContent.resolvedExternalAttributions.forEach((attribution) =>
       dispatch(addResolvedExternalAttribution(attribution)),
     );


### PR DESCRIPTION
### Summary of changes

We remove the feature flag to activate the preferred attributions feature.

### Context and reason for change

The feature was disabled for a release and can now be enabled again.


