### PR TITLE
Rename tooltip of locate icon

### DIFF
--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -34,10 +34,10 @@ import { getResourceBrowserTreeItemLabel } from './get-resource-browser-tree-ite
 import { useWindowHeight } from '../../util/use-window-height';
 import { topBarHeight } from '../TopBar/TopBar';
 import {
+  OpossumColors,
   TREE_ROOT_FOLDER_LABEL,
   TREE_ROW_HEIGHT,
   treeClasses,
-  OpossumColors,
 } from '../../shared-styles';
 import { isLocateSignalActive } from '../../state/selectors/locate-popup-selectors';
 import { IconButton } from '../IconButton/IconButton';
@@ -144,7 +144,7 @@ export function ResourceBrowser(): ReactElement | null {
     <IconButton
       iconSx={classes.locatorIcon}
       containerSx={classes.locatorIconContainer}
-      tooltipTitle="filters active"
+      tooltipTitle="locate active"
       tooltipPlacement="right"
       onClick={(): void => {
         dispatch(openPopup(PopupType.LocatorPopup));

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -336,9 +336,9 @@ describe('ResourceBrowser', () => {
       );
     });
 
-    expect(screen.getByLabelText('filters active')).toBeInTheDocument();
+    expect(screen.getByLabelText('locate active')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('filters active'));
+    fireEvent.click(screen.getByLabelText('locate active'));
 
     expect(getOpenPopup(store.getState())).toBe(PopupType.LocatorPopup);
   });


### PR DESCRIPTION
### Summary of changes

Rename tooltip of locate icon.

### Context and reason for change

The old tooltip was misleading. 

### How can the changes be tested

<img width="339" alt="Screenshot 2023-09-27 at 14 19 54" src="https://github.com/opossum-tool/OpossumUI/assets/46576389/3d1fec61-bf4b-4d92-a960-f82c0deff0c9">
