### PR TITLE
Improve styling V2: using styled components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
     'object-shorthand': 2,
     'react/prop-types': 'off',
     'testing-library/no-node-access': 'off', // TODO: remove this line and fix warnings
-    'filenames/match-regex': [2, '^[a-zA-Z0-9\\-]+(.d|.test)?$', true],
+    'filenames/match-regex': [2, '^[a-zA-Z0-9\\-]+(.d|.test|.styles)?$', true],
     quotes: [2, 'single', { avoidEscape: true }],
   },
 };

--- a/src/Frontend/Components/App/App.styles.tsx
+++ b/src/Frontend/Components/App/App.styles.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import styled from '@emotion/styled';
+import { Box, createTheme } from '@mui/material';
+
+import { OpossumColors } from '../../shared-styles';
+
+export const RootContainer = styled(Box)({
+  width: '100vw',
+  height: '100vh',
+});
+
+export const PanelContainer = styled(Box)({
+  display: 'flex',
+  height: 'calc(100vh - 36px)',
+  width: '100%',
+  overflow: 'hidden',
+});
+
+export const theme = createTheme({
+  components: {
+    MuiTypography: {
+      styleOverrides: {
+        body1: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiFormLabel: {
+      styleOverrides: {
+        root: {
+          fontSize: '0.85rem',
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          color: OpossumColors.lightestBlue,
+        },
+        colorPrimary: {
+          '&.Mui-checked': {
+            color: OpossumColors.middleBlue,
+          },
+        },
+        track: {
+          opacity: 0.7,
+          backgroundColor: OpossumColors.lightestBlue,
+          '.Mui-checked.Mui-checked + &': {
+            opacity: 0.7,
+            backgroundColor: OpossumColors.middleBlue,
+          },
+        },
+      },
+    },
+  },
+});

--- a/src/Frontend/Components/App/App.tsx
+++ b/src/Frontend/Components/App/App.tsx
@@ -2,13 +2,10 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { createTheme } from '@mui/material';
-import MuiBox from '@mui/material/Box';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
 import { ReactElement } from 'react';
 
 import { View } from '../../enums/enums';
-import { OpossumColors } from '../../shared-styles';
 import { useAppSelector } from '../../state/hooks';
 import {
   getIsLoading,
@@ -21,71 +18,7 @@ import { GlobalPopup } from '../GlobalPopup/GlobalPopup';
 import { ReportView } from '../ReportView/ReportView';
 import { Spinner } from '../Spinner/Spinner';
 import { TopBar } from '../TopBar/TopBar';
-
-const classes = {
-  root: {
-    width: '100vw',
-    height: '100vh',
-  },
-  panelDiv: {
-    display: 'flex',
-    height: 'calc(100vh - 36px)',
-    width: '100%',
-    overflow: 'hidden',
-  },
-  spinner: {
-    margin: 'auto',
-  },
-};
-
-const theme = createTheme({
-  components: {
-    MuiTypography: {
-      styleOverrides: {
-        body1: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiInputBase: {
-      styleOverrides: {
-        root: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiFormLabel: {
-      styleOverrides: {
-        root: {
-          fontSize: '0.85rem',
-          letterSpacing: '0.01071em',
-        },
-      },
-    },
-    MuiSwitch: {
-      styleOverrides: {
-        switchBase: {
-          color: OpossumColors.lightestBlue,
-        },
-        colorPrimary: {
-          '&.Mui-checked': {
-            color: OpossumColors.middleBlue,
-          },
-        },
-        track: {
-          opacity: 0.7,
-          backgroundColor: OpossumColors.lightestBlue,
-          '.Mui-checked.Mui-checked + &': {
-            opacity: 0.7,
-            backgroundColor: OpossumColors.middleBlue,
-          },
-        },
-      },
-    },
-  },
-});
+import { PanelContainer, RootContainer, theme } from './App.styles';
 
 export function App(): ReactElement {
   const selectedView = useAppSelector(getSelectedView);
@@ -93,7 +26,7 @@ export function App(): ReactElement {
 
   function getSelectedViewContainer(): ReactElement {
     if (isLoading) {
-      return <Spinner sx={classes.spinner} />;
+      return <Spinner sx={{ margin: 'auto' }} />;
     }
 
     switch (selectedView) {
@@ -111,10 +44,10 @@ export function App(): ReactElement {
       <StyledEngineProvider injectFirst>
         <ThemeProvider theme={theme}>
           <GlobalPopup />
-          <MuiBox sx={classes.root}>
+          <RootContainer>
             <TopBar />
-            <MuiBox sx={classes.panelDiv}>{getSelectedViewContainer()}</MuiBox>
-          </MuiBox>
+            <PanelContainer>{getSelectedViewContainer()}</PanelContainer>
+          </RootContainer>
         </ThemeProvider>
       </StyledEngineProvider>
     </ErrorBoundary>

--- a/src/Frontend/Components/Spinner/Spinner.styles.tsx
+++ b/src/Frontend/Components/Spinner/Spinner.styles.tsx
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import styled from '@emotion/styled';
+import { Box } from '@mui/material';
+
+export const Container = styled(Box)({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});

--- a/src/Frontend/Components/Spinner/Spinner.tsx
+++ b/src/Frontend/Components/Spinner/Spinner.tsx
@@ -1,34 +1,18 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { SxProps } from '@mui/material';
-import MuiBox from '@mui/material/Box';
 import MuiSpinner from '@mui/material/CircularProgress';
 import { ReactElement } from 'react';
 
-import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
+import { StyleProps } from '../../../shared/shared-types';
+import { Container } from './Spinner.styles';
 
-const classes = {
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-};
+type SpinnerProps = StyleProps;
 
-interface SpinnerProps {
-  sx?: SxProps;
-}
-
-export function Spinner(props: SpinnerProps): ReactElement {
+export function Spinner({ className, style, sx }: SpinnerProps): ReactElement {
   return (
-    <MuiBox
-      sx={getSxFromPropsAndClasses({
-        styleClass: classes.root,
-        sxProps: props.sx,
-      })}
-    >
+    <Container className={className} style={style} sx={sx}>
       <MuiSpinner />
-    </MuiBox>
+    </Container>
   );
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -3,10 +3,17 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { SxProps, Theme } from '@mui/material';
 import { IpcRendererEvent } from 'electron';
-import { ErrorInfo } from 'react';
+import { CSSProperties, ErrorInfo } from 'react';
 
 import { AllowedFrontendChannels } from './ipc-channels';
+
+export type StyleProps<T extends object = object> = {
+  className?: string;
+  style?: CSSProperties;
+  sx?: SxProps<Theme>;
+} & T;
 
 export interface Resources {
   [resourceName: string]: Resources | 1;


### PR DESCRIPTION
### Summary of changes

- convert App and Spinner to use styled components
- use .styles files to contain style definitions

This is the second version of styling components consistently using styled components.
See the other alternative here: https://github.com/opossum-tool/OpossumUI/pull/2130

Main disadvantage: more code by needing to define wrappers around all components.
Main advantage: native styling (no extra dependencies) recommended by MUI with high performance, full typing, access to props.

### Context and reason for change

MUI is not meant to be consistently styled using the `sx` prop.

The way we're currently styling  our components using `classes` as an object where we define all CSS classes and then reference them via `sx` has the following disadvantages:
a) negative performance implications
b) untyped
c) we have no access to props inside the FCs

Read more here: https://mui.com/system/getting-started/usage/#when-to-use-mui-system

### How can the changes be tested

Do a UI check that `App` and `Spinner` still look correct.