### PR TITLE
Hide search field in package panel

### DIFF
--- a/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/__tests__/ResourceDetailsTabs.test.tsx
@@ -145,6 +145,12 @@ describe('The ResourceDetailsTabs', () => {
     screen.getByText(/package name 2/);
     screen.getByText(/package name 3/);
 
+    fireEvent.click(
+      screen.getByLabelText(
+        'Search signals by name, license name, copyright text and version',
+      ),
+    );
+
     fireEvent.change(screen.getByRole('searchbox'), {
       target: { value: 'name 1' },
     });

--- a/src/Frontend/Components/SearchTextField/SearchTextField.tsx
+++ b/src/Frontend/Components/SearchTextField/SearchTextField.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import ClearIcon from '@mui/icons-material/Clear';
-import SearchIcon from '@mui/icons-material/Search';
 import { InputAdornment, SxProps } from '@mui/material';
 import MuiTextField from '@mui/material/TextField';
 import { ReactElement } from 'react';
@@ -45,7 +44,7 @@ interface SearchTextFieldProps {
 export function SearchTextField(props: SearchTextFieldProps): ReactElement {
   return (
     <MuiTextField
-      aria-label="Search"
+      label="Search"
       type="search"
       variant="outlined"
       autoFocus={props.autoFocus ?? false}
@@ -61,11 +60,6 @@ export function SearchTextField(props: SearchTextFieldProps): ReactElement {
       fullWidth={true}
       onChange={(event): void => props.onInputChange(event.target.value)}
       InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon sx={classes.startAdornment} />
-          </InputAdornment>
-        ),
         endAdornment: (
           <InputAdornment position="end">
             <ClearIcon

--- a/src/Frontend/state/actions/resource-actions/audit-view-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/audit-view-simple-actions.ts
@@ -14,6 +14,7 @@ import {
   ACTION_SET_SELECTED_RESOURCE_ID,
   ACTION_SET_TARGET_DISPLAYED_PANEL_PACKAGE,
   ACTION_SET_TARGET_SELECTED_RESOURCE_ID,
+  ACTION_TOGGLE_ACCORDION_SEARCH_FIELD,
   AddResolvedExternalAttribution,
   RemoveResolvedExternalAttribution,
   SetDisplayedPanelPackageAction,
@@ -23,6 +24,7 @@ import {
   SetSelectedResourceIdAction,
   SetTargetDisplayedPanelPackageAction,
   SetTargetSelectedResourceId,
+  ToggleAccordionSearchField,
 } from './types';
 
 export function setSelectedResourceId(
@@ -89,6 +91,10 @@ export function removeResolvedExternalAttribution(
     type: ACTION_REMOVE_RESOLVED_EXTERNAL_ATTRIBUTION,
     payload: resolvedExternalAttribution,
   };
+}
+
+export function toggleAccordionSearchField(): ToggleAccordionSearchField {
+  return { type: ACTION_TOGGLE_ACCORDION_SEARCH_FIELD };
 }
 
 export function setPackageSearchTerm(searchTerm: string): SetPackageSearchTerm {

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -78,6 +78,8 @@ export const ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES =
   'ACTION_SET_EXTERNAL_ATTRIBUTION_SOURCES';
 export const ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS =
   'ACTION_SET_ATTRIBUTION_IDS_MARKED_FOR_MULTISELECT';
+export const ACTION_TOGGLE_ACCORDION_SEARCH_FIELD =
+  'ACTION_TOGGLE_ACCORDION_SEARCH_FIELD';
 export const ACTION_SET_PACKAGE_SEARCH_TERM = 'ACTION_SET_PACKAGE_SEARCH_TERM';
 export const ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION =
   'ACTION_SET_ATTRIBUTION_WIZARD_ORIGINAL_ATTRIBUTION';
@@ -132,6 +134,7 @@ export type ResourceAction =
   | SetAttributionIdMarkedForReplacement
   | SetExternalAttributionSources
   | SetMultiSelectSelectedAttributionIds
+  | ToggleAccordionSearchField
   | SetPackageSearchTerm
   | SetAttributionWizardOriginalAttribution
   | SetAttributionWizardPackageNamespaces
@@ -316,6 +319,10 @@ export interface SetAttributionIdMarkedForReplacement {
 export interface SetMultiSelectSelectedAttributionIds {
   type: typeof ACTION_SET_MULTI_SELECT_SELECTED_ATTRIBUTION_IDS;
   payload: Array<string>;
+}
+
+export interface ToggleAccordionSearchField {
+  type: typeof ACTION_TOGGLE_ACCORDION_SEARCH_FIELD;
 }
 
 export interface SetPackageSearchTerm {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -67,6 +67,7 @@ import {
   ACTION_SET_TARGET_SELECTED_ATTRIBUTION_ID,
   ACTION_SET_TARGET_SELECTED_RESOURCE_ID,
   ACTION_SET_TEMPORARY_PACKAGE_INFO,
+  ACTION_TOGGLE_ACCORDION_SEARCH_FIELD,
   ACTION_UNLINK_RESOURCE_FROM_ATTRIBUTION,
   ACTION_UPDATE_ATTRIBUTION,
   ResourceAction,
@@ -770,6 +771,18 @@ export const resourceState = (
         fileSearchPopup: {
           ...state.fileSearchPopup,
           fileSearch: action.payload,
+        },
+      };
+    case ACTION_TOGGLE_ACCORDION_SEARCH_FIELD:
+      return {
+        ...state,
+        auditView: {
+          ...state.auditView,
+          accordionSearchField: {
+            ...state.auditView.accordionSearchField,
+            isSearchFieldDisplayed:
+              !state.auditView.accordionSearchField.isSearchFieldDisplayed,
+          },
         },
       };
     case ACTION_SET_PACKAGE_SEARCH_TERM:

--- a/src/Frontend/state/selectors/audit-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/audit-view-resource-selectors.ts
@@ -125,6 +125,11 @@ export function getDisplayPackageInfoOfDisplayedPackage(
   return displayedPackage ? displayedPackage.displayPackageInfo : null;
 }
 
+export function getIsAccordionSearchFieldDisplayed(state: State): boolean {
+  return state.resourceState.auditView.accordionSearchField
+    .isSearchFieldDisplayed;
+}
+
 export function getPackageSearchTerm(state: State): string {
   return state.resourceState.auditView.accordionSearchField.searchTerm;
 }


### PR DESCRIPTION
### Summary of changes

#2145 introduced some changes concerning the search bar in the package panel in Audit View. This commit reverts part of it. The search bar should be hidden per default and be available by clicking on the Search icon.
I decided to keep only the clear icon for all SearchFields so that we don't need a special treatment for the SearchField in the package panel. This way #1773 is still fixed. 

### Context and reason for change

Fixes #2155.

### How can the changes be tested

Checkout the commit, open OpossumUI with an example file and observe that the search is hidden per default
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/587bf648-c618-4dce-8c6d-2d706e73c02d)
Clicking on the search icon opens the search. 


