### PR TITLE
Fix: add basic CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="OpossumUI" />


### PR DESCRIPTION
### Summary of changes

- add basic CSP

### Context and reason for change

Every app should have a CSP. Without one, you even get a console warning every time the app starts.

https://www.electronjs.org/docs/latest/tutorial/security#7-define-a-content-security-policy

### How can the changes be tested

Notice that there is no longer a console warning about a missing CSP when you start the app.