### PR TITLE
Implement signal search

### DIFF
--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -28,6 +28,7 @@ import { OpossumColors } from '../../shared-styles';
 import MuiTypography from '@mui/material/Typography';
 import { compareAlphabeticalStrings } from '../../util/get-alphabetical-comparer';
 import { locateSignalsFromLocatorPopup } from '../../state/actions/popup-actions/popup-actions';
+import { SearchTextField } from '../SearchTextField/SearchTextField';
 
 const classes = {
   dropdown: {
@@ -142,18 +143,13 @@ export function LocatorPopup(): ReactElement {
 
   const content = (
     <>
-      <AutoComplete
-        isEditable={true}
+      <SearchTextField
         sx={classes.autocomplete}
-        title={'Search'}
-        handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
-          setSearchedSignal(event.target.value);
+        onInputChange={(search: string): void => {
+          setSearchedSignal(search);
         }}
-        isHighlighted={false}
-        options={new Array<string>()}
-        inputValue={searchedSignal}
-        showTextBold={false}
-        formatOptionForDisplay={(option: string): string => option}
+        search={searchedSignal}
+        showIcon={true}
       />
       <Checkbox
         sx={classes.checkboxContainer}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -156,6 +156,7 @@ export function LocatorPopup(): ReactElement {
         sx={classes.checkboxContainer}
         label={CheckboxLabel.OnlyInLicenseField}
         checked={displaySearchOnlyInLicenseField}
+        disabled={searchedSignal === ''}
         onChange={(): void => {
           setDisplaySearchOnlyInLicenseField(!displaySearchOnlyInLicenseField);
         }}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -74,7 +74,7 @@ export function getLicenseNames(attributions: Attributions): Array<string> {
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
   const externalAttributions = useAppSelector(getExternalAttributions);
-  const { selectedCriticality, selectedLicenses } = useAppSelector(
+  const { selectedCriticality, selectedLicenses, searchTerm, searchOnlyInLicenseField } = useAppSelector(
     getLocatePopupFilters,
   );
   const showNoSignalsLocatedMessage = useAppSelector(
@@ -89,9 +89,9 @@ export function LocatorPopup(): ReactElement {
 
   const [searchedLicense, setSearchedLicense] = useState(selectedLicense);
 
-  const [searchedSignal, setSearchedSignal] = useState('');
-  const [searchOnlyInLicenseField, setSearchOnlyInLicenseField] =
-    useState(false);
+  const [searchedSignal, setSearchedSignal] = useState(searchTerm);
+  const [displaySearchOnlyInLicenseField, setDisplaySearchOnlyInLicenseField] =
+    useState(searchOnlyInLicenseField);
 
   const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
     useState<SelectedCriticality>(selectedCriticality);
@@ -107,11 +107,12 @@ export function LocatorPopup(): ReactElement {
       searchedLicense.length == 0
         ? new Set<string>()
         : new Set([searchedLicense]);
-
     dispatch(
       locateSignalsFromLocatorPopup(
         criticalityDropDownChoice,
         searchedLicenses,
+        searchedSignal,
+        displaySearchOnlyInLicenseField
       ),
     );
   }
@@ -120,11 +121,13 @@ export function LocatorPopup(): ReactElement {
     setCriticalityDropDownChoice(SelectedCriticality.Any);
     setSearchedLicense('');
     setSearchedSignal('');
-    setSearchOnlyInLicenseField(false);
+    setDisplaySearchOnlyInLicenseField(false);
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(),
+        searchTerm: '',
+        searchOnlyInLicenseField: false,
       }),
     );
     dispatch(setShowNoSignalsLocatedMessage(false));
@@ -152,9 +155,9 @@ export function LocatorPopup(): ReactElement {
       <Checkbox
         sx={classes.checkboxContainer}
         label={CheckboxLabel.OnlyInLicenseField}
-        checked={searchOnlyInLicenseField}
+        checked={displaySearchOnlyInLicenseField}
         onChange={(): void => {
-          setSearchOnlyInLicenseField(!searchOnlyInLicenseField);
+          setDisplaySearchOnlyInLicenseField(!displaySearchOnlyInLicenseField);
         }}
       />
       <Dropdown

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -79,7 +79,7 @@ export function LocatorPopup(): ReactElement {
     selectedCriticality,
     selectedLicenses,
     searchTerm,
-    searchOnlyInLicenseField,
+    searchOnlyLicenseName,
   } = useAppSelector(getLocatePopupFilters);
   const showNoSignalsLocatedMessage = useAppSelector(
     getShowNoSignalsLocatedMessage,
@@ -94,8 +94,8 @@ export function LocatorPopup(): ReactElement {
   const [searchedLicense, setSearchedLicense] = useState(selectedLicense);
 
   const [searchedSignal, setSearchedSignal] = useState(searchTerm);
-  const [displaySearchOnlyInLicenseField, setDisplaySearchOnlyInLicenseField] =
-    useState(searchOnlyInLicenseField);
+  const [displaySearchOnlyLicenseName, setDisplaySearchOnlyLicenseName] =
+    useState(searchOnlyLicenseName);
 
   const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
     useState<SelectedCriticality>(selectedCriticality);
@@ -116,7 +116,7 @@ export function LocatorPopup(): ReactElement {
         criticalityDropDownChoice,
         searchedLicenses,
         searchedSignal,
-        displaySearchOnlyInLicenseField,
+        displaySearchOnlyLicenseName,
       ),
     );
   }
@@ -125,13 +125,13 @@ export function LocatorPopup(): ReactElement {
     setCriticalityDropDownChoice(SelectedCriticality.Any);
     setSearchedLicense('');
     setSearchedSignal('');
-    setDisplaySearchOnlyInLicenseField(false);
+    setDisplaySearchOnlyLicenseName(false);
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(),
         searchTerm: '',
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
       }),
     );
     dispatch(setShowNoSignalsLocatedMessage(false));
@@ -153,11 +153,11 @@ export function LocatorPopup(): ReactElement {
       />
       <Checkbox
         sx={classes.checkboxContainer}
-        label={CheckboxLabel.OnlyInLicenseField}
-        checked={displaySearchOnlyInLicenseField}
+        label={CheckboxLabel.OnlyLicenseName}
+        checked={displaySearchOnlyLicenseName}
         disabled={searchedSignal === ''}
         onChange={(): void => {
-          setDisplaySearchOnlyInLicenseField(!displaySearchOnlyInLicenseField);
+          setDisplaySearchOnlyLicenseName(!displaySearchOnlyLicenseName);
         }}
       />
       <Dropdown

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -74,9 +74,12 @@ export function getLicenseNames(attributions: Attributions): Array<string> {
 export function LocatorPopup(): ReactElement {
   const dispatch = useAppDispatch();
   const externalAttributions = useAppSelector(getExternalAttributions);
-  const { selectedCriticality, selectedLicenses, searchTerm, searchOnlyInLicenseField } = useAppSelector(
-    getLocatePopupFilters,
-  );
+  const {
+    selectedCriticality,
+    selectedLicenses,
+    searchTerm,
+    searchOnlyInLicenseField,
+  } = useAppSelector(getLocatePopupFilters);
   const showNoSignalsLocatedMessage = useAppSelector(
     getShowNoSignalsLocatedMessage,
   );
@@ -112,7 +115,7 @@ export function LocatorPopup(): ReactElement {
         criticalityDropDownChoice,
         searchedLicenses,
         searchedSignal,
-        displaySearchOnlyInLicenseField
+        displaySearchOnlyInLicenseField,
       ),
     );
   }

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -75,6 +75,8 @@ describe('Locator popup ', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
 
     clickOnButton(screen, 'Apply');
@@ -82,6 +84,8 @@ describe('Locator popup ', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.High,
       selectedLicenses: new Set<string>(),
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
   });
 
@@ -91,6 +95,8 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Medium,
         selectedLicenses: new Set<string>(),
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
     renderComponentWithStore(<LocatorPopup />, { store: testStore });
@@ -105,6 +111,8 @@ describe('Locator popup ', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
   });
 
@@ -143,6 +151,8 @@ describe('Locator popup ', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: licenseSet,
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual(
       expectedLocatedResources,
@@ -157,6 +167,8 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseSet,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -166,6 +178,8 @@ describe('Locator popup ', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedLicenses: new Set<string>(),
       selectedCriticality: SelectedCriticality.Any,
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -211,6 +225,8 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseSet,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -260,6 +276,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
     GPLMediumAttribution: {
       licenseName: 'General Public License',
       criticality: Criticality.Medium,
+      packageVersion: '2.0',
     },
   };
   const testResourcesToAttributions: ResourcesToAttributions = {
@@ -296,6 +313,8 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -311,6 +330,70 @@ describe('locateResourcesByCriticalityAndLicense', () => {
     );
   });
 
+  it('locates attribution and parent if only search term set', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setExternalData(testAttributions, testResourcesToAttributions),
+    );
+    testStore.dispatch(setFrequentLicenses(testFrequentLicenses));
+
+    const searchTerm = '2.0';
+    testStore.dispatch(
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.Any,
+        selectedLicenses: new Set(),
+        searchOnlyInLicenseField: false,
+        searchTerm,
+      }),
+    );
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+    clickOnButton(screen, 'Apply');
+
+    const expectedLocatedResources = {
+      resourcesWithLocatedChildren: new Set(['/']),
+      locatedResources: new Set([
+        '/pathToApacheHigh',
+        '/pathToApacheMedium',
+        '/pathToGPLMedium',
+      ]),
+    };
+    const actualLocatedResources = getResourcesWithLocatedAttributions(
+      testStore.getState(),
+    );
+    expect(actualLocatedResources).toEqual(expectedLocatedResources);
+  });
+
+  it('locates attribution and parent when searching for license name only', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setExternalData(testAttributions, testResourcesToAttributions),
+    );
+    testStore.dispatch(setFrequentLicenses(testFrequentLicenses));
+
+    const searchTerm = '2.0';
+    testStore.dispatch(
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.Any,
+        selectedLicenses: new Set(),
+        searchOnlyInLicenseField: true,
+        searchTerm,
+      }),
+    );
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+    clickOnButton(screen, 'Apply');
+
+    const expectedLocatedResources = {
+      resourcesWithLocatedChildren: new Set(['/']),
+      locatedResources: new Set(['/pathToApacheHigh', '/pathToApacheMedium']),
+    };
+    const actualLocatedResources = getResourcesWithLocatedAttributions(
+      testStore.getState(),
+    );
+    expect(actualLocatedResources).toEqual(expectedLocatedResources);
+  });
+
   it('locates attribution and parent if only licenses set', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
@@ -323,6 +406,8 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseNames,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -353,6 +438,8 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: new Set<string>(),
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -385,6 +472,8 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 
@@ -414,6 +503,8 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
+        searchOnlyInLicenseField: false,
+        searchTerm: '',
       }),
     );
 

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -73,7 +73,7 @@ describe('Locator popup ', () => {
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
 
     clickOnButton(screen, 'Apply');
@@ -82,7 +82,7 @@ describe('Locator popup ', () => {
       selectedCriticality: SelectedCriticality.High,
       selectedLicenses: new Set<string>(),
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
   });
 
@@ -92,7 +92,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Medium,
         selectedLicenses: new Set<string>(),
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -109,7 +109,7 @@ describe('Locator popup ', () => {
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
   });
 
@@ -149,7 +149,7 @@ describe('Locator popup ', () => {
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: licenseSet,
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual(
       expectedLocatedResources,
@@ -164,7 +164,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseSet,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -176,7 +176,7 @@ describe('Locator popup ', () => {
       selectedLicenses: new Set<string>(),
       selectedCriticality: SelectedCriticality.Any,
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -190,7 +190,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Medium,
         selectedLicenses: new Set<string>(),
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: 'jquery',
       }),
     );
@@ -203,7 +203,7 @@ describe('Locator popup ', () => {
       selectedLicenses: new Set<string>(),
       selectedCriticality: SelectedCriticality.Any,
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -217,7 +217,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Medium,
         selectedLicenses: new Set<string>(),
-        searchOnlyInLicenseField: true,
+        searchOnlyLicenseName: true,
         searchTerm: '',
       }),
     );
@@ -240,7 +240,7 @@ describe('Locator popup ', () => {
       selectedLicenses: new Set<string>(),
       selectedCriticality: SelectedCriticality.Any,
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -254,7 +254,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Medium,
         selectedLicenses: new Set<string>(),
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -283,7 +283,7 @@ describe('Locator popup ', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseSet,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -371,7 +371,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -400,7 +400,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set(),
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm,
       }),
     );
@@ -434,7 +434,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set(),
-        searchOnlyInLicenseField: true,
+        searchOnlyLicenseName: true,
         searchTerm,
       }),
     );
