### PR TITLE
Improve styling V1: using TSS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
     'object-shorthand': 2,
     'react/prop-types': 'off',
     'testing-library/no-node-access': 'off', // TODO: remove this line and fix warnings
-    'filenames/match-regex': [2, '^[a-zA-Z0-9\\-]+(.d|.test)?$', true],
+    'filenames/match-regex': [2, '^[a-zA-Z0-9\\-]+(.d|.test|.styles)?$', true],
     quotes: [2, 'single', { avoidEscape: true }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "redux-thunk": "^2.4.2",
     "spdx-license-ids": "^3.0.16",
     "stream-json": "^1.8.0",
+    "tss-react": "^4.9.2",
     "upath": "^2.0.1",
     "url": "^0.11.3",
     "uuid": "^9.0.1",

--- a/src/Frontend/Components/App/App.styles.ts
+++ b/src/Frontend/Components/App/App.styles.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { makeStyles } from 'tss-react/mui';
+import { OpossumColors } from '../../shared-styles';
+import { createTheme } from '@mui/system';
+
+export const useStyles = makeStyles()({
+  root: {
+    width: '100vw',
+    height: '100vh',
+  },
+  panelDiv: {
+    display: 'flex',
+    height: 'calc(100vh - 36px)',
+    width: '100%',
+    overflow: 'hidden',
+  },
+  spinner: {
+    margin: 'auto',
+  },
+});
+
+export const theme = createTheme({
+  components: {
+    MuiTypography: {
+      styleOverrides: {
+        body1: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiFormLabel: {
+      styleOverrides: {
+        root: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          color: OpossumColors.lightestBlue,
+        },
+        colorPrimary: {
+          '&.Mui-checked': {
+            color: OpossumColors.middleBlue,
+          },
+        },
+        track: {
+          opacity: 0.7,
+          backgroundColor: OpossumColors.lightestBlue,
+          '.Mui-checked.Mui-checked + &': {
+            opacity: 0.7,
+            backgroundColor: OpossumColors.middleBlue,
+          },
+        },
+      },
+    },
+  },
+});

--- a/src/Frontend/Components/App/App.tsx
+++ b/src/Frontend/Components/App/App.tsx
@@ -3,97 +3,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import MuiBox from '@mui/material/Box';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
 import { ReactElement } from 'react';
 import { View } from '../../enums/enums';
+import { useAppSelector } from '../../state/hooks';
 import {
   getIsLoading,
   getSelectedView,
 } from '../../state/selectors/view-selector';
-import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
-import { ReportView } from '../ReportView/ReportView';
 import { AttributionView } from '../AttributionView/AttributionView';
-import { GlobalPopup } from '../GlobalPopup/GlobalPopup';
 import { AuditView } from '../AuditView/AuditView';
-import { TopBar } from '../TopBar/TopBar';
-import { createTheme } from '@mui/material';
-import { useAppSelector } from '../../state/hooks';
-import MuiBox from '@mui/material/Box';
+import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
+import { GlobalPopup } from '../GlobalPopup/GlobalPopup';
+import { ReportView } from '../ReportView/ReportView';
 import { Spinner } from '../Spinner/Spinner';
-import { OpossumColors } from '../../shared-styles';
-
-const classes = {
-  root: {
-    width: '100vw',
-    height: '100vh',
-  },
-  panelDiv: {
-    display: 'flex',
-    height: 'calc(100vh - 36px)',
-    width: '100%',
-    overflow: 'hidden',
-  },
-  spinner: {
-    margin: 'auto',
-  },
-};
-
-const theme = createTheme({
-  components: {
-    MuiTypography: {
-      styleOverrides: {
-        body1: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiInputBase: {
-      styleOverrides: {
-        root: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiFormLabel: {
-      styleOverrides: {
-        root: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiSwitch: {
-      styleOverrides: {
-        switchBase: {
-          color: OpossumColors.lightestBlue,
-        },
-        colorPrimary: {
-          '&.Mui-checked': {
-            color: OpossumColors.middleBlue,
-          },
-        },
-        track: {
-          opacity: 0.7,
-          backgroundColor: OpossumColors.lightestBlue,
-          '.Mui-checked.Mui-checked + &': {
-            opacity: 0.7,
-            backgroundColor: OpossumColors.middleBlue,
-          },
-        },
-      },
-    },
-  },
-});
+import { TopBar } from '../TopBar/TopBar';
+import { theme, useStyles } from './App.styles';
 
 export function App(): ReactElement {
   const selectedView = useAppSelector(getSelectedView);
   const isLoading = useAppSelector(getIsLoading);
+  const { classes } = useStyles();
 
   function getSelectedViewContainer(): ReactElement {
     if (isLoading) {
-      return <Spinner sx={classes.spinner} />;
+      return <Spinner className={classes.spinner} />;
     }
 
     switch (selectedView) {
@@ -111,9 +46,11 @@ export function App(): ReactElement {
       <StyledEngineProvider injectFirst>
         <ThemeProvider theme={theme}>
           <GlobalPopup />
-          <MuiBox sx={classes.root}>
+          <MuiBox className={classes.root}>
             <TopBar />
-            <MuiBox sx={classes.panelDiv}>{getSelectedViewContainer()}</MuiBox>
+            <MuiBox className={classes.panelDiv}>
+              {getSelectedViewContainer()}
+            </MuiBox>
           </MuiBox>
         </ThemeProvider>
       </StyledEngineProvider>

--- a/src/Frontend/Components/Spinner/Spinner.styles.ts
+++ b/src/Frontend/Components/Spinner/Spinner.styles.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { makeStyles } from 'tss-react/mui';
+
+export const useStyles = makeStyles()({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/Frontend/Components/Spinner/Spinner.tsx
+++ b/src/Frontend/Components/Spinner/Spinner.tsx
@@ -2,32 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactElement } from 'react';
-import MuiSpinner from '@mui/material/CircularProgress';
 import MuiBox from '@mui/material/Box';
-import { SxProps } from '@mui/material';
-import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
-
-const classes = {
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-};
+import MuiSpinner from '@mui/material/CircularProgress';
+import { ReactElement } from 'react';
+import { useStyles } from './Spinner.styles';
 
 interface SpinnerProps {
-  sx?: SxProps;
+  className?: string;
 }
 
 export function Spinner(props: SpinnerProps): ReactElement {
+  const { classes, cx } = useStyles();
+
   return (
-    <MuiBox
-      sx={getSxFromPropsAndClasses({
-        styleClass: classes.root,
-        sxProps: props.sx,
-      })}
-    >
+    <MuiBox className={cx(classes.root, props.className)}>
       <MuiSpinner />
     </MuiBox>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,7 +1494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.11.0":
+"@emotion/cache@npm:*, @emotion/cache@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/cache@npm:11.11.0"
   dependencies:
@@ -1551,7 +1551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.1.2":
+"@emotion/serialize@npm:*, @emotion/serialize@npm:^1.1.2":
   version: 1.1.2
   resolution: "@emotion/serialize@npm:1.1.2"
   dependencies:
@@ -1607,7 +1607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.2.1":
+"@emotion/utils@npm:*, @emotion/utils@npm:^1.2.1":
   version: 1.2.1
   resolution: "@emotion/utils@npm:1.2.1"
   checksum: e0b44be0705b56b079c55faff93952150be69e79b660ae70ddd5b6e09fc40eb1319654315a9f34bb479d7f4ec94be6068c061abbb9e18b9778ae180ad5d97c73
@@ -8881,6 +8881,7 @@ __metadata:
     start-server-and-test: ^2.0.1
     stream-json: ^1.8.0
     ts-jest: ^29.1.1
+    tss-react: ^4.9.2
     typescript: ^5.2.2
     upath: ^2.0.1
     url: ^0.11.3
@@ -10755,6 +10756,27 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
+"tss-react@npm:^4.9.2":
+  version: 4.9.2
+  resolution: "tss-react@npm:4.9.2"
+  dependencies:
+    "@emotion/cache": "*"
+    "@emotion/serialize": "*"
+    "@emotion/utils": "*"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/server": ^11.4.0
+    "@mui/material": ^5.0.0
+    react: ^16.8.0 || ^17.0.2 || ^18.0.0
+  peerDependenciesMeta:
+    "@emotion/server":
+      optional: true
+    "@mui/material":
+      optional: true
+  checksum: e998ba9e458601dc540e91c4cae424f2533b6edc013831a6ade8b35281cf7798e1ad1d9358a094fd57904f858f01fb80313437acc5377c914701c6ce75f3abac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary of changes

- add tss-react dependency
- convert App and Spinner to use TSS
- use .styles files to contain style definitions

This is the first version of styling components consistently using [TSS](https://docs.tss-react.dev/).
See the other alternative here: https://github.com/opossum-tool/OpossumUI/pull/2131

Main disadvantage: extra dependency.
Main advantage: very similar to defining `classes` the way we currently do, but with the benefit of being performant, fully typed, and having access to props.

### Context and reason for change

MUI is not meant to be consistently styled using the `sx` prop.

The way we're currently styling  our components using `classes` as an object where we define all CSS classes and then reference them via `sx` has the following disadvantages:
a) negative performance implications
b) untyped
c) we have no access to props inside the FCs

Read more here: https://mui.com/system/getting-started/usage/#when-to-use-mui-system

### How can the changes be tested

Do a UI check that `App` and `Spinner` still look correct.