### PR TITLE
Fix marking of located signals

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -15,6 +15,7 @@ import { ButtonText, PopupType, View } from '../../enums/enums';
 import { useSelector } from 'react-redux';
 import {
   getAttributionIdMarkedForReplacement,
+  getFrequentLicensesNameOrder,
   getManualAttributions,
   getManualAttributionsToResources,
   wereTemporaryDisplayPackageInfoModified,
@@ -136,6 +137,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
       ? selectedAttributionIdAttributionView
       : selectedAttributionIdAuditView;
 
+  const frequentLicenseNames = useAppSelector(getFrequentLicensesNameOrder);
   function getListCardConfig(): ListCardConfig {
     let listCardConfig: ListCardConfig = {
       ...props.cardConfig,
@@ -169,6 +171,7 @@ export function PackageCard(props: PackageCardProps): ReactElement | null {
           ? attributionMatchesLocateFilter(
               props.displayPackageInfo,
               locatePopupFilter,
+              frequentLicenseNames,
             )
           : false,
       };

--- a/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/action-and-reducer-helpers.test.ts
@@ -616,7 +616,7 @@ describe('attributionMatchesLocatedFilters', () => {
       searchOnlyLicenseName: false,
     };
     expect(
-      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter),
+      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter, []),
     ).toBeTruthy();
   });
 
@@ -632,7 +632,7 @@ describe('attributionMatchesLocatedFilters', () => {
       searchOnlyLicenseName: false,
     };
     expect(
-      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter),
+      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter, []),
     ).toBeFalsy();
   });
   it('is true if no filter selected', () => {
@@ -647,7 +647,25 @@ describe('attributionMatchesLocatedFilters', () => {
       searchOnlyLicenseName: false,
     };
     expect(
-      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter),
+      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter, []),
+    ).toBeTruthy();
+  });
+
+  it('is true if the license matches a frequent license', () => {
+    const testPackageInfo: PackageInfo = {
+      criticality: Criticality.High,
+      licenseName: 'MIT License',
+    };
+    const locatePopupFilter: LocatePopupFilters = {
+      selectedCriticality: SelectedCriticality.Any,
+      selectedLicenses: new Set(['MIT']),
+      searchTerm: '',
+      searchOnlyLicenseName: false,
+    };
+    expect(
+      attributionMatchesLocateFilter(testPackageInfo, locatePopupFilter, [
+        { shortName: 'MIT', fullName: 'MIT License' },
+      ]),
     ).toBeTruthy();
   });
 });

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -291,26 +291,18 @@ export function calculateResourcesWithLocatedAttributions(
   externalAttributionsToResources: AttributionsToResources,
   frequentLicenseNames: Array<FrequentLicenseName>,
 ): Set<string> {
-  const augmentedLicenseNames = augmentFrequentLicenseNamesIfPresent(
-    locatePopupFilters.selectedLicenses,
-    frequentLicenseNames,
-  );
   const locatedResources = new Set<string>();
-  if (
-    !anyLocateFilterIsSet({
-      ...locatePopupFilters,
-      selectedLicenses: augmentedLicenseNames,
-    })
-  ) {
+  if (!anyLocateFilterIsSet(locatePopupFilters)) {
     return locatedResources;
   }
   for (const attributionId in externalAttributions) {
     const attribution = externalAttributions[attributionId];
     if (
-      attributionMatchesLocateFilter(attribution, {
-        ...locatePopupFilters,
-        selectedLicenses: augmentedLicenseNames,
-      })
+      attributionMatchesLocateFilter(
+        attribution,
+        locatePopupFilters,
+        frequentLicenseNames,
+      )
     ) {
       externalAttributionsToResources[attributionId].forEach((resource) => {
         locatedResources.add(resource);
@@ -333,13 +325,18 @@ export function anyLocateFilterIsSet(
 export function attributionMatchesLocateFilter(
   attribution: PackageInfo,
   locatePopupFilter: LocatePopupFilters,
+  frequentLicenseNames: Array<FrequentLicenseName>,
 ): boolean {
   const licenseIsSet = locatePopupFilter.selectedLicenses.size > 0;
   const criticalityIsSet =
     locatePopupFilter.selectedCriticality != SelectedCriticality.Any;
+  const augmentedLicenseNames = augmentFrequentLicenseNamesIfPresent(
+    locatePopupFilter.selectedLicenses,
+    frequentLicenseNames,
+  );
   const licenseMatches =
     attribution.licenseName !== undefined &&
-    locatePopupFilter.selectedLicenses.has(attribution.licenseName);
+    augmentedLicenseNames.has(attribution.licenseName);
   const criticalityMatches =
     attribution.criticality == locatePopupFilter.selectedCriticality;
   const searchTermMatches =


### PR DESCRIPTION
### Summary of changes

Mark located signals if the selected license matches either the short name or full name of a frequent license.

### Context and reason for change
#2183 introduced the marking of signals with an icon if they match the filters from the LocatorPopup. If we have `frequentLicenses` in the file and search for a short name of a `frequentLicense` we also want to locate and mark the signals that have the corresponding full name as license name or the other way around. We marked the resources correctly for these cases but didn't mark the corresponding signal, this is fixed with this PR.

### How can the changes be tested
 
See the new test case and the passing CI. Additionally you can checkout this PR, open the "opossum_input.json" file and locate signals with the license name "MIT License" as in the screenshot below:
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/200cacf4-de59-419e-af57-6720c67237cf)

Observe that the corrresponding signal in "index.tsx" is located and marked with an icon eventhough the license name is just "MIT". 
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/9a7de591-92d9-49f7-a54d-91a752596bb1)