@@ -464,7 +464,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: licenseNames,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -496,7 +496,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: new Set<string>(),
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -530,7 +530,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );
@@ -561,7 +561,7 @@ describe('locateResourcesByCriticalityAndLicense', () => {
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
         searchTerm: '',
       }),
     );

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -43,12 +43,10 @@ describe('Locator popup ', () => {
       screen.getByText('Locate Signals', { exact: true }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Search')).toBeInTheDocument();
-    expect(
-      screen.getByText('Only search in the license field'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Only search license names')).toBeInTheDocument();
     expect(
       screen.getByRole('checkbox', {
-        name: 'checkbox Only search in the license field',
+        name: 'checkbox Only search license names',
       }),
     ).not.toBeChecked();
     expect(screen.getByLabelText('Criticality')).toBeInTheDocument();
@@ -225,7 +223,7 @@ describe('Locator popup ', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'checkbox Only search in the license field',
+        name: 'checkbox Only search license names',
       }),
     ).toBeChecked();
 
@@ -233,7 +231,7 @@ describe('Locator popup ', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'checkbox Only search in the license field',
+        name: 'checkbox Only search license names',
       }),
     ).not.toBeChecked();
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
@@ -262,7 +260,7 @@ describe('Locator popup ', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'checkbox Only search in the license field',
+        name: 'checkbox Only search license names',
       }),
     ).toBeDisabled();
 
@@ -270,7 +268,7 @@ describe('Locator popup ', () => {
 
     expect(
       screen.getByRole('checkbox', {
-        name: 'checkbox Only search in the license field',
+        name: 'checkbox Only search license names',
       }),
     ).toBeEnabled();
   });

--- a/src/Frontend/Components/PackageList/__tests__/package-list-helpers.test.ts
+++ b/src/Frontend/Components/PackageList/__tests__/package-list-helpers.test.ts
@@ -8,37 +8,15 @@ import { getFilteredPackageCardIdsFromDisplayPackageInfos } from '../package-lis
 
 describe('getFilteredPackageCardIdsFromDisplayPackageInfos', () => {
   it('filters PackageCardIds', () => {
-    const testSortedPackageCardIds = [
-      'Signals-0',
-      'Signals-1',
-      'Signals-2',
-      'Signals-3',
-      'Signals-4',
-    ];
+    const testSortedPackageCardIds = ['Signals-0', 'Signals-1'];
 
-    /* eslint-disable @typescript-eslint/no-magic-numbers */
     const testDisplayPackageInfos: DisplayPackageInfos = {
       [testSortedPackageCardIds[0]]: {
         packageName: 'Search_term package',
-        attributionIds: ['uuid1'],
+        attributionIds: ['uuid0'],
       },
       [testSortedPackageCardIds[1]]: {
-        copyright: '(c) Search_term 2022',
-        attributionIds: ['uuid2'],
-      },
-      [testSortedPackageCardIds[2]]: {
-        licenseName: 'Search_term licence',
-        attributionIds: ['uuid3'],
-      },
-      [testSortedPackageCardIds[3]]: {
-        packageVersion: 'version search_term',
-        attributionIds: ['uuid4'],
-      },
-      [testSortedPackageCardIds[4]]: {
-        comments: ['comment search_term'],
-        licenseText: 'text search_term',
-        url: 'www.search_term.com',
-        attributionIds: ['uuid5'],
+        attributionIds: ['uuid1'],
       },
     };
 
@@ -50,12 +28,8 @@ describe('getFilteredPackageCardIdsFromDisplayPackageInfos', () => {
       );
 
     expect(testFilteredPackageCardIds).toContain(testSortedPackageCardIds[0]);
-    expect(testFilteredPackageCardIds).toContain(testSortedPackageCardIds[1]);
-    expect(testFilteredPackageCardIds).toContain(testSortedPackageCardIds[2]);
-    expect(testFilteredPackageCardIds).toContain(testSortedPackageCardIds[3]);
     expect(testFilteredPackageCardIds).not.toContain(
-      testSortedPackageCardIds[4],
+      testSortedPackageCardIds[1],
     );
-    /* eslint-enable @typescript-eslint/no-magic-numbers */
   });
 });

--- a/src/Frontend/Components/PackageList/package-list-helpers.ts
+++ b/src/Frontend/Components/PackageList/package-list-helpers.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { DisplayPackageInfo } from '../../../shared/shared-types';
+import { PackageInfoCore } from '../../../shared/shared-types';
 import { DisplayPackageInfos } from '../../types/types';
 
 export function getFilteredPackageCardIdsFromDisplayPackageInfos(
@@ -19,28 +19,29 @@ export function getFilteredPackageCardIdsFromDisplayPackageInfos(
   });
 }
 
-function displayPackageInfoContainsSearchTerm(
-  attribution: DisplayPackageInfo,
+export function displayPackageInfoContainsSearchTerm(
+  attribution: PackageInfoCore,
   searchTerm: string,
 ): boolean {
+  console.log(attribution);
   return Boolean(
     attribution &&
-      (searchTerm === '' ||
-        (attribution.packageName &&
-          attribution.packageName
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())) ||
-        (attribution.licenseName &&
-          attribution.licenseName
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())) ||
-        (attribution.copyright &&
-          attribution.copyright
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())) ||
-        (attribution.packageVersion &&
-          attribution.packageVersion
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()))),
+    (searchTerm === '' ||
+      (attribution.packageName &&
+        attribution.packageName
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())) ||
+      (attribution.licenseName &&
+        attribution.licenseName
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())) ||
+      (attribution.copyright &&
+        attribution.copyright
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())) ||
+      (attribution.packageVersion &&
+        attribution.packageVersion
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()))),
   );
 }

--- a/src/Frontend/Components/PackageList/package-list-helpers.ts
+++ b/src/Frontend/Components/PackageList/package-list-helpers.ts
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfoCore } from '../../../shared/shared-types';
 import { DisplayPackageInfos } from '../../types/types';
