### PR TITLE
Rectify the behavior of `LocatorPopup` and `ProjectStatisticsPopup`

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -31,6 +31,7 @@ import {
   getSelectedView,
 } from '../../../state/selectors/view-selector';
 import { getSelectedResourceId } from '../../../state/selectors/audit-view-resource-selectors';
+import { getResourcesWithLocatedAttributions } from '../../../state/selectors/all-views-resource-selectors';
 
 describe('The ProjectStatisticsPopup', () => {
   it('displays license names and source names', () => {
@@ -100,7 +101,7 @@ describe('The ProjectStatisticsPopup', () => {
     expect(iconButtonMIT).toBeEnabled();
   });
 
-  it('locates attributions in resource browser when clicking on a search license icon', () => {
+  it('locates attributions when clicking on a search license icon', () => {
     const store = createTestAppStore();
     const testExternalAttributions: Attributions = {
       uuid_1: {
@@ -133,10 +134,24 @@ describe('The ProjectStatisticsPopup', () => {
       name: 'locate signals with "MIT"',
     });
     fireEvent.click(iconButtonMIT);
-    expect(getSelectedView(store.getState())).toBe(View.Audit);
-    expect(['/folder/file', '/folder/otherFile']).toContain(
-      getSelectedResourceId(store.getState()),
+
+    const { locatedResources, resourcesWithLocatedChildren } =
+      getResourcesWithLocatedAttributions(store.getState());
+    const expectedLocatedResources = new Set<string>([
+      '/folder/file',
+      '/folder/otherFile',
+    ]);
+    const expectedResourcesWithLocatedChildren = new Set<string>([
+      '/',
+      '/folder/',
+    ]);
+
+    expect(locatedResources).toEqual(expectedLocatedResources);
+    expect(resourcesWithLocatedChildren).toEqual(
+      expectedResourcesWithLocatedChildren,
     );
+    expect(getSelectedView(store.getState())).toBe(View.Audit);
+    expect(getSelectedResourceId(store.getState())).toBe('');
     expect(getOpenPopup(store.getState())).toBeNull();
   });
 

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -16,7 +16,7 @@ import {
   getTemporaryDisplayPackageInfo,
   wereTemporaryDisplayPackageInfoModified,
 } from '../../selectors/all-views-resource-selectors';
-import { getTargetView } from '../../selectors/view-selector';
+import { getSelectedView, getTargetView } from '../../selectors/view-selector';
 import {
   openResourceInResourceBrowser,
   setDisplayedPackageAndResetTemporaryDisplayPackageInfo,
@@ -378,11 +378,9 @@ export function locateSignalsFromLocatorPopup(
 
     if (!showNoSignalsLocatedMessage) {
       dispatch(closePopup());
-      dispatch(
-        navigateToSelectedPathOrOpenUnsavedPopup(
-          locatedResources.values().next().value,
-        ),
-      );
+      if (getSelectedView(getState()) !== View.Audit) {
+        dispatch(setViewOrOpenUnsavedPopup(View.Audit));
+      }
     }
   };
 }
@@ -397,14 +395,9 @@ export function locateSignalsFromProjectStatisticsPopup(
         selectedLicenses: new Set([licenseName]),
       }),
     );
-    const { locatedResources } = getResourcesWithLocatedAttributions(
-      getState(),
-    );
     dispatch(closePopup());
-    dispatch(
-      navigateToSelectedPathOrOpenUnsavedPopup(
-        locatedResources.values().next().value,
-      ),
-    );
+    if (getSelectedView(getState()) !== View.Audit) {
+      dispatch(setViewOrOpenUnsavedPopup(View.Audit));
+    }
   };
 }


### PR DESCRIPTION
### Summary of changes

Both popups are closed after initiating the location process. There is no navigation to found resources. The user is navigated to audit view. Unsaved changes are handled with `NotSavedPopup`.

### Context and reason for change

We locate critical signals via `LocatorPopup` and `ProjectStatisticsPopup`. The behavior of both popups turned out to be not ideal, hence, we want to change it.

### How can the changes be tested
Automatically:
Run adapted tests in `ProjectStatisticsPopup.test.tsx` and `popup-actions.test.ts`.
Manually:
Open an example file and test the expected behavior mentioned above.


Fix: #2070