### PR TITLE
Cache data on Folder Progress Bar Worker

### DIFF
--- a/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
@@ -72,18 +72,8 @@ export function FolderProgressBar(props: FolderProgressBarProps): ReactElement {
   const folderProgressBarWorkerArgs = useMemo(
     () => ({
       resourceId,
-      manualAttributions,
-      externalAttributions,
-      resourcesToManualAttributions,
-      resolvedExternalAttributions,
     }),
-    [
-      resourceId,
-      manualAttributions,
-      externalAttributions,
-      resourcesToManualAttributions,
-      resolvedExternalAttributions,
-    ],
+    [resourceId],
   );
 
   const folderProgressBarSyncFallbackArgs = useMemo(

--- a/src/Frontend/web-workers/progress-bar-worker.ts
+++ b/src/Frontend/web-workers/progress-bar-worker.ts
@@ -2,15 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Resources, ResourcesToAttributions } from '../../shared/shared-types';
+import {
+  Attributions,
+  Resources,
+  ResourcesToAttributions,
+} from '../../shared/shared-types';
 import { getUpdatedProgressBarData } from '../state/helpers/progress-bar-data-helpers';
 import { ProgressBarDataAndResourceId } from '../types/types';
 
 let cachedResources: Resources | null = null;
+let cachedExternalAttributions: Attributions | null = null;
 let cachedResourcesToExternalAttributions: ResourcesToAttributions | null =
   null;
 let cachedAttributionBreakpoints: Set<string> | null = null;
 let cachedFilesWithChildren: Set<string> | null = null;
+let cachedManualAttributions: Attributions | null = null;
+let cachedResourcesToManualAttributions: ResourcesToAttributions | null = null;
+let cachedResolvedExternalAttributions: Set<string> | null = null;
 
 self.onmessage = ({
   data: {
@@ -26,12 +34,29 @@ self.onmessage = ({
     filesWithChildren,
   },
 }): void => {
+  if (
+    manualAttributions !== undefined &&
+    resourcesToManualAttributions !== undefined &&
+    resolvedExternalAttributions !== undefined
+  ) {
+    cachedManualAttributions = manualAttributions;
+    cachedResourcesToManualAttributions = resourcesToManualAttributions;
+    cachedResolvedExternalAttributions = resolvedExternalAttributions;
+  }
+
   if (isCacheInitializationMessage) {
     cachedResources = resources;
+    cachedExternalAttributions = externalAttributions;
     cachedResourcesToExternalAttributions = resourcesToExternalAttributions;
     cachedAttributionBreakpoints = attributionBreakpoints;
     cachedFilesWithChildren = filesWithChildren;
-  } else if (
+  }
+
+  if (
+    cachedManualAttributions &&
+    cachedExternalAttributions &&
+    cachedResourcesToManualAttributions &&
+    cachedResolvedExternalAttributions &&
     cachedResources &&
     cachedResourcesToExternalAttributions &&
     cachedAttributionBreakpoints &&
@@ -40,11 +65,11 @@ self.onmessage = ({
     const progressBarData = getUpdatedProgressBarData({
       resources: cachedResources,
       resourceId,
-      manualAttributions,
-      externalAttributions,
-      resourcesToManualAttributions,
+      manualAttributions: cachedManualAttributions,
+      externalAttributions: cachedExternalAttributions,
+      resourcesToManualAttributions: cachedResourcesToManualAttributions,
       resourcesToExternalAttributions: cachedResourcesToExternalAttributions,
-      resolvedExternalAttributions,
+      resolvedExternalAttributions: cachedResolvedExternalAttributions,
       attributionBreakpoints: cachedAttributionBreakpoints,
       filesWithChildren: cachedFilesWithChildren,
     });


### PR DESCRIPTION

### Summary of changes

Added caching to the folder progress bar worker.

### Context and reason for change

Currently, all information needed for calculating the folder progress bar is sent to the worker on every click on a new resource. That is slow and not necessary, as most of the data just changes after saving. Therefore, in this commit, the progress-bar-worker is modified such that it caches information and only reloads the cache after saving.

### How can the changes be tested

- Check out `main`, run `yarn start`, open a large input file and see long loading times for folder progress bar when switching between folders
- Check out this pr, run `yarn start`, open a large input file and see shorter loading times for folder progress bar when switching between folders