+import { packageInfoContainsSearchTerm } from '../../util/search-package-info';
 
 export function getFilteredPackageCardIdsFromDisplayPackageInfos(
   displayPackageInfos: DisplayPackageInfos,
@@ -12,36 +12,9 @@ export function getFilteredPackageCardIdsFromDisplayPackageInfos(
   searchTerm: string,
 ): Array<string> {
   return sortedPackageCardIds.filter((packageCardId) => {
-    return displayPackageInfoContainsSearchTerm(
+    return packageInfoContainsSearchTerm(
       displayPackageInfos[packageCardId],
       searchTerm,
     );
   });
-}
-
-export function displayPackageInfoContainsSearchTerm(
-  attribution: PackageInfoCore,
-  searchTerm: string,
-): boolean {
-  console.log(attribution);
-  return Boolean(
-    attribution &&
-    (searchTerm === '' ||
-      (attribution.packageName &&
-        attribution.packageName
-          .toLowerCase()
-          .includes(searchTerm.toLowerCase())) ||
-      (attribution.licenseName &&
-        attribution.licenseName
-          .toLowerCase()
-          .includes(searchTerm.toLowerCase())) ||
-      (attribution.copyright &&
-        attribution.copyright
-          .toLowerCase()
-          .includes(searchTerm.toLowerCase())) ||
-      (attribution.packageVersion &&
-        attribution.packageVersion
-          .toLowerCase()
-          .includes(searchTerm.toLowerCase()))),
-  );
 }

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -175,7 +175,7 @@ describe('ResourceBrowser', () => {
           selectedCriticality: testLocatePopupSelectedCriticality,
           selectedLicenses: new Set<string>(),
           searchTerm: '',
-          searchOnlyInLicenseField: false,
+          searchOnlyLicenseName: false,
         }),
       );
     });
@@ -335,7 +335,7 @@ describe('ResourceBrowser', () => {
           selectedCriticality: SelectedCriticality.High,
           selectedLicenses: new Set<string>(),
           searchTerm: '',
-          searchOnlyInLicenseField: false,
+          searchOnlyLicenseName: false,
         }),
       );
     });

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -174,6 +174,7 @@ describe('ResourceBrowser', () => {
         setLocatePopupFilters({
           selectedCriticality: testLocatePopupSelectedCriticality,
           selectedLicenses: new Set<string>(),
+          searchTerm: '',
         }),
       );
     });
@@ -332,6 +333,7 @@ describe('ResourceBrowser', () => {
         setLocatePopupFilters({
           selectedCriticality: SelectedCriticality.High,
           selectedLicenses: new Set<string>(),
+          searchTerm: '',
         }),
       );
     });
@@ -355,11 +357,11 @@ function expectIconToExist(
     ?.parentElement as HTMLElement;
   expectedToExist
     ? // eslint-disable-next-line testing-library/prefer-screen-queries
-      expect(getByLabelText(resourceTreeRow, iconLabel)).toBeInTheDocument()
+    expect(getByLabelText(resourceTreeRow, iconLabel)).toBeInTheDocument()
     : expect(
-        // eslint-disable-next-line testing-library/prefer-screen-queries
-        queryByLabelText(resourceTreeRow, iconLabel),
-      ).not.toBeInTheDocument();
+      // eslint-disable-next-line testing-library/prefer-screen-queries
+      queryByLabelText(resourceTreeRow, iconLabel),
+    ).not.toBeInTheDocument();
 }
 
 function expectResourceIconLabelToBe(

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -175,6 +175,7 @@ describe('ResourceBrowser', () => {
           selectedCriticality: testLocatePopupSelectedCriticality,
           selectedLicenses: new Set<string>(),
           searchTerm: '',
+          searchOnlyInLicenseField: false,
         }),
       );
     });
@@ -334,6 +335,7 @@ describe('ResourceBrowser', () => {
           selectedCriticality: SelectedCriticality.High,
           selectedLicenses: new Set<string>(),
           searchTerm: '',
+          searchOnlyInLicenseField: false,
         }),
       );
     });

