### PR TITLE
Mark located signals in package card

### DIFF
--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -31,6 +31,7 @@ import { SxProps } from '@mui/material';
 import RectangleIcon from '@mui/icons-material/Rectangle';
 import { Criticality } from '../../../shared/shared-types';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
+import MuiBox from '@mui/material/Box';
 
 const classes = {
   clickableIcon,
@@ -287,7 +288,17 @@ export function MissingPackageNameIcon(props: IconProps): ReactElement {
 }
 
 export function LocateSignalsIcon(props: IconProps): ReactElement {
-  return <MyLocationIcon arial-abel={'locate signals icon'} sx={props.sx} />;
+  return <MyLocationIcon aria-label={'locate signals icon'} sx={props.sx} />;
+}
+
+export function LocateSignalsIconWithTooltip(): ReactElement {
+  return (
+    <MuiTooltip sx={classes.tooltip} title="signal matches locate filters">
+      <MuiBox>
+        <LocateSignalsIcon sx={classes.nonClickableIcon} />
+      </MuiBox>
+    </MuiTooltip>
+  );
 }
 
 export function PreferredIcon(props: IconProps): ReactElement {

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -14,6 +14,7 @@ import {
   FirstPartyIcon,
   FollowUpIcon,
   IncompleteAttributionsIcon,
+  LocateSignalsIconWithTooltip,
   NeedsReviewIcon,
   PreSelectedIcon,
   SearchPackagesIcon,
@@ -91,6 +92,12 @@ describe('The Icons', () => {
     render(<SearchPackagesIcon />);
 
     expect(screen.getByLabelText('Search packages icon'));
+  });
+
+  it('renders LocateSignalsIconWithTooltip', () => {
+    render(<LocateSignalsIconWithTooltip />);
+
+    expect(screen.getByLabelText('locate signals icon'));
   });
 });
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -59,6 +59,11 @@ import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser';
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import MuiBox from '@mui/material/Box';
 import { openAttributionWizardPopup } from '../../state/actions/popup-actions/popup-actions';
+import { getLocatePopupFilters } from '../../state/selectors/locate-popup-selectors';
+import {
+  attributionMatchesLocateFilter,
+  anyLocateFilterIsSet,
+} from '../../state/helpers/action-and-reducer-helpers';
 
 const classes = {
   hiddenIcon: {
@@ -116,6 +121,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
   const multiSelectSelectedAttributionIds = useAppSelector(
     getMultiSelectSelectedAttributionIds,
   );
+  const locatePopupFilter = useAppSelector(getLocatePopupFilters);
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
   const [showAssociatedResourcesPopup, setShowAssociatedResourcesPopup] =
@@ -155,6 +161,16 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           attributionId === attributionIdMarkedForReplacement,
         isMultiSelected:
           multiSelectSelectedAttributionIds.includes(attributionId),
+      };
+    } else {
+      listCardConfig = {
+        ...listCardConfig,
+        isLocated: anyLocateFilterIsSet(locatePopupFilter)
+          ? attributionMatchesLocateFilter(
+              props.displayPackageInfo,
+              locatePopupFilter,
+            )
+          : false,
       };
     }
 

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -13,6 +13,7 @@ import {
   PreSelectedIcon,
   PreferredIcon,
   WasPreferredIcon,
+  LocateSignalsIconWithTooltip,
 } from '../Icons/Icons';
 import { OpossumColors } from '../../shared-styles';
 import { DisplayPackageInfo } from '../../../shared/shared-types';
@@ -85,6 +86,11 @@ export function getRightIcons(
   } else if (cardConfig.wasPreferred) {
     rightIcons.push(
       <WasPreferredIcon key={getKey('was-preferred-icon', cardId)} />,
+    );
+  }
+  if (cardConfig.isLocated) {
+    rightIcons.push(
+      <LocateSignalsIconWithTooltip key={getKey('is-located-icon', cardId)} />,
     );
   }
 

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -862,17 +862,8 @@ export const resourceState = (
         },
       };
     case ACTION_SET_LOCATE_POPUP_FILTERS:
-      const {
-        selectedCriticality,
-        selectedLicenses,
-        searchTerm,
-        searchOnlyLicenseName,
-      } = action.payload;
       const locatedResources = calculateResourcesWithLocatedAttributions(
-        selectedCriticality,
-        selectedLicenses,
-        searchTerm,
-        searchOnlyLicenseName,
+        action.payload,
         state.allViews.externalData.attributions,
         state.allViews.externalData.attributionsToResources,
         state.allViews.frequentLicenses.nameOrder,
@@ -888,12 +879,7 @@ export const resourceState = (
             resourcesWithLocatedChildren,
           },
         },
-        locatePopup: {
-          selectedCriticality,
-          selectedLicenses,
-          searchTerm,
-          searchOnlyLicenseName,
-        },
+        locatePopup: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -76,6 +76,7 @@ export interface ListCardConfig {
   isContextMenuOpen?: boolean;
   isMultiSelected?: boolean;
   criticality?: Criticality;
+  isLocated?: boolean;
 }
 
 export interface PathPredicate {


### PR DESCRIPTION
### Summary of changes

We already implemented the functionality to locate resources which contain signals based on criticality and license names. This commit adds an icon to each signal which matches the selected filter.

### Context and reason for change

Fixes #2148

### How can the changes be tested

There are new unit tests, so the CI should be green.
Additionally you can checkout the PR, open the "opossum_input.json" file with OpossumUI and click on the locate Icon next to the Apache license in the project statistics. Click on the resources "index.tsx" which is marked with an arrow and observe the locate icons in all suggested signals like below: 
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/26d37e0a-38d7-458e-ad54-f684aa775395)


If you open the LocatorPopup again and clear the search, all icons will be gone.

