### PR TITLE
feat: make columns resizable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "object-hash": "^3.0.0",
     "packageurl-js": "^1.2.0",
     "proxy-memoize": "^2.0.4",
+    "re-resizable": "^6.9.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -3,30 +3,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import { ReactElement, useCallback } from 'react';
-import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { DisplayPackageInfo } from '../../../shared/shared-types';
-import { getTemporaryDisplayPackageInfo } from '../../state/selectors/all-views-resource-selectors';
-import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
+import { PopupType } from '../../enums/enums';
+import { OpossumColors } from '../../shared-styles';
+import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   deleteAttributionGloballyAndSave,
   savePackageInfo,
   savePackageInfoIfSavingIsNotDisabled,
 } from '../../state/actions/resource-actions/save-actions';
-import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getTemporaryDisplayPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import {
   getResourceIdsOfSelectedAttribution,
   getSelectedAttributionIdInAttributionView,
 } from '../../state/selectors/attribution-view-resource-selectors';
-import { OpossumColors, treeClasses } from '../../shared-styles';
-import { useWindowHeight } from '../../util/use-window-height';
-import { openPopup } from '../../state/actions/view-actions/view-actions';
-import { PopupType } from '../../enums/enums';
-import { setUpdateTemporaryDisplayPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
-import MuiBox from '@mui/material/Box';
-import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
+import { setUpdateTemporaryDisplayPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
+import { useWindowHeight } from '../../util/use-window-height';
+import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
+import { ResizableBox } from '../ResizableBox/ResizableBox';
+import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
 
 const VERTICAL_RESOURCE_COLUMN_PADDING = 24;
 const VERTICAL_RESOURCE_HEADER_AND_FOOTER_SIZE = 72;
@@ -42,14 +43,17 @@ const classes = {
   resourceColumn: {
     display: 'flex',
     flexDirection: 'column',
-    width: '30%',
     height: `calc(100% - ${VERTICAL_RESOURCE_COLUMN_PADDING}px)`,
     paddingRight: '8px',
     overflowY: 'auto',
-    minWidth: '240px',
   },
   typography: {
     marginTop: '8px',
+  },
+  tree: {
+    background: OpossumColors.white,
+    height: '100%',
+    position: 'relative',
   },
 };
 
@@ -108,7 +112,11 @@ export function AttributionDetailsViewer(): ReactElement | null {
 
   return selectedAttributionId ? (
     <MuiBox sx={classes.root}>
-      <MuiBox sx={classes.resourceColumn}>
+      <ResizableBox
+        sx={classes.resourceColumn}
+        defaultSize={{ width: '30%', height: 'auto' }}
+        minWidth={240}
+      >
         <MuiTypography sx={classes.typography} variant={'subtitle1'}>
           Linked Resources
         </MuiTypography>
@@ -116,9 +124,9 @@ export function AttributionDetailsViewer(): ReactElement | null {
           resourcePaths={resourceIdsOfSelectedAttributionId}
           highlightSelectedResources={false}
           maxHeight={maxTreeHeight}
-          sx={treeClasses.tree('attributionView')}
+          sx={classes.tree}
         />
-      </MuiBox>
+      </ResizableBox>
       <AttributionColumn
         isEditable={true}
         showManualAttributionData={true}

--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactElement } from 'react';
-import { PackageCard } from '../PackageCard/PackageCard';
-import { DisplayPackageInfos, PackageCardConfig } from '../../types/types';
-import { checkboxClass } from '../../shared-styles';
-import MuiBox from '@mui/material/Box';
 import { SxProps } from '@mui/material';
+import MuiBox from '@mui/material/Box';
+import { ReactElement } from 'react';
+import { checkboxClass } from '../../shared-styles';
+import { DisplayPackageInfos, PackageCardConfig } from '../../types/types';
+import { PackageCard } from '../PackageCard/PackageCard';
 import { AttributionsViewPackageList } from '../PackageList/AttributionsViewPackageList';
+import { ResizableBox } from '../ResizableBox/ResizableBox';
 
 const classes = {
   ...checkboxClass,
@@ -64,7 +65,7 @@ export function AttributionList(props: AttributionListProps): ReactElement {
   }
 
   return (
-    <MuiBox sx={props.sx}>
+    <ResizableBox sx={props.sx} defaultSize={{ width: '30%', height: 'auto' }}>
       <MuiBox sx={classes.topElements}>
         {props.title}
         {props.topRightElement}
@@ -76,6 +77,6 @@ export function AttributionList(props: AttributionListProps): ReactElement {
         getAttributionCard={getAttributionCard}
         max={{ height: props.maxHeight }}
       />
-    </MuiBox>
+    </ResizableBox>
   );
 }

--- a/src/Frontend/Components/AttributionView/AttributionView.tsx
+++ b/src/Frontend/Components/AttributionView/AttributionView.tsx
@@ -36,7 +36,6 @@ const classes = {
     backgroundColor: OpossumColors.white,
   },
   attributionList: {
-    width: '30%',
     margin: '5px',
   },
   disabledIcon,

--- a/src/Frontend/Components/ResizableBox/ResizableBox.tsx
+++ b/src/Frontend/Components/ResizableBox/ResizableBox.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import MuiBox from '@mui/material/Box';
+import { SxProps } from '@mui/system';
+import { Resizable, ResizableProps } from 're-resizable';
+
+interface Props extends ResizableProps {
+  children: React.ReactNode;
+  sx?: SxProps;
+}
+
+export function ResizableBox({
+  children,
+  enable = {
+    top: false,
+    right: true,
+    bottom: false,
+    left: false,
+    topRight: false,
+    bottomRight: false,
+    bottomLeft: false,
+    topLeft: false,
+  },
+  sx,
+  ...props
+}: Props): React.ReactElement {
+  return (
+    <Resizable enable={enable} {...props}>
+      <MuiBox sx={sx}>{children}</MuiBox>
+    </Resizable>
+  );
+}

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -65,6 +65,12 @@ const classes = {
     stroke: OpossumColors.darkBlue,
     fontSize: '20px',
   },
+  tree: {
+    padding: '4px 0',
+    background: OpossumColors.white,
+    height: '100%',
+    position: 'relative',
+  },
 };
 
 export function ResourceBrowser(): ReactElement | null {
@@ -173,7 +179,7 @@ export function ResourceBrowser(): ReactElement | null {
       breakpoints={attributionBreakpoints}
       cardHeight={TREE_ROW_HEIGHT}
       maxHeight={maxTreeHeight}
-      sx={treeClasses.tree('browser')}
+      sx={classes.tree}
       alwaysShowHorizontalScrollBar={true}
       treeNodeStyle={{
         root: treeClasses.treeItemLabel,
@@ -187,6 +193,8 @@ export function ResourceBrowser(): ReactElement | null {
       resourcesWithLocatedChildren={
         resourcesWithLocatedAttributions.resourcesWithLocatedChildren
       }
+      resizable
+      width={420}
     />
   ) : null;
 }

--- a/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/ResourceDetailsViewer.tsx
@@ -3,42 +3,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import MuiBox from '@mui/material/Box';
 import { ReactElement, useEffect, useState } from 'react';
-import { PanelPackage } from '../../types/types';
-import { ManualPackagePanel } from '../ManualPackagePanel/ManualPackagePanel';
-import { PathBar } from '../PathBar/PathBar';
-import { ResourceDetailsTabs } from '../ResourceDetailsTabs/ResourceDetailsTabs';
-import { ResourceDetailsAttributionColumn } from '../ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn';
 import { PackagePanelTitle } from '../../enums/enums';
-import { setDisplayedPackage } from '../../state/actions/resource-actions/audit-view-simple-actions';
+import {
+  ADD_NEW_ATTRIBUTION_BUTTON_ID,
+  EMPTY_DISPLAY_PACKAGE_INFO,
+} from '../../shared-constants';
+import { OpossumColors } from '../../shared-styles';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
+import { setDisplayedPackage } from '../../state/actions/resource-actions/audit-view-simple-actions';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getAttributionBreakpoints } from '../../state/selectors/all-views-resource-selectors';
 import {
   getAttributionIdsOfSelectedResource,
   getAttributionIdsOfSelectedResourceClosestParent,
   getDisplayedPackage,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
-import {
-  OpossumColors,
-  resourceBrowserWidthInPixels,
-} from '../../shared-styles';
-import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
-import { getAttributionBreakpoints } from '../../state/selectors/all-views-resource-selectors';
+import { PanelPackage } from '../../types/types';
 import { isIdOfResourceWithChildren } from '../../util/can-resource-have-children';
+import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
+import { ManualPackagePanel } from '../ManualPackagePanel/ManualPackagePanel';
+import { PathBar } from '../PathBar/PathBar';
 import { FolderProgressBar } from '../ProgressBar/FolderProgressBar';
-import MuiBox from '@mui/material/Box';
-import {
-  ADD_NEW_ATTRIBUTION_BUTTON_ID,
-  EMPTY_DISPLAY_PACKAGE_INFO,
-} from '../../shared-constants';
+import { ResizableBox } from '../ResizableBox/ResizableBox';
+import { ResourceDetailsAttributionColumn } from '../ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn';
+import { ResourceDetailsTabs } from '../ResourceDetailsTabs/ResourceDetailsTabs';
 
 const classes = {
   root: {
     background: OpossumColors.lightestBlue,
     flex: 1,
     padding: '8px',
-    width: `calc(95% - ${resourceBrowserWidthInPixels}px)`,
   },
   columnDiv: {
     display: 'flex',
@@ -48,10 +45,8 @@ const classes = {
   packageColumn: {
     display: 'flex',
     flexDirection: 'column',
-    width: '30%',
     height: '100%',
     marginRight: '4px',
-    minWidth: '240px',
   },
   tabsDiv: {
     overflowY: 'auto',
@@ -112,7 +107,11 @@ export function ResourceDetailsViewer(): ReactElement | null {
     <MuiBox sx={classes.root}>
       <PathBar />
       <MuiBox sx={classes.columnDiv}>
-        <MuiBox sx={classes.packageColumn}>
+        <ResizableBox
+          sx={classes.packageColumn}
+          defaultSize={{ width: '30%', height: 'auto' }}
+          minWidth={240}
+        >
           {!resourceIsAttributionBreakpoint && (
             <ManualPackagePanel
               showParentAttributions={showParentAttributions}
@@ -130,7 +129,7 @@ export function ResourceDetailsViewer(): ReactElement | null {
               isAddToPackageEnabled={!resourceIsAttributionBreakpoint}
             />
           </MuiBox>
-        </MuiBox>
+        </ResizableBox>
         <ResourceDetailsAttributionColumn
           showParentAttributions={showParentAttributions}
         />

--- a/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
+++ b/src/Frontend/Components/ResourcePathPopup/ResourcePathPopup.tsx
@@ -3,23 +3,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactElement } from 'react';
-import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { useWindowHeight } from '../../util/use-window-height';
-import { useAppSelector } from '../../state/hooks';
-import { ButtonText } from '../../enums/enums';
 import MuiBox from '@mui/material/Box';
-import { treeClasses } from '../../shared-styles';
-import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
-import { getAllResourcePathsForAttributions } from './resource-path-popup-helpers';
+import { ReactElement } from 'react';
+import { ButtonText } from '../../enums/enums';
+import { OpossumColors } from '../../shared-styles';
+import { useAppSelector } from '../../state/hooks';
 import {
   getExternalAttributionsToResources,
   getManualAttributionsToResources,
 } from '../../state/selectors/all-views-resource-selectors';
+import { useWindowHeight } from '../../util/use-window-height';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
+import { getAllResourcePathsForAttributions } from './resource-path-popup-helpers';
 
 const VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 236;
-const HORIZONTAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES = 112;
 const POPUP_CONTENT_PADDING = 48;
+
+const classes = {
+  tree: {
+    background: OpossumColors.white,
+    position: 'relative',
+  },
+  header: {
+    whiteSpace: 'nowrap',
+    width: `calc(100% - ${POPUP_CONTENT_PADDING}px)`,
+  },
+  container: {
+    overflow: 'hidden',
+    height: `calc(100vh - ${VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES}px)`,
+  },
+};
 
 interface ResourcePathPopupProps {
   closePopup(): void;
@@ -49,7 +63,7 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
   return (
     <NotificationPopup
       header={header}
-      headerSx={treeClasses.header(POPUP_CONTENT_PADDING)}
+      headerSx={classes.header}
       rightButtonConfig={{
         onClick: props.closePopup,
         buttonText: ButtonText.Close,
@@ -57,25 +71,17 @@ export function ResourcePathPopup(props: ResourcePathPopupProps): ReactElement {
       onBackdropClick={props.closePopup}
       onEscapeKeyDown={props.closePopup}
       content={
-        <MuiBox
-          sx={treeClasses.treeContainer(
-            VERTICAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES,
-          )}
-        >
+        <MuiBox sx={classes.container}>
           <ResourcesTree
             resourcePaths={allResourcePaths}
             highlightSelectedResources={true}
             maxHeight={maxTreeHeight}
-            sx={treeClasses.tree(
-              'popup',
-              HORIZONTAL_SPACE_BETWEEN_TREE_AND_VIEWPORT_EDGES,
-              POPUP_CONTENT_PADDING,
-            )}
+            sx={classes.tree}
           />
         </MuiBox>
       }
       isOpen={true}
-      fullWidth={false}
+      fullWidth
     />
   );
 }

--- a/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
+++ b/src/Frontend/extracted/VirtualisedTree/VirtualizedTree.tsx
@@ -20,6 +20,7 @@ import {
 import { getTreeNodeProps } from './utils/get-tree-node-props';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
+import { ResizableBox } from '../../Components/ResizableBox/ResizableBox';
 
 const classes = {
   content: {
@@ -44,6 +45,7 @@ interface VirtualizedTreeProps {
   ariaLabel?: string;
   cardHeight: number;
   maxHeight?: number;
+  width?: number | string;
   expandedNodeIcon?: ReactElement;
   nonExpandedNodeIcon?: ReactElement;
   sx?: SxProps;
@@ -54,6 +56,7 @@ interface VirtualizedTreeProps {
   locatedResourceIcon?: ReactElement;
   locatedResources?: Set<string>;
   resourcesWithLocatedChildren?: Set<string>;
+  resizable?: boolean;
 }
 
 export function VirtualizedTree(
@@ -89,7 +92,12 @@ export function VirtualizedTree(
   );
 
   return props.nodes ? (
-    <MuiBox aria-label={props.ariaLabel} sx={props.sx}>
+    <ResizableBox
+      aria-label={props.ariaLabel}
+      sx={props.sx}
+      defaultSize={{ width: props.width ?? 'auto', height: 'auto' }}
+      enable={props.resizable === true ? undefined : false}
+    >
       {props.locatorIcon}
       <MuiBox sx={classes.content}>
         <List
@@ -111,6 +119,6 @@ export function VirtualizedTree(
           indexToScrollTo={indexToScrollTo}
         />
       </MuiBox>
-    </MuiBox>
+    </ResizableBox>
   ) : null;
 }

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SxProps } from '@mui/material';
-import { shouldNotBeCalled } from './util/should-not-be-called';
+import { Breakpoint } from '@mui/material';
 
 export const OpossumColors = {
   white: 'hsl(0, 0%, 100%)',
@@ -46,8 +45,6 @@ export const criticalityColor = {
   medium: OpossumColors.mediumOrange,
   undefined: OpossumColors.darkBlue,
 };
-
-export const resourceBrowserWidthInPixels = 420;
 
 export const tooltipStyle = {
   '& tooltip': {
@@ -110,76 +107,9 @@ export const tableClasses = {
 
 export const TREE_ROW_HEIGHT = 20;
 export const TREE_ROOT_FOLDER_LABEL = '';
-export const POPUP_MAX_WIDTH_BREAKPOINT = 'xl';
-export const MUI_BREAKPOINTS_TO_PIXELS_MAPPING = {
-  xs: 0,
-  sm: 600,
-  md: 900,
-  lg: 1200,
-  xl: 1536,
-};
+export const POPUP_MAX_WIDTH_BREAKPOINT: Breakpoint = 'xl';
 
 export const treeClasses = {
-  header: (popupContentPadding: number): SxProps => {
-    return {
-      whiteSpace: 'nowrap',
-      width: `calc(100% - ${popupContentPadding}px)`,
-    };
-  },
-  treeContainer: (
-    verticalSpaceBetweenTreeAndViewportEdges: number,
-  ): SxProps => {
-    return {
-      overflow: 'hidden',
-      height: `calc(100vh - ${verticalSpaceBetweenTreeAndViewportEdges}px)`,
-    };
-  },
-  tree: (
-    treeLocation: 'attributionView' | 'popup' | 'browser',
-    horizontalSpaceBetweenTreeAndViewportEdges?: number,
-    popupContentPadding?: number,
-  ): SxProps => {
-    switch (treeLocation) {
-      case 'attributionView': {
-        return {
-          background: OpossumColors.white,
-          height: '100%',
-          position: 'relative',
-        };
-      }
-      case 'browser': {
-        return {
-          width: resourceBrowserWidthInPixels,
-          padding: '4px 0',
-          background: OpossumColors.white,
-          height: '100%',
-          position: 'relative',
-        };
-      }
-      case 'popup': {
-        const popupMaxWidth =
-          MUI_BREAKPOINTS_TO_PIXELS_MAPPING[POPUP_MAX_WIDTH_BREAKPOINT];
-        if (
-          horizontalSpaceBetweenTreeAndViewportEdges !== undefined &&
-          popupContentPadding !== undefined
-        ) {
-          return {
-            width: `calc(100vw - ${horizontalSpaceBetweenTreeAndViewportEdges}px)`,
-            maxWidth: `calc(${popupMaxWidth}px - ${popupContentPadding}px)`,
-            background: OpossumColors.white,
-            position: 'relative',
-          };
-        } else {
-          throw Error(
-            "horizontalSpaceBetweenTreeAndViewportEdges and popupContentPadding have to be provided if treeLocation='popup'",
-          );
-        }
-      }
-      default: {
-        shouldNotBeCalled(treeLocation);
-      }
-    }
-  },
   treeItemLabel: {
     height: '19px',
     whiteSpace: 'nowrap',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8960,6 +8960,7 @@ __metadata:
     packageurl-js: ^1.2.0
     prettier: ^3.0.3
     proxy-memoize: ^2.0.4
+    re-resizable: ^6.9.11
     react: ^18.2.0
     react-dom: ^18.2.0
     react-redux: ^8.1.3
@@ -9437,6 +9438,16 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
+  languageName: node
+  linkType: hard
+
+"re-resizable@npm:^6.9.11":
+  version: 6.9.11
+  resolution: "re-resizable@npm:6.9.11"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: 04be62e2985caff8ff082664b9b66d7c49df383a9560e691f32f583cba75ce51077be8b718c5cda5a1fa07e701337102cbd9ff5b03a58541d9092f25753f47f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary of changes

- make the following components resizable by the user: ResourceBrowser, ResourceDetailsViewer, AttributionList, AttributionDetailsViewer
- simplify styling and move non-shared styles to the components they belong to

https://github.com/opossum-tool/OpossumUI/assets/46091730/597c6764-3ba6-4a4e-a65d-44b43caf7322

### Context and reason for change

Closes #1483

### How can the changes be tested

Test resizing of the two columns in audit view and the two columns in attribution view.
Also test that the ResourcePathPopup is unaffected, i.e., the single column is not resizable and the popup still looks correct.