### PR TITLE
Prefer attribution only in QA mode

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -17,7 +17,10 @@ import {
   getTemporaryDisplayPackageInfo,
   wereTemporaryDisplayPackageInfoModified,
 } from '../../state/selectors/all-views-resource-selectors';
-import { getSelectedView } from '../../state/selectors/view-selector';
+import {
+  getQAMode,
+  getSelectedView,
+} from '../../state/selectors/view-selector';
 import {
   getDisplayedPackage,
   getResolvedExternalAttributions,
@@ -114,6 +117,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const wasPreferredFieldChanged: boolean =
     initialManualDisplayPackageInfo.preferred !==
     temporaryDisplayPackageInfo.preferred;
+  const qaMode = useAppSelector(getQAMode);
 
   const {
     isLicenseTextShown,
@@ -150,7 +154,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       temporaryDisplayPackageInfo.preSelected,
     ),
     targetAttributionIsExternalAttribution: false,
-    isPreferenceFeatureEnabled,
+    isPreferenceFeatureEnabled: isPreferenceFeatureEnabled && qaMode,
     attributionIsPreferred: temporaryDisplayPackageInfo.preferred ?? false,
     view,
   });

--- a/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
+++ b/src/Frontend/Components/AttributionColumn/__tests__/attribution-column-helpers.test.ts
@@ -216,7 +216,7 @@ describe('getMergeButtonsDisplayState', () => {
     });
   });
 
-  it('activates UnmarkAsPreferredButton when attribution is not preferred', () => {
+  it('deactivates UnmarkAsPreferredButton when attribution is not preferred in QA mode', () => {
     expect(
       getMergeButtonsDisplayState({
         attributionIdMarkedForReplacement: 'attr2',
@@ -239,7 +239,7 @@ describe('getMergeButtonsDisplayState', () => {
     });
   });
 
-  it('activates UnmarkAsPreferredButton when attribution is preferred', () => {
+  it('activates UnmarkAsPreferredButton when attribution is preferred in QA mode', () => {
     expect(
       getMergeButtonsDisplayState({
         attributionIdMarkedForReplacement: 'attr2',
@@ -274,6 +274,29 @@ describe('getMergeButtonsDisplayState', () => {
         attributionIsPreferred: false,
         view: View.Attribution,
         isPreferenceFeatureEnabled: true,
+      }),
+    ).toStrictEqual({
+      hideMarkForReplacementButton: false,
+      hideUnmarkForReplacementButton: true,
+      hideReplaceMarkedByButton: false,
+      deactivateReplaceMarkedByButton: true,
+      hideMarkAsPreferredButton: true,
+      hideUnmarkAsPreferredButton: true,
+    });
+  });
+
+  it('hides MarkAsPreferredButton & UnmarkAsPreferredButton when preference feature is disabled', () => {
+    expect(
+      getMergeButtonsDisplayState({
+        attributionIdMarkedForReplacement: 'attr2',
+        targetAttributionId: 'attr',
+        selectedAttributionId: 'attr',
+        packageInfoWereModified: false,
+        targetAttributionIsPreSelected: true,
+        targetAttributionIsExternalAttribution: false,
+        attributionIsPreferred: true,
+        view: View.Audit,
+        isPreferenceFeatureEnabled: false,
       }),
     ).toStrictEqual({
       hideMarkForReplacementButton: false,

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -25,7 +25,10 @@ import {
   ResourcesToAttributions,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
-import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
 import { ButtonText, PackagePanelTitle } from '../../../enums/enums';
 import {
   clickAddIconOnCardInAttributionList,
@@ -59,6 +62,7 @@ import {
   expectReplaceAttributionPopupIsNotShown,
   expectReplaceAttributionPopupIsShown,
 } from '../../../test-helpers/popup-test-helpers';
+import { setQAMode } from '../../../state/actions/view-actions/view-actions';
 
 describe('The App in Audit View', () => {
   it('renders TopBar and no ResourceBrowser when no resource file has been loaded', () => {
@@ -575,7 +579,7 @@ describe('The App in Audit View', () => {
     );
   });
 
-  it('preferred button is shown and sets an attribution as preferred', () => {
+  it('preferred button is shown and sets an attribution as preferred if QA mode is enabled', () => {
     function getExpectedSaveFileArgs(
       preferred: boolean,
       preferredOverOriginIds?: Array<string>,
@@ -644,7 +648,9 @@ describe('The App in Audit View', () => {
         resourcesToExternalAttributions: testResourcesToExternalAttributions,
       }),
     );
-    renderComponentWithStore(<App />);
+    const testStore = createTestAppStore();
+    renderComponentWithStore(<App />, { store: testStore });
+    testStore.dispatch(setQAMode(true));
     clickOnButton(screen, ButtonText.Close);
 
     clickOnElementInResourceBrowser(screen, 'file');
@@ -673,7 +679,7 @@ describe('The App in Audit View', () => {
     expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(2);
   });
 
-  it('after setting an attribution to preferred, global save is disabled', () => {
+  it('after setting an attribution to preferred in QA mode, global save is disabled', () => {
     const testResources: Resources = {
       file: 1,
       other_file: 1,
@@ -705,7 +711,9 @@ describe('The App in Audit View', () => {
         },
       }),
     );
-    renderComponentWithStore(<App />);
+    const testStore = createTestAppStore();
+    renderComponentWithStore(<App />, { store: testStore });
+    testStore.dispatch(setQAMode(true));
     clickOnButton(screen, ButtonText.Close);
 
     clickOnElementInResourceBrowser(screen, 'file');


### PR DESCRIPTION
### Summary of changes

With these changes the user will only be able to prefer an attribution if OpossumUI is in QA mode. If OpossumUI is not in QA mode, the button to prefer (or undo prefer if it was preferred before) is hidden.

Note: This PR is based on #2100 and therefore includes two commits, only the second one is relevant for this PR. This PR needs to be rebased once #2100 is merged. 

### Context and reason for change

Preferring an attribution should only be possible in QA mode. 

### How can the changes be tested

Besides the unit and integration tests: 
Check out the commit and open `opossum_input.json` from the example-files. Click on the `index.tsx` file in the resource tree and see one attribution with a grey star. If you open the context menu `...` for this attribution you only see the options `Mark for replacement` and `Delete`. Enable QA mode by clicking the menu item below `View` and observe that there is an addtional option `Mark as preferred`. If you prefer this attribution and save it, the option will change to `Unmark as preferred`. If you once again change the mode by clicking the respective menu item, the option will disappear. 