### PR TITLE
Fix bug regarding preferred attributions

### DIFF
--- a/src/Frontend/state/actions/resource-actions/preference-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/preference-actions.ts
@@ -109,23 +109,22 @@ function getResourceIdsInSubtreeWithBreakpoints(
 ): Array<string> {
   const resources: Array<string> = [pathToRootResource];
 
-  for (const [childResourceName, childResource] of Object.entries(
-    rootResource,
-  )) {
+  for (const childResourceName of Object.keys(rootResource)) {
     const pathToChildResource = pathToRootResource + childResourceName;
     if (isBreakpoint(pathToChildResource)) {
       continue;
     }
-    if (childResource === 1) {
+    if (rootResource[childResourceName] === 1) {
       resources.push(pathToChildResource);
     } else {
-      resources.push(
-        ...getResourceIdsInSubtreeWithBreakpoints(
-          pathToChildResource + '/',
-          childResource,
-          isBreakpoint,
-        ),
+      const results = getResourceIdsInSubtreeWithBreakpoints(
+        pathToChildResource + '/',
+        rootResource[childResourceName] as Resources,
+        isBreakpoint,
       );
+      for (const result of results) {
+        resources.push(result);
+      }
     }
   }
 


### PR DESCRIPTION
### Summary of changes

We improve the preformance of collecting the resource ids in a subtree to avoid an error for large files.

### Context and reason for change

When one tries to mark an attribution for a large folder as preferred, previously we got an error "Maximum call stack size exceeded". These improvements avoid this error.

### How can the changes be tested

Open a large input file and try to mark an attribution of the root folder as preferred. Then click "save".