### PR TITLE
Modify statistics popup

### DIFF
--- a/src/Frontend/Components/AccordionWithPieChart/AccordionWithPieChart.tsx
+++ b/src/Frontend/Components/AccordionWithPieChart/AccordionWithPieChart.tsx
@@ -10,7 +10,7 @@ import MuiTypography from '@mui/material/Typography';
 import { ReactElement } from 'react';
 
 import {
-  CriticalityTypes,
+  PieChartCriticalityNames,
   ProjectStatisticsPopupTitle,
 } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
@@ -51,10 +51,10 @@ export function getColorsForPieChart(
   ) {
     for (const pieChartSegment of pieChartData) {
       switch (pieChartSegment.name) {
-        case CriticalityTypes.HighCriticality:
+        case PieChartCriticalityNames.HighCriticality:
           pieChartColors.push(OpossumColors.orange);
           break;
-        case CriticalityTypes.MediumCriticality:
+        case PieChartCriticalityNames.MediumCriticality:
           pieChartColors.push(OpossumColors.mediumOrange);
           break;
         default:

--- a/src/Frontend/Components/AccordionWithPieChart/__tests__/accordion-with-pie-chart-helpers.test.tsx
+++ b/src/Frontend/Components/AccordionWithPieChart/__tests__/accordion-with-pie-chart-helpers.test.tsx
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ProjectStatisticsPopupTitle } from '../../../enums/enums';
+import {
+  PieChartCriticalityNames,
+  ProjectStatisticsPopupTitle,
+} from '../../../enums/enums';
 import { OpossumColors } from '../../../shared-styles';
 import { PieChartData } from '../../../types/types';
 import { getColorsForPieChart } from '../AccordionWithPieChart';
@@ -16,15 +19,15 @@ describe('getColorsForPieChart', () => {
     ];
     const criticalSignalsCount: Array<PieChartData> = [
       {
-        name: 'High',
+        name: PieChartCriticalityNames.HighCriticality,
         count: 3,
       },
       {
-        name: 'Medium',
+        name: PieChartCriticalityNames.MediumCriticality,
         count: 4,
       },
       {
-        name: 'Not critical',
+        name: PieChartCriticalityNames.NoCriticality,
         count: 2,
       },
     ];

--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -16,7 +16,7 @@ import { LocateSignalsIcon } from '../Icons/Icons';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
-const COUNT_COLUMN_NAME_IN_TABLE = 'Count';
+const COUNT_COLUMN_NAME_IN_TABLE = 'Signals Count';
 const FOOTER_TITLE = 'Total';
 const TABLE_COLUMN_NAMES = [
   LICENSE_COLUMN_NAME_IN_TABLE,

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -12,6 +12,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getExternalAttributions,
   getExternalAttributionSources,
+  getExternalAttributionsToHashes,
   getManualAttributions,
 } from '../../state/selectors/all-views-resource-selectors';
 import { AccordionWithPieChart } from '../AccordionWithPieChart/AccordionWithPieChart';
@@ -40,8 +41,14 @@ export function ProjectStatisticsPopup(): ReactElement {
   const manualAttributions = useAppSelector(getManualAttributions);
   const externalAttributions = useAppSelector(getExternalAttributions);
   const attributionSources = useAppSelector(getExternalAttributionSources);
-  const strippedLicenseNameToAttribution =
-    getUniqueLicenseNameToAttribution(externalAttributions);
+  const externalAttributionsToHashes = useAppSelector(
+    getExternalAttributionsToHashes,
+  );
+
+  const strippedLicenseNameToAttribution = getUniqueLicenseNameToAttribution(
+    externalAttributions,
+    externalAttributionsToHashes,
+  );
 
   const { licenseCounts, licenseNamesWithCriticality } =
     aggregateLicensesAndSourcesFromAttributions(
@@ -50,15 +57,15 @@ export function ProjectStatisticsPopup(): ReactElement {
       attributionSources,
     );
 
-  const manualAttributionPropertyCounts =
-    aggregateAttributionPropertiesFromAttributions(manualAttributions);
-
   const mostFrequentLicenseCountData = getMostFrequentLicenses(licenseCounts);
 
   const criticalSignalsCountData = getCriticalSignalsCount(
     licenseCounts,
     licenseNamesWithCriticality,
   );
+
+  const manualAttributionPropertyCounts =
+    aggregateAttributionPropertiesFromAttributions(manualAttributions);
 
   const incompleteAttributionsData =
     getIncompleteAttributionsCount(manualAttributions);

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -200,9 +200,21 @@ describe('The ProjectStatisticsPopup', () => {
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
 
-    expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
-    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
-    expect(screen.getAllByText('Incomplete Attributions')).toHaveLength(2);
+    expect(
+      screen.getByText(
+        ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        ProjectStatisticsPopupTitle.IncompleteLicensesPieChart,
+      ),
+    ).toHaveLength(2);
   });
 
   it('does not render pie charts when there are no attributions', () => {
@@ -218,11 +230,23 @@ describe('The ProjectStatisticsPopup', () => {
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
     expect(
-      screen.queryByText('Most Frequent Licenses'),
+      screen.queryByText(
+        ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart,
+      ),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText('Critical Signals')).not.toBeInTheDocument();
-    expect(screen.getByText('Incomplete Attributions')).toBeInTheDocument();
-    expect(screen.getAllByText('Incomplete Attributions')).not.toHaveLength(2);
+    expect(
+      screen.queryByText(
+        ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart,
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(ProjectStatisticsPopupTitle.IncompleteLicensesPieChart),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        ProjectStatisticsPopupTitle.IncompleteLicensesPieChart,
+      ),
+    ).not.toHaveLength(2);
   });
 
   it('renders pie charts pie charts related to signals even if there are no attributions', () => {
@@ -254,10 +278,24 @@ describe('The ProjectStatisticsPopup', () => {
     );
 
     renderComponentWithStore(<ProjectStatisticsPopup />, { store });
-    expect(screen.getByText('Most Frequent Licenses')).toBeInTheDocument();
-    expect(screen.getByText('Critical Signals')).toBeInTheDocument();
-    expect(screen.getByText('Incomplete Attributions')).toBeInTheDocument();
-    expect(screen.getAllByText('Incomplete Attributions')).not.toHaveLength(2);
+    expect(
+      screen.getByText(
+        ProjectStatisticsPopupTitle.MostFrequentLicenseCountPieChart,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        ProjectStatisticsPopupTitle.CriticalSignalsCountPieChart,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(ProjectStatisticsPopupTitle.IncompleteLicensesPieChart),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        ProjectStatisticsPopupTitle.IncompleteLicensesPieChart,
+      ),
+    ).not.toHaveLength(2);
   });
 
   it('renders tables when there are no attributions', () => {

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/project-statistics-popup-helpers.test.tsx
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
   Attributions,
+  AttributionsToHashes,
   Criticality,
   ExternalAttributionSources,
   FollowUp,
@@ -76,6 +77,14 @@ const testAttributions_1: Attributions = {
     licenseName: 'The MIT License (MIT)',
     firstParty: true,
   },
+  uuid7: {
+    source: {
+      name: 'SC',
+      documentConfidence: 10,
+    },
+    licenseName: 'The MIT License (MIT)',
+    firstParty: true,
+  },
 };
 
 const testAttributions_2: Attributions = {
@@ -128,6 +137,10 @@ const attributionSources: ExternalAttributionSources = {
 
 describe('aggregateLicensesAndSourcesFromAttributions', () => {
   it('counts sources for licenses, criticality', () => {
+    const testExternalAttributionsToHashes: AttributionsToHashes = {
+      uuid6: 'hash',
+      uuid7: 'hash',
+    };
     const expectedAttributionCountPerSourcePerLicense = {
       'Apache License Version 2.0': { ScanCode: 1, reuser: 2 },
       'The MIT License (MIT)': { ScanCode: 2, reuser: 1 },
@@ -145,8 +158,10 @@ describe('aggregateLicensesAndSourcesFromAttributions', () => {
       'The MIT License (MIT)': undefined,
     };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
+    const strippedLicenseNameToAttribution = getUniqueLicenseNameToAttribution(
+      testAttributions_1,
+      testExternalAttributionsToHashes,
+    );
     const { licenseCounts, licenseNamesWithCriticality } =
       aggregateLicensesAndSourcesFromAttributions(
         testAttributions_1,
@@ -192,7 +207,7 @@ describe('getLicenseCriticality', () => {
   it('obtains high criticality', () => {
     const expectedLicenseCriticality: Criticality | undefined =
       Criticality.High;
-    const licenseCriticalityCounts = { high: 1, medium: 3, none: 1 };
+    const licenseCriticalityCounts = { high: 1, medium: 3, none: 10 };
 
     const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
 
@@ -250,9 +265,9 @@ describe('aggregateAttributionPropertiesFromAttributions', () => {
     } = {
       needsReview: 2,
       followUp: 1,
-      firstParty: 2,
+      firstParty: 3,
       incomplete: 4,
-      [ATTRIBUTION_TOTAL]: 6,
+      [ATTRIBUTION_TOTAL]: 7,
     };
 
     const attributionPropertyCountsObject =
@@ -391,15 +406,15 @@ describe('getCriticalSignalsCount', () => {
   it('counts number of critical signals across all licenses', () => {
     const expectedCriticalSignalCount: Array<PieChartData> = [
       {
-        name: 'High',
+        name: 'Highly critical signals',
         count: 3,
       },
       {
-        name: 'Medium',
+        name: 'Medium critical signals',
         count: 4,
       },
       {
-        name: 'Not critical',
+        name: 'Not critical signals',
         count: 2,
       },
     ];
@@ -445,7 +460,7 @@ describe('getIncompleteAttributionsCount', () => {
     const expectedIncompleteAttributionCount: Array<PieChartData> = [
       {
         name: 'Complete attributions',
-        count: 2,
+        count: 3,
       },
       {
         name: 'Incomplete attributions',

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -106,15 +106,20 @@ export enum ProjectStatisticsPopupTitle {
   CriticalLicensesTable = 'Critical Licenses',
   PieChartsSectionHeader = 'Pie Charts',
   MostFrequentLicenseCountPieChart = 'Most Frequent Licenses',
-  CriticalSignalsCountPieChart = 'Critical Signals',
+  CriticalSignalsCountPieChart = 'Signals by Criticality',
   IncompleteLicensesPieChart = 'Incomplete Attributions',
 }
 
 export enum CriticalityTypes {
   HighCriticality = 'High',
   MediumCriticality = 'Medium',
-  NoCriticality = 'Not critical',
   AnyCriticality = 'Any',
+}
+
+export enum PieChartCriticalityNames {
+  HighCriticality = 'Highly critical signals',
+  MediumCriticality = 'Medium critical signals',
+  NoCriticality = 'Not critical signals',
 }
 
 export enum HighlightingColor {


### PR DESCRIPTION
### Summary of changes

* Merged signals should be counted as one item at the project statistics popup
* Use "Signals Count" instead of "Count"
* Rename "Critical signals" to "Signals by criticality" and the pie chart legend
* Modify the heuristics to take the highest criticality at the statistics when there are license variants with different criticalities (here we take the risk of false-critical signals). At the end, colors at the "Critical signals" pie chart should agree with colors at Criticality Progress bar

### Context and reason for change

Fix #2146

### How can the changes be tested

See unit tests.
Open any example file and see the changes at Project Statistics popup. (see opossum_input file below)

**Before**
![image](https://github.com/opossum-tool/OpossumUI/assets/85183359/104b6cae-c120-444b-a8ef-221dd726ac6f)


**After**
![image](https://github.com/opossum-tool/OpossumUI/assets/85183359/86705a3b-7762-4451-9150-f4226929603d)