--- a/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/ResourceBrowser.test.tsx
@@ -357,11 +357,11 @@ function expectIconToExist(
     ?.parentElement as HTMLElement;
   expectedToExist
     ? // eslint-disable-next-line testing-library/prefer-screen-queries
-    expect(getByLabelText(resourceTreeRow, iconLabel)).toBeInTheDocument()
+      expect(getByLabelText(resourceTreeRow, iconLabel)).toBeInTheDocument()
     : expect(
-      // eslint-disable-next-line testing-library/prefer-screen-queries
-      queryByLabelText(resourceTreeRow, iconLabel),
-    ).not.toBeInTheDocument();
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        queryByLabelText(resourceTreeRow, iconLabel),
+      ).not.toBeInTheDocument();
 }
 
 function expectResourceIconLabelToBe(

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -97,7 +97,7 @@ export enum CheckboxLabel {
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',
   NeedsReview = 'Needs Review',
-  OnlyInLicenseField = 'Only search in the license field',
+  OnlyLicenseName = 'Only search the license name',
 }
 
 export enum ProjectStatisticsPopupTitle {

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -97,7 +97,7 @@ export enum CheckboxLabel {
   FollowUp = 'Follow-up',
   ExcludeFromNotice = 'Exclude From Notice',
   NeedsReview = 'Needs Review',
-  OnlyLicenseName = 'Only search the license name',
+  OnlyLicenseName = 'Only search license names',
 }
 
 export enum ProjectStatisticsPopupTitle {

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -734,6 +734,8 @@ describe('locateSignalsFromLocatorPopup', () => {
       locateSignalsFromLocatorPopup(
         SelectedCriticality.High,
         new Set<string>(['GPL-2.0']),
+        '',
+        false,
       ),
     );
 
@@ -767,6 +769,8 @@ describe('locateSignalsFromLocatorPopup', () => {
       locateSignalsFromLocatorPopup(
         SelectedCriticality.High,
         new Set<string>(['GPL-2.0']),
+        'gpl',
+        true,
       ),
     );
     expect(getShowNoSignalsLocatedMessage(testStore.getState())).toBe(false);
@@ -815,7 +819,12 @@ describe('locateSignalsFromLocatorPopup', () => {
       setTemporaryDisplayPackageInfo(changedDisplayPackageInfo),
     );
     testStore.dispatch(
-      locateSignalsFromLocatorPopup(Criticality.High, new Set(['GPL-2.0'])),
+      locateSignalsFromLocatorPopup(
+        Criticality.High,
+        new Set(['GPL-2.0']),
+        'gpl',
+        true,
+      ),
     );
     expect(getOpenPopup(testStore.getState())).toBe(PopupType.NotSavedPopup);
     testStore.dispatch(

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -357,7 +357,7 @@ export function locateSignalsFromLocatorPopup(
   criticality: SelectedCriticality,
   licenseNames: Set<string>,
   searchTerm: string,
-  searchOnlyInLicenseField: boolean,
+  searchOnlyLicenseName: boolean,
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     dispatch(
@@ -365,7 +365,7 @@ export function locateSignalsFromLocatorPopup(
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
         searchTerm,
-        searchOnlyInLicenseField,
+        searchOnlyLicenseName,
       }),
     );
 
@@ -400,7 +400,7 @@ export function locateSignalsFromProjectStatisticsPopup(
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set([licenseName]),
         searchTerm: '',
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
       }),
     );
     dispatch(closePopup());

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -209,7 +209,7 @@ export function navigateToTargetResourceOrAttribution(): AppThunkAction {
     dispatch(
       setTemporaryDisplayPackageInfo(
         getDisplayPackageInfoOfSelected(getState()) ||
-        EMPTY_DISPLAY_PACKAGE_INFO,
+          EMPTY_DISPLAY_PACKAGE_INFO,
       ),
     );
 
@@ -266,9 +266,9 @@ export function openAttributionWizardPopup(
     const originalDisplayPackageInfo =
       originalAttributionId !== null
         ? convertPackageInfoToDisplayPackageInfo(
-          manualAttributions[originalAttributionId],
-          [originalAttributionId],
-        )
+            manualAttributions[originalAttributionId],
+            [originalAttributionId],
+          )
         : EMPTY_DISPLAY_PACKAGE_INFO;
 
     const {
@@ -365,7 +365,7 @@ export function locateSignalsFromLocatorPopup(
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
         searchTerm,
-        searchOnlyInLicenseField
+        searchOnlyInLicenseField,
       }),
     );
 
@@ -374,7 +374,9 @@ export function locateSignalsFromLocatorPopup(
     const noSignalsAreFound =
       locatedResources.size === 0 && resourcesWithLocatedChildren.size === 0;
     const allFiltersAreEmpty =
-      criticality === SelectedCriticality.Any && licenseNames.size === 0 && searchTerm === '';
+      criticality === SelectedCriticality.Any &&
+      licenseNames.size === 0 &&
+      searchTerm === '';
     const showNoSignalsLocatedMessage =
       noSignalsAreFound && !allFiltersAreEmpty;
 
@@ -398,7 +400,7 @@ export function locateSignalsFromProjectStatisticsPopup(
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set([licenseName]),
         searchTerm: '',
-        searchOnlyInLicenseField: false
+        searchOnlyInLicenseField: false,
       }),
     );
     dispatch(closePopup());

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -209,7 +209,7 @@ export function navigateToTargetResourceOrAttribution(): AppThunkAction {
     dispatch(
       setTemporaryDisplayPackageInfo(
         getDisplayPackageInfoOfSelected(getState()) ||
-          EMPTY_DISPLAY_PACKAGE_INFO,
+        EMPTY_DISPLAY_PACKAGE_INFO,
       ),
     );
 
@@ -266,9 +266,9 @@ export function openAttributionWizardPopup(
     const originalDisplayPackageInfo =
       originalAttributionId !== null
         ? convertPackageInfoToDisplayPackageInfo(
-            manualAttributions[originalAttributionId],
-            [originalAttributionId],
-          )
+          manualAttributions[originalAttributionId],
+          [originalAttributionId],
+        )
         : EMPTY_DISPLAY_PACKAGE_INFO;
 
     const {
@@ -356,12 +356,16 @@ export function closeAttributionWizardPopup(): AppThunkAction {
 export function locateSignalsFromLocatorPopup(
   criticality: SelectedCriticality,
   licenseNames: Set<string>,
+  searchTerm: string,
+  searchOnlyInLicenseField: boolean,
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: criticality,
         selectedLicenses: licenseNames,
+        searchTerm,
+        searchOnlyInLicenseField
       }),
     );
 
@@ -370,7 +374,7 @@ export function locateSignalsFromLocatorPopup(
     const noSignalsAreFound =
       locatedResources.size === 0 && resourcesWithLocatedChildren.size === 0;
     const allFiltersAreEmpty =
-      criticality === SelectedCriticality.Any && licenseNames.size === 0;
+      criticality === SelectedCriticality.Any && licenseNames.size === 0 && searchTerm === '';
     const showNoSignalsLocatedMessage =
       noSignalsAreFound && !allFiltersAreEmpty;
 
@@ -393,6 +397,8 @@ export function locateSignalsFromProjectStatisticsPopup(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set([licenseName]),
+        searchTerm: '',
+        searchOnlyInLicenseField: false
       }),
     );
     dispatch(closePopup());

--- a/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
@@ -34,7 +34,7 @@ describe('The locatePopup actions', () => {
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
       searchTerm: '',
-      searchOnlyInLicenseField: false,
+      searchOnlyLicenseName: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -54,7 +54,7 @@ describe('The locatePopup actions', () => {
         selectedCriticality: SelectedCriticality.High,
         selectedLicenses: new Set<string>(['GPL-2.0']),
         searchTerm: 'gpl',
-        searchOnlyInLicenseField: true,
+        searchOnlyLicenseName: true,
       }),
     );
 
@@ -62,7 +62,7 @@ describe('The locatePopup actions', () => {
       selectedCriticality: SelectedCriticality.High,
       selectedLicenses: new Set<string>(['GPL-2.0']),
       searchTerm: 'gpl',
-      searchOnlyInLicenseField: true,
+      searchOnlyLicenseName: true,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set<string>(['/', '/folder/']),

--- a/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
@@ -51,6 +51,7 @@ describe('The locatePopup actions', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.High,
         selectedLicenses: new Set<string>(['GPL-2.0']),
+        searchTerm: '',
       }),
     );
 

--- a/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/locate-popup-actions.test.ts
@@ -33,6 +33,8 @@ describe('The locatePopup actions', () => {
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
       selectedLicenses: new Set<string>(),
+      searchTerm: '',
+      searchOnlyInLicenseField: false,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set(),
@@ -51,13 +53,16 @@ describe('The locatePopup actions', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.High,
         selectedLicenses: new Set<string>(['GPL-2.0']),
-        searchTerm: '',
+        searchTerm: 'gpl',
+        searchOnlyInLicenseField: true,
       }),
     );
 
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.High,
       selectedLicenses: new Set<string>(['GPL-2.0']),
+      searchTerm: 'gpl',
+      searchOnlyInLicenseField: true,
     });
     expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual({
       resourcesWithLocatedChildren: new Set<string>(['/', '/folder/']),

--- a/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
@@ -391,6 +391,8 @@ describe('calculateResourcesWithLocatedAttributions', () => {
     const locatedResources = calculateResourcesWithLocatedAttributions(
       selectedCriticality,
       licenseNames,
+      'gpl',
+      false,
       externalAttributions,
       externalAttributionsToResources,
       frequentLicenseNames,
@@ -422,6 +424,8 @@ describe('calculateResourcesWithLocatedAttributions', () => {
     const locatedResources = calculateResourcesWithLocatedAttributions(
       selectedCriticality,
       licenseNames,
+      '',
+      false,
       externalAttributions,
       externalAttributionsToResources,
       frequentLicenseNames,
@@ -460,6 +464,8 @@ describe('calculateResourcesWithLocatedAttributions', () => {
     const locatedResources = calculateResourcesWithLocatedAttributions(
       selectedCriticality,
       licenseNames,
+      '',
+      false,
       externalAttributions,
       externalAttributionsToResources,
       frequentLicenseNames,
@@ -502,6 +508,8 @@ describe('calculateResourcesWithLocatedAttributions', () => {
     const locatedResources = calculateResourcesWithLocatedAttributions(
       selectedCriticality,
       licenseNames,
+      '',
+      false,
       externalAttributions,
       externalAttributionsToResources,
       frequentLicenseNames,
@@ -511,6 +519,45 @@ describe('calculateResourcesWithLocatedAttributions', () => {
       '/folder/file2',
       '/folder/file3',
     ]);
+
+    expect(locatedResources).toEqual(expectedLocatedResources);
+  });
+
+  it('yields results satisfying the search query', () => {
+    const licenseNames = new Set<string>();
+    const externalAttributions: Attributions = {
+      uuid_1: {
+        packageName: 'react',
+        licenseName: 'GPL-2.0-or-later',
+        criticality: Criticality.High,
+      },
+      uuid_2: {
+        packageName: 'angular',
+        licenseName: 'GPL-2.0-only',
+        criticality: Criticality.High,
+      },
+      uuid_3: {
+        packageName: 'vue',
+        licenseName: 'MIT',
+        criticality: Criticality.High,
+      },
+    };
+    const externalAttributionsToResources: AttributionsToResources = {
+      uuid_1: ['/folder/file1'],
+      uuid_2: ['/folder/file2'],
+      uuid_3: ['/folder/file3'],
+    };
+    const frequentLicenseNames: Array<FrequentLicenseName> = [];
+    const locatedResources = calculateResourcesWithLocatedAttributions(
+      SelectedCriticality.Any,
+      licenseNames,
+      '2.0-only',
+      false,
+      externalAttributions,
+      externalAttributionsToResources,
+      frequentLicenseNames,
+    );
+    const expectedLocatedResources = new Set<string>(['/folder/file2']);
 
     expect(locatedResources).toEqual(expectedLocatedResources);
   });

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -26,7 +26,7 @@ import { getAlphabeticalComparerForAttributions } from '../../util/get-alphabeti
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAttributionBreakpointCheckForResourceState } from '../../util/is-attribution-breakpoint';
 import {
-  licenseContainsSearchTerm,
+  licenseNameContainsSearchTerm,
   packageInfoContainsSearchTerm,
 } from '../../util/search-package-info';
 
@@ -287,7 +287,7 @@ export function calculateResourcesWithLocatedAttributions(
   selectedCriticality: SelectedCriticality,
   licenseNames: Set<string>,
   searchTerm: string,
-  searchOnlyInLicenseFields: boolean,
+  searchOnlyLicenseNames: boolean,
   externalAttributions: Attributions,
   externalAttributionsToResources: AttributionsToResources,
   frequentLicenseNames: Array<FrequentLicenseName>,
@@ -311,9 +311,9 @@ export function calculateResourcesWithLocatedAttributions(
       augmentedLicenseNames.has(attribution.licenseName);
     const criticalityMatches = attribution.criticality == selectedCriticality;
     const searchTermMatches =
-      (searchOnlyInLicenseFields &&
-        licenseContainsSearchTerm(attribution, searchTerm)) ||
-      (!searchOnlyInLicenseFields &&
+      (searchOnlyLicenseNames &&
+        licenseNameContainsSearchTerm(attribution, searchTerm)) ||
+      (!searchOnlyLicenseNames &&
         packageInfoContainsSearchTerm(attribution, searchTerm));
 
     if (

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -25,6 +25,8 @@ import { ResourceState } from '../reducers/resource-reducer';
 import { getAlphabeticalComparerForAttributions } from '../../util/get-alphabetical-comparer';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAttributionBreakpointCheckForResourceState } from '../../util/is-attribution-breakpoint';
+import { displayPackageInfoContainsSearchTerm } from '../../Components/PackageList/package-list-helpers';
+import { licenseContainsSearchTerm } from '../../util/search-package-info';
 
 export function getMatchingAttributionId(
   packageInfoToMatch: PackageInfo,
@@ -282,6 +284,8 @@ export function getIndexOfAttributionInManualPackagePanel(
 export function calculateResourcesWithLocatedAttributions(
   selectedCriticality: SelectedCriticality,
   licenseNames: Set<string>,
+  searchTerm: string,
+  searchOnlyInLicenseFields: boolean,
   externalAttributions: Attributions,
   externalAttributionsToResources: AttributionsToResources,
   frequentLicenseNames: Array<FrequentLicenseName>,
@@ -303,10 +307,14 @@ export function calculateResourcesWithLocatedAttributions(
       attribution.licenseName !== undefined &&
       augmentedLicenseNames.has(attribution.licenseName);
     const criticalityMatches = attribution.criticality == selectedCriticality;
+    const packageInfoContainsSearchTerm = displayPackageInfoContainsSearchTerm(attribution, searchTerm);
+    const searchTermMatches = (searchOnlyInLicenseFields && licenseContainsSearchTerm)
+      || (!searchOnlyInLicenseFields && packageInfoContainsSearchTerm);
 
     if (
       (licenseMatches || !licenseIsSet) &&
-      (criticalityMatches || !criticalityIsSet)
+      (criticalityMatches || !criticalityIsSet) &&
+      searchTermMatches
     ) {
       externalAttributionsToResources[attributionId].forEach((resource) => {
         locatedResources.add(resource);

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -25,8 +25,7 @@ import { ResourceState } from '../reducers/resource-reducer';
 import { getAlphabeticalComparerForAttributions } from '../../util/get-alphabetical-comparer';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAttributionBreakpointCheckForResourceState } from '../../util/is-attribution-breakpoint';
-import { displayPackageInfoContainsSearchTerm } from '../../Components/PackageList/package-list-helpers';
-import { licenseContainsSearchTerm } from '../../util/search-package-info';
+import { licenseContainsSearchTerm, packageInfoContainsSearchTerm } from '../../util/search-package-info';
 
 export function getMatchingAttributionId(
   packageInfoToMatch: PackageInfo,
@@ -298,7 +297,8 @@ export function calculateResourcesWithLocatedAttributions(
 
   const licenseIsSet = augmentedLicenseNames.size > 0;
   const criticalityIsSet = selectedCriticality != SelectedCriticality.Any;
-  if (!licenseIsSet && !criticalityIsSet) {
+  const searchTermIsSet = searchTerm != "";
+  if (!licenseIsSet && !criticalityIsSet && !searchTermIsSet) {
     return locatedResources;
   }
   for (const attributionId in externalAttributions) {
@@ -307,9 +307,8 @@ export function calculateResourcesWithLocatedAttributions(
       attribution.licenseName !== undefined &&
       augmentedLicenseNames.has(attribution.licenseName);
     const criticalityMatches = attribution.criticality == selectedCriticality;
-    const packageInfoContainsSearchTerm = displayPackageInfoContainsSearchTerm(attribution, searchTerm);
-    const searchTermMatches = (searchOnlyInLicenseFields && licenseContainsSearchTerm)
-      || (!searchOnlyInLicenseFields && packageInfoContainsSearchTerm);
+    const searchTermMatches = (searchOnlyInLicenseFields && licenseContainsSearchTerm(attribution, searchTerm))
+      || (!searchOnlyInLicenseFields && packageInfoContainsSearchTerm(attribution, searchTerm));
 
     if (
       (licenseMatches || !licenseIsSet) &&

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -25,7 +25,10 @@ import { ResourceState } from '../reducers/resource-reducer';
 import { getAlphabeticalComparerForAttributions } from '../../util/get-alphabetical-comparer';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAttributionBreakpointCheckForResourceState } from '../../util/is-attribution-breakpoint';
-import { licenseContainsSearchTerm, packageInfoContainsSearchTerm } from '../../util/search-package-info';
+import {
+  licenseContainsSearchTerm,
+  packageInfoContainsSearchTerm,
+} from '../../util/search-package-info';
 
 export function getMatchingAttributionId(
   packageInfoToMatch: PackageInfo,
@@ -297,7 +300,7 @@ export function calculateResourcesWithLocatedAttributions(
 
   const licenseIsSet = augmentedLicenseNames.size > 0;
   const criticalityIsSet = selectedCriticality != SelectedCriticality.Any;
-  const searchTermIsSet = searchTerm != "";
+  const searchTermIsSet = searchTerm != '';
   if (!licenseIsSet && !criticalityIsSet && !searchTermIsSet) {
     return locatedResources;
   }
@@ -307,8 +310,11 @@ export function calculateResourcesWithLocatedAttributions(
       attribution.licenseName !== undefined &&
       augmentedLicenseNames.has(attribution.licenseName);
     const criticalityMatches = attribution.criticality == selectedCriticality;
-    const searchTermMatches = (searchOnlyInLicenseFields && licenseContainsSearchTerm(attribution, searchTerm))
-      || (!searchOnlyInLicenseFields && packageInfoContainsSearchTerm(attribution, searchTerm));
+    const searchTermMatches =
+      (searchOnlyInLicenseFields &&
+        licenseContainsSearchTerm(attribution, searchTerm)) ||
+      (!searchOnlyInLicenseFields &&
+        packageInfoContainsSearchTerm(attribution, searchTerm));
 
     if (
       (licenseMatches || !licenseIsSet) &&

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -151,7 +151,7 @@ export const initialResourceState: ResourceState = {
   locatePopup: {
     selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set<string>(),
-    searchTerm: "",
+    searchTerm: '',
     searchOnlyInLicenseField: false,
   },
 };
@@ -273,9 +273,9 @@ export const resourceState = (
 
       const displayPackageInfoForNewResource = displayedAttributionId
         ? convertPackageInfoToDisplayPackageInfo(
-          state.allViews.manualData.attributions[displayedAttributionId],
-          [displayedAttributionId],
-        )
+            state.allViews.manualData.attributions[displayedAttributionId],
+            [displayedAttributionId],
+          )
         : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -403,18 +403,18 @@ export const resourceState = (
       const packageCardIdOfNewAttribution =
         packageCardIndex !== null
           ? createPackageCardId(
-            PackagePanelTitle.ManualPackages,
-            packageCardIndex,
-          )
+              PackagePanelTitle.ManualPackages,
+              packageCardIndex,
+            )
           : null;
 
       const newDisplayPackageInfo =
         action.payload.jumpToCreatedAttribution &&
-          packageCardIdOfNewAttribution !== null
+        packageCardIdOfNewAttribution !== null
           ? convertPackageInfoToDisplayPackageInfo(
-            newManualData.attributions[newAttributionId],
-            [newAttributionId],
-          )
+              newManualData.attributions[newAttributionId],
+              [newAttributionId],
+            )
           : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -424,19 +424,19 @@ export const resourceState = (
           manualData: newManualData,
           ...(action.payload.jumpToCreatedAttribution &&
             packageCardIdOfNewAttribution !== null && {
-            temporaryDisplayPackageInfo: newDisplayPackageInfo,
-          }),
+              temporaryDisplayPackageInfo: newDisplayPackageInfo,
+            }),
         },
         auditView: {
           ...state.auditView,
           ...(action.payload.jumpToCreatedAttribution &&
             packageCardIdOfNewAttribution !== null && {
-            displayedPanelPackage: {
-              panel: PackagePanelTitle.ManualPackages,
-              packageCardId: packageCardIdOfNewAttribution,
-              displayPackageInfo: newDisplayPackageInfo,
-            },
-          }),
+              displayedPanelPackage: {
+                panel: PackagePanelTitle.ManualPackages,
+                packageCardId: packageCardIdOfNewAttribution,
+                displayPackageInfo: newDisplayPackageInfo,
+              },
+            }),
         },
       };
     case ACTION_UPDATE_ATTRIBUTION:
@@ -456,9 +456,9 @@ export const resourceState = (
       const packageCardIdAfterUpdate =
         packageCardIndexAfterUpdate !== null
           ? createPackageCardId(
-            PackagePanelTitle.ManualPackages,
-            packageCardIndexAfterUpdate,
-          )
+              PackagePanelTitle.ManualPackages,
+              packageCardIndexAfterUpdate,
+            )
           : null;
 
       const temporaryDisplayPackageInfoAfterUpdate =
@@ -480,12 +480,12 @@ export const resourceState = (
           ...state.auditView,
           ...(action.payload.jumpToUpdatedAttribution &&
             packageCardIdAfterUpdate !== null && {
-            displayedPanelPackage: {
-              panel: PackagePanelTitle.ManualPackages,
-              packageCardId: packageCardIdAfterUpdate,
-              displayPackageInfo: temporaryDisplayPackageInfoAfterUpdate,
-            },
-          }),
+              displayedPanelPackage: {
+                panel: PackagePanelTitle.ManualPackages,
+                packageCardId: packageCardIdAfterUpdate,
+                displayPackageInfo: temporaryDisplayPackageInfoAfterUpdate,
+              },
+            }),
         },
       };
     case ACTION_DELETE_ATTRIBUTION:
@@ -507,12 +507,12 @@ export const resourceState = (
       const newDisplayedPanelPackage: PanelPackage | null =
         state.auditView.displayedPanelPackage?.panel ===
           PackagePanelTitle.ManualPackages &&
-          attributionIdsOfDisplayedDisplayPackageInfo[0] === attributionToDeleteId
+        attributionIdsOfDisplayedDisplayPackageInfo[0] === attributionToDeleteId
           ? {
-            panel: PackagePanelTitle.ManualPackages,
-            packageCardId: ADD_NEW_ATTRIBUTION_BUTTON_ID,
-            displayPackageInfo: EMPTY_DISPLAY_PACKAGE_INFO,
-          }
+              panel: PackagePanelTitle.ManualPackages,
+              packageCardId: ADD_NEW_ATTRIBUTION_BUTTON_ID,
+              displayPackageInfo: EMPTY_DISPLAY_PACKAGE_INFO,
+            }
           : state.auditView.displayedPanelPackage;
 
       const newSelectedAttributionId: string =
@@ -522,7 +522,7 @@ export const resourceState = (
 
       const newAttributionIdMarkedForReplacement: string =
         state.allViews.attributionIdMarkedForReplacement ===
-          attributionToDeleteId
+        attributionToDeleteId
           ? ''
           : state.allViews.attributionIdMarkedForReplacement;
 
@@ -567,20 +567,20 @@ export const resourceState = (
       const packageCardIdForReplaceAttribution =
         packageCardIndexForReplaceAttribution !== null
           ? createPackageCardId(
-            PackagePanelTitle.ManualPackages,
-            packageCardIndexForReplaceAttribution,
-          )
+              PackagePanelTitle.ManualPackages,
+              packageCardIndexForReplaceAttribution,
+            )
           : null;
 
       const temporaryDisplayPackageInfoAfterReplace =
         action.payload.jumpToMatchingAttribution &&
-          packageCardIdForReplaceAttribution
+        packageCardIdForReplaceAttribution
           ? convertPackageInfoToDisplayPackageInfo(
-            manualDataForReplace.attributions[
-            matchingAttributionIdForReplace
-            ],
-            [matchingAttributionIdForReplace],
-          )
+              manualDataForReplace.attributions[
+                matchingAttributionIdForReplace
+              ],
+              [matchingAttributionIdForReplace],
+            )
           : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -590,27 +590,27 @@ export const resourceState = (
           manualData: manualDataForReplace,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-            temporaryDisplayPackageInfo:
-              temporaryDisplayPackageInfoAfterReplace,
-          }),
+              temporaryDisplayPackageInfo:
+                temporaryDisplayPackageInfoAfterReplace,
+            }),
         },
         auditView: {
           ...state.auditView,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-            displayedPanelPackage: {
-              panel: PackagePanelTitle.ManualPackages,
-              packageCardId: packageCardIdForReplaceAttribution,
-              displayPackageInfo: temporaryDisplayPackageInfoAfterReplace,
-            },
-          }),
+              displayedPanelPackage: {
+                panel: PackagePanelTitle.ManualPackages,
+                packageCardId: packageCardIdForReplaceAttribution,
+                displayPackageInfo: temporaryDisplayPackageInfoAfterReplace,
+              },
+            }),
         },
         attributionView: {
           ...state.attributionView,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-            selectedAttributionId: matchingAttributionIdForReplace,
-          }),
+              selectedAttributionId: matchingAttributionIdForReplace,
+            }),
         },
       };
     case ACTION_LINK_TO_ATTRIBUTION:
@@ -638,9 +638,9 @@ export const resourceState = (
       const packageCardIdOfLinkingAttribution =
         packageCardIndexOfLinkingAttribution !== null
           ? createPackageCardId(
-            PackagePanelTitle.ManualPackages,
-            packageCardIndexOfLinkingAttribution,
-          )
+              PackagePanelTitle.ManualPackages,
+              packageCardIndexOfLinkingAttribution,
+            )
           : ADD_NEW_ATTRIBUTION_BUTTON_ID;
 
       return {
@@ -656,7 +656,7 @@ export const resourceState = (
             packageCardId: packageCardIdOfLinkingAttribution,
             displayPackageInfo: convertPackageInfoToDisplayPackageInfo(
               manualDataAfterForLinking.attributions[
-              matchingAttributionIdForLinking
+                matchingAttributionIdForLinking
               ],
               [matchingAttributionIdForLinking],
             ),
@@ -702,7 +702,7 @@ export const resourceState = (
 
       const resourcesWithOnlyHiddenAttributions = (
         state.allViews.externalData.attributionsToResources[
-        resolvedAttributionId
+          resolvedAttributionId
         ] ?? []
       ).filter((resourceId) => {
         const resourceAttributionIds =
@@ -754,7 +754,7 @@ export const resourceState = (
                     .resourcesWithAttributedChildren,
                 },
                 state.allViews.externalData.attributionsToResources[
-                action.payload
+                  action.payload
                 ],
               ),
           },
@@ -862,7 +862,12 @@ export const resourceState = (
         },
       };
     case ACTION_SET_LOCATE_POPUP_FILTERS:
-      const { selectedCriticality, selectedLicenses, searchTerm, searchOnlyInLicenseField } = action.payload;
+      const {
+        selectedCriticality,
+        selectedLicenses,
+        searchTerm,
+        searchOnlyInLicenseField,
+      } = action.payload;
       const locatedResources = calculateResourcesWithLocatedAttributions(
         selectedCriticality,
         selectedLicenses,
@@ -886,7 +891,8 @@ export const resourceState = (
         locatePopup: {
           selectedCriticality,
           selectedLicenses,
-          searchTerm, searchOnlyInLicenseField
+          searchTerm,
+          searchOnlyInLicenseField,
         },
       };
     default:

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -151,6 +151,8 @@ export const initialResourceState: ResourceState = {
   locatePopup: {
     selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set<string>(),
+    searchTerm: "",
+    searchOnlyInLicenseField: false,
   },
 };
 
@@ -271,9 +273,9 @@ export const resourceState = (
 
       const displayPackageInfoForNewResource = displayedAttributionId
         ? convertPackageInfoToDisplayPackageInfo(
-            state.allViews.manualData.attributions[displayedAttributionId],
-            [displayedAttributionId],
-          )
+          state.allViews.manualData.attributions[displayedAttributionId],
+          [displayedAttributionId],
+        )
         : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -401,18 +403,18 @@ export const resourceState = (
       const packageCardIdOfNewAttribution =
         packageCardIndex !== null
           ? createPackageCardId(
-              PackagePanelTitle.ManualPackages,
-              packageCardIndex,
-            )
+            PackagePanelTitle.ManualPackages,
+            packageCardIndex,
+          )
           : null;
 
       const newDisplayPackageInfo =
         action.payload.jumpToCreatedAttribution &&
-        packageCardIdOfNewAttribution !== null
+          packageCardIdOfNewAttribution !== null
           ? convertPackageInfoToDisplayPackageInfo(
-              newManualData.attributions[newAttributionId],
-              [newAttributionId],
-            )
+            newManualData.attributions[newAttributionId],
+            [newAttributionId],
+          )
           : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -422,19 +424,19 @@ export const resourceState = (
           manualData: newManualData,
           ...(action.payload.jumpToCreatedAttribution &&
             packageCardIdOfNewAttribution !== null && {
-              temporaryDisplayPackageInfo: newDisplayPackageInfo,
-            }),
+            temporaryDisplayPackageInfo: newDisplayPackageInfo,
+          }),
         },
         auditView: {
           ...state.auditView,
           ...(action.payload.jumpToCreatedAttribution &&
             packageCardIdOfNewAttribution !== null && {
-              displayedPanelPackage: {
-                panel: PackagePanelTitle.ManualPackages,
-                packageCardId: packageCardIdOfNewAttribution,
-                displayPackageInfo: newDisplayPackageInfo,
-              },
-            }),
+            displayedPanelPackage: {
+              panel: PackagePanelTitle.ManualPackages,
+              packageCardId: packageCardIdOfNewAttribution,
+              displayPackageInfo: newDisplayPackageInfo,
+            },
+          }),
         },
       };
     case ACTION_UPDATE_ATTRIBUTION:
@@ -454,9 +456,9 @@ export const resourceState = (
       const packageCardIdAfterUpdate =
         packageCardIndexAfterUpdate !== null
           ? createPackageCardId(
-              PackagePanelTitle.ManualPackages,
-              packageCardIndexAfterUpdate,
-            )
+            PackagePanelTitle.ManualPackages,
+            packageCardIndexAfterUpdate,
+          )
           : null;
 
       const temporaryDisplayPackageInfoAfterUpdate =
@@ -478,12 +480,12 @@ export const resourceState = (
           ...state.auditView,
           ...(action.payload.jumpToUpdatedAttribution &&
             packageCardIdAfterUpdate !== null && {
-              displayedPanelPackage: {
-                panel: PackagePanelTitle.ManualPackages,
-                packageCardId: packageCardIdAfterUpdate,
-                displayPackageInfo: temporaryDisplayPackageInfoAfterUpdate,
-              },
-            }),
+            displayedPanelPackage: {
+              panel: PackagePanelTitle.ManualPackages,
+              packageCardId: packageCardIdAfterUpdate,
+              displayPackageInfo: temporaryDisplayPackageInfoAfterUpdate,
+            },
+          }),
         },
       };
     case ACTION_DELETE_ATTRIBUTION:
@@ -505,12 +507,12 @@ export const resourceState = (
       const newDisplayedPanelPackage: PanelPackage | null =
         state.auditView.displayedPanelPackage?.panel ===
           PackagePanelTitle.ManualPackages &&
-        attributionIdsOfDisplayedDisplayPackageInfo[0] === attributionToDeleteId
+          attributionIdsOfDisplayedDisplayPackageInfo[0] === attributionToDeleteId
           ? {
-              panel: PackagePanelTitle.ManualPackages,
-              packageCardId: ADD_NEW_ATTRIBUTION_BUTTON_ID,
-              displayPackageInfo: EMPTY_DISPLAY_PACKAGE_INFO,
-            }
+            panel: PackagePanelTitle.ManualPackages,
+            packageCardId: ADD_NEW_ATTRIBUTION_BUTTON_ID,
+            displayPackageInfo: EMPTY_DISPLAY_PACKAGE_INFO,
+          }
           : state.auditView.displayedPanelPackage;
 
       const newSelectedAttributionId: string =
@@ -520,7 +522,7 @@ export const resourceState = (
 
       const newAttributionIdMarkedForReplacement: string =
         state.allViews.attributionIdMarkedForReplacement ===
-        attributionToDeleteId
+          attributionToDeleteId
           ? ''
           : state.allViews.attributionIdMarkedForReplacement;
 
@@ -565,20 +567,20 @@ export const resourceState = (
       const packageCardIdForReplaceAttribution =
         packageCardIndexForReplaceAttribution !== null
           ? createPackageCardId(
-              PackagePanelTitle.ManualPackages,
-              packageCardIndexForReplaceAttribution,
-            )
+            PackagePanelTitle.ManualPackages,
+            packageCardIndexForReplaceAttribution,
+          )
           : null;
 
       const temporaryDisplayPackageInfoAfterReplace =
         action.payload.jumpToMatchingAttribution &&
-        packageCardIdForReplaceAttribution
+          packageCardIdForReplaceAttribution
           ? convertPackageInfoToDisplayPackageInfo(
-              manualDataForReplace.attributions[
-                matchingAttributionIdForReplace
-              ],
-              [matchingAttributionIdForReplace],
-            )
+            manualDataForReplace.attributions[
+            matchingAttributionIdForReplace
+            ],
+            [matchingAttributionIdForReplace],
+          )
           : EMPTY_DISPLAY_PACKAGE_INFO;
 
       return {
@@ -588,27 +590,27 @@ export const resourceState = (
           manualData: manualDataForReplace,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-              temporaryDisplayPackageInfo:
-                temporaryDisplayPackageInfoAfterReplace,
-            }),
+            temporaryDisplayPackageInfo:
+              temporaryDisplayPackageInfoAfterReplace,
+          }),
         },
         auditView: {
           ...state.auditView,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-              displayedPanelPackage: {
-                panel: PackagePanelTitle.ManualPackages,
-                packageCardId: packageCardIdForReplaceAttribution,
-                displayPackageInfo: temporaryDisplayPackageInfoAfterReplace,
-              },
-            }),
+            displayedPanelPackage: {
+              panel: PackagePanelTitle.ManualPackages,
+              packageCardId: packageCardIdForReplaceAttribution,
+              displayPackageInfo: temporaryDisplayPackageInfoAfterReplace,
+            },
+          }),
         },
         attributionView: {
           ...state.attributionView,
           ...(action.payload.jumpToMatchingAttribution &&
             packageCardIdForReplaceAttribution && {
-              selectedAttributionId: matchingAttributionIdForReplace,
-            }),
+            selectedAttributionId: matchingAttributionIdForReplace,
+          }),
         },
       };
     case ACTION_LINK_TO_ATTRIBUTION:
