### PR TITLE
Update tooltip text of the criticality bar for improved understandability

### DIFF
--- a/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/TopProgressBar.test.tsx
@@ -227,13 +227,14 @@ describe('TopProgressBar', () => {
       jest.runAllTimers();
     });
     expect(
-      screen.getByText(/Files without attributions but/),
+      screen.getByText(
+        /Number of files with signals and no attributions \(3\)/,
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText(/with signals: 3/)).toBeInTheDocument();
     expect(
-      screen.getByText(/with highly-critical signals: 1/) &&
-        screen.getByText(/with medium-critical signals: 1/) &&
-        screen.getByText(/with non-critical signals: 1/),
+      screen.getByText(/containing highly-critical signals: 1/) &&
+        screen.getByText(/containing medium-critical signals: 1/) &&
+        screen.getByText(/containing only non-critical signals: 1/),
     ).toBeDefined();
   });
 });

--- a/src/Frontend/Components/ProgressBar/progress-bar-helpers.tsx
+++ b/src/Frontend/Components/ProgressBar/progress-bar-helpers.tsx
@@ -58,16 +58,14 @@ export function getCriticalityBarTooltipText(
     progressBarData.filesWithMediumCriticalExternalAttributionsCount;
   return (
     <MuiBox>
-      Files without attributions but <br />
-      with signals: {progressBarData.filesWithOnlyExternalAttributionCount}
-      <br />
-      with highly-critical signals:{' '}
-      {progressBarData.filesWithHighlyCriticalExternalAttributionsCount}
-      <br />
-      with medium-critical signals:{' '}
-      {progressBarData.filesWithMediumCriticalExternalAttributionsCount}
-      <br />
-      with non-critical signals: {filesWithNonCriticalExternalAttributions}
+      Number of files with signals and no attributions (
+      {progressBarData.filesWithOnlyExternalAttributionCount}) <br />
+      containing highly-critical signals:{' '}
+      {progressBarData.filesWithHighlyCriticalExternalAttributionsCount} <br />
+      containing medium-critical signals:{' '}
+      {progressBarData.filesWithMediumCriticalExternalAttributionsCount} <br />
+      containing only non-critical signals:{' '}
+      {filesWithNonCriticalExternalAttributions}
     </MuiBox>
   );
 }


### PR DESCRIPTION
### Summary of changes

Changed the tooltip text for the criticality-bar.

### Context and reason for change

The previous tooltip text caused irritations about whether the first number 'with signals' is the total number, i.e., the width of the total bar, or not. The changes introduced in this diff should make clear what is the total number of resources and what are the respective subparts of resources with highly-, medium- or non-critical signals.

### How can the changes be tested
- checkout diff
- run `yarn start`
- open the `opossum_ui_scan_input.json.gz` file
- click the toggel in order to switch to criticality-bar
- hover over the criticality-bar in order to see the tooltip
