### PR TITLE
Fix sorting of licenses in project statistics popup

### DIFF
--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -6,6 +6,7 @@
 import React, { ReactElement } from 'react';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
 import { LicenseCounts, LicenseNamesWithCriticality } from '../../types/types';
+import { compareAlphabeticalStrings } from '../../util/get-alphabetical-comparer';
 
 const classes = {
   container: {
@@ -64,7 +65,9 @@ export function AttributionCountPerSourcePerLicenseTable(
       containerStyle={classes.container}
       columnHeaders={headerRow}
       columnNames={headerRow}
-      rowNames={Object.keys(props.licenseNamesWithCriticality).sort()}
+      rowNames={Object.keys(props.licenseNamesWithCriticality).sort((a, b) =>
+        compareAlphabeticalStrings(a, b),
+      )}
       tableContent={props.licenseCounts.attributionCountPerSourcePerLicense}
       tableFooter={footerRow}
       licenseNamesWithCriticality={props.licenseNamesWithCriticality}

--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -13,6 +13,7 @@ import { clickableIcon } from '../../shared-styles';
 import { useAppDispatch } from '../../state/hooks';
 import { AppThunkDispatch } from '../../state/types';
 import { locateSignalsFromProjectStatisticsPopup } from '../../state/actions/popup-actions/popup-actions';
+import { compareAlphabeticalStrings } from '../../util/get-alphabetical-comparer';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
 const COUNT_COLUMN_NAME_IN_TABLE = 'Count';
@@ -70,9 +71,13 @@ export function CriticalLicensesTable(
       props.totalAttributionsPerLicense,
       mediumCriticalityLicenseNames,
     );
-  const criticalLicensesTotalAttributions =
-    highCriticalityLicensesTotalAttributions.concat(
-      mediumCriticalityLicensesTotalAttributions,
+  const sortedCriticalLicensesTotalAttributions =
+    sortLicenseNamesWithTotalAttributions(
+      highCriticalityLicensesTotalAttributions,
+    ).concat(
+      sortLicenseNamesWithTotalAttributions(
+        mediumCriticalityLicensesTotalAttributions,
+      ),
     );
 
   return (
@@ -82,16 +87,16 @@ export function CriticalLicensesTable(
       columnHeaders={TABLE_COLUMN_NAMES}
       columnNames={TABLE_COLUMN_NAMES}
       firstColumnIconButtons={Object.fromEntries(
-        criticalLicensesTotalAttributions.map(({ licenseName }) => [
+        sortedCriticalLicensesTotalAttributions.map(({ licenseName }) => [
           licenseName,
           getLocateSignalsIconButton(licenseName, dispatch),
         ]),
       )}
-      rowNames={criticalLicensesTotalAttributions.map(
+      rowNames={sortedCriticalLicensesTotalAttributions.map(
         (attribution) => attribution.licenseName,
       )}
       tableContent={Object.fromEntries(
-        criticalLicensesTotalAttributions.map(
+        sortedCriticalLicensesTotalAttributions.map(
           ({ licenseName, totalNumberOfAttributions }) => [
             licenseName,
             {
@@ -102,7 +107,7 @@ export function CriticalLicensesTable(
       )}
       tableFooter={[FOOTER_TITLE].concat(
         getTotalNumberOfAttributions(
-          criticalLicensesTotalAttributions,
+          sortedCriticalLicensesTotalAttributions,
         ).toString(),
       )}
       licenseNamesWithCriticality={props.licenseNamesWithCriticality}
@@ -171,5 +176,16 @@ function getLocateSignalsIconButton(
       iconSx={classes.iconButton}
       icon={<LocateSignalsIcon sx={classes.clickableIcon} />}
     />
+  );
+}
+
+function sortLicenseNamesWithTotalAttributions(
+  licenseNamesWithTotalAttributions: Array<{
+    licenseName: string;
+    totalNumberOfAttributions: number;
+  }>,
+): Array<{ licenseName: string; totalNumberOfAttributions: number }> {
+  return licenseNamesWithTotalAttributions.sort((a, b) =>
+    compareAlphabeticalStrings(a.licenseName, b.licenseName),
   );
 }


### PR DESCRIPTION
### Summary of changes

We here fix the sorting of licenses in the "Critical Licenses" and the "Signals per Sources" tables.
In the "Critical Licenses" table, we are showing the entries with "high" criticality alphabetically sorted on top, and those with "medium" criticality alphabetically sorted below.
In the "Signals per Sources" table, on the other hand, we are showing all entries alphabetically sorted by license name.

Fixes #2050

### Context and reason for change

To provide better overview in the project statistics popup, we sort the entries in the shown tables according to different criteria.

### How can the changes be tested

Create an Opossum input file with multiple licenses with high and medium criticality that are assigned to resources. Open the file in OpossumUI and verify that they are sorted correctly in the project statistics popup.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
