### PR TITLE
fix: package card padding missing

### DIFF
--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -164,7 +164,7 @@ interface ListCardProps {
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
-  function getDisplayedCount(): string {
+  const displayedCount = ((): string => {
     const digitsInAThousand = 4;
     const digitsInAMillion = 7;
     const count = props.count ? props.count.toString() : '';
@@ -176,7 +176,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
     } else {
       return `${count.slice(0, -(digitsInAMillion - 1))}M`;
     }
-  }
+  })();
 
   function calculateRightPadding(): number {
     return Math.max(
@@ -189,7 +189,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
 
   return (
     <MuiBox sx={getSx(props.cardConfig, props.highlighting)}>
-      {props.leftElement ? props.leftElement : null}
+      {props.leftElement}
       <MuiBox
         sx={{
           ...classes.root,
@@ -198,10 +198,10 @@ export function ListCard(props: ListCardProps): ReactElement | null {
         onClick={props.onClick}
       >
         <MuiBox sx={classes.iconColumn}>
-          {props.leftIcon ? props.leftIcon : null}
-          {getDisplayedCount() ? (
+          {props.leftIcon}
+          {displayedCount ? (
             <MuiTypography variant={'body2'} sx={classes.count}>
-              {getDisplayedCount()}
+              {displayedCount}
             </MuiTypography>
           ) : null}
         </MuiBox>
@@ -217,6 +217,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
           <MuiTypography
             variant={'body2'}
             sx={{
+              ...(!props.leftIcon && !displayedCount && { paddingLeft: '6px' }),
               ...(props.cardConfig.isHeader
                 ? classes.header
                 : classes.textLine),
@@ -231,6 +232,8 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             <MuiTypography
               variant={'body2'}
               sx={{
+                ...(!props.leftIcon &&
+                  !displayedCount && { paddingLeft: '6px' }),
                 ...classes.textLine,
                 ...(props.cardConfig.isResource
                   ? classes.textShortenedFromLeftSide


### PR DESCRIPTION
### Summary of changes

- add a small left padding when there are no icons to the left of the text on a package card

BEFORE:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/400dd7ae-eefb-4626-929d-37168e576462)

AFTER:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/0d60c626-dcab-43cd-ae2f-6e409cedb000)

WITH SECOND LINE TEXT:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/e7fbbbe3-8e95-419d-830c-e0df2151a135)

### Context and reason for change

UI bugfix.

### How can the changes be tested

Check package cards with and without icons to the left.