### PR TITLE
Improve search bar

### DIFF
--- a/src/Frontend/Components/FileSearchTextField/FileSearchTextField.tsx
+++ b/src/Frontend/Components/FileSearchTextField/FileSearchTextField.tsx
@@ -61,7 +61,6 @@ export function FileSearchTextField(
       onInputChange={handleChange}
       search={search}
       autoFocus={true}
-      showIcon={true}
     />
   );
 }

--- a/src/Frontend/Components/FileSearchTextField/__tests__/FileSearchTextField.test.tsx
+++ b/src/Frontend/Components/FileSearchTextField/__tests__/FileSearchTextField.test.tsx
@@ -17,7 +17,7 @@ describe('The FileSearchTextField', () => {
     renderComponentWithStore(
       <FileSearchTextField setFilteredPaths={setFilteredPaths} />,
     );
-    screen.getAllByText('Search');
+    screen.getByLabelText('Search');
   });
 
   it('calls callback after debounce time', () => {
@@ -26,7 +26,7 @@ describe('The FileSearchTextField', () => {
       <FileSearchTextField setFilteredPaths={setFilteredPaths} />,
     );
 
-    screen.getAllByText('Search');
+    screen.getByLabelText('Search');
 
     fireEvent.change(screen.getByRole('searchbox'), {
       target: { value: 'test' },

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -148,7 +148,6 @@ export function LocatorPopup(): ReactElement {
             setSearchedSignal(search);
           }}
           search={searchedSignal}
-          showIcon={true}
         />
         <Checkbox
           sx={classes.checkboxContainer}

--- a/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
+++ b/src/Frontend/Components/LocatorPopup/__tests__/LocatorPopup.test.tsx
@@ -3,32 +3,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  createTestAppStore,
-  renderComponentWithStore,
-} from '../../../test-helpers/render-component-with-store';
 import { fireEvent, screen } from '@testing-library/react';
-import { getLocatePopupFilters } from '../../../state/selectors/locate-popup-selectors';
-import { clickOnButton } from '../../../test-helpers/general-test-helpers';
-import { setLocatePopupFilters } from '../../../state/actions/resource-actions/locate-popup-actions';
 import {
+  Attributions,
   Criticality,
   FrequentLicenses,
+  PackageInfo,
+  ResourcesToAttributions,
   SelectedCriticality,
 } from '../../../../shared/shared-types';
-import { getLicenseNames, LocatorPopup } from '../LocatorPopup';
-import { expectElementsInAutoCompleteAndSelectFirst } from '../../../test-helpers/general-test-helpers';
 import {
   setExternalData,
   setFrequentLicenses,
 } from '../../../state/actions/resource-actions/all-views-simple-actions';
-import {
-  Attributions,
-  PackageInfo,
-  ResourcesToAttributions,
-} from '../../../../shared/shared-types';
+import { setLocatePopupFilters } from '../../../state/actions/resource-actions/locate-popup-actions';
 import { getResourcesWithLocatedAttributions } from '../../../state/selectors/all-views-resource-selectors';
-import { expectValueInTextBox } from '../../../test-helpers/attribution-column-test-helpers';
+import { getLocatePopupFilters } from '../../../state/selectors/locate-popup-selectors';
+import {
+  clickOnButton,
+  expectElementsInAutoCompleteAndSelectFirst,
+} from '../../../test-helpers/general-test-helpers';
+import {
+  createTestAppStore,
+  renderComponentWithStore,
+} from '../../../test-helpers/render-component-with-store';
+import { LocatorPopup, getLicenseNames } from '../LocatorPopup';
 
 describe('Locator popup ', () => {
   jest.useFakeTimers();
@@ -242,7 +241,7 @@ describe('Locator popup ', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }) as Element);
 
-    expectValueInTextBox(screen, 'Search', '');
+    expect(screen.getByRole('searchbox')).toHaveValue('');
     expect(getLocatePopupFilters(testStore.getState())).toEqual({
       selectedLicenses: new Set<string>(),
       selectedCriticality: SelectedCriticality.Any,

--- a/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
+++ b/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
@@ -39,11 +39,7 @@ export function AttributionsViewPackageList(
 
   return (
     <div>
-      <SearchTextField
-        onInputChange={setSearch}
-        search={search}
-        showIcon={true}
-      />
+      <SearchTextField onInputChange={setSearch} search={search} />
       <List
         getListItem={(index: number): ReactElement | null =>
           props.getAttributionCard(filteredAndSortedPackageCardIds[index])

--- a/src/Frontend/Components/PackageList/PackageList.tsx
+++ b/src/Frontend/Components/PackageList/PackageList.tsx
@@ -12,13 +12,6 @@ import { getFilteredPackageCardIdsFromDisplayPackageInfos } from './package-list
 import { DisplayPackageInfos } from '../../types/types';
 
 const CARD_VERTICAL_DISTANCE = 41;
-const TYPICAL_SCROLLBAR_WIDTH = 13;
-
-const classes = {
-  paddingRight: {
-    paddingRight: `${TYPICAL_SCROLLBAR_WIDTH}px`,
-  },
-};
 
 interface PackageListProps {
   displayPackageInfos: DisplayPackageInfos;
@@ -41,10 +34,6 @@ export function PackageList(props: PackageListProps): ReactElement {
     [props.displayPackageInfos, props.sortedPackageCardIds, searchTerm],
   );
 
-  const currentHeight =
-    props.sortedPackageCardIds.length * CARD_VERTICAL_DISTANCE;
-  const maxHeight = props.maxNumberOfDisplayedItems * CARD_VERTICAL_DISTANCE;
-
   return (
     <>
       {filteredPackageCardIds.length === 0 ? null : (
@@ -59,7 +48,6 @@ export function PackageList(props: PackageListProps): ReactElement {
             max={{ numberOfDisplayedItems: props.maxNumberOfDisplayedItems }}
             length={filteredPackageCardIds.length}
             cardVerticalDistance={CARD_VERTICAL_DISTANCE}
-            sx={currentHeight < maxHeight ? classes.paddingRight : {}}
           />
         </>
       )}

--- a/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/PackageSearchPopup.tsx
@@ -115,7 +115,6 @@ export function PackageSearchPopup(): ReactElement {
         onInputChange={handleChange}
         search={currentSearchTerm}
         autoFocus={false}
-        showIcon={true}
       />
       {isLoading && Boolean(currentSearchTerm) ? (
         <Spinner />

--- a/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
+++ b/src/Frontend/Components/PackageSearchPopup/__tests__/PackageSearchPopup.test.tsx
@@ -102,8 +102,9 @@ describe('PackageSearchPopup', () => {
         <PackageSearchPopup />
       </QueryClientProvider>,
     );
-    const searchField = screen.getByLabelText('Search');
-    fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
+    fireEvent.change(screen.getByRole('searchbox'), {
+      target: { value: 'sqlalchemy' },
+    });
     act(() => {
       // advance timer as form is debounced
       jest.advanceTimersByTime(serverErrorStatus);
@@ -126,8 +127,9 @@ describe('PackageSearchPopup', () => {
       </QueryClientProvider>,
     );
 
-    const searchField = screen.getByLabelText('Search');
-    fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
+    fireEvent.change(screen.getByRole('searchbox'), {
+      target: { value: 'sqlalchemy' },
+    });
     act(() => {
       // advance timer as form is debounced
       jest.advanceTimersByTime(serverErrorStatus);
@@ -149,8 +151,9 @@ describe('PackageSearchPopup', () => {
       </QueryClientProvider>,
     );
 
-    const searchField = screen.getByLabelText('Search');
-    fireEvent.change(searchField, { target: { value: 'sqlalchemy' } });
+    fireEvent.change(screen.getByRole('searchbox'), {
+      target: { value: 'sqlalchemy' },
+    });
     act(() => {
       // advance timer as form is debounced
       jest.advanceTimersByTime(serverErrorStatus);

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -3,39 +3,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactElement, useEffect, useMemo, useState } from 'react';
-import MuiTabs from '@mui/material/Tabs';
+import MuiBox from '@mui/material/Box';
 import MuiTab from '@mui/material/Tab';
-import { getManualData } from '../../state/selectors/all-views-resource-selectors';
-import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
-import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
+import MuiTabs from '@mui/material/Tabs';
 import { remove } from 'lodash';
+import { ReactElement, useEffect, useState } from 'react';
+import { Attributions } from '../../../shared/shared-types';
+import { PackagePanelTitle } from '../../enums/enums';
+import { OpossumColors } from '../../shared-styles';
+import { setPackageSearchTerm } from '../../state/actions/resource-actions/audit-view-simple-actions';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getManualData } from '../../state/selectors/all-views-resource-selectors';
 import {
   getAttributionIdsOfSelectedResource,
   getDisplayedPackage,
-  getIsAccordionSearchFieldDisplayed,
   getPackageSearchTerm,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
-import { OpossumColors } from '../../shared-styles';
-import { useAppDispatch, useAppSelector } from '../../state/hooks';
-
-import { IconButton } from '../IconButton/IconButton';
-import { SearchPackagesIcon } from '../Icons/Icons';
-import {
-  setPackageSearchTerm,
-  toggleAccordionSearchField,
-} from '../../state/actions/resource-actions/audit-view-simple-actions';
-import { SearchTextField } from '../SearchTextField/SearchTextField';
-import { getDisplayPackageInfoWithCountFromAttributions } from '../../util/get-display-attributions-with-count-from-attributions';
 import { DisplayPackageInfos } from '../../types/types';
-import { PackagePanelTitle } from '../../enums/enums';
 import { createPackageCardId } from '../../util/create-package-card-id';
-import { Attributions } from '../../../shared/shared-types';
+import { getDisplayPackageInfoWithCountFromAttributions } from '../../util/get-display-attributions-with-count-from-attributions';
+import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
+import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
+import { SearchTextField } from '../SearchTextField/SearchTextField';
 
 const classes = {
+  container: {
+    position: 'relative',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
   tabsRoot: {
     minHeight: 'fit-content',
+    overflow: 'initial',
   },
   tab: {
     backgroundColor: OpossumColors.almostWhiteBlue,
@@ -50,23 +51,8 @@ const classes = {
       color: OpossumColors.black,
     },
   },
-  searchToggle: {
-    position: 'absolute',
-    right: '0px',
-    top: '0px',
-  },
   indicator: {
     backgroundColor: OpossumColors.darkBlue,
-  },
-  largeClickableIcon: {
-    width: '26px',
-    height: '26px',
-    padding: '2px',
-    margin: '0 2px',
-    color: OpossumColors.darkBlue,
-    '&:hover': {
-      background: OpossumColors.middleBlue,
-    },
   },
   searchBox: {
     marginTop: '10px',
@@ -87,9 +73,6 @@ export function ResourceDetailsTabs(
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const attributionIdsOfSelectedResource: Array<string> =
     useAppSelector(getAttributionIdsOfSelectedResource) || [];
-  const isAccordionSearchFieldDisplayed = useAppSelector(
-    getIsAccordionSearchFieldDisplayed,
-  );
   const searchTerm = useAppSelector(getPackageSearchTerm);
 
   const dispatch = useAppDispatch();
@@ -113,31 +96,18 @@ export function ResourceDetailsTabs(
 
   const isAddToPackageEnabled: boolean =
     props.isGlobalTabEnabled && props.isAddToPackageEnabled;
-  const aggregatedAttributionsPanel = useMemo(
-    () => (
-      <AggregatedAttributionsPanel
-        isAddToPackageEnabled={isAddToPackageEnabled}
-      />
-    ),
-    [isAddToPackageEnabled],
-  );
 
   const tabLabels = {
     [Tabs.Local]: 'Local',
     [Tabs.Global]: 'Global',
   };
 
-  function onSearchToggleClick(): void {
-    dispatch(toggleAccordionSearchField());
-    dispatch(setPackageSearchTerm(''));
-  }
-
   function onSearchInputChange(input: string): void {
     dispatch(setPackageSearchTerm(input));
   }
 
   return (
-    <div style={{ position: 'relative' }}>
+    <MuiBox sx={classes.container}>
       <MuiTabs
         value={selectedTab}
         onChange={(_: React.SyntheticEvent, newTab: Tabs): void => {
@@ -145,6 +115,7 @@ export function ResourceDetailsTabs(
         }}
         aria-label="Add To Tabs"
         sx={{ ...classes.tabsRoot, indicator: classes.indicator }}
+        variant="fullWidth"
       >
         <MuiTab
           label={tabLabels[Tabs.Local]}
@@ -163,36 +134,30 @@ export function ResourceDetailsTabs(
           sx={classes.tab}
         />
       </MuiTabs>
-      <IconButton
-        tooltipTitle="Search signals by name, license name, copyright text and version"
-        tooltipPlacement="right"
-        onClick={onSearchToggleClick}
-        icon={<SearchPackagesIcon sx={classes.largeClickableIcon} />}
-        iconSx={classes.searchToggle}
+      <SearchTextField
+        onInputChange={onSearchInputChange}
+        search={searchTerm}
+        autoFocus={true}
+        sx={classes.searchBox}
       />
-      {isAccordionSearchFieldDisplayed ? (
-        <SearchTextField
-          onInputChange={onSearchInputChange}
-          search={searchTerm}
-          autoFocus={true}
-          showIcon={false}
-          sx={classes.searchBox}
-        />
-      ) : null}
-      {selectedTab === Tabs.Local ? (
-        aggregatedAttributionsPanel
-      ) : (
-        <AllAttributionsPanel
-          displayPackageInfos={displayPackageInfos}
-          selectedPackageCardId={
-            selectedPackage && selectedPackage.packageCardId
-          }
-          isAddToPackageEnabled={
-            props.isGlobalTabEnabled && props.isAddToPackageEnabled
-          }
-        />
-      )}
-    </div>
+      <MuiBox style={{ overflow: 'auto' }}>
+        {selectedTab === Tabs.Local ? (
+          <AggregatedAttributionsPanel
+            isAddToPackageEnabled={isAddToPackageEnabled}
+          />
+        ) : (
+          <AllAttributionsPanel
+            displayPackageInfos={displayPackageInfos}
+            selectedPackageCardId={
+              selectedPackage && selectedPackage.packageCardId
+            }
+            isAddToPackageEnabled={
+              props.isGlobalTabEnabled && props.isAddToPackageEnabled
+            }
+          />
+        )}
+      </MuiBox>
+    </MuiBox>
   );
 }
 

--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -145,12 +145,6 @@ describe('The ResourceDetailsTabs', () => {
     screen.getByText(/package name 2/);
     screen.getByText(/package name 3/);
 
-    fireEvent.click(
-      screen.getByLabelText(
-        'Search signals by name, license name, copyright text and version',
-      ),
-    );
-
     fireEvent.change(screen.getByRole('searchbox'), {
       target: { value: 'name 1' },
     });

--- a/src/Frontend/Components/SearchTextField/SearchTextField.tsx
+++ b/src/Frontend/Components/SearchTextField/SearchTextField.tsx
@@ -3,9 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import ClearIcon from '@mui/icons-material/Clear';
+import SearchIcon from '@mui/icons-material/Search';
 import { InputAdornment, SxProps } from '@mui/material';
 import MuiTextField from '@mui/material/TextField';
-import { Search } from '@mui/icons-material';
 import { ReactElement } from 'react';
 import { OpossumColors } from '../../shared-styles';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
@@ -18,10 +19,19 @@ const classes = {
     '& div': {
       borderRadius: '0px',
     },
+    '& input[type=search]::-webkit-search-cancel-button': { display: 'none' },
+  },
+  startAdornment: {
+    width: '20px',
+    color: OpossumColors.grey,
   },
   endAdornment: {
     width: '20px',
     color: OpossumColors.grey,
+    '&:hover': {
+      color: OpossumColors.darkBlue,
+      cursor: 'pointer',
+    },
   },
 };
 
@@ -29,14 +39,13 @@ interface SearchTextFieldProps {
   onInputChange(search: string): void;
   search: string;
   autoFocus?: boolean;
-  showIcon: boolean;
   sx?: SxProps;
 }
 
 export function SearchTextField(props: SearchTextFieldProps): ReactElement {
   return (
     <MuiTextField
-      label="Search"
+      aria-label="Search"
       type="search"
       variant="outlined"
       autoFocus={props.autoFocus ?? false}
@@ -51,17 +60,21 @@ export function SearchTextField(props: SearchTextFieldProps): ReactElement {
       value={props.search}
       fullWidth={true}
       onChange={(event): void => props.onInputChange(event.target.value)}
-      InputProps={
-        props.showIcon
-          ? {
-              endAdornment: (
-                <InputAdornment position="end">
-                  <Search sx={classes.endAdornment} />
-                </InputAdornment>
-              ),
-            }
-          : {}
-      }
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon sx={classes.startAdornment} />
+          </InputAdornment>
+        ),
+        endAdornment: (
+          <InputAdornment position="end">
+            <ClearIcon
+              onClick={(): void => props.onInputChange('')}
+              sx={classes.endAdornment}
+            />
+          </InputAdornment>
+        ),
+      }}
     />
   );
 }

--- a/src/Frontend/Components/SearchTextField/__tests__/SearchTextField.test.tsx
+++ b/src/Frontend/Components/SearchTextField/__tests__/SearchTextField.test.tsx
@@ -11,14 +11,8 @@ describe('The SearchTextField', () => {
   it('has search functionality', () => {
     const onInputchange = jest.fn();
     renderComponentWithStore(
-      <SearchTextField
-        onInputChange={onInputchange}
-        search={'test-search'}
-        showIcon={true}
-      />,
+      <SearchTextField onInputChange={onInputchange} search={'test-search'} />,
     );
-    screen.getAllByText('Search');
-
     fireEvent.change(screen.getByRole('searchbox'), {
       target: { value: 'test' },
     });

--- a/src/Frontend/state/actions/resource-actions/audit-view-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/audit-view-simple-actions.ts
@@ -14,7 +14,6 @@ import {
   ACTION_SET_SELECTED_RESOURCE_ID,
   ACTION_SET_TARGET_DISPLAYED_PANEL_PACKAGE,
   ACTION_SET_TARGET_SELECTED_RESOURCE_ID,
-  ACTION_TOGGLE_ACCORDION_SEARCH_FIELD,
   AddResolvedExternalAttribution,
   RemoveResolvedExternalAttribution,
   SetDisplayedPanelPackageAction,
@@ -24,7 +23,6 @@ import {
   SetSelectedResourceIdAction,
   SetTargetDisplayedPanelPackageAction,
   SetTargetSelectedResourceId,
-  ToggleAccordionSearchField,
 } from './types';
 
 export function setSelectedResourceId(
@@ -91,10 +89,6 @@ export function removeResolvedExternalAttribution(
     type: ACTION_REMOVE_RESOLVED_EXTERNAL_ATTRIBUTION,
     payload: resolvedExternalAttribution,
   };
-}
-
-export function toggleAccordionSearchField(): ToggleAccordionSearchField {
-  return { type: ACTION_TOGGLE_ACCORDION_SEARCH_FIELD };
 }
 
 export function setPackageSearchTerm(searchTerm: string): SetPackageSearchTerm {

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -78,8 +78,6 @@ export const ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES =
   'ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES';
 export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
   'ACTION_SET_ATTRIBUTION_IDS_MARKED_FOR_MULTISELECT';
-export const ACTION_TOGGLE_ACCORDION_SEARCH_FIELD =
-  'ACTION_TOGGLE_ACCORDION_SEARCH_FIELD';
 export const ACTION_SET_PACKAGE_SEARCH_TERM = 'ACTION_SET_PACKAGE_SEARCH_TERM';
 export const ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION =
   'ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION';
@@ -134,7 +132,6 @@ export type ResourceAction =
   | SetAttributionIdMarkedForReplacement
   | SetExternalAttributionSources
   | SetMultiSelectSelectedAttributionIds
-  | ToggleAccordionSearchField
   | SetPackageSearchTerm
   | SetAttributionWizardOriginalAttribution
   | SetAttributionWizardPackageNamespaces
@@ -319,10 +316,6 @@ export interface SetAttributionIdMarkedForReplacement {
 export interface SetMultiSelectSelectedAttributionIds {
   type: typeof ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS;
   payload: Array<string>;
-}
-
-export interface ToggleAccordionSearchField {
-  type: typeof ACTION_TOGGLE_ACCORDION_SEARCH_FIELD;
 }
 
 export interface SetPackageSearchTerm {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -67,7 +67,6 @@ import {
   ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
   ACTION_SET_TARGET_SELECTED_RESOURCE_ID,
   ACTION_SET_TEMPORARY_PACKAGE_INFO,
-  ACTION_TOGGLE_ACCORDION_SEARCH_FIELD,
   ACTION_UNLINK_RESOURCE_FROM_ATTRIBUTION,
   ACTION_UPDATE_ATTRIBUTION,
   ResourceAction,
@@ -771,18 +770,6 @@ export const resourceState = (
         fileSearchPopup: {
           ...state.fileSearchPopup,
           fileSearch: action.payload,
-        },
-      };
-    case ACTION_TOGGLE_ACCORDION_SEARCH_FIELD:
-      return {
-        ...state,
-        auditView: {
-          ...state.auditView,
-          accordionSearchField: {
-            ...state.auditView.accordionSearchField,
-            isSearchFieldDisplayed:
-              !state.auditView.accordionSearchField.isSearchFieldDisplayed,
-          },
         },
       };
     case ACTION_SET_PACKAGE_SEARCH_TERM:

--- a/src/Frontend/state/selectors/audit-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/audit-view-resource-selectors.ts
@@ -125,11 +125,6 @@ export function getDisplayPackageInfoOfDisplayedPackage(
   return displayedPackage ? displayedPackage.displayPackageInfo : null;
 }
 
-export function getIsAccordionSearchFieldDisplayed(state: State): boolean {
-  return state.resourceState.auditView.accordionSearchField
-    .isSearchFieldDisplayed;
-}
-
 export function getPackageSearchTerm(state: State): string {
   return state.resourceState.auditView.accordionSearchField.searchTerm;
 }


### PR DESCRIPTION
### Summary of changes

- remove default clear icon that comes with input fields of type "search"
- in search textfield, move search icon before cursor and place clear icon with custom hover state at the rear
- always display search bar in resource details tabs
- make tabs in resource details full width 
- move scroll bar to below search bar to make search bar sticky

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/efc452d2-c9fd-40d9-bef1-192593dc47f8)
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/84f6453f-a8c5-4691-96d1-b7305112d218)
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/0366a370-3b4d-46ab-a100-22f666af7c6f)
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/df060596-5eea-4186-8164-452f9fb26eee)

### Context and reason for change

The default clear icon that webkit browsers add by default to text inputs of type "search" is not good enough for us.

About always showing the search bar inside the resource details tabs:
- there is enough space to always show the search
- better UX (fewer clicks)
- makes the code simpler
- avoids the need to treat this search bar differently from others where the spy glass is always shown

Closes #1773.
Closes #2076.

### How can the changes be tested

Check out a few places where the search bar is used: resource details tabs, package search popup, file search.