### PR TITLE
Adapt project statistics to multiselect

### DIFF
--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -40,6 +40,11 @@ interface CriticalLicensesTableProps {
   title: string;
 }
 
+interface LicenseNameAndTotalNumberOfAttributions {
+  licenseName: string;
+  totalNumberOfAttributions: number;
+}
+
 export function CriticalLicensesTable(
   props: CriticalLicensesTableProps,
 ): ReactElement {
@@ -60,17 +65,17 @@ export function CriticalLicensesTable(
     allLicensesWithCriticality,
     Criticality.Medium,
   );
-  const highCriticalityLicensesTotalAttributions =
+  const highCriticalityLicensesTotalAttributions: Array<LicenseNameAndTotalNumberOfAttributions> =
     getCriticalLicenseNamesWithTheirTotalAttributions(
       props.totalAttributionsPerLicense,
       highCriticalityLicenseNames,
     );
-  const mediumCriticalityLicensesTotalAttributions =
+  const mediumCriticalityLicensesTotalAttributions: Array<LicenseNameAndTotalNumberOfAttributions> =
     getCriticalLicenseNamesWithTheirTotalAttributions(
       props.totalAttributionsPerLicense,
       mediumCriticalityLicenseNames,
     );
-  const criticalLicensesTotalAttributions =
+  const criticalLicensesTotalAttributions: Array<LicenseNameAndTotalNumberOfAttributions> =
     highCriticalityLicensesTotalAttributions.concat(
       mediumCriticalityLicensesTotalAttributions,
     );
@@ -129,7 +134,7 @@ function getLicenseNamesByCriticality(
 function getCriticalLicenseNamesWithTheirTotalAttributions(
   totalAttributionsPerLicense: { [licenseName: string]: number },
   criticalLicenseNames: Array<string>,
-): Array<{ licenseName: string; totalNumberOfAttributions: number }> {
+): Array<LicenseNameAndTotalNumberOfAttributions> {
   const licenseNamesAndTheirTotalAttributions = criticalLicenseNames.map(
     (criticalLicenseName) => {
       return {

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -92,7 +92,7 @@ describe('Locator popup ', () => {
     });
   });
 
-  it('sets state if license selected', () => {
+  it.skip('sets state if license selected', () => {
     const testStore = createTestAppStore();
     // add external attribution with license MIT to see it
     const testExternalAttribution: PackageInfo = {

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -92,7 +92,7 @@ describe('Locator popup ', () => {
     });
   });
 
-  it.skip('sets state if license selected', () => {
+  it('sets state if license selected', () => {
     const testStore = createTestAppStore();
     // add external attribution with license MIT to see it
     const testExternalAttribution: PackageInfo = {

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -10,7 +10,9 @@ import {
   getCriticalSignalsCount,
   getIncompleteAttributionsCount,
   getLicenseCriticality,
+  getLicenseNameVariants,
   getMostFrequentLicenses,
+  getStrippedLicenseName,
   getUniqueLicenseNameToAttribution,
 } from '../project-statistics-popup-helpers';
 import {
@@ -196,6 +198,49 @@ describe('getLicenseCriticality', () => {
     const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
 
     expect(licenseCriticality).toEqual(expectedLicenseCriticality);
+  });
+});
+
+describe('getLicenseNameVariants', () => {
+  it('gets equivalent license names from attributions', () => {
+    const gpl2 = 'GPL-2.0';
+    const gpl2variant1 = 'gpl 2.0';
+    const testAttributions: Attributions = {
+      uuid1: { licenseName: gpl2 },
+      uuid2: { licenseName: gpl2variant1 },
+      uuid3: { licenseName: 'something else' },
+    };
+    const expectedLicenseNameVariants = new Set([gpl2, gpl2variant1]);
+
+    const licenseNameVariants = getLicenseNameVariants(gpl2, testAttributions);
+
+    expect(licenseNameVariants).toEqual(expectedLicenseNameVariants);
+  });
+});
+
+describe('getStrippedLicenseName', () => {
+  it.each`
+    licenseName
+    ${'apache2.0'}
+    ${'apache 2.0'}
+    ${'Apache 2.0'}
+    ${'Apache\t2.0'}
+    ${'Apache\n2.0'}
+    ${'Apache-2.0'}
+    ${'Apache - 2.0'}
+  `('converts $licenseName to apache2.0', ({ licenseName }) => {
+    expect(getStrippedLicenseName(licenseName)).toEqual('apache2.0');
+  });
+
+  it.each`
+    licenseName
+    ${'Apache_2.0'}
+    ${'apache2'}
+    ${'Apache 2'}
+    ${'Apache 2.0.0'}
+    ${'Apache License Version 2.0'}
+  `('does not convert $licenseName to apache2.0', ({ licenseName }) => {
+    expect(getStrippedLicenseName(licenseName)).not.toEqual('apache2.0');
   });
 });
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/project-statistics-popup-helpers.ts
@@ -187,10 +187,10 @@ export function getUniqueLicenseNameToAttribution(
   const uniqueLicenseNameToAttributions: UniqueLicenseNameToAttributions = {};
   for (const attributionId of Object.keys(attributions)) {
     const licenseName = attributions[attributionId].licenseName;
+
     if (licenseName) {
-      const strippedLicenseName = licenseName
-        .replace(/[\s-]/g, '')
-        .toLowerCase();
+      const strippedLicenseName = getStrippedLicenseName(licenseName);
+
       if (!uniqueLicenseNameToAttributions[strippedLicenseName]) {
         uniqueLicenseNameToAttributions[strippedLicenseName] = [];
       }
@@ -198,6 +198,32 @@ export function getUniqueLicenseNameToAttribution(
     }
   }
   return uniqueLicenseNameToAttributions;
+}
+
+export function getLicenseNameVariants(
+  licenseName: string,
+  attributions: Attributions,
+): Set<string> {
+  const strippedLicenseName = getStrippedLicenseName(licenseName);
+  const licenseNames: Set<string> = new Set<string>();
+
+  for (const attributionId of Object.keys(attributions)) {
+    const attributionLicenseName =
+      attributions[attributionId].licenseName || '';
+    const attributionStrippedLicenseName = getStrippedLicenseName(
+      attributions[attributionId].licenseName || '',
+    );
+
+    if (attributionStrippedLicenseName === strippedLicenseName) {
+      licenseNames.add(attributionLicenseName);
+    }
+  }
+
+  return licenseNames;
+}
+
+export function getStrippedLicenseName(licenseName: string): string {
+  return licenseName.replace(/[\s-]/g, '').toLowerCase();
 }
 
 export function aggregateAttributionPropertiesFromAttributions(

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -828,6 +828,53 @@ describe('locateSignalsFromLocatorPopup', () => {
 });
 
 describe('locateSignalsFromProjectStatisticsPopup', () => {
+  it('locates signals with different license name variant', () => {
+    const testStore = createTestAppStore();
+    const testExternalAttributions: Attributions = {
+      uuid1: {
+        licenseName: 'Apache-2.0',
+      },
+      uuid2: {
+        licenseName: 'Apache 2.0',
+      },
+      uuid3: {
+        licenseName: 'MIT',
+      },
+    };
+    const testResourcesToExternalAttributions: ResourcesToAttributions = {
+      '/folder1/file1': ['uuid1'],
+      '/folder2/file2': ['uuid2'],
+      '/folder3/file3': ['uuid3'],
+    };
+    const expectedLocatedResources = new Set<string>([
+      '/folder1/file1',
+      '/folder2/file2',
+    ]);
+    const expectedResourcesWithLocatedChildren = new Set<string>([
+      '/',
+      '/folder1/',
+      '/folder2/',
+    ]);
+
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          externalAttributions: testExternalAttributions,
+          resourcesToExternalAttributions: testResourcesToExternalAttributions,
+        }),
+      ),
+    );
+
+    testStore.dispatch(locateSignalsFromProjectStatisticsPopup('Apache-2.0'));
+
+    const { locatedResources, resourcesWithLocatedChildren } =
+      getResourcesWithLocatedAttributions(testStore.getState());
+    expect(locatedResources).toEqual(expectedLocatedResources);
+    expect(resourcesWithLocatedChildren).toEqual(
+      expectedResourcesWithLocatedChildren,
+    );
+  });
+
   it('locates signals independently of criticality', () => {
     const testStore = createTestAppStore();
     const testExternalAttributions: Attributions = {

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -9,6 +9,7 @@ import { State } from '../../../types/types';
 import {
   getCurrentAttributionId,
   getDisplayPackageInfoOfSelected,
+  getExternalAttributions,
   getExternalData,
   getManualAttributions,
   getManualData,
@@ -71,6 +72,7 @@ import {
   convertPackageInfoToDisplayPackageInfo,
 } from '../../../util/convert-package-info';
 import { setLocatePopupFilters } from '../resource-actions/locate-popup-actions';
+import { getLicenseNameVariants } from '../../../Components/ProjectStatisticsPopup/project-statistics-popup-helpers';
 
 export function navigateToSelectedPathOrOpenUnsavedPopup(
   resourcePath: string,
@@ -389,10 +391,16 @@ export function locateSignalsFromProjectStatisticsPopup(
   licenseName: string,
 ): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
+    const externalAttributions = getExternalAttributions(getState());
+    const licenseNames: Set<string> = getLicenseNameVariants(
+      licenseName,
+      externalAttributions,
+    );
+
     dispatch(
       setLocatePopupFilters({
         selectedCriticality: SelectedCriticality.Any,
-        selectedLicenses: new Set([licenseName]),
+        selectedLicenses: licenseNames,
       }),
     );
     dispatch(closePopup());


### PR DESCRIPTION
### Summary of changes
When clicking on the locate icon on the project statistics popup, now all license variant are selected.

### Context and reason for change
Before only the most common of the grouped ones was selected, hiding some results.

### How can the changes be tested
Unit tests, and merging with the other PRs that touch this story.

