### PR TITLE
Add dummy signal search component

### DIFF
--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { Checkbox } from '../Checkbox/Checkbox';
 import React, { ChangeEvent, ReactElement, useState } from 'react';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import {
   closePopup,
   setShowNoSignalsLocatedMessage,
 } from '../../state/actions/view-actions/view-actions';
-import { ButtonText, CriticalityTypes } from '../../enums/enums';
+import { ButtonText, CheckboxLabel, CriticalityTypes } from '../../enums/enums';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { Dropdown, menuItem } from '../InputElements/Dropdown';
 import {
@@ -36,6 +37,10 @@ const classes = {
   noSignalsMessage: { color: OpossumColors.red, marginTop: '8px' },
   dialogContent: {
     width: '25vw',
+  },
+  checkboxContainer: {
+    display: 'flex',
+    alignItems: 'center',
   },
 };
 
@@ -83,6 +88,11 @@ export function LocatorPopup(): ReactElement {
     selectedLicenses.size == 0 ? '' : selectedLicenses.values().next().value;
 
   const [searchedLicense, setSearchedLicense] = useState(selectedLicense);
+
+  const [searchedSignal, setSearchedSignal] = useState('');
+  const [searchOnlyInLicenseField, setSearchOnlyInLicenseField] =
+    useState(false);
+
   const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
     useState<SelectedCriticality>(selectedCriticality);
 
@@ -109,6 +119,8 @@ export function LocatorPopup(): ReactElement {
   function handleClearClick(): void {
     setCriticalityDropDownChoice(SelectedCriticality.Any);
     setSearchedLicense('');
+    setSearchedSignal('');
+    setSearchOnlyInLicenseField(false);
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
@@ -124,6 +136,27 @@ export function LocatorPopup(): ReactElement {
 
   const content = (
     <>
+      <AutoComplete
+        isEditable={true}
+        sx={classes.autocomplete}
+        title={'Search'}
+        handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
+          setSearchedSignal(event.target.value);
+        }}
+        isHighlighted={false}
+        options={new Array<string>()}
+        inputValue={searchedSignal}
+        showTextBold={false}
+        formatOptionForDisplay={(option: string): string => option}
+      />
+      <Checkbox
+        sx={classes.checkboxContainer}
+        label={CheckboxLabel.OnlyInLicenseField}
+        checked={searchOnlyInLicenseField}
+        onChange={(): void => {
+          setSearchOnlyInLicenseField(!searchOnlyInLicenseField);
+        }}
+      />
       <Dropdown
         sx={classes.dropdown}
         isEditable={true}

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -10,7 +10,10 @@ import {
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { getLocatePopupFilters } from '../../../state/selectors/locate-popup-selectors';
-import { clickOnButton } from '../../../test-helpers/general-test-helpers';
+import {
+  clickOnButton,
+  clickOnCheckbox,
+} from '../../../test-helpers/general-test-helpers';
 import { setLocatePopupFilters } from '../../../state/actions/resource-actions/locate-popup-actions';
 import {
   Criticality,
@@ -29,6 +32,10 @@ import {
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
 import { getResourcesWithLocatedAttributions } from '../../../state/selectors/all-views-resource-selectors';
+import {
+  expectValueInTextBox,
+  insertValueIntoTextBox,
+} from '../../../test-helpers/attribution-column-test-helpers';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -38,6 +45,15 @@ describe('Locator popup ', () => {
     expect(
       screen.getByText('Locate Signals', { exact: true }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+    expect(
+      screen.getByText('Only search in the license field'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'checkbox Only search in the license field',
+      }),
+    ).not.toBeChecked();
     expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
     expect(screen.getByText('Any')).toBeInTheDocument();
     expect(
@@ -122,7 +138,7 @@ describe('Locator popup ', () => {
 
     renderComponentWithStore(<LocatorPopup />, { store: testStore });
 
-    expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT']);
+    expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT'], 'License');
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }) as Element);
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
@@ -155,6 +171,36 @@ describe('Locator popup ', () => {
       resourcesWithLocatedChildren: new Set(),
       locatedResources: new Set(),
     });
+  });
+
+  it('clears search field if clear button pressed', () => {
+    renderComponentWithStore(<LocatorPopup />);
+    insertValueIntoTextBox(screen, 'Search', 'jquery');
+    expectValueInTextBox(screen, 'Search', 'jquery');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }) as Element);
+
+    expectValueInTextBox(screen, 'Search', '');
+  });
+
+  it('unchecks checkbox if clear button pressed', () => {
+    renderComponentWithStore(<LocatorPopup />);
+
+    clickOnCheckbox(screen, 'Only search in the license field');
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'checkbox Only search in the license field',
+      }),
+    ).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }) as Element);
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'checkbox Only search in the license field',
+      }),
+    ).not.toBeChecked();
   });
 
   it('shows license if selected beforehand', () => {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -97,6 +97,7 @@ export enum CheckboxLabel {
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',
   NeedsReview = 'Needs Review',
+  OnlyInLicenseField = 'Only search in the license field',
 }
 
 export enum ProjectStatisticsPopupTitle {

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -261,8 +261,9 @@ export function closeProjectStatisticsPopup(screen: Screen): void {
 export function expectElementsInAutoCompleteAndSelectFirst(
   screen: Screen,
   elements: Array<string>,
+  autocompleteName?: string,
 ): void {
-  const autoComplete = screen.getByRole('combobox');
+  const autoComplete = screen.getByRole('combobox', { name: autocompleteName });
   autoComplete.focus();
   fireEvent.keyDown(autoComplete, { key: 'ArrowDown' });
 


### PR DESCRIPTION
### Summary of changes

Adds a signal search UI component. Currtently, it does nothing.

### Context and reason for change

In #1934 we decided that we want a search field for signals.

### How can the changes be tested

Open the popup with ctrl+L