### PR TITLE
feat: show warning popup if attribution is modified that was preferred

### DIFF
--- a/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
+++ b/src/Frontend/Components/AttributionDetailsViewer/AttributionDetailsViewer.tsx
@@ -61,23 +61,31 @@ export function AttributionDetailsViewer(): ReactElement | null {
   const dispatch = useAppDispatch();
 
   const saveFileRequestListener = useCallback(() => {
-    dispatch(
-      savePackageInfoIfSavingIsNotDisabled(
-        null,
-        selectedAttributionId,
-        temporaryDisplayPackageInfo,
-      ),
-    );
+    if (temporaryDisplayPackageInfo.wasPreferred) {
+      dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
+    } else {
+      dispatch(
+        savePackageInfoIfSavingIsNotDisabled(
+          null,
+          selectedAttributionId,
+          temporaryDisplayPackageInfo,
+        ),
+      );
+    }
   }, [dispatch, selectedAttributionId, temporaryDisplayPackageInfo]);
 
-  const dispatchSavePackageInfo = useCallback(() => {
-    dispatch(
-      savePackageInfo(
-        null,
-        selectedAttributionId,
-        convertDisplayPackageInfoToPackageInfo(temporaryDisplayPackageInfo),
-      ),
-    );
+  const dispatchSavePackageInfoOrOpenWasPreferredPopup = useCallback(() => {
+    if (temporaryDisplayPackageInfo.wasPreferred) {
+      dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
+    } else {
+      dispatch(
+        savePackageInfo(
+          null,
+          selectedAttributionId,
+          convertDisplayPackageInfoToPackageInfo(temporaryDisplayPackageInfo),
+        ),
+      );
+    }
   }, [dispatch, selectedAttributionId, temporaryDisplayPackageInfo]);
 
   function deleteAttribution(): void {
@@ -110,7 +118,7 @@ export function AttributionDetailsViewer(): ReactElement | null {
         isEditable={true}
         showManualAttributionData={true}
         areButtonsHidden={false}
-        onSaveButtonClick={dispatchSavePackageInfo}
+        onSaveButtonClick={dispatchSavePackageInfoOrOpenWasPreferredPopup}
         onDeleteButtonClick={deleteAttribution}
         saveFileRequestListener={saveFileRequestListener}
       />

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -19,6 +19,7 @@ import { FileSearchPopup } from '../FileSearchPopup/FileSearchPopup';
 import { FileSupportDotOpossumAlreadyExistsPopup } from '../FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup';
 import { FileSupportPopup } from '../FileSupportPopup/FileSupportPopup';
 import { LocatorPopup } from '../LocatorPopup/LocatorPopup';
+import { ModifyWasPreferredAttributionPopup } from '../ModifyWasPreferredAttributionPopup/ModifyWasPreferredAttributionPopup';
 import { NotSavedPopup } from '../NotSavedPopup/NotSavedPopup';
 import { PackageSearchPopup } from '../PackageSearchPopup/PackageSearchPopup';
 import { ProjectMetadataPopup } from '../ProjectMetadataPopup/ProjectMetadataPopup';
@@ -64,6 +65,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <UpdateAppPopup />;
     case PopupType.LocatorPopup:
       return <LocatorPopup />;
+    case PopupType.ModifyWasPreferredAttributionPopup:
+      return <ModifyWasPreferredAttributionPopup />;
     default:
       return null;
   }

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -29,6 +29,7 @@ export enum PopupType {
   FileSupportDotOpossumAlreadyExistsPopup = 'FileSupportDotOpossumAlreadyExistsPopup',
   UpdateAppPopup = 'UpdateAppPopup',
   LocatorPopup = 'LocatorPopup',
+  ModifyWasPreferredAttributionPopup = 'ModifyWasPreferredAttributionPopup',
 }
 
 export enum SavePackageInfoOperation {

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -322,3 +322,13 @@ export function getOpenResourcesButtonForPackagePanel(
     name: 'show resources',
   });
 }
+
+export function expectNoAttributionIsMarkedAsWasPreferred(
+  screen: Screen,
+): void {
+  expect(screen.queryByLabelText('Was Preferred icon')).not.toBeInTheDocument();
+}
+
+export function expectAttributionIsMarkedAsWasPreferred(screen: Screen): void {
+  expect(screen.getByLabelText('Was Preferred icon'));
+}

--- a/src/Frontend/test-helpers/popup-test-helpers.ts
+++ b/src/Frontend/test-helpers/popup-test-helpers.ts
@@ -77,3 +77,21 @@ export function expectConfirmMultiSelectDeletionPopupNotVisible(
 ): void {
   expect(screen.queryByText('Confirm Deletion')).not.toBeInTheDocument();
 }
+
+export function expectModifyWasPreferredPopupIsShown(screen: Screen): void {
+  expect(screen.getByText('Warning'));
+  expect(
+    screen.getByText(
+      'You are about to modify an attribution that was preferred in the past.',
+      { exact: false },
+    ),
+  );
+}
+
+export function expectEditAttributionPopupIsShown(screen: Screen): void {
+  expect(screen.getByText('Edit Attribution')).toBeInTheDocument();
+}
+
+export function expectEditAttributionPopupIsNotShown(screen: Screen): void {
+  expect(screen.queryByText('Edit Attribution')).not.toBeInTheDocument();
+}


### PR DESCRIPTION
### Summary of changes

This PR introduces a new popup (`ModifyWasPreferredPopup`) that displays a warning whenever a user wants to save a change for an attribution that was preferred previously.

<img width="1015" alt="waspreferred" src="https://github.com/opossum-tool/OpossumUI/assets/82914459/82ae2a32-7fac-4784-8945-7952407a490f">


There are three potential paths into the popup:
- Clicking the `Save` or `Save Globally` button
- Clicking `Save` or `Save Globally` in a `NotSavedPopup`
- Saving changes via the electron menu or hotkey (like cmd+S)

The popup is wired such that it is displayed for all three of these cases and always shown after the `NotSavedPopup`.

This diff also includes few changes in the way multiple popups are interacting. Instead of closing and reopening popups, like the `EditAttributionPopup`, the popup stack is used to care of that.

### Context and reason for change

Closes #2205

### How can the changes be tested

Added unit tests for the popup and the actions that are added or modified.
Added two integration tests (in audit and report view) for two different click paths.

Tested all possible paths manually, I hope ;)



