### PR TITLE
feat: highlight missing namespaces

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -5,10 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
 import { IpcRendererEvent } from 'electron';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
-import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { ButtonText, PopupType, View } from '../../enums/enums';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -72,15 +71,11 @@ interface AttributionColumnProps {
   showParentAttributions?: boolean;
   showManualAttributionData: boolean;
   resetViewIfThisIdChanges?: string;
-  setUpdateTemporaryDisplayPackageInfoFor(
-    propertyToUpdate: string,
-  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   onSaveButtonClick?(): void;
   onSaveGloballyButtonClick?(): void;
   onDeleteButtonClick?(): void;
   onDeleteGloballyButtonClick?(): void;
   saveFileRequestListener(): void;
-  setTemporaryDisplayPackageInfo(displayPackageInfo: DisplayPackageInfo): void;
   smallerLicenseTextOrCommentField?: boolean;
   addMarginForNeedsReviewCheckbox?: boolean;
 }
@@ -137,7 +132,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       selectedPackage,
       selectedAttributionIdInAttributionView,
     );
-  const nameAndVersionAreEditable = props.isEditable && temporaryPurl === '';
+  const arePurlElementsEditable = props.isEditable && temporaryPurl === '';
   const selectedManualAttributionIdInCurrentView =
     view === View.Attribution
       ? selectedAttributionIdInAttributionView
@@ -302,10 +297,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         handlePurlChange={handlePurlChange}
         isDisplayedPurlValid={isDisplayedPurlValid}
         isEditable={props.isEditable}
