### PR TITLE
Introduce state for QA mode

### DIFF
--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -327,6 +327,9 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               'enabled-qa-mode',
               'disabled-qa-mode',
             );
+            webContents.send(AllowedFrontendChannels.SetQAMode, {
+              qaMode: true,
+            });
           },
           visible: true,
         },
@@ -342,6 +345,9 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
               'disabled-qa-mode',
               'enabled-qa-mode',
             );
+            webContents.send(AllowedFrontendChannels.SetQAMode, {
+              qaMode: false,
+            });
           },
           visible: false,
         },

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -18,6 +18,7 @@ import {
   FileSupportPopupArgs,
   IsLoadingArgs,
   ParsedFileContent,
+  QAModeArgs,
 } from '../../../shared/shared-types';
 import { PopupType } from '../../enums/enums';
 import {
@@ -44,6 +45,7 @@ import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
 import {
   openPopup,
   setIsLoading,
+  setQAMode,
 } from '../../state/actions/view-actions/view-actions';
 
 export function BackendCommunication(): ReactElement | null {
@@ -280,6 +282,15 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
+  function setQAModeListener(
+    event: IpcRendererEvent,
+    qaModeArgs: QAModeArgs,
+  ): void {
+    if (qaModeArgs) {
+      dispatch(setQAMode(qaModeArgs.qaMode));
+    }
+  }
+
   useIpcRenderer(AllowedFrontendChannels.FileLoaded, fileLoadedListener, [
     dispatch,
   ]);
@@ -342,6 +353,9 @@ export function BackendCommunication(): ReactElement | null {
     showUpdateAppPopupListener,
     [dispatch],
   );
+  useIpcRenderer(AllowedFrontendChannels.SetQAMode, setQAModeListener, [
+    dispatch,
+  ]);
 
   return null;
 }

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -16,7 +16,7 @@ import { Attributions, ExportType } from '../../../../shared/shared-types';
 describe('BackendCommunication', () => {
   it('renders an Open file icon', () => {
     renderComponentWithStore(<BackendCommunication />);
-    const expectedNumberOfCalls = 13;
+    const expectedNumberOfCalls = 14;
     expect(window.electronAPI.on).toHaveBeenCalledTimes(expectedNumberOfCalls);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
@@ -60,6 +60,10 @@ describe('BackendCommunication', () => {
     );
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.ShowLocatorPopup,
+      expect.anything(),
+    );
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.SetQAMode,
       expect.anything(),
     );
   });

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -23,7 +23,7 @@ import { setResources } from '../../../state/actions/resource-actions/all-views-
 describe('TopBar', () => {
   it('renders an Open file icon', () => {
     const { store } = renderComponentWithStore(<TopBar />);
-    const totalNumberOfCalls = 13;
+    const totalNumberOfCalls = 14;
     expect(window.electronAPI.on).toHaveBeenCalledTimes(totalNumberOfCalls);
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.FileLoaded,
@@ -67,6 +67,10 @@ describe('TopBar', () => {
     );
     expect(window.electronAPI.on).toHaveBeenCalledWith(
       AllowedFrontendChannels.ShowLocatorPopup,
+      expect.anything(),
+    );
+    expect(window.electronAPI.on).toHaveBeenCalledWith(
+      AllowedFrontendChannels.SetQAMode,
       expect.anything(),
     );
 

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -11,6 +11,7 @@ import {
   getIsLoading,
   getOpenPopup,
   getPopupAttributionId,
+  getQAMode,
   getSelectedView,
   getTargetView,
   isAttributionViewSelected,
@@ -23,6 +24,7 @@ import {
   openPopup,
   resetViewState,
   setIsLoading,
+  setQAMode,
   setTargetView,
   updateActiveFilters,
 } from '../view-actions';
@@ -158,6 +160,15 @@ describe('view actions', () => {
     expect(getIsLoading(testStore.getState())).toBe(true);
     testStore.dispatch(setIsLoading(false));
     expect(getIsLoading(testStore.getState())).toBe(false);
+  });
+
+  it('sets and gets QA mode state', () => {
+    const testStore = createTestAppStore();
+    expect(getQAMode(testStore.getState())).toBe(false);
+    testStore.dispatch(setQAMode(true));
+    expect(getQAMode(testStore.getState())).toBe(true);
+    testStore.dispatch(setQAMode(false));
+    expect(getQAMode(testStore.getState())).toBe(false);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -16,6 +16,8 @@ export const ACTION_SET_IS_LOADING = 'ACTION_SET_IS_LOADING';
 export const ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE =
   'ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE';
 
+export const ACTION_SET_QA_MODE = 'ACTION_SET_QA_MODE';
+
 export type ViewAction =
   | SetView
   | SetTargetView
@@ -24,7 +26,8 @@ export type ViewAction =
   | OpenPopupAction
   | UpdateActiveFilters
   | SetIsLoadingAction
-  | SetShowNoSignalsLocatedMessage;
+  | SetShowNoSignalsLocatedMessage
+  | SetQAModeAction;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -61,5 +64,10 @@ export interface SetIsLoadingAction {
 
 export interface SetShowNoSignalsLocatedMessage {
   type: typeof ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE;
+  payload: boolean;
+}
+
+export interface SetQAModeAction {
+  type: typeof ACTION_SET_QA_MODE;
   payload: boolean;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -16,6 +16,7 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_IS_LOADING,
+  ACTION_SET_QA_MODE,
   ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -24,6 +25,7 @@ import {
   OpenPopupAction,
   ResetViewStateAction,
   SetIsLoadingAction,
+  SetQAModeAction,
   SetShowNoSignalsLocatedMessage,
   SetTargetView,
   SetView,
@@ -109,4 +111,8 @@ export function setShowNoSignalsLocatedMessage(
     type: ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
     payload: showMessage,
   };
+}
+
+export function setQAMode(qaMode: boolean): SetQAModeAction {
+  return { type: ACTION_SET_QA_MODE, payload: qaMode };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -11,6 +11,7 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_IS_LOADING,
+  ACTION_SET_QA_MODE,
   ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -26,6 +27,7 @@ export interface ViewState {
   activeFilters: Set<FilterType>;
   isLoading: boolean;
   showNoSignalsLocatedMessage: boolean;
+  qaMode: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -35,6 +37,7 @@ export const initialViewState: ViewState = {
   activeFilters: new Set<FilterType>(),
   isLoading: false,
   showNoSignalsLocatedMessage: false,
+  qaMode: false,
 };
 
 export function viewState(
@@ -82,6 +85,11 @@ export function viewState(
       return {
         ...state,
         showNoSignalsLocatedMessage: action.payload,
+      };
+    case ACTION_SET_QA_MODE:
+      return {
+        ...state,
+        qaMode: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -46,3 +46,7 @@ export function getPopupAttributionId(state: State): string | null {
 export function getIsLoading(state: State): boolean {
   return state.viewState.isLoading;
 }
+
+export function getQAMode(state: State): boolean {
+  return state.viewState.qaMode;
+}

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -13,6 +13,7 @@ import {
   FileSupportPopupArgs,
   IsLoadingArgs,
   ParsedFileContent,
+  QAModeArgs,
 } from '../../shared/shared-types';
 
 type ResetStateListener = (
@@ -47,6 +48,11 @@ type ShowFileSupportPopupListener = (
   fileSupportPopupArgs: FileSupportPopupArgs,
 ) => void;
 
+type SetQAModeListener = (
+  event: IpcRendererEvent,
+  qaModeArgs: QAModeArgs,
+) => void;
+
 type Listener =
   | ResetStateListener
   | SetStateListener
@@ -54,7 +60,8 @@ type Listener =
   | ExportFileRequestListener
   | SetBaseURLForRootListener
   | IsLoadingListener
-  | ShowFileSupportPopupListener;
+  | ShowFileSupportPopupListener
+  | SetQAModeListener;
 
 export function useIpcRenderer(
   channel: AllowedFrontendChannels,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -33,4 +33,5 @@ export enum AllowedFrontendChannels {
   ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',
   ShowUpdateAppPopup = 'show-update-app-pop-up',
   ShowLocatorPopup = 'show-locator-pop-up',
+  SetQAMode = 'set-qa-mode',
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -215,6 +215,10 @@ export interface IsLoadingArgs {
   isLoading: boolean;
 }
 
+export interface QAModeArgs {
+  qaMode: boolean;
+}
+
 export interface ExternalAttributionSources {
   [source: string]: {
     name: string;


### PR DESCRIPTION
### Summary of changes

This commit adds a new state for the QA mode. If the corresponding menu item is clicked the mode will change, either from QA to normal mode or normal to QA mode.

~~Note: The branch is based on #2090 and needs to be rebased before merging once the other PR is merged.~~ Done

### Context and reason for change

Selecting preferred attributions should only be possible in the new QA mode. This PR adds the respective state and integrates it with the previous implemented menu item. 

### How can the changes be tested
Checkout the changes and open OpossumUI. Open the Redux tab in the developer tools and see the new field `qaMode` as part of the `viewState`. This one is set to false.  Click the menu item `QA Mode` in the `View` submenu and observe the change of the state to be `true`. Click the menu item again and the state will change to `false`. The state should correspond to the respective icon: if the `qaMode` is `true` the icon should be a checked checkbox, if `false` unchecked.  