@@ -636,9 +638,9 @@ export const resourceState = (
       const packageCardIdOfLinkingAttribution =
         packageCardIndexOfLinkingAttribution !== null
           ? createPackageCardId(
-              PackagePanelTitle.ManualPackages,
-              packageCardIndexOfLinkingAttribution,
-            )
+            PackagePanelTitle.ManualPackages,
+            packageCardIndexOfLinkingAttribution,
+          )
           : ADD_NEW_ATTRIBUTION_BUTTON_ID;
 
       return {
@@ -654,7 +656,7 @@ export const resourceState = (
             packageCardId: packageCardIdOfLinkingAttribution,
             displayPackageInfo: convertPackageInfoToDisplayPackageInfo(
               manualDataAfterForLinking.attributions[
-                matchingAttributionIdForLinking
+              matchingAttributionIdForLinking
               ],
               [matchingAttributionIdForLinking],
             ),
@@ -700,7 +702,7 @@ export const resourceState = (
 
       const resourcesWithOnlyHiddenAttributions = (
         state.allViews.externalData.attributionsToResources[
-          resolvedAttributionId
+        resolvedAttributionId
         ] ?? []
       ).filter((resourceId) => {
         const resourceAttributionIds =
@@ -752,7 +754,7 @@ export const resourceState = (
                     .resourcesWithAttributedChildren,
                 },
                 state.allViews.externalData.attributionsToResources[
-                  action.payload
+                action.payload
                 ],
               ),
           },
@@ -860,10 +862,12 @@ export const resourceState = (
         },
       };
     case ACTION_SET_LOCATE_POPUP_FILTERS:
-      const { selectedCriticality, selectedLicenses } = action.payload;
+      const { selectedCriticality, selectedLicenses, searchTerm, searchOnlyInLicenseField } = action.payload;
       const locatedResources = calculateResourcesWithLocatedAttributions(
         selectedCriticality,
         selectedLicenses,
+        searchTerm,
+        searchOnlyInLicenseField,
         state.allViews.externalData.attributions,
         state.allViews.externalData.attributionsToResources,
         state.allViews.frequentLicenses.nameOrder,
@@ -882,6 +886,7 @@ export const resourceState = (
         locatePopup: {
           selectedCriticality,
           selectedLicenses,
+          searchTerm, searchOnlyInLicenseField
         },
       };
     default:

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -152,7 +152,7 @@ export const initialResourceState: ResourceState = {
     selectedCriticality: SelectedCriticality.Any,
     selectedLicenses: new Set<string>(),
     searchTerm: '',
-    searchOnlyInLicenseField: false,
+    searchOnlyLicenseName: false,
   },
 };
 
@@ -866,13 +866,13 @@ export const resourceState = (
         selectedCriticality,
         selectedLicenses,
         searchTerm,
-        searchOnlyInLicenseField,
+        searchOnlyLicenseName,
       } = action.payload;
       const locatedResources = calculateResourcesWithLocatedAttributions(
         selectedCriticality,
         selectedLicenses,
         searchTerm,
-        searchOnlyInLicenseField,
+        searchOnlyLicenseName,
         state.allViews.externalData.attributions,
         state.allViews.externalData.attributionsToResources,
         state.allViews.frequentLicenses.nameOrder,
@@ -892,7 +892,7 @@ export const resourceState = (
           selectedCriticality,
           selectedLicenses,
           searchTerm,
-          searchOnlyInLicenseField,
+          searchOnlyLicenseName,
         },
       };
     default:

--- a/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
@@ -11,7 +11,7 @@ import { isLocateSignalActive } from '../locate-popup-selectors';
 describe('isLocateSignalActive', () => {
   it('returns false in the default state', () => {
     const testStore = createTestAppStore();
-    expect(!isLocateSignalActive(testStore.getState()));
+    expect(!isLocateSignalActive(testStore.getState())).toEqual(true);
   });
 
   it('returns true if the selected criticality is not the default', () => {
@@ -25,7 +25,7 @@ describe('isLocateSignalActive', () => {
       }),
     );
 
-    expect(isLocateSignalActive(testStore.getState()));
+    expect(isLocateSignalActive(testStore.getState())).toEqual(true);
   });
 
   it('returns true if there are selected licenses', () => {
@@ -38,7 +38,8 @@ describe('isLocateSignalActive', () => {
         searchOnlyInLicenseField: false,
       }),
     );
-    expect(isLocateSignalActive(testStore.getState()));
+
+    expect(isLocateSignalActive(testStore.getState())).toEqual(true);
   });
 
   it('returns true if the search term is set', () => {
@@ -51,7 +52,8 @@ describe('isLocateSignalActive', () => {
         searchOnlyInLicenseField: false,
       }),
     );
-    expect(isLocateSignalActive(testStore.getState()));
+
+    expect(isLocateSignalActive(testStore.getState())).toEqual(true);
   });
 
   it('returns false if only searchOnlyInLicenseField is set', () => {
@@ -64,6 +66,7 @@ describe('isLocateSignalActive', () => {
         searchOnlyInLicenseField: true,
       }),
     );
-    expect(isLocateSignalActive(testStore.getState()));
+
+    expect(isLocateSignalActive(testStore.getState())).toEqual(false);
   });
 });

