### PR TITLE
Allow to locate several licenses at once

### DIFF
--- a/src/Frontend/Components/InputElements/AutoComplete.tsx
+++ b/src/Frontend/Components/InputElements/AutoComplete.tsx
@@ -13,7 +13,8 @@ import MuiBox from '@mui/material/Box';
 interface AutoCompleteProps extends InputElementProps {
   options: Array<string>;
   endAdornmentText?: string;
-  inputValue: string;
+  inputValue?: string;
+  value?: Array<string>; // Use value if multiple is true and inputValue otherwise.
   showTextBold?: boolean;
   multiple?: boolean;
   formatOptionForDisplay?(value: string): string;
@@ -31,9 +32,9 @@ function enterWasPressed(event: KeyboardEvent): boolean {
 }
 
 export function AutoComplete(props: AutoCompleteProps): ReactElement {
-  function onInputChange(
+  function onChange(
     event: ChangeEvent<unknown> | KeyboardEvent,
-    value: string,
+    value: Array<string> | string,
   ): void {
     if (
       value &&
@@ -42,9 +43,10 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
     ) {
       props.handleChange({
         target: {
-          value: props.formatOptionForDisplay
-            ? props.formatOptionForDisplay(value)
-            : value,
+          value:
+            props.formatOptionForDisplay && typeof value === 'string'
+              ? props.formatOptionForDisplay(value)
+              : value,
         },
       } as unknown as ChangeEvent<HTMLInputElement | HTMLTextAreaElement>);
     }
@@ -67,7 +69,8 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
         disableClearable={true}
         disabled={!props.isEditable}
         inputValue={props.inputValue}
-        onInputChange={onInputChange}
+        value={props.value}
+        onChange={onChange}
         renderInput={(params): ReactElement => {
           const paramsWithAdornment = props.endAdornmentText
             ? {
@@ -94,7 +97,7 @@ export function AutoComplete(props: AutoCompleteProps): ReactElement {
               }}
               variant="outlined"
               size="small"
-              onChange={props.handleChange}
+              onChange={props.multiple ? undefined : props.handleChange}
             />
           );
         }}

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -77,12 +77,8 @@ export function LocatorPopup(): ReactElement {
   );
 
   const licenseNameOptions = getLicenseNames(externalAttributions);
-  // currently we only support sets with one element
-  // once we support multiple elements we will have to adapt the logic to not take one arbitrary element of the set
-  const selectedLicense: string =
-    selectedLicenses.size == 0 ? '' : selectedLicenses.values().next().value;
 
-  const [searchedLicense, setSearchedLicense] = useState(selectedLicense);
+  const [searchedLicenses, setSearchedLicenses] = useState(selectedLicenses);
   const [criticalityDropDownChoice, setCriticalityDropDownChoice] =
     useState<SelectedCriticality>(selectedCriticality);
 
@@ -93,11 +89,6 @@ export function LocatorPopup(): ReactElement {
   }
 
   function handleApplyClick(): void {
-    const searchedLicenses =
-      searchedLicense.length == 0
-        ? new Set<string>()
-        : new Set([searchedLicense]);
-
     dispatch(
       locateSignalsFromLocatorPopup(
         criticalityDropDownChoice,
@@ -108,7 +99,7 @@ export function LocatorPopup(): ReactElement {
 
   function handleClearClick(): void {
     setCriticalityDropDownChoice(SelectedCriticality.Any);
-    setSearchedLicense('');
+    setSearchedLicenses(new Set());
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
@@ -137,13 +128,17 @@ export function LocatorPopup(): ReactElement {
         sx={classes.autocomplete}
         title={'License'}
         handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
-          setSearchedLicense(event.target.value);
+          const values =
+            typeof event.target.value === 'string'
+              ? new Set([event.target.value])
+              : new Set(event.target.value as Array<string>);
+          setSearchedLicenses(values);
         }}
         isHighlighted={false}
         options={licenseNameOptions.sort((a, b) =>
           compareAlphabeticalStrings(a, b),
         )}
-        inputValue={searchedLicense}
+        value={[...searchedLicenses]}
         showTextBold={false}
         multiple={true}
         formatOptionForDisplay={(option: string): string => option}

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -92,7 +92,7 @@ describe('Locator popup ', () => {
     });
   });
 
-  it.skip('sets state if license selected', () => {
+  it('sets state if license selected', () => {
     const testStore = createTestAppStore();
     // add external attribution with license MIT to see it
     const testExternalAttribution: PackageInfo = {
@@ -123,6 +123,54 @@ describe('Locator popup ', () => {
     renderComponentWithStore(<LocatorPopup />, { store: testStore });
 
     expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT']);
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }) as Element);
+    expect(getLocatePopupFilters(testStore.getState())).toEqual({
+      selectedCriticality: SelectedCriticality.Any,
+      selectedLicenses: licenseSet,
+    });
+    expect(getResourcesWithLocatedAttributions(testStore.getState())).toEqual(
+      expectedLocatedResources,
+    );
+  });
+
+  it('sets state if several licenses selected', () => {
+    const testStore = createTestAppStore();
+    const testExternalAttribution: PackageInfo = {
+      packageName: 'jQuery',
+      packageVersion: '16.0.0',
+      licenseName: 'MIT',
+      comment: 'ManualPackage',
+    };
+    const otherTestExternalAttribution: PackageInfo = {
+      packageName: 'jQuery',
+      packageVersion: '16.0.0',
+      licenseName: 'GPL-2.0',
+      comment: 'ManualPackage',
+    };
+    const testExternalAttributions: Attributions = {
+      uuid_1: testExternalAttribution,
+      uuid_2: otherTestExternalAttribution,
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/root/': ['uuid_1', 'uuid_2'],
+    };
+
+    testStore.dispatch(
+      setExternalData(
+        testExternalAttributions,
+        testResourcesToExternalAttributions,
+      ),
+    );
+    const licenseSet = new Set(['MIT', 'GPL-2.0']);
+    const expectedLocatedResources = {
+      resourcesWithLocatedChildren: new Set(['/']),
+      locatedResources: new Set(['/root/']),
+    };
+
+    renderComponentWithStore(<LocatorPopup />, { store: testStore });
+
+    expectElementsInAutoCompleteAndSelectFirst(screen, ['MIT']);
+    expectElementsInAutoCompleteAndSelectFirst(screen, ['GPL-2.0']);
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }) as Element);
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedCriticality: SelectedCriticality.Any,
@@ -169,7 +217,7 @@ describe('Locator popup ', () => {
     );
 
     renderComponentWithStore(<LocatorPopup />, { store: testStore });
-    expect(screen.getByDisplayValue('MIT')).toBeInTheDocument();
+    expect(screen.getByText('MIT')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
### Summary of changes

Here we add the logic for the license multiselect field in the locate popup which was introduced in #2089.

### Context and reason for change

We want to make it possible to select not just one but several licenses in the locate popup; in particular, we want to be able to select different names of the same license.

### How can the changes be tested

Run the unit tests in src\Frontend\Components\LocatorPopup\__tests__\LocatorPopup.test.tsx.
Open the file opossum_input.json from the example files, open the locate popup and select both "MIT" and "The MIT license (MIT)" as licenses. Click apply and check that both index.tsx and ElectronBackend/Types/types.ts are marked with an arrow.
Also check that the license field in Attribution View is not affected by the changes made here.