### PR TITLE
Fix folder progress bar

### DIFF
--- a/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/FolderProgressBar.tsx
@@ -71,9 +71,11 @@ export function FolderProgressBar(props: FolderProgressBarProps): ReactElement {
 
   const folderProgressBarWorkerArgs = useMemo(
     () => ({
+      manualAttributions,
       resourceId,
+      resourcesToManualAttributions,
     }),
-    [resourceId],
+    [manualAttributions, resourceId, resourcesToManualAttributions],
   );
 
   const folderProgressBarSyncFallbackArgs = useMemo(


### PR DESCRIPTION
### Summary of changes

After changing and saving an attribution the folder progress bar is correctly re-rendered.

### Context and reason for change

Fixes #2147

### How can the changes be tested

Checkout the commit, open a file with OpossumUI, change an attribution and see observe that the FolderProgressBar is updated.
