### PR TITLE
feat: add popup to warn user if attribution is saved globally that is marked as preferred

### DIFF
--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -22,6 +22,7 @@ import { LocatorPopup } from '../LocatorPopup/LocatorPopup';
 import { ModifyWasPreferredAttributionPopup } from '../ModifyWasPreferredAttributionPopup/ModifyWasPreferredAttributionPopup';
 import { NotSavedPopup } from '../NotSavedPopup/NotSavedPopup';
 import { PackageSearchPopup } from '../PackageSearchPopup/PackageSearchPopup';
+import { PreferGloballyPopup } from '../PreferGloballyPopup/PreferGloballyPopup';
 import { ProjectMetadataPopup } from '../ProjectMetadataPopup/ProjectMetadataPopup';
 import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup/ProjectStatisticsPopup';
 import { ReplaceAttributionPopup } from '../ReplaceAttributionPopup/ReplaceAttributionPopup';
@@ -67,6 +68,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <LocatorPopup />;
     case PopupType.ModifyWasPreferredAttributionPopup:
       return <ModifyWasPreferredAttributionPopup />;
+    case PopupType.PreferGloballyPopup:
+      return <PreferGloballyPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/PreferGloballyPopup/PreferGloballyPopup.tsx
+++ b/src/Frontend/Components/PreferGloballyPopup/PreferGloballyPopup.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ReactElement } from 'react';
+
+import { text } from '../../../shared/text';
+import { ButtonText } from '../../enums/enums';
+import {
+  closePopupAndUnsetTargets,
+  saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled,
+} from '../../state/actions/popup-actions/popup-actions';
+import { useAppDispatch } from '../../state/hooks';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+
+export function PreferGloballyPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+
+  function handleOkClick(): void {
+    dispatch(
+      saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled(),
+    );
+  }
+
+  function handleCancelClick(): void {
+    dispatch(closePopupAndUnsetTargets());
+  }
+
+  return (
+    <NotificationPopup
+      content={text.preferGloballyPopup.content}
+      header={'Warning'}
+      centerRightButtonConfig={{
+        onClick: handleOkClick,
+        buttonText: ButtonText.Ok,
+      }}
+      rightButtonConfig={{
+        onClick: handleCancelClick,
+        buttonText: ButtonText.Cancel,
+      }}
+      isOpen={true}
+    />
+  );
+}

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -30,6 +30,7 @@ export enum PopupType {
   UpdateAppPopup = 'UpdateAppPopup',
   LocatorPopup = 'LocatorPopup',
   ModifyWasPreferredAttributionPopup = 'ModifyWasPreferredAttributionPopup',
+  PreferGloballyPopup = 'PreferGloballyPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -83,6 +84,7 @@ export enum ButtonText {
   OpenDotOpossumFile = 'Open ".opossum" file',
   MarkAsPreferred = 'Mark as preferred',
   UnmarkAsPreferred = 'Unmark as preferred',
+  Ok = 'Ok',
 }
 
 export enum FilterType {

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -17,4 +17,7 @@ export const text = {
       searchForPackage: 'Search for package information',
     },
   },
+  preferGloballyPopup: {
+    content: 'Do you really want to prefer the attribution globally?',
+  },
 };


### PR DESCRIPTION
### Summary of changes

This PR introduces a new warning popup that is warning the user if changes to an attribution are saved globally and these changes encompass that the attribution is marked as preferred. 

This PR is part of a stack and just adds the popup without wiring it to the code base. Opening the popup and sufficient integration testing follows in the next PRs.

### Context and reason for change

We want to give the user the possibility to globally mark attributions as preferred. But since that should be handled with caution a user should be alerted and asked for confirmation if he saves changes to an attribution globally that include that the attribution is marked as preferred.

This PR introduces the popup. In the next PR saving globally will be enabled and in a subsequent PR the warning popup will be opened. 

### How can the changes be tested

Can't be tested at this stage.