--- a/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
@@ -21,7 +21,7 @@ describe('isLocateSignalActive', () => {
         selectedCriticality: SelectedCriticality.High,
         selectedLicenses: new Set<string>(),
         searchTerm: '',
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
       }),
     );
 
@@ -35,7 +35,7 @@ describe('isLocateSignalActive', () => {
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(['testLicenseId']),
         searchTerm: '',
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
       }),
     );
 
@@ -49,21 +49,21 @@ describe('isLocateSignalActive', () => {
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(),
         searchTerm: 'testSearchterm',
-        searchOnlyInLicenseField: false,
+        searchOnlyLicenseName: false,
       }),
     );
 
     expect(isLocateSignalActive(testStore.getState())).toEqual(true);
   });
 
-  it('returns false if only searchOnlyInLicenseField is set', () => {
+  it('returns false if only searchOnlyLicenseName is set', () => {
     const testStore = createTestAppStore();
     testStore.dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(),
         searchTerm: '',
-        searchOnlyInLicenseField: true,
+        searchOnlyLicenseName: true,
       }),
     );
 

--- a/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/locate-popup-selectors.test.ts
@@ -20,6 +20,8 @@ describe('isLocateSignalActive', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.High,
         selectedLicenses: new Set<string>(),
+        searchTerm: '',
+        searchOnlyInLicenseField: false,
       }),
     );
 
@@ -32,6 +34,34 @@ describe('isLocateSignalActive', () => {
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
         selectedLicenses: new Set<string>(['testLicenseId']),
+        searchTerm: '',
+        searchOnlyInLicenseField: false,
+      }),
+    );
+    expect(isLocateSignalActive(testStore.getState()));
+  });
+
+  it('returns true if the search term is set', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.Any,
+        selectedLicenses: new Set<string>(),
+        searchTerm: 'testSearchterm',
+        searchOnlyInLicenseField: false,
+      }),
+    );
+    expect(isLocateSignalActive(testStore.getState()));
+  });
+
+  it('returns false if only searchOnlyInLicenseField is set', () => {
+    const testStore = createTestAppStore();
+    testStore.dispatch(
+      setLocatePopupFilters({
+        selectedCriticality: SelectedCriticality.Any,
+        selectedLicenses: new Set<string>(),
+        searchTerm: '',
+        searchOnlyInLicenseField: true,
       }),
     );
     expect(isLocateSignalActive(testStore.getState()));

--- a/src/Frontend/state/selectors/locate-popup-selectors.ts
+++ b/src/Frontend/state/selectors/locate-popup-selectors.ts
@@ -15,8 +15,9 @@ export function isLocateSignalActive(state: State): boolean {
 
   return (
     locatePopupFilters.selectedCriticality !==
-      initialResourceState.locatePopup.selectedCriticality ||
-    locatePopupFilters.selectedLicenses.size > 0
+    initialResourceState.locatePopup.selectedCriticality ||
+    locatePopupFilters.selectedLicenses.size > 0 ||
+    locatePopupFilters.searchTerm !== ''
   );
 }
 

--- a/src/Frontend/state/selectors/locate-popup-selectors.ts
+++ b/src/Frontend/state/selectors/locate-popup-selectors.ts
@@ -15,7 +15,7 @@ export function isLocateSignalActive(state: State): boolean {
 
   return (
     locatePopupFilters.selectedCriticality !==
-    initialResourceState.locatePopup.selectedCriticality ||
+      initialResourceState.locatePopup.selectedCriticality ||
     locatePopupFilters.selectedLicenses.size > 0 ||
     locatePopupFilters.searchTerm !== ''
   );

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -196,4 +196,6 @@ export interface DisplayPackageInfosWithCount {
 export interface LocatePopupFilters {
   selectedCriticality: SelectedCriticality;
   selectedLicenses: Set<string>;
+  searchTerm: string;
+  searchOnlyInLicenseField: boolean;
 }

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -197,5 +197,5 @@ export interface LocatePopupFilters {
   selectedCriticality: SelectedCriticality;
   selectedLicenses: Set<string>;
   searchTerm: string;
-  searchOnlyInLicenseField: boolean;
+  searchOnlyLicenseName: boolean;
 }

--- a/src/Frontend/util/__tests__/search-package-info.test.ts
+++ b/src/Frontend/util/__tests__/search-package-info.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  licenseContainsSearchTerm,
+  packageInfoContainsSearchTerm,
+} from '../search-package-info';
+
+describe('packageInfoContainsSearchTerm', () => {
+  it('searches by package name', () => {
+    const testPackageInfo = {
+      packageName: 'Search_term package',
+      attributionIds: ['uuid1'],
+    };
+
+    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      true,
+    );
+  });
+
+  it('searches by copyright', () => {
+    const testPackageInfo = {
+      copyright: '(c) Search_term 2022',
+      attributionIds: ['uuid2'],
+    };
+
+    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      true,
+    );
+  });
+
+  it('searches by license name', () => {
+    const testPackageInfo = {
+      licenseName: 'Search_term licence',
+      attributionIds: ['uuid3'],
+    };
+
+    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      true,
+    );
+  });
+
+  it('searches by package version', () => {
+    const testPackageInfo = {
+      packageVersion: 'version search_term',
+      attributionIds: ['uuid4'],
+    };
+
+    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      true,
+    );
+  });
+
+  it('ignores other fields', () => {
+    const testPackageInfo = {
+      comments: ['comment search_term'],
+      licenseText: 'text search_term',
+      url: 'www.search_term.com',
+      attributionIds: ['uuid5'],
+    };
+
+    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      false,
+    );
+  });
+});
+
+describe('licenseContainsSearchTerm', () => {
+  it('searches by license name', () => {
+    const testPackageInfo = {
+      licenseName: 'Search_term licence',
+      attributionIds: ['uuid3'],
+    };
+
+    expect(licenseContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+      true,
+    );
+  });
+});