-        nameAndVersionAreEditable={nameAndVersionAreEditable}
-        setUpdateTemporaryDisplayPackageInfoFor={
-          props.setUpdateTemporaryDisplayPackageInfoFor
-        }
+        arePurlElementsEditable={arePurlElementsEditable}
         temporaryPurl={temporaryPurl}
         openPackageSearchPopup={(): void => {
           dispatch(openPopup(PopupType.PackageSearchPopup));
@@ -313,9 +305,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         showHighlight={showHighlight}
       />
       <CopyrightSubPanel
-        setUpdateTemporaryDisplayPackageInfoFor={
-          props.setUpdateTemporaryDisplayPackageInfoFor
-        }
         isEditable={props.isEditable}
         displayPackageInfo={temporaryDisplayPackageInfo}
         copyrightRows={copyrightRows}
@@ -325,9 +314,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
         isLicenseTextShown={isLicenseTextShown}
         displayPackageInfo={temporaryDisplayPackageInfo}
         isEditable={props.isEditable}
-        setUpdateTemporaryDisplayPackageInfoFor={
-          props.setUpdateTemporaryDisplayPackageInfoFor
-        }
         licenseTextRows={licenseTextRows}
         setIsLicenseTextShown={setIsLicenseTextShown}
         showHighlight={showHighlight}
@@ -335,9 +321,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
       <AuditingSubPanel
         commentBoxHeight={commentBoxHeight}
         isCommentsBoxCollapsed={isLicenseTextShown}
-        setUpdateTemporaryDisplayPackageInfoFor={
-          props.setUpdateTemporaryDisplayPackageInfoFor
-        }
         isEditable={props.isEditable}
         displayPackageInfo={temporaryDisplayPackageInfo}
         firstPartyChangeHandler={getFirstPartyChangeHandler(

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
 import MuiPaper from '@mui/material/Paper';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import {
   DiscreteConfidence,
@@ -17,6 +17,7 @@ import { getExternalAttributionSources } from '../../state/selectors/all-views-r
 import { doNothing } from '../../util/do-nothing';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { prettifySource } from '../../util/prettify-source';
+import { usePackageInfoChangeHandler } from '../../util/use-package-info-change-handler';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Dropdown } from '../InputElements/Dropdown';
 import { NumberBox } from '../InputElements/NumberBox';
@@ -52,14 +53,12 @@ interface AuditingSubPanelProps {
     event: React.ChangeEvent<HTMLInputElement>,
   ): void;
   firstPartyChangeHandler(event: React.ChangeEvent<HTMLInputElement>): void;
-  setUpdateTemporaryDisplayPackageInfoFor(
-    propertyToUpdate: string,
-  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   showHighlight?: boolean;
 }
 
 export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
   const attributionSources = useAppSelector(getExternalAttributionSources);
+  const handleChange = usePackageInfoChangeHandler();
 
   return (
     <MuiPaper sx={classes.panel} elevation={0} square={true}>
@@ -110,9 +109,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
           <NumberBox
             sx={classes.confidenceDropDown}
             title={'Confidence'}
-            handleChange={props.setUpdateTemporaryDisplayPackageInfoFor(
-              'attributionConfidence',
-            )}
+            handleChange={handleChange('attributionConfidence')}
             isEditable={props.isEditable}
             step={1}
             min={0}
@@ -130,7 +127,7 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
         {props.displayPackageInfo.source ? (
           <TextBox
             isEditable={false}
-            sx={{ ...classes.sourceField, ...classes.rightTextBox }}
+            sx={classes.sourceField}
             title={'Source'}
             text={prettifySource(
               props.displayPackageInfo.source.name,
@@ -145,7 +142,6 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
         comments={props.displayPackageInfo.comments || []}
         isCollapsed={props.isCommentsBoxCollapsed}
         commentBoxHeight={props.commentBoxHeight}
-        handleChange={props.setUpdateTemporaryDisplayPackageInfoFor}
       />
     </MuiPaper>
   );

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -4,24 +4,24 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
 import MuiPaper from '@mui/material/Paper';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
+import { usePackageInfoChangeHandler } from '../../util/use-package-info-change-handler';
 import { TextBox } from '../InputElements/TextBox';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
 interface CopyrightSubPanelProps {
   isEditable: boolean;
   displayPackageInfo: DisplayPackageInfo;
-  setUpdateTemporaryDisplayPackageInfoFor(
-    propertyToUpdate: string,
-  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   copyrightRows: number;
   showHighlight?: boolean;
 }
 
 export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
+  const handleChange = usePackageInfoChangeHandler();
+
   return (
     <MuiPaper sx={attributionColumnClasses.panel} elevation={0} square={true}>
       <MuiBox sx={attributionColumnClasses.displayRow}>
@@ -33,9 +33,7 @@ export function CopyrightSubPanel(props: CopyrightSubPanelProps): ReactElement {
           minRows={props.copyrightRows}
           maxRows={props.copyrightRows}
           multiline={true}
-          handleChange={props.setUpdateTemporaryDisplayPackageInfoFor(
-            'copyright',
-          )}
+          handleChange={handleChange('copyright')}
           isHighlighted={
             props.showHighlight &&
             isImportantAttributionInformationMissing(

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -8,7 +8,7 @@ import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import MuiBox from '@mui/material/Box';
 import MuiPaper from '@mui/material/Paper';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { OpossumColors } from '../../shared-styles';
@@ -16,6 +16,7 @@ import { useAppSelector } from '../../state/hooks';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
 import { doNothing } from '../../util/do-nothing';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
+import { usePackageInfoChangeHandler } from '../../util/use-package-info-change-handler';
 import { TextBox } from '../InputElements/TextBox';
 import { getLicenseTextLabelText } from './attribution-column-helpers';
 import { LicenseField } from './LicenseField';
@@ -62,9 +63,6 @@ interface LicenseSubPanelProps {
   isLicenseTextShown: boolean;
   licenseTextRows: number;
   showHighlight?: boolean;
-  setUpdateTemporaryDisplayPackageInfoFor(
-    propertyToUpdate: string,
-  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   setIsLicenseTextShown(isLicenseTextShown: boolean): void;
 }
 
@@ -78,6 +76,8 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
   function toggleIsLicenseTextShown(): void {
     props.setIsLicenseTextShown(!props.isLicenseTextShown);
   }
+
+  const handleChange = usePackageInfoChangeHandler();
 
   return (
     <MuiPaper sx={licenseSubPanelClasses.panel} elevation={0} square={true}>
@@ -110,9 +110,7 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
             title={'License Name'}
             text={props.displayPackageInfo.licenseName}
             frequentLicenseNames={frequentLicensesNameOrder}
-            handleChange={props.setUpdateTemporaryDisplayPackageInfoFor(
-              'licenseName',
-            )}
+            handleChange={handleChange('licenseName')}
             endAdornmentText={
               props.displayPackageInfo.licenseText
                 ? '(Licence text modified)'
@@ -143,9 +141,7 @@ export function LicenseSubPanel(props: LicenseSubPanelProps): ReactElement {
               frequentLicensesNameOrder,
             )}
             text={props.displayPackageInfo.licenseText}
-            handleChange={props.setUpdateTemporaryDisplayPackageInfoFor(
-              'licenseText',
-            )}
+            handleChange={handleChange('licenseText')}
           />
         </MuiAccordionDetails>
       </MuiAccordion>

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -14,6 +14,7 @@ import {
   SaveFileArgs,
   Source,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { ButtonText, CheckboxLabel } from '../../../enums/enums';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 import {
@@ -38,7 +39,7 @@ import { AttributionColumn } from '../AttributionColumn';
 
 describe('The AttributionColumn', () => {
   it('renders TextBoxes with right titles and content', () => {
-    const testTemporaryDisplayPackageInfo: DisplayPackageInfo = {
+    const testTemporaryDisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.Low,
       packageName: 'jQuery',
       packageVersion: '16.5.0',
@@ -51,13 +52,11 @@ describe('The AttributionColumn', () => {
       licenseName: 'Made up license name',
       url: 'www.1999.com',
       attributionIds: [],
-    };
+    } satisfies DisplayPackageInfo;
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -75,22 +74,38 @@ describe('The AttributionColumn', () => {
     expect(screen.queryAllByText('Confidence')).toHaveLength(2);
     expect(
       screen.getByDisplayValue(
-        (
-          testTemporaryDisplayPackageInfo.attributionConfidence as unknown as number
-        ).toString(),
+        testTemporaryDisplayPackageInfo.attributionConfidence.toString(),
       ),
     );
-    expect(screen.queryAllByText('Name')).toHaveLength(2);
+    expect(
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.packageType),
+    ).toHaveLength(2);
+    expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageType),
+    );
+    expect(
+      screen.queryAllByText(
+        text.attributionColumn.packageSubPanel.packageNamespace,
+      ),
+    ).toHaveLength(2);
     expect(
       screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.packageName as string,
+        testTemporaryDisplayPackageInfo.packageNamespace,
       ),
     );
-    expect(screen.queryAllByText('Version')).toHaveLength(2);
     expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.packageVersion as string,
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.packageName),
+    ).toHaveLength(2);
+    expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageName),
+    );
+    expect(
+      screen.queryAllByText(
+        text.attributionColumn.packageSubPanel.packageVersion,
       ),
+    ).toHaveLength(2);
+    expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageVersion),
     );
     expect(
       screen.queryByText('(Defined in parent folder)'),
@@ -98,21 +113,17 @@ describe('The AttributionColumn', () => {
     expect(screen.queryByText('Override parent')).not.toBeInTheDocument();
     expect(screen.queryByText('Source')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Copyright'));
-    expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.copyright as string,
-      ),
-    );
+    expect(screen.getByDisplayValue(testTemporaryDisplayPackageInfo.copyright));
     expect(screen.getByLabelText('License Name'));
     expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.licenseName as string,
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.licenseName),
+    );
+    expect(
+      screen.getByLabelText(
+        text.attributionColumn.packageSubPanel.repositoryUrl,
       ),
     );
-    expect(screen.getByLabelText('URL'));
-    expect(
-      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.url as string),
-    );
+    expect(screen.getByDisplayValue(testTemporaryDisplayPackageInfo.url));
     expect(screen.getByLabelText(/License Text/));
     expect(
       screen.getByDisplayValue('Permission is hereby granted', {
@@ -124,7 +135,9 @@ describe('The AttributionColumn', () => {
       ? testTemporaryDisplayPackageInfo.comments[0]
       : '';
     expect(screen.getByDisplayValue(testComment));
-    expect(screen.queryAllByText('PURL')).toHaveLength(2);
+    expect(
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.purl),
+    ).toHaveLength(2);
     expect(
       screen.getByDisplayValue('pkg:type/namespace/jQuery@16.5.0?appendix'),
     );
@@ -148,9 +161,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -167,13 +178,13 @@ describe('The AttributionColumn', () => {
 
     insertValueIntoTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:type/namespace/jQuery@16.5.0?appendix&#test',
     );
     clickOnButton(screen, ButtonText.Save);
     expectValueInTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:type/namespace/jQuery@16.5.0?appendix=#test',
     );
   });
@@ -196,9 +207,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -215,13 +224,13 @@ describe('The AttributionColumn', () => {
 
     insertValueIntoTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:type/namespace/jQuery@16.5.0?test=appendix&appendix=test#test',
     );
     clickOnButton(screen, ButtonText.Save);
     expectValueInTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:type/namespace/jQuery@16.5.0?appendix=test&test=appendix#test',
     );
   });
@@ -244,9 +253,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -261,9 +268,17 @@ describe('The AttributionColumn', () => {
       );
     });
 
-    insertValueIntoTextBox(screen, 'PURL', 'pkg:type/namespace/jQuery@16.5.0?');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      'pkg:type/namespace/jQuery@16.5.0?',
+    );
     clickOnButton(screen, ButtonText.Save);
-    expectValueInTextBox(screen, 'PURL', 'pkg:type/namespace/jQuery@16.5.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      'pkg:type/namespace/jQuery@16.5.0',
+    );
   });
 
   it('renders a TextBox for the source, if it is defined', () => {
@@ -274,9 +289,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -306,9 +319,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -340,9 +351,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -374,9 +383,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -408,9 +415,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -439,9 +444,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -469,9 +472,7 @@ describe('The AttributionColumn', () => {
     const { store } = renderComponentWithStore(
       <AttributionColumn
         isEditable={true}
-        setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) => doNothing}
         onSaveButtonClick={doNothing}
-        setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
         onSaveGloballyButtonClick={doNothing}
         showManualAttributionData={true}
         saveFileRequestListener={doNothing}
@@ -499,11 +500,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={true}
           saveFileRequestListener={doNothing}
@@ -533,11 +530,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={false}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={true}
           saveFileRequestListener={doNothing}
@@ -570,11 +563,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={true}
           saveFileRequestListener={doNothing}
@@ -610,11 +599,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={true}
           saveFileRequestListener={doNothing}
@@ -648,11 +633,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={true}
           saveFileRequestListener={doNothing}
@@ -690,11 +671,7 @@ describe('The AttributionColumn', () => {
       const { store } = renderComponentWithStore(
         <AttributionColumn
           isEditable={true}
-          setUpdateTemporaryDisplayPackageInfoFor={(): (() => void) =>
-            doNothing
-          }
           onSaveButtonClick={doNothing}
-          setTemporaryDisplayPackageInfo={(): (() => void) => doNothing}
           onSaveGloballyButtonClick={doNothing}
           showManualAttributionData={false}
           saveFileRequestListener={doNothing}

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -28,6 +28,7 @@ import {
   parsePurl,
 } from '../../util/handle-purl';
 import { isExternalPackagePanel } from '../../util/is-external-package-panel';
+import { isNamespaceRequiredButMissing } from '../../util/is-important-attribution-information-missing';
 import { useWindowHeight } from '../../util/use-window-height';
 
 const PRE_SELECTED_LABEL = 'Attribution was pre-selected';
@@ -261,7 +262,12 @@ export function usePurl(
   updatePurl: (displayPackageInfo: DisplayPackageInfo) => void;
 } {
   const [temporaryPurl, setTemporaryPurl] = useState<string>('');
-  const isDisplayedPurlValid: boolean = parsePurl(temporaryPurl).isValid;
+  const isDisplayedPurlValid: boolean =
+    parsePurl(temporaryPurl).isValid &&
+    !isNamespaceRequiredButMissing(
+      temporaryDisplayPackageInfo.packageType,
+      temporaryDisplayPackageInfo.packageNamespace,
+    );
 
   const isAllSavingDisabled =
     (!packageInfoWereModified || !isDisplayedPurlValid) &&

--- a/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
+++ b/src/Frontend/Components/AttributionColumn/shared-attribution-column-styles.ts
@@ -14,17 +14,10 @@ export const attributionColumnClasses = {
   },
   displayRow: {
     display: 'flex',
+    gap: '8px',
   },
   textBox: {
     marginBottom: '4px',
     flex: 1,
-  },
-  rightTextBox: {
-    marginLeft: '8px',
-  },
-  textBoxInvalidInput: {
-    '& textarea, input': {
-      color: OpossumColors.orange,
-    },
   },
 };

--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -6,10 +6,8 @@ import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import { ReactElement, useCallback } from 'react';
 
-import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { PopupType } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
-import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   deleteAttributionGloballyAndSave,
   savePackageInfo,
@@ -23,7 +21,6 @@ import {
   getSelectedAttributionIdInAttributionView,
 } from '../../state/selectors/attribution-view-resource-selectors';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
-import { setUpdateTemporaryDisplayPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 import { ResizableBox } from '../ResizableBox/ResizableBox';
 import { ResourcesTree } from '../ResourcesTree/ResourcesTree';
@@ -83,12 +80,6 @@ export function AttributionDetailsViewer(): ReactElement | null {
     );
   }, [dispatch, selectedAttributionId, temporaryDisplayPackageInfo]);
 
-  const setUpdateTemporaryDisplayPackageInfoFor =
-    setUpdateTemporaryDisplayPackageInfoForCreator(
-      dispatch,
-      temporaryDisplayPackageInfo,
-    );
-
   function deleteAttribution(): void {
     if (temporaryDisplayPackageInfo.preSelected) {
       dispatch(deleteAttributionGloballyAndSave(selectedAttributionId));
@@ -119,16 +110,8 @@ export function AttributionDetailsViewer(): ReactElement | null {
         isEditable={true}
         showManualAttributionData={true}
         areButtonsHidden={false}
-        setUpdateTemporaryDisplayPackageInfoFor={
-          setUpdateTemporaryDisplayPackageInfoFor
-        }
         onSaveButtonClick={dispatchSavePackageInfo}
         onDeleteButtonClick={deleteAttribution}
-        setTemporaryDisplayPackageInfo={(
-          displayPackageInfo: DisplayPackageInfo,
-        ): void => {
-          dispatch(setTemporaryDisplayPackageInfo(displayPackageInfo));
-        }}
         saveFileRequestListener={saveFileRequestListener}
       />
     </MuiBox>

--- a/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/__tests__/AttributionDetailsViewer.test.tsx
@@ -10,6 +10,7 @@ import {
   DisplayPackageInfo,
   PackageInfo,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { View } from '../../../enums/enums';
 import { setTemporaryDisplayPackageInfo } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { setSelectedAttributionId } from '../../../state/actions/resource-actions/attribution-view-simple-actions';
@@ -53,13 +54,19 @@ describe('The AttributionDetailsViewer', () => {
     testTemporaryDisplayPackageInfo.comments?.forEach((comment) =>
       expect(screen.getByDisplayValue(comment)),
     );
-    expect(screen.queryAllByText('Name'));
+    expect(
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.packageName),
+    );
     expect(
       screen.getByDisplayValue(
         testTemporaryDisplayPackageInfo.packageName as string,
       ),
     );
-    expect(screen.queryAllByText('Version'));
+    expect(
+      screen.queryAllByText(
+        text.attributionColumn.packageSubPanel.packageVersion,
+      ),
+    );
     expect(
       screen.getByDisplayValue(
         testTemporaryDisplayPackageInfo.packageVersion as string,

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -4,10 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ReactElement, useCallback } from 'react';
 
-import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { ButtonText } from '../../enums/enums';
 import { closeEditAttributionPopupOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
-import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   savePackageInfo,
   savePackageInfoIfSavingIsNotDisabled,
@@ -20,7 +18,6 @@ import {
 } from '../../state/selectors/all-views-resource-selectors';
 import { getPopupAttributionId } from '../../state/selectors/view-selector';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
-import { setUpdateTemporaryDisplayPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 
@@ -30,11 +27,6 @@ export function EditAttributionPopup(): ReactElement {
   const temporaryDisplayPackageInfo = useAppSelector(
     getTemporaryDisplayPackageInfo,
   );
-  const setUpdateTemporaryDisplayPackageInfoFor =
-    setUpdateTemporaryDisplayPackageInfoForCreator(
-      dispatch,
-      temporaryDisplayPackageInfo,
-    );
 
   const saveFileRequestListener = useCallback(() => {
     dispatch(
@@ -73,14 +65,6 @@ export function EditAttributionPopup(): ReactElement {
           isEditable
           areButtonsHidden
           showManualAttributionData
-          setUpdateTemporaryDisplayPackageInfoFor={
-            setUpdateTemporaryDisplayPackageInfoFor
-          }
-          setTemporaryDisplayPackageInfo={(
-            displayPackageInfo: DisplayPackageInfo,
-          ): void => {
-            dispatch(setTemporaryDisplayPackageInfo(displayPackageInfo));
-          }}
           saveFileRequestListener={saveFileRequestListener}
           smallerLicenseTextOrCommentField
           addMarginForNeedsReviewCheckbox

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -6,7 +6,6 @@ import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiInputAdornment from '@mui/material/InputAdornment';
 import MuiTextField from '@mui/material/TextField';
-import { SystemStyleObject } from '@mui/system/styleFunctionSx';
 import { ReactElement } from 'react';
 
 import { HighlightingColor } from '../../enums/enums';
@@ -14,13 +13,13 @@ import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-class
 import { inputElementClasses, InputElementProps } from './shared';
 
 interface TextProps extends InputElementProps {
-  textFieldSx?: SxProps;
   textFieldInputSx?: SxProps;
   minRows?: number;
   maxRows?: number;
   endIcon?: ReactElement;
   multiline?: boolean;
   highlightingColor?: HighlightingColor;
+  error?: boolean;
 }
 
 export function TextBox(props: TextProps): ReactElement {
@@ -36,15 +35,13 @@ export function TextBox(props: TextProps): ReactElement {
 
   const textBoxSx = getSxFromPropsAndClasses({
     sxProps: props.isHighlighted ? highlightedStyling : {},
-    styleClass: {
-      ...(props.textFieldSx as SystemStyleObject),
-      ...inputElementClasses.textField,
-    },
+    styleClass: inputElementClasses.textField,
   });
   return (
     <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
+        error={props.error}
         sx={textBoxSx}
         label={props.title}
         InputProps={{

--- a/src/Frontend/Components/PackageCard/__tests__/package-card-helpers.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/package-card-helpers.test.tsx
@@ -38,6 +38,20 @@ describe('The PackageCardHelper', () => {
       {
         licenseName: 'some license name',
         packageName: 'some package name',
+        packageNamespace: 'some package namespace',
+        packageType: 'github',
+        packageVersion: 'some package version',
+        url: 'some url',
+        copyright: 'some copyright',
+        attributionIds: ['abc'],
+      },
+      undefined,
+    ],
+    [
+      {
+        licenseName: 'some license name',
+        packageName: 'some package name',
+        packageType: 'some type',
         packageVersion: 'some package version',
         url: 'some url',
         copyright: 'some copyright',
@@ -49,10 +63,10 @@ describe('The PackageCardHelper', () => {
     'for %s packageInfo gives %s highlighting',
     (
       displayPackageInfo: DisplayPackageInfo,
-      expected_highlighting: HighlightingColor | undefined,
+      expectedHighlighting: HighlightingColor | undefined,
     ) => {
       const actualHighlighting = getPackageCardHighlighting(displayPackageInfo);
-      expect(actualHighlighting).toEqual(expected_highlighting);
+      expect(actualHighlighting).toEqual(expectedHighlighting);
     },
   );
 });

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ReactElement } from 'react';
 
-import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { PackagePanelTitle, PopupType } from '../../enums/enums';
-import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
@@ -32,7 +30,6 @@ import { PanelPackage } from '../../types/types';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 import { hasAttributionMultipleResources } from '../../util/has-attribution-multiple-resources';
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
-import { setUpdateTemporaryDisplayPackageInfoForCreator } from '../../util/set-update-temporary-package-info-for-creator';
 import { AttributionColumn } from '../AttributionColumn/AttributionColumn';
 
 interface ResourceDetailsAttributionColumnProps {
@@ -183,21 +180,12 @@ export function ResourceDetailsAttributionColumn(
       showParentAttributions={props.showParentAttributions}
       showSaveGloballyButton={showSaveGloballyButton}
       hideDeleteButtons={hideDeleteButtons}
-      setUpdateTemporaryDisplayPackageInfoFor={setUpdateTemporaryDisplayPackageInfoForCreator(
-        dispatch,
-        temporaryDisplayPackageInfo,
-      )}
       onSaveButtonClick={
         showSaveGloballyButton
           ? dispatchUnlinkAttributionAndSavePackageInfo
           : dispatchSavePackageInfo
       }
       onSaveGloballyButtonClick={dispatchSavePackageInfo}
-      setTemporaryDisplayPackageInfo={(
-        displayPackageInfo: DisplayPackageInfo,
-      ): void => {
-        dispatch(setTemporaryDisplayPackageInfo(displayPackageInfo));
-      }}
       saveFileRequestListener={saveFileRequestListener}
       onDeleteButtonClick={openConfirmDeletionPopup}
       onDeleteGloballyButtonClick={openConfirmDeletionGloballyPopup}

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/__tests__/ResourceDetailsAttributionColumn.test.tsx
@@ -10,6 +10,7 @@ import {
   DisplayPackageInfo,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import {
   setManualData,
   setTemporaryDisplayPackageInfo,
@@ -70,7 +71,7 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 
 describe('The ResourceDetailsAttributionColumn', () => {
   it('renders TextBoxes with right titles and content', () => {
-    const testTemporaryDisplayPackageInfo: DisplayPackageInfo = {
+    const testTemporaryDisplayPackageInfo = {
       attributionConfidence: DiscreteConfidence.High,
       comments: ['some comment'],
       packageName: 'Some package',
@@ -78,7 +79,7 @@ describe('The ResourceDetailsAttributionColumn', () => {
       copyright: 'Copyright Doe Inc. 2019',
       licenseText: 'Permission is hereby granted',
       attributionIds: [],
-    };
+    } satisfies DisplayPackageInfo;
     const { store } = renderComponentWithStore(
       <ResourceDetailsAttributionColumn showParentAttributions={true} />,
     );
@@ -92,9 +93,7 @@ describe('The ResourceDetailsAttributionColumn', () => {
     expect(screen.queryAllByText('Confidence'));
     expect(
       screen.getByDisplayValue(
-        (
-          testTemporaryDisplayPackageInfo.attributionConfidence as unknown as number
-        ).toString(),
+        testTemporaryDisplayPackageInfo.attributionConfidence.toString(),
       ),
     );
     expect(screen.queryAllByText('Comment'));
@@ -103,24 +102,22 @@ describe('The ResourceDetailsAttributionColumn', () => {
         ? testTemporaryDisplayPackageInfo?.comments[0]
         : '';
     expect(screen.getByDisplayValue(testComment));
-    expect(screen.queryAllByText('Name'));
     expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.packageName as string,
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.packageName),
+    );
+    expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageName),
+    );
+    expect(
+      screen.queryAllByText(
+        text.attributionColumn.packageSubPanel.packageVersion,
       ),
     );
-    expect(screen.queryAllByText('Version'));
     expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.packageVersion as string,
-      ),
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageVersion),
     );
     expect(screen.queryAllByText('Copyright'));
-    expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.copyright as string,
-      ),
-    );
+    expect(screen.getByDisplayValue(testTemporaryDisplayPackageInfo.copyright));
     expect(
       screen.queryAllByText('License Text (to appear in attribution document)'),
     );

--- a/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
+++ b/src/Frontend/Components/ResourceDetailsViewer/__tests__/ResourceDetailsViewer.test.tsx
@@ -11,6 +11,7 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { PackagePanelTitle } from '../../../enums/enums';
 import {
   ADD_NEW_ATTRIBUTION_BUTTON_TEXT,
@@ -82,10 +83,10 @@ function getTestTemporaryAndExternalStateWithParentAttribution(
 
 describe('The ResourceDetailsViewer', () => {
   it('renders an Attribution column', () => {
-    const testTemporaryDisplayPackageInfo: DisplayPackageInfo = {
+    const testTemporaryDisplayPackageInfo = {
       packageName: 'jQuery',
       attributionIds: [],
-    };
+    } satisfies DisplayPackageInfo;
     const { store } = renderComponentWithStore(<ResourceDetailsViewer />);
     act(() => {
       store.dispatch(setSelectedResourceId('test_id'));
@@ -94,11 +95,11 @@ describe('The ResourceDetailsViewer', () => {
       );
     });
 
-    expect(screen.queryAllByText('Name'));
     expect(
-      screen.getByDisplayValue(
-        testTemporaryDisplayPackageInfo.packageName as string,
-      ),
+      screen.queryAllByText(text.attributionColumn.packageSubPanel.packageName),
+    );
+    expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.packageName),
     );
   });
 

--- a/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
+++ b/src/Frontend/Components/TextFieldStack/TextFieldStack.tsx
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement } from 'react';
 
+import { usePackageInfoChangeHandler } from '../../util/use-package-info-change-handler';
 import { TextBox } from '../InputElements/TextBox';
 
 const classes = {
@@ -21,14 +22,12 @@ interface TextFieldStackProps {
   isCollapsed: boolean;
   isEditable: boolean;
   comments: string[];
-  handleChange(
-    propertyToUpdate: string,
-  ): (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   showHighlight?: boolean;
   commentBoxHeight: number;
 }
 
 export function TextFieldStack(props: TextFieldStackProps): ReactElement {
+  const handleChange = usePackageInfoChangeHandler();
   const filteredComments = props.comments.filter(
     (comment) => comment.replace(/\s/g, '') != '',
   );
@@ -45,7 +44,7 @@ export function TextFieldStack(props: TextFieldStackProps): ReactElement {
         text={''}
         minRows={1}
         maxRows={1}
-        handleChange={props.handleChange('comments')}
+        handleChange={handleChange('comments')}
       />
     </MuiBox>
   ) : (
@@ -62,7 +61,7 @@ export function TextFieldStack(props: TextFieldStackProps): ReactElement {
               minRows={numLines}
               maxRows={numLines}
               multiline={true}
-              handleChange={props.handleChange('comments')}
+              handleChange={handleChange('comments')}
             />
           </MuiBox>
         );

--- a/src/Frontend/Components/TextFieldStack/__tests__/TextFieldStack.test.tsx
+++ b/src/Frontend/Components/TextFieldStack/__tests__/TextFieldStack.test.tsx
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
-import { doNothing } from '../../../util/do-nothing';
+import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { TextFieldStack } from '../TextFieldStack';
 
 describe('The TextFieldStack', () => {
@@ -20,13 +20,12 @@ describe('The TextFieldStack', () => {
     const isCollapsed = false;
     const commentBoxHeight = 300;
 
-    render(
+    renderComponentWithStore(
       <TextFieldStack
         isEditable={isEditable}
         comments={comments}
         isCollapsed={isCollapsed}
         commentBoxHeight={commentBoxHeight}
-        handleChange={(): (() => void) => doNothing}
       />,
     );
     comments.forEach((comment, index) => {
@@ -46,13 +45,12 @@ describe('The TextFieldStack', () => {
     const isCollapsed = true;
     const commentBoxHeight = 300;
 
-    render(
+    renderComponentWithStore(
       <TextFieldStack
         isEditable={isEditable}
         comments={comments}
         isCollapsed={isCollapsed}
         commentBoxHeight={commentBoxHeight}
-        handleChange={(): (() => void) => doNothing}
       />,
     );
     expect(screen.getByLabelText('4 comments (collapsed)'));
@@ -64,13 +62,12 @@ describe('The TextFieldStack', () => {
     const isCollapsed = true;
     const commentBoxHeight = 300;
 
-    render(
+    renderComponentWithStore(
       <TextFieldStack
         isEditable={isEditable}
         comments={comments}
         isCollapsed={isCollapsed}
         commentBoxHeight={commentBoxHeight}
-        handleChange={(): (() => void) => doNothing}
       />,
     );
     expect(screen.getByLabelText('1 comment (collapsed)'));
@@ -82,13 +79,12 @@ describe('The TextFieldStack', () => {
     const isCollapsed = true;
     const commentBoxHeight = 300;
 
-    render(
+    renderComponentWithStore(
       <TextFieldStack
         isEditable={isEditable}
         comments={comments}
         isCollapsed={isCollapsed}
         commentBoxHeight={commentBoxHeight}
-        handleChange={(): (() => void) => doNothing}
       />,
     );
     expect(screen.getByLabelText('No comments'));

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/context-menu-all-views.test.tsx
@@ -9,6 +9,7 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -102,7 +103,11 @@ describe('The ContextMenu', () => {
       renderComponentWithStore(<App />);
 
       clickOnElementInResourceBrowser(screen, 'firstResource.js');
-      expectValueInTextBox(screen, 'Name', 'Angular');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 5, 0, 0);
       expectContextMenuForNotPreSelectedAttributionMultipleResources(
@@ -116,10 +121,18 @@ describe('The ContextMenu', () => {
       );
       expectConfirmDeletionPopupVisible(screen);
       clickOnButton(screen, ButtonText.Confirm);
-      expectValueNotInTextBox(screen, 'Name', 'Angular');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
 
       clickOnCardInAttributionList(screen, 'React, 16.5.0');
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       expectContextMenuForNotPreSelectedAttributionMultipleResources(
         screen,
         'React, 16.5.0',
@@ -131,19 +144,31 @@ describe('The ContextMenu', () => {
       );
       expectConfirmDeletionPopupVisible(screen);
       clickOnButton(screen, ButtonText.Confirm);
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 4, 0, 0);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       expectContextMenuForNotPreSelectedAttributionMultipleResources(
         screen,
         'React, 16.5.0',
       );
 
       clickOnElementInResourceBrowser(screen, 'fourthResource.js');
-      expectValueInTextBox(screen, 'Name', 'Vue');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Vue',
+      );
       clickOnTab(screen, 'Global Tab');
 
       expectGlobalOnlyContextMenuForNotPreselectedAttribution(
@@ -159,12 +184,20 @@ describe('The ContextMenu', () => {
       clickOnButton(screen, ButtonText.Confirm);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 2, 0, 0);
 
       clickOnElementInResourceBrowser(screen, 'thirdResource.js');
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
 
       goToView(screen, View.Attribution);
       expectResourceBrowserIsNotShown(screen);
@@ -211,7 +244,11 @@ describe('The ContextMenu', () => {
       renderComponentWithStore(<App />);
 
       clickOnElementInResourceBrowser(screen, 'firstResource.js');
-      expectValueInTextBox(screen, 'Name', 'Angular');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
       expectContextMenuForPreSelectedAttributionMultipleResources(
         screen,
         'Angular, 12.2.8',
@@ -222,10 +259,18 @@ describe('The ContextMenu', () => {
         ButtonText.DeleteGlobally,
       );
       expectConfirmDeletionPopupNotVisible(screen);
-      expectValueNotInTextBox(screen, 'Name', 'Angular');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
 
       clickOnCardInAttributionList(screen, 'React, 16.5.0');
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       expectContextMenuForPreSelectedAttributionMultipleResources(
         screen,
         'React, 16.5.0',
@@ -236,19 +281,31 @@ describe('The ContextMenu', () => {
         ButtonText.Delete,
       );
       expectConfirmDeletionPopupNotVisible(screen);
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 4, 0);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       expectContextMenuForPreSelectedAttributionMultipleResources(
         screen,
         'React, 16.5.0',
       );
 
       clickOnElementInResourceBrowser(screen, 'fourthResource.js');
-      expectValueInTextBox(screen, 'Name', 'Vue');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Vue',
+      );
       clickOnTab(screen, 'Global Tab');
       expectGlobalOnlyContextMenuForPreselectedAttribution(
         screen,
@@ -262,12 +319,20 @@ describe('The ContextMenu', () => {
       expectConfirmDeletionPopupNotVisible(screen);
 
       clickOnElementInResourceBrowser(screen, 'secondResource.js');
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
       expectValuesInTopProgressbarTooltip(screen, 5, 0, 2, 0);
 
       clickOnElementInResourceBrowser(screen, 'thirdResource.js');
-      expectValueNotInTextBox(screen, 'Name', 'React');
+      expectValueNotInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
 
       goToView(screen, View.Attribution);
       expectResourceBrowserIsNotShown(screen);
@@ -377,7 +442,11 @@ describe('The ContextMenu', () => {
     expectShowResourcesPopupVisible(screen);
     clickOnNodeInPopupWithResources(screen, 'thirdResource.js');
 
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     closePopup(screen);
     clickOnTab(screen, 'Global Tab');
@@ -393,7 +462,11 @@ describe('The ContextMenu', () => {
     expectShowResourcesPopupVisible(screen);
     clickOnNodeInPopupWithResources(screen, 'secondResource.js');
 
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
     goToView(screen, View.Attribution);
     expectResourceBrowserIsNotShown(screen);
@@ -410,6 +483,10 @@ describe('The ContextMenu', () => {
     expectShowResourcesPopupVisible(screen);
     clickOnNodeInPopupWithResources(screen, 'secondResource.js');
 
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
   });
 });

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/not-saved-popup.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import { ParsedFileContent } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -105,15 +106,27 @@ describe('Not saved popup of the app', () => {
 
     clickOnElementInResourceBrowser(screen, 'root');
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Attribution);
     expectUnsavedChangesPopupIsShown(screen);
 
     clickOnButton(screen, ButtonText.Cancel);
     getElementInResourceBrowser(screen, 'root');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Attribution);
     expectUnsavedChangesPopupIsShown(screen);
@@ -124,8 +137,16 @@ describe('Not saved popup of the app', () => {
     goToView(screen, View.Audit);
     getElementInResourceBrowser(screen, 'root');
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Attribution);
     expectUnsavedChangesPopupIsShown(screen);
@@ -141,17 +162,33 @@ describe('Not saved popup of the app', () => {
     clickOnOpenFileIcon(screen);
 
     clickOnElementInResourceBrowser(screen, 'root');
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    insertValueIntoTextBox(screen, 'Version', '1.1.1');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '1.1.1',
+    );
 
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Report);
     expectUnsavedChangesPopupIsShown(screen);
 
     clickOnButton(screen, ButtonText.Cancel);
     getElementInResourceBrowser(screen, 'root');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Report);
     expectUnsavedChangesPopupIsShown(screen);
@@ -161,7 +198,11 @@ describe('Not saved popup of the app', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByLabelText('edit Angular'));
-    expectValueInTextBox(screen, 'Version', '1.1.1');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '1.1.1',
+    );
   });
 
   it('shows unsaved popup switching from attribution view to standard view', () => {
@@ -174,15 +215,27 @@ describe('Not saved popup of the app', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('React, 16.0.0'));
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Audit);
     expectUnsavedChangesPopupIsShown(screen);
 
     clickOnButton(screen, ButtonText.Cancel);
     expect(screen.getByText('React, 16.0.0'));
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Audit);
     expectUnsavedChangesPopupIsShown(screen);
@@ -193,13 +246,25 @@ describe('Not saved popup of the app', () => {
     clickOnElementInResourceBrowser(screen, 'root');
     clickOnElementInResourceBrowser(screen, 'src');
     clickOnElementInResourceBrowser(screen, 'file_1');
-    expectValueNotInTextBox(screen, 'Name', 'Angular');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Attribution);
     expect(screen.getByText('React, 16.0.0'));
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Audit);
     expectUnsavedChangesPopupIsShown(screen);
@@ -212,8 +277,16 @@ describe('Not saved popup of the app', () => {
 
     goToView(screen, View.Attribution);
     fireEvent.click(screen.getByText('Angular, 16.0.0'));
-    insertValueIntoTextBox(screen, 'Name', 'Vue');
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
     clickOnTopProgressBar(screen);
     expectUnsavedChangesPopupIsShown(screen);
@@ -239,8 +312,16 @@ describe('Not saved popup of the app', () => {
       clickOnElementInResourceBrowser(screen, 'src');
       clickOnElementInResourceBrowser(screen, 'file_2');
 
-      insertValueIntoTextBox(screen, 'Name', 'Angular');
-      expectValueInTextBox(screen, 'Name', 'Angular');
+      insertValueIntoTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
 
       clickAddIconOnCardInAttributionList(screen, 'Vue, 2.6.0');
       expectUnsavedChangesPopupIsShown(screen);
@@ -337,8 +418,16 @@ describe('Not saved popup of the app', () => {
     clickOnElementInResourceBrowser(screen, 'src');
 
     clickAddNewAttributionButton(screen);
-    insertValueIntoTextBox(screen, 'Name', 'My great manual package');
-    expectValueInTextBox(screen, 'Name', 'My great manual package');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'My great manual package',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'My great manual package',
+    );
 
     expectPackagePanelShown(screen, 'Signals in Folder Content');
     expectPackageInPackagePanel(screen, 'JQuery', 'Signals');
@@ -347,7 +436,11 @@ describe('Not saved popup of the app', () => {
     expectUnsavedChangesPopupIsShown(screen);
 
     clickOnButton(screen, ButtonText.Cancel);
-    expectValueInTextBox(screen, 'Name', 'My great manual package');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'My great manual package',
+    );
 
     fireEvent.click(getCardInAttributionList(screen, 'JQuery'));
     expectUnsavedChangesPopupIsShown(screen);
@@ -355,8 +448,16 @@ describe('Not saved popup of the app', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.Undo);
 
     // This behavior could be changed in the future. One could jump to JQuery.
-    expectValueNotInTextBox(screen, 'Name', 'My great manual package');
-    expectValueNotInTextBox(screen, 'Name', 'JQuery');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'My great manual package',
+    );
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'JQuery',
+    );
     expectPackageNotInPackagePanel(
       screen,
       'My great manual package',

--- a/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
+++ b/src/Frontend/integration-tests/all-views-tests/__tests-ci__/other-popups.test.tsx
@@ -12,6 +12,7 @@ import {
   ParsedFileContent,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { TIME_POPUP_IS_DISPLAYED } from '../../../Components/ErrorPopup/ErrorPopup';
 import { ButtonText } from '../../../enums/enums';
@@ -86,8 +87,16 @@ describe('Other popups of the app', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
-    insertValueIntoTextBox(screen, 'Name', 'new Name');
-    expectValueInTextBox(screen, 'Name', 'new Name');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'new Name',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'new Name',
+    );
 
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
@@ -97,13 +106,25 @@ describe('Other popups of the app', () => {
 
     clickOnButton(screen, ButtonText.Cancel);
     expectUnsavedChangesPopupIsNotShown(screen);
-    expectValueInTextBox(screen, 'Name', 'new Name');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'new Name',
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     clickOnButton(screen, ButtonText.Save);
 
-    insertValueIntoTextBox(screen, 'Name', 'another new Name');
-    expectValueInTextBox(screen, 'Name', 'another new Name');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'another new Name',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'another new Name',
+    );
 
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
@@ -141,12 +162,24 @@ describe('Other popups of the app', () => {
     closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', testInitialPackageName);
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testInitialPackageName,
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
 
-    insertValueIntoTextBox(screen, 'Name', testPackageName);
-    expectValueInTextBox(screen, 'Name', testPackageName);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     expectUnsavedChangesPopupIsNotShown(screen);
@@ -171,7 +204,11 @@ describe('Other popups of the app', () => {
       expectedSaveFileArgs,
     );
     expectUnsavedChangesPopupIsNotShown(screen);
-    expectValueNotInTextBox(screen, 'Name', testPackageName);
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
     expectButton(screen, ButtonText.Save, true);
   });
 
@@ -203,12 +240,24 @@ describe('Other popups of the app', () => {
     closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', testInitialPackageName);
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testInitialPackageName,
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
 
-    insertValueIntoTextBox(screen, 'Name', testPackageName);
-    expectValueInTextBox(screen, 'Name', testPackageName);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     expectUnsavedChangesPopupIsNotShown(screen);
@@ -306,7 +355,11 @@ describe('Other popups of the app', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
 
     mockSaveFileRequestChannel();
-    insertValueIntoTextBox(screen, 'PURL', testInvalidPurl);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      testInvalidPurl,
+    );
 
     // Trigger sending external attribution in IpcChannel without the clicking on save button
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
@@ -348,7 +401,11 @@ describe('Other popups of the app', () => {
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
 
     mockSaveFileRequestChannel();
-    insertValueIntoTextBox(screen, 'PURL', testValidPurl);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      testValidPurl,
+    );
 
     // Trigger sending external attribution in IpcChannel without the clicking on save button
     clickOnElementInResourceBrowser(screen, 'firstResource.js');

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests-ci__/context-menu-attribution-view.test.tsx
@@ -12,6 +12,7 @@ import {
   ResourcesToAttributions,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -107,7 +108,11 @@ describe('In Attribution View the ContextMenu', () => {
       'React, 16.5.0',
     );
     clickOnCardInAttributionList(screen, 'React, 16.5.0');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectNoConfirmationButtonsShown(screen, 'React, 16.5.0');
@@ -118,7 +123,11 @@ describe('In Attribution View the ContextMenu', () => {
       screen,
       'React, 16.5.0',
     );
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
   });
@@ -188,7 +197,11 @@ describe('In Attribution View the ContextMenu', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('jQuery, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
     screen.getByText('file_1');
 
     clickOnButtonInPackageContextMenu(
@@ -212,7 +225,11 @@ describe('In Attribution View the ContextMenu', () => {
       'React, 16.0.0',
       ButtonText.Replace,
     );
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectGlobalOnlyContextMenuForNotPreselectedAttribution(
       screen,
       'React, 16.0.0',

--- a/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
+++ b/src/Frontend/integration-tests/attribution-view-tests/__tests__/attribution-view.test.tsx
@@ -11,6 +11,7 @@ import {
   ParsedFileContent,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -79,7 +80,11 @@ describe('The App in attribution view', () => {
 
     clickOnElementInResourceBrowser(screen, 'file2');
     clickOnPackageInPackagePanel(screen, 'Angular', 'Signals');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
     goToView(screen, View.Attribution);
 
@@ -120,25 +125,57 @@ describe('The App in attribution view', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('Angular, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Version', '16.0.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.0.0',
+    );
     expectValueInTextBox(screen, 'Comment', 'ManualPackage');
     expect(screen.queryByText('jQuery')).not.toBeInTheDocument();
 
-    insertValueIntoTextBox(screen, 'Name', 'jQuery');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
 
     fireEvent.click(screen.getByText('Vue, 2.6.0') as Element);
     expectUnsavedChangesPopupIsShown(screen);
     clickOnButton(screen, ButtonText.Save);
 
-    expectValueInTextBox(screen, 'Name', 'Vue');
-    expectValueInTextBox(screen, 'Version', '2.6.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '2.6.0',
+    );
     expectValueInTextBox(screen, 'Comment', 'ManualPackage 2');
     expect(screen.queryByText('jQuery')).not.toBeInTheDocument();
 
-    insertValueIntoTextBox(screen, 'Name', 'jQuery');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
   });
 
   it('handles purls correctly', () => {
@@ -176,47 +213,99 @@ describe('The App in attribution view', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('Angular, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Version', '16.0.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.0.0',
+    );
     expectValueInTextBox(screen, 'Comment', 'ManualPackage');
 
     insertValueIntoTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed',
     );
     expectValueInTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed',
     );
-    expectValueInTextBox(screen, 'Name', 'curl');
-    expectValueInTextBox(screen, 'Version', '7.56.1-1.1.');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'curl',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '7.56.1-1.1.',
+    );
 
     fireEvent.click(screen.getByText('Vue, 2.6.0') as Element);
     expectUnsavedChangesPopupIsShown(screen);
     clickOnButton(screen, ButtonText.Save);
-    expectValueInTextBox(screen, 'PURL', '');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      '',
+    );
 
     fireEvent.click(screen.getByText('curl, 7.56.1-1.1.') as Element);
 
     expectValueInTextBox(
       screen,
-      'PURL',
+      text.attributionColumn.packageSubPanel.purl,
       'pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed',
     );
-    expectValueInTextBox(screen, 'Name', 'curl');
-    expectValueInTextBox(screen, 'Version', '7.56.1-1.1.');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'curl',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '7.56.1-1.1.',
+    );
 
-    insertValueIntoTextBox(screen, 'PURL', 'invalid-purl');
-    expectValueInTextBox(screen, 'Name', 'curl');
-    expectValueInTextBox(screen, 'Version', '7.56.1-1.1.');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      'invalid-purl',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'curl',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '7.56.1-1.1.',
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
 
-    insertValueIntoTextBox(screen, 'PURL', 'pkg:test/name@version');
-    expectValueInTextBox(screen, 'Name', 'name');
-    expectValueInTextBox(screen, 'Version', 'version');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.purl,
+      'pkg:test/name@version',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'name',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      'version',
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     clickOnButton(screen, ButtonText.Save);
@@ -317,21 +406,53 @@ describe('The App in attribution view', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('jQuery, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'jQuery');
-    expectValueInTextBox(screen, 'Version', '16.0.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.0.0',
+    );
     expectValueInTextBox(screen, 'Comment', 'ManualPackage');
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
     clickOnButtonInHamburgerMenu(screen, ButtonText.Undo);
 
-    expectValueInTextBox(screen, 'Name', 'jQuery');
-    expectValueNotInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
     clickOnButton(screen, ButtonText.Save);
 
-    expectValueInTextBox(screen, 'Name', 'Angular');
-    expectValueNotInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
     expect(screen.getByText('Angular, 16.0.0'));
 
     expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
@@ -388,12 +509,28 @@ describe('The App in attribution view', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('jQuery, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'jQuery');
-    expectValueInTextBox(screen, 'Version', '16.0.0');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.0.0',
+    );
     expectValueInTextBox(screen, 'Comment', 'ManualPackage');
 
-    insertValueIntoTextBox(screen, 'Name', '');
-    insertValueIntoTextBox(screen, 'Version', '');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      '',
+    );
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '',
+    );
     insertValueIntoTextBox(screen, 'Comment', '');
     clickOnButton(screen, ButtonText.Save);
 
@@ -456,13 +593,21 @@ describe('The App in attribution view', () => {
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('jQuery, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
     screen.getByText('file_1');
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.MarkForReplacement);
 
     fireEvent.click(screen.getByText('React, 16.0.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     screen.getByText('file_2');
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.ReplaceMarked);
@@ -474,7 +619,11 @@ describe('The App in attribution view', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.ReplaceMarked);
     expectReplaceAttributionPopupIsShown(screen);
     clickOnButton(screen, ButtonText.Replace);
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectReplaceAttributionPopupIsNotShown(screen);
     expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
     screen.getByText('file_1');

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/add-to-attribution.test.tsx
@@ -10,6 +10,7 @@ import {
   Resources,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText } from '../../../enums/enums';
 import {
@@ -103,7 +104,11 @@ describe('Add to attribution', () => {
         'License Text (to appear in attribution document)',
         'Permission is not granted',
       );
-      expectValueInTextBox(screen, 'Name', 'Vue');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Vue',
+      );
       expectValueInConfidenceField(screen, `Low (${DiscreteConfidence.Low})`);
       clickAddIconOnCardInAttributionList(screen, 'Angular, 10');
 
@@ -115,7 +120,11 @@ describe('Add to attribution', () => {
         'License Text (to appear in attribution document)',
         'Permission is maybe granted.',
       );
-      expectValueInTextBox(screen, 'Name', 'Angular');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'Angular',
+      );
       expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     },
   );
@@ -170,7 +179,11 @@ describe('Add to attribution', () => {
       'License Text (to appear in attribution document)',
       'Permission is not granted',
     );
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
     expectValueInAddToAttributionList(screen, 'Angular, 10');
 
@@ -230,10 +243,22 @@ describe('Add to attribution', () => {
       'License Text (to appear in attribution document)',
       'Permission is not granted',
     );
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
-    insertValueIntoTextBox(screen, 'Name', '');
-    insertValueIntoTextBox(screen, 'Version', '');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      '',
+    );
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '',
+    );
     insertValueIntoTextBox(
       screen,
       'License Text (to appear in attribution document)',
@@ -352,7 +377,11 @@ describe('Add to attribution', () => {
     expectValueInTextBox(screen, 'Comment 2', 'I do not like this package.');
 
     clickAddIconOnCardInAttributionList(screen, 'Jquery, 16.5.0');
-    expectValueInTextBox(screen, 'Name', 'Jquery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Jquery',
+    );
     expectValueInTextBox(screen, 'Comment', '');
   });
 });

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/context-menu-audit-view.test.tsx
@@ -12,6 +12,7 @@ import {
   ResourcesToAttributions,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText } from '../../../enums/enums';
 import { ADD_NEW_ATTRIBUTION_BUTTON_TEXT } from '../../../shared-constants';
@@ -131,7 +132,11 @@ describe('In Audit View the ContextMenu', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 0, 4, 0);
@@ -152,7 +157,11 @@ describe('In Audit View the ContextMenu', () => {
     expectNoConfirmationButtonsShown(screen, 'React, 16.5.0');
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     expectValueNotInConfidenceField(
       screen,
@@ -194,7 +203,11 @@ describe('In Audit View the ContextMenu', () => {
     );
 
     clickOnElementInResourceBrowser(screen, 'fourthResource.js');
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
     expectValueNotInConfidenceField(screen, '90');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
@@ -430,7 +443,11 @@ describe('In Audit View the ContextMenu', () => {
       clickOnElementInResourceBrowser(screen, 'root');
       clickOnElementInResourceBrowser(screen, 'src');
       clickOnElementInResourceBrowser(screen, 'file_1');
-      expectValueInTextBox(screen, 'Name', 'jQuery');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'jQuery',
+      );
 
       clickOnButtonInPackageContextMenu(
         screen,
@@ -446,7 +463,11 @@ describe('In Audit View the ContextMenu', () => {
       );
 
       clickOnElementInResourceBrowser(screen, 'file_1');
-      expectValueInTextBox(screen, 'Name', 'jQuery');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'jQuery',
+      );
 
       clickOnElementInResourceBrowser(screen, 'file_2');
       handleReplaceMarkedAttributionViaContextMenu(
@@ -454,7 +475,11 @@ describe('In Audit View the ContextMenu', () => {
         'React, 16.0.0',
         ButtonText.Replace,
       );
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
       expectContextMenuForNotPreSelectedAttributionMultipleResources(
         screen,
         'React, 16.0.0',
@@ -462,7 +487,11 @@ describe('In Audit View the ContextMenu', () => {
 
       clickOnElementInResourceBrowser(screen, 'file_1');
       expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
-      expectValueInTextBox(screen, 'Name', 'React');
+      expectValueInTextBox(
+        screen,
+        text.attributionColumn.packageSubPanel.packageName,
+        'React',
+      );
 
       // make sure resources are now linked to React attribution
       expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/delete-attributions.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import { ParsedFileContent } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -74,7 +75,11 @@ describe('The App in Audit View', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 5, 0, 0);
@@ -85,12 +90,20 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectConfirmDeletionPopupVisible(screen);
     clickOnButton(screen, ButtonText.Confirm);
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 4, 0, 0);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectButtonInHamburgerMenu(screen, ButtonText.DeleteGlobally);
@@ -98,19 +111,31 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.DeleteGlobally);
     expectConfirmDeletionPopupVisible(screen);
     clickOnButton(screen, ButtonText.Confirm);
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 2, 0, 0);
 
     clickOnElementInResourceBrowser(screen, 'thirdResource.js');
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.Delete);
 
     goToView(screen, View.Attribution);
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('Vue, 1.2.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.DeleteGlobally);
@@ -165,7 +190,11 @@ describe('The App in Audit View', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 5, 0);
@@ -175,31 +204,51 @@ describe('The App in Audit View', () => {
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectConfirmDeletionPopupNotVisible(screen);
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 4, 0);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectButtonInHamburgerMenu(screen, ButtonText.DeleteGlobally);
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.DeleteGlobally);
     expectConfirmDeletionPopupNotVisible(screen);
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 5, 0, 2, 0);
 
     clickOnElementInResourceBrowser(screen, 'thirdResource.js');
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.Delete);
 
     goToView(screen, View.Attribution);
     expectResourceBrowserIsNotShown(screen);
 
     fireEvent.click(screen.getByText('Vue, 1.2.0') as Element);
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
     expectButtonInHamburgerMenu(screen, ButtonText.Delete);
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.DeleteGlobally);

--- a/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests-ci__/save-attributions.test.tsx
@@ -10,6 +10,7 @@ import {
   ParsedFileContent,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText } from '../../../enums/enums';
 import {
@@ -80,22 +81,46 @@ describe('The App in Audit View', () => {
     closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'something.js');
-    expectValueInTextBox(screen, 'Name', 'InitialPackageName');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'InitialPackageName',
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
 
-    insertValueIntoTextBox(screen, 'Name', testPackageName);
-    expectValueInTextBox(screen, 'Name', testPackageName);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.Undo);
-    expectValueNotInTextBox(screen, 'Name', testPackageName);
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
 
-    insertValueIntoTextBox(screen, 'Name', testPackageName);
-    expectValueInTextBox(screen, 'Name', testPackageName);
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      testPackageName,
+    );
 
     selectConfidenceInDropdown(screen, `Low (${DiscreteConfidence.Low})`);
     expect(screen.queryAllByText(`Low (${DiscreteConfidence.Low})`).length);
@@ -161,38 +186,74 @@ describe('The App in Audit View', () => {
     closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
     expectButton(screen, ButtonText.SaveGlobally, true);
 
-    insertValueIntoTextBox(screen, 'Name', 'Typescript');
-    expectValueInTextBox(screen, 'Name', 'Typescript');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Typescript',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Typescript',
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     expectButton(screen, ButtonText.SaveGlobally, false);
 
     clickOnButton(screen, ButtonText.SaveGlobally);
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    expectValueInTextBox(screen, 'Name', 'Typescript');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Typescript',
+    );
     expectButton(screen, ButtonText.Save, true);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, true);
     expectButton(screen, ButtonText.SaveGlobally, true);
 
-    insertValueIntoTextBox(screen, 'Name', 'Vue');
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
     expectButton(screen, ButtonText.SaveGlobally, false);
 
     clickOnButton(screen, ButtonText.Save);
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'Typescript');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Typescript',
+    );
 
     clickAddNewAttributionButton(screen);
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
     expectButton(screen, ButtonText.Save, false);
     expectButtonInHamburgerMenu(screen, ButtonText.Undo, false);
 
@@ -244,7 +305,11 @@ describe('The App in Audit View', () => {
     closeProjectStatisticsPopup(screen);
 
     clickOnElementInResourceBrowser(screen, 'firstResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     expectValuesInTopProgressbarTooltip(screen, 4, 0, 4, 0);
@@ -260,7 +325,11 @@ describe('The App in Audit View', () => {
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 
     clickOnElementInResourceBrowser(screen, 'secondResource.js');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInConfidenceField(screen, '10');
     expectValueNotInConfidenceField(
       screen,
@@ -289,7 +358,11 @@ describe('The App in Audit View', () => {
       screen,
       `High (${DiscreteConfidence.High})`,
     );
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
     expectButton(screen, ButtonText.Confirm);
     expectButtonIsNotShown(screen, ButtonText.ConfirmGlobally);
 

--- a/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
+++ b/src/Frontend/integration-tests/audit-view-tests/__tests__/audit-view.test.tsx
@@ -13,6 +13,7 @@ import {
   ResourcesToAttributions,
   SaveFileArgs,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, PackagePanelTitle } from '../../../enums/enums';
 import { setQAMode } from '../../../state/actions/view-actions/view-actions';
@@ -93,11 +94,27 @@ describe('The App in Audit View', () => {
     renderComponentWithStore(<App />);
 
     clickOnElementInResourceBrowser(screen, 'something.js');
-    insertValueIntoTextBox(screen, 'Name', 'Vue');
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
 
-    insertValueIntoTextBox(screen, 'Version', '16.5.1');
-    expectValueInTextBox(screen, 'Version', '16.5.1');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.5.1',
+    );
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageVersion,
+      '16.5.1',
+    );
 
     insertValueIntoTextBox(
       screen,
@@ -168,21 +185,41 @@ describe('The App in Audit View', () => {
     expectValueInManualPackagePanel(screen, 'React');
 
     clickOnElementInResourceBrowser(screen, 'file_manual');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectValueInManualPackagePanelForParentAttribution(screen, 'React');
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.Delete);
 
     clickOnValueInManualPackagePanelForParentAttribution(screen, 'React');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     clearPopover(screen);
     clickOnButton(screen, 'Override parent');
     expectValueNotInManualPackagePanel(screen, 'React');
-    expectValueNotInTextBox(screen, 'Name', 'React');
+    expectValueNotInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
-    insertValueIntoTextBox(screen, 'Name', 'Angular');
+    insertValueIntoTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
     clickOnButton(screen, ButtonText.Save);
-    expectValueInTextBox(screen, 'Name', 'Angular');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Angular',
+    );
   });
 
   it('show confidence correctly', () => {
@@ -238,11 +275,19 @@ describe('The App in Audit View', () => {
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
     expectValueInTextBox(screen, 'Comment', 'React comment');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     clickOnButton(screen, ButtonText.Save);
 
     clickOnElementInResourceBrowser(screen, 'withManualAttribution.js');
-    expectValueInTextBox(screen, 'Name', 'Vue');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'Vue',
+    );
     expectValueNotInConfidenceField(screen, '10');
     expectValueInConfidenceField(screen, `High (${DiscreteConfidence.High})`);
 
@@ -533,7 +578,11 @@ describe('The App in Audit View', () => {
     clickOnElementInResourceBrowser(screen, 'root');
     clickOnElementInResourceBrowser(screen, 'src');
     clickOnElementInResourceBrowser(screen, 'file_1');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
 
     expectButtonInHamburgerMenuIsNotShown(
       screen,
@@ -552,7 +601,11 @@ describe('The App in Audit View', () => {
     clickOnButtonInHamburgerMenu(screen, ButtonText.MarkForReplacement);
 
     clickOnElementInResourceBrowser(screen, 'file_2');
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.ReplaceMarked);
     expectReplaceAttributionPopupIsShown(screen);
@@ -560,18 +613,30 @@ describe('The App in Audit View', () => {
     expectReplaceAttributionPopupIsNotShown(screen);
 
     clickOnElementInResourceBrowser(screen, 'file_1');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
 
     clickOnElementInResourceBrowser(screen, 'file_2');
     clickOnButtonInHamburgerMenu(screen, ButtonText.ReplaceMarked);
     expectReplaceAttributionPopupIsShown(screen);
     clickOnButton(screen, ButtonText.Replace);
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
     expectReplaceAttributionPopupIsNotShown(screen);
 
     clickOnElementInResourceBrowser(screen, 'file_1');
     expect(screen.queryByText('jQuery, 16.0.0')).not.toBeInTheDocument();
-    expectValueInTextBox(screen, 'Name', 'React');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'React',
+    );
 
     // make sure resources are now linked to React attribution
     expect(window.electronAPI.saveFile).toHaveBeenCalledTimes(1);
@@ -655,7 +720,11 @@ describe('The App in Audit View', () => {
     clickOnButton(screen, ButtonText.Close);
 
     clickOnElementInResourceBrowser(screen, 'file');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
 
     expectButtonInHamburgerMenuIsNotShown(screen, ButtonText.UnmarkAsPreferred);
 
@@ -718,7 +787,11 @@ describe('The App in Audit View', () => {
     clickOnButton(screen, ButtonText.Close);
 
     clickOnElementInResourceBrowser(screen, 'file');
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
 
     clickOnButtonInHamburgerMenu(screen, ButtonText.MarkAsPreferred);
     expect(getButton(screen, ButtonText.SaveGlobally)).toBeDisabled();

--- a/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
+++ b/src/Frontend/integration-tests/report-view-tests/__tests__/report-view.test.tsx
@@ -8,6 +8,7 @@ import {
   DiscreteConfidence,
   ParsedFileContent,
 } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { App } from '../../../Components/App/App';
 import { ButtonText, View } from '../../../enums/enums';
 import {
@@ -69,7 +70,11 @@ describe('The report view', () => {
 
     clickOnEditIconForElement(screen, 'jQuery');
     expect(screen.getByText('Edit Attribution'));
-    expectValueInTextBox(screen, 'Name', 'jQuery');
+    expectValueInTextBox(
+      screen,
+      text.attributionColumn.packageSubPanel.packageName,
+      'jQuery',
+    );
     expectValueInTextBox(
       screen,
       'License Text (to appear in attribution document)',

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -38,6 +38,7 @@ export function isImportantAttributionInformationMissing(
     case 'copyright':
     case 'licenseName':
     case 'packageName':
+    case 'packageType':
     case 'packageVersion':
     case 'url':
       return !extendedAttributionInfo[attributionProperty];
@@ -51,7 +52,7 @@ export function isImportantAttributionInformationMissing(
   }
 }
 
-function isNamespaceRequiredButMissing(
+export function isNamespaceRequiredButMissing(
   packageType?: string,
   packageNamespace?: string,
 ): boolean {

--- a/src/Frontend/util/use-package-info-change-handler.ts
+++ b/src/Frontend/util/use-package-info-change-handler.ts
@@ -6,13 +6,18 @@ import { ChangeEvent } from 'react';
 
 import { DisplayPackageInfo } from '../../shared/shared-types';
 import { setTemporaryDisplayPackageInfo } from '../state/actions/resource-actions/all-views-simple-actions';
-import { AppThunkDispatch } from '../state/types';
+import { useAppDispatch, useAppSelector } from '../state/hooks';
+import { getTemporaryDisplayPackageInfo } from '../state/selectors/all-views-resource-selectors';
 
-export function setUpdateTemporaryDisplayPackageInfoForCreator(
-  dispatch: AppThunkDispatch,
-  temporaryDisplayPackageInfo: DisplayPackageInfo,
-) {
-  return (propertyToUpdate: string) => {
+export function usePackageInfoChangeHandler(): (
+  propertyToUpdate: keyof DisplayPackageInfo,
+) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void {
+  const dispatch = useAppDispatch();
+  const temporaryDisplayPackageInfo = useAppSelector(
+    getTemporaryDisplayPackageInfo,
+  );
+
+  return (propertyToUpdate: keyof DisplayPackageInfo) => {
     return (
       event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     ): void => {

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export const text = {
+  attributionColumn: {
+    packageSubPanel: {
+      packageType: 'Package Type',
+      packageNamespace: 'Package Namespace',
+      packageName: 'Package Name',
+      packageVersion: 'Package Version',
+      purl: 'PURL',
+      repositoryUrl: 'Repository URL',
+      openLinkInBrowser: 'Open link in browser',
+      noLinkToOpen: 'No link to open. Please enter a URL.',
+      searchForPackage: 'Search for package information',
+    },
+  },
+};


### PR DESCRIPTION
### Summary of changes

- explicitly display package type and namespace in attribution details view
- highlight PURLs whose namespace is required but missing
- create dedicated file for storing user-facing texts and extract package sub-panel labels there
- create hook to update temporarily displayed package info to avoid prop-drilling redux actions through several levels of components

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/382a1d7f-1533-48a0-a17e-68c16d442c8f)

### Context and reason for change

Progress on #2213.

This is only the first step in a line work that should lead to better UX and higher PURL quality.