--- a/src/Frontend/util/__tests__/search-package-info.test.ts
+++ b/src/Frontend/util/__tests__/search-package-info.test.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  licenseContainsSearchTerm,
+  licenseNameContainsSearchTerm,
   packageInfoContainsSearchTerm,
 } from '../search-package-info';
 
@@ -67,15 +67,15 @@ describe('packageInfoContainsSearchTerm', () => {
   });
 });
 
-describe('licenseContainsSearchTerm', () => {
+describe('licenseNameContainsSearchTerm', () => {
   it('searches by license name', () => {
     const testPackageInfo = {
       licenseName: 'Search_term licence',
       attributionIds: ['uuid3'],
     };
 
-    expect(licenseContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toEqual(
-      true,
-    );
+    expect(
+      licenseNameContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm'),
+    ).toEqual(true);
   });
 });

--- a/src/Frontend/util/__tests__/search-package-info.test.ts
+++ b/src/Frontend/util/__tests__/search-package-info.test.ts
@@ -26,9 +26,9 @@ describe('packageInfoContainsSearchTerm', () => {
       attributionIds: ['uuid2'],
     };
 
-    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
-      true,
-    );
+    expect(
+      packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm'),
+    ).toEqual(true);
   });
 
   it('searches by license name', () => {
@@ -37,9 +37,9 @@ describe('packageInfoContainsSearchTerm', () => {
       attributionIds: ['uuid3'],
     };
 
-    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
-      true,
-    );
+    expect(
+      packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm'),
+    ).toEqual(true);
   });
 
   it('searches by package version', () => {
@@ -48,9 +48,9 @@ describe('packageInfoContainsSearchTerm', () => {
       attributionIds: ['uuid4'],
     };
 
-    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
-      true,
-    );
+    expect(
+      packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm'),
+    ).toEqual(true);
   });
 
   it('ignores other fields', () => {
@@ -61,9 +61,9 @@ describe('packageInfoContainsSearchTerm', () => {
       attributionIds: ['uuid5'],
     };
 
-    expect(packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
-      false,
-    );
+    expect(
+      packageInfoContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm'),
+    ).toEqual(false);
   });
 });
 
@@ -74,7 +74,7 @@ describe('licenseContainsSearchTerm', () => {
       attributionIds: ['uuid3'],
     };
 
-    expect(licenseContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toBe(
+    expect(licenseContainsSearchTerm(testPackageInfo, 'SeArCh_TeRm')).toEqual(
       true,
     );
   });

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -1,0 +1,43 @@
+
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { PackageInfoCore } from "../../shared/shared-types";
+
+export function displayPackageInfoContainsSearchTerm(
+    attribution: PackageInfoCore,
+    searchTerm: string,
+): boolean {
+    return Boolean(
+        attribution &&
+        (searchTerm === '' ||
+            (attribution.packageName &&
+                attribution.packageName
+                    .toLowerCase()
+                    .includes(searchTerm.toLowerCase())) ||
+            (attribution.licenseName &&
+                attribution.licenseName
+                    .toLowerCase()
+                    .includes(searchTerm.toLowerCase())) ||
+            (attribution.copyright &&
+                attribution.copyright
+                    .toLowerCase()
+                    .includes(searchTerm.toLowerCase())) ||
+            (attribution.packageVersion &&
+                attribution.packageVersion
+                    .toLowerCase()
+                    .includes(searchTerm.toLowerCase()))),
+    );
+}
+
+export function licenseContainsSearchTerm(
+    attribution: PackageInfoCore,
+    searchTerm: string,
+): boolean {
+    return Boolean(attribution.licenseName && attribution.licenseName
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()));
+}

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -9,7 +9,6 @@ export function packageInfoContainsSearchTerm(
   attribution: PackageInfoCore,
   searchTerm: string,
 ): boolean {
-  console.log();
   return Boolean(
     attribution &&
       (searchTerm === '' ||

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -7,10 +7,11 @@
 
 import { PackageInfoCore } from "../../shared/shared-types";
 
-export function displayPackageInfoContainsSearchTerm(
+export function packageInfoContainsSearchTerm(
     attribution: PackageInfoCore,
     searchTerm: string,
 ): boolean {
+    console.log()
     return Boolean(
         attribution &&
         (searchTerm === '' ||

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -1,44 +1,44 @@
-
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PackageInfoCore } from "../../shared/shared-types";
+import { PackageInfoCore } from '../../shared/shared-types';
 
 export function packageInfoContainsSearchTerm(
-    attribution: PackageInfoCore,
-    searchTerm: string,
+  attribution: PackageInfoCore,
+  searchTerm: string,
 ): boolean {
-    console.log()
-    return Boolean(
-        attribution &&
-        (searchTerm === '' ||
-            (attribution.packageName &&
-                attribution.packageName
-                    .toLowerCase()
-                    .includes(searchTerm.toLowerCase())) ||
-            (attribution.licenseName &&
-                attribution.licenseName
-                    .toLowerCase()
-                    .includes(searchTerm.toLowerCase())) ||
-            (attribution.copyright &&
-                attribution.copyright
-                    .toLowerCase()
-                    .includes(searchTerm.toLowerCase())) ||
-            (attribution.packageVersion &&
-                attribution.packageVersion
-                    .toLowerCase()
-                    .includes(searchTerm.toLowerCase()))),
-    );
+  console.log();
+  return Boolean(
+    attribution &&
+      (searchTerm === '' ||
+        (attribution.packageName &&
+          attribution.packageName
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase())) ||
+        (attribution.licenseName &&
+          attribution.licenseName
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase())) ||
+        (attribution.copyright &&
+          attribution.copyright
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase())) ||
+        (attribution.packageVersion &&
+          attribution.packageVersion
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()))),
+  );
 }
 
 export function licenseContainsSearchTerm(
-    attribution: PackageInfoCore,
-    searchTerm: string,
+  attribution: PackageInfoCore,
+  searchTerm: string,
 ): boolean {
-    return Boolean(attribution.licenseName && attribution.licenseName
-        .toLowerCase()
-        .includes(searchTerm.toLowerCase()));
+  return Boolean(
+    attribution.licenseName &&
+      attribution.licenseName.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
 }

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
-// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/Frontend/util/search-package-info.ts
+++ b/src/Frontend/util/search-package-info.ts
@@ -31,7 +31,7 @@ export function packageInfoContainsSearchTerm(
   );
 }
 
-export function licenseContainsSearchTerm(
+export function licenseNameContainsSearchTerm(
   attribution: PackageInfoCore,
   searchTerm: string,
 ): boolean {

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -36,7 +36,7 @@ export enum DiscreteConfidence {
   Low = 20,
 }
 
-interface PackageInfoCore {
+export interface PackageInfoCore {
   attributionConfidence?: number;
   packageName?: string;
   packageVersion?: string;


### PR DESCRIPTION
### Summary of changes

Adds signal search in the locate signals popup. It uses the already existing search function to search for packages that match the search term.

### Context and reason for change

Gives the user another option for locating signals.

### How can the changes be tested

Open the popup with ctrl+L and play around. (For example, try searching for '4.1.1' in the example file - it should give a result where a package has this version.)