### PR TITLE
feat: enable preferring attribution globally and add warning popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -105,10 +105,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
   const isPreferenceFeatureEnabled = useAppSelector(
     getIsPreferenceFeatureEnabled,
   );
-  const initialIsPreferred = initialManualDisplayPackageInfo.preferred ?? false;
-  const tempIsPreferred =
-    temporaryDisplayPackageInfo.preferred ?? initialIsPreferred;
-  const wasPreferredFieldChanged = initialIsPreferred !== tempIsPreferred;
   const qaMode = useAppSelector(getQAMode);
 
   const {
@@ -126,7 +122,6 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
     usePurl(
       dispatch,
       packageInfoWereModified,
-      wasPreferredFieldChanged,
       temporaryDisplayPackageInfo,
       selectedPackage,
       selectedAttributionIdInAttributionView,

--- a/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
+++ b/src/Frontend/Components/AttributionColumn/attribution-column-helpers.ts
@@ -251,7 +251,6 @@ export function getMergeButtonsDisplayState(currentState: {
 export function usePurl(
   dispatch: AppThunkDispatch,
   packageInfoWereModified: boolean,
-  wasPreferredFieldChanged: boolean,
   temporaryDisplayPackageInfo: DisplayPackageInfo,
   selectedPackage: PanelPackage | null,
   selectedAttributionId: string | null,
@@ -275,9 +274,7 @@ export function usePurl(
 
   const savingStatus = isAllSavingDisabled
     ? AllowedSaveOperations.None
-    : wasPreferredFieldChanged
-      ? AllowedSaveOperations.Local
-      : AllowedSaveOperations.All;
+    : AllowedSaveOperations.All;
 
   useEffect(() => {
     dispatch(setAllowedSaveOperations(savingStatus));

--- a/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
+++ b/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
@@ -48,6 +48,7 @@ export function ChangePreferredStatusGloballyPopup(): ReactElement {
         buttonText: ButtonText.Cancel,
       }}
       isOpen={true}
+      aria-label={'change preferred status globally popup'}
     />
   );
 }

--- a/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
+++ b/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { ReactElement } from 'react';
+
+import { text } from '../../../shared/text';
+import { ButtonText } from '../../enums/enums';
+import {
+  closePopupAndUnsetTargets,
+  saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled,
+} from '../../state/actions/popup-actions/popup-actions';
+import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getTemporaryDisplayPackageInfo } from '../../state/selectors/all-views-resource-selectors';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+
+export function ChangePreferredStatusGloballyPopup(): ReactElement {
+  const dispatch = useAppDispatch();
+  const temporaryDisplayPackageInfo = useAppSelector(
+    getTemporaryDisplayPackageInfo,
+  );
+
+  function handleOkClick(): void {
+    dispatch(
+      saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled(),
+    );
+  }
+
+  function handleCancelClick(): void {
+    dispatch(closePopupAndUnsetTargets());
+  }
+
+  const content = temporaryDisplayPackageInfo.preferred
+    ? text.changePreferredStatusGloballyPopup.markAsPreferred
+    : text.changePreferredStatusGloballyPopup.unmarkAsPreferred;
+
+  return (
+    <NotificationPopup
+      content={content}
+      header={'Warning'}
+      centerRightButtonConfig={{
+        onClick: handleOkClick,
+        buttonText: ButtonText.Ok,
+        isDark: true,
+      }}
+      rightButtonConfig={{
+        onClick: handleCancelClick,
+        buttonText: ButtonText.Cancel,
+      }}
+      isOpen={true}
+    />
+  );
+}

--- a/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
+++ b/src/Frontend/Components/GlobalPopup/GlobalPopup.tsx
@@ -10,6 +10,7 @@ import { useAppSelector } from '../../state/hooks';
 import { getOpenPopup } from '../../state/selectors/view-selector';
 import { AttributionWizardPopup } from '../AttributionWizardPopup/AttributionWizardPopup';
 import { ChangedInputFilePopup } from '../ChangedInputFilePopup/ChangedInputFilePopup';
+import { ChangePreferredStatusGloballyPopup } from '../ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup';
 import { ConfirmDeletionGloballyPopup } from '../ConfirmDeletionGloballyPopup/ConfirmDeletionGloballyPopup';
 import { ConfirmDeletionPopup } from '../ConfirmDeletionPopup/ConfirmDeletionPopup';
 import { ConfirmMultiSelectDeletionPopup } from '../ConfirmMultiSelectDeletionPopup/ConfirmMultiSelectDeletionPopup';
@@ -67,6 +68,8 @@ function getPopupComponent(popupType: PopupType | null): ReactElement | null {
       return <LocatorPopup />;
     case PopupType.ModifyWasPreferredAttributionPopup:
       return <ModifyWasPreferredAttributionPopup />;
+    case PopupType.ChangePreferredStatusGloballyPopup:
+      return <ChangePreferredStatusGloballyPopup />;
     default:
       return null;
   }

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -17,13 +17,16 @@ import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionBreakpoints,
+  getAttributionIdOfDisplayedPackageInManualPanel,
+  getDisplayedPackage,
   getIsGlobalSavingDisabled,
   getManualData,
   getTemporaryDisplayPackageInfo,
 } from '../../state/selectors/all-views-resource-selectors';
-import { getDisplayedPackage } from '../../state/selectors/all-views-resource-selectors';
-import { getAttributionIdOfDisplayedPackageInManualPanel } from '../../state/selectors/all-views-resource-selectors';
-import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
+import {
+  getDidPreferredFieldChange,
+  getSelectedResourceId,
+} from '../../state/selectors/audit-view-resource-selectors';
 import { PanelPackage } from '../../types/types';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 import { hasAttributionMultipleResources } from '../../util/has-attribution-multiple-resources';
@@ -51,6 +54,7 @@ export function ResourceDetailsAttributionColumn(
   const selectedResourceIsAttributionBreakpoint = getAttributionBreakpointCheck(
     attributionBreakpoints,
   )(selectedResourceId);
+  const didPreferredFieldChange = useAppSelector(getDidPreferredFieldChange);
   const dispatch = useAppDispatch();
 
   function dispatchUnlinkAttributionAndSavePackageInfoOrOpenWasPreferredPopup(): void {
@@ -70,7 +74,7 @@ export function ResourceDetailsAttributionColumn(
   function dispatchSavePackageInfoOrOpenWasPreferredPopup(): void {
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
-    } else if (showSaveGloballyButton && preferredFieldChanged) {
+    } else if (showSaveGloballyButton && didPreferredFieldChange) {
       dispatch(openPopup(PopupType.ChangePreferredStatusGloballyPopup));
     } else {
       dispatch(
@@ -127,7 +131,7 @@ export function ResourceDetailsAttributionColumn(
     } else if (
       showSaveGloballyButton &&
       !isGlobalSavingDisabled &&
-      preferredFieldChanged
+      didPreferredFieldChange
     ) {
       dispatch(openPopup(PopupType.ChangePreferredStatusGloballyPopup));
     } else if (

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -70,6 +70,8 @@ export function ResourceDetailsAttributionColumn(
   function dispatchSavePackageInfoOrOpenWasPreferredPopup(): void {
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
+    } else if (showSaveGloballyButton && preferredFieldChanged) {
+      dispatch(openPopup(PopupType.ChangePreferredStatusGloballyPopup));
     } else {
       dispatch(
         savePackageInfo(
@@ -122,6 +124,12 @@ export function ResourceDetailsAttributionColumn(
   function saveFileRequestListener(): void {
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
+    } else if (
+      showSaveGloballyButton &&
+      !isGlobalSavingDisabled &&
+      preferredFieldChanged
+    ) {
+      dispatch(openPopup(PopupType.ChangePreferredStatusGloballyPopup));
     } else if (
       showSaveGloballyButton &&
       isGlobalSavingDisabled &&

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -30,6 +30,7 @@ export enum PopupType {
   UpdateAppPopup = 'UpdateAppPopup',
   LocatorPopup = 'LocatorPopup',
   ModifyWasPreferredAttributionPopup = 'ModifyWasPreferredAttributionPopup',
+  ChangePreferredStatusGloballyPopup = 'ChangePreferredStatusGloballyPopup',
 }
 
 export enum SavePackageInfoOperation {
@@ -83,6 +84,7 @@ export enum ButtonText {
   OpenDotOpossumFile = 'Open ".opossum" file',
   MarkAsPreferred = 'Mark as preferred',
   UnmarkAsPreferred = 'Unmark as preferred',
+  Ok = 'Ok',
 }
 
 export enum FilterType {

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -15,6 +15,7 @@ import {
   convertDisplayPackageInfoToPackageInfo,
   convertPackageInfoToDisplayPackageInfo,
 } from '../../../util/convert-package-info';
+import { hasAttributionMultipleResources } from '../../../util/has-attribution-multiple-resources';
 import {
   getAllAttributionIdsWithCountsFromResourceAndChildren,
   getAttributionWizardInitialState,
@@ -27,6 +28,7 @@ import {
   getExternalData,
   getIsSavingDisabled,
   getManualAttributions,
+  getManualAttributionsToResources,
   getManualData,
   getResourcesWithLocatedAttributions,
   getTemporaryDisplayPackageInfo,
@@ -234,6 +236,15 @@ export function checkIfWasPreferredAndShowWarningOrSave(): AppThunkAction {
     const currentAttributionId = getCurrentAttributionId(getState());
     const temporaryDisplayPackageInfo =
       getTemporaryDisplayPackageInfo(getState());
+    const attributionsToResources =
+      getManualAttributionsToResources(getState());
+    const view = getSelectedView(getState());
+    const showSaveGloballyButton =
+      view === View.Audit &&
+      hasAttributionMultipleResources(
+        currentAttributionId,
+        attributionsToResources,
+      );
 
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(closePopup());
@@ -244,6 +255,12 @@ export function checkIfWasPreferredAndShowWarningOrSave(): AppThunkAction {
             currentAttributionId,
           ),
         );
+    } else if (
+      showSaveGloballyButton &&
+      getDidPreferredFieldChange(getState())
+    ) {
+      dispatch(closePopup());
+      dispatch(openPopup(PopupType.ChangePreferredStatusGloballyPopup));
     } else {
       dispatch(
         saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled(),

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -35,6 +35,7 @@ import {
   wereTemporaryDisplayPackageInfoModified,
 } from '../../selectors/all-views-resource-selectors';
 import {
+  getDidPreferredFieldChange,
   getResolvedExternalAttributions,
   getSelectedResourceId,
 } from '../../selectors/audit-view-resource-selectors';

--- a/src/Frontend/state/selectors/audit-view-resource-selectors.ts
+++ b/src/Frontend/state/selectors/audit-view-resource-selectors.ts
@@ -5,12 +5,15 @@
 import { pick } from 'lodash';
 
 import { Attributions } from '../../../shared/shared-types';
+import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 import { PanelPackage, State } from '../../types/types';
 import { getClosestParentAttributionIds } from '../../util/get-closest-parent-attributions';
 import { getAttributionBreakpointCheckForState } from '../../util/is-attribution-breakpoint';
 import {
   getManualAttributions,
+  getManualDisplayPackageInfoOfSelected,
   getResourcesToManualAttributions,
+  getTemporaryDisplayPackageInfo,
 } from './all-views-resource-selectors';
 
 export function getSelectedResourceId(state: State): string {
@@ -89,4 +92,14 @@ export function getIsAccordionSearchFieldDisplayed(state: State): boolean {
 
 export function getPackageSearchTerm(state: State): string {
   return state.resourceState.auditView.accordionSearchField.searchTerm;
+}
+
+export function getDidPreferredFieldChange(state: State): boolean {
+  const temporaryDisplayPackageInfo = getTemporaryDisplayPackageInfo(state);
+  const initialManualDisplayPackageInfo =
+    getManualDisplayPackageInfoOfSelected(state) || EMPTY_DISPLAY_PACKAGE_INFO;
+  const initialIsPreferred = initialManualDisplayPackageInfo.preferred ?? false;
+  const tempIsPreferred =
+    temporaryDisplayPackageInfo.preferred ?? initialIsPreferred;
+  return initialIsPreferred !== tempIsPreferred;
 }

--- a/src/e2e-tests/__tests__/preferring-attributions.test.ts
+++ b/src/e2e-tests/__tests__/preferring-attributions.test.ts
@@ -76,7 +76,7 @@ test('allows QA user to mark and unmark attributions as preferred, but not globa
 
   await attributionDetails.hamburgerMenu.markAsPreferred.click();
   await attributionDetails.assert.saveButtonIsEnabled();
-  await attributionDetails.assert.saveGloballyButtonIsDisabled();
+  await attributionDetails.assert.saveGloballyButtonIsEnabled();
   await attributionDetails.openHamburgerMenu();
   await attributionDetails.assert.buttonInHamburgerMenuIsVisible(
     'unmarkAsPreferred',

--- a/src/e2e-tests/__tests__/saving-preferred-attributions-globally.test.ts
+++ b/src/e2e-tests/__tests__/saving-preferred-attributions-globally.test.ts
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { faker, test } from '../utils';
+
+const [resourceName1, resourceName2, resourceName3, resourceName4] =
+  faker.opossum.resourceNames({ count: 4 });
+const [attributionId1, packageInfo1] = faker.opossum.manualAttribution();
+const [attributionId2, packageInfo2] = faker.opossum.manualAttribution();
+const externalAttributionSource = faker.opossum.externalAttributionSource({
+  isRelevantForPreferred: true,
+});
+const [attributionId3, packageInfo3] = faker.opossum.externalAttribution({
+  source: faker.opossum.source({ name: externalAttributionSource.name }),
+});
+
+test.use({
+  data: {
+    inputData: faker.opossum.inputData({
+      resources: faker.opossum.resources({
+        [resourceName1]: 1,
+        [resourceName2]: 1,
+        [resourceName3]: 1,
+        [resourceName4]: 1,
+      }),
+      externalAttributionSources: faker.opossum.externalAttributionSources({
+        externalAttributionSource,
+      }),
+      externalAttributions: faker.opossum.externalAttributions({
+        [attributionId3]: packageInfo3,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName1)]: [attributionId3],
+        [faker.opossum.filePath(resourceName2)]: [attributionId3],
+        [faker.opossum.filePath(resourceName3)]: [attributionId3],
+        [faker.opossum.filePath(resourceName4)]: [attributionId3],
+      }),
+    }),
+    outputData: faker.opossum.outputData({
+      manualAttributions: faker.opossum.manualAttributions({
+        [attributionId1]: packageInfo1,
+        [attributionId2]: packageInfo2,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName1)]: [attributionId1],
+        [faker.opossum.filePath(resourceName2)]: [attributionId1],
+        [faker.opossum.filePath(resourceName3)]: [attributionId1],
+        [faker.opossum.filePath(resourceName4)]: [attributionId2],
+      }),
+    }),
+  },
+});
+
+test('marks and unmarks an attribution as preferred globally if user saves globally via button', async ({
+  attributionDetails,
+  changePreferredStatusGloballyPopup,
+  projectStatisticsPopup,
+  resourceBrowser,
+  resourceDetails,
+  menuBar,
+}) => {
+  await projectStatisticsPopup.close();
+  await menuBar.toggleQaMode();
+  const preferLocallyComment = faker.lorem.sentence();
+
+  await test.step('prefer attribution locally', async () => {
+    await resourceBrowser.goto(resourceName1);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+
+    await attributionDetails.comment().fill(preferLocallyComment);
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+    await attributionDetails.saveButton.click();
+    await changePreferredStatusGloballyPopup.assert.isHidden();
+
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+    await attributionDetails.assert.commentIs(preferLocallyComment);
+  });
+
+  await test.step('prefer attribution globally', async () => {
+    await resourceBrowser.goto(resourceName2);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+    await attributionDetails.saveGloballyButton.click();
+    await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
+
+    await changePreferredStatusGloballyPopup.okButton.click();
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+
+    await resourceBrowser.goto(resourceName3);
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+  });
+
+  await test.step('unmark preferred globally', async () => {
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.unmarkAsPreferred.click();
+
+    await attributionDetails.saveGloballyButton.click();
+    await changePreferredStatusGloballyPopup.assert.unmarkAsPreferredWarningIsVisible();
+
+    await changePreferredStatusGloballyPopup.okButton.click();
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+
+    await resourceBrowser.goto(resourceName2);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+  });
+
+  await test.step('check that independent attribution is not modified', async () => {
+    await resourceBrowser.goto(resourceName4);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo2,
+    );
+  });
+
+  await test.step('check locally preferred attribution is unchanged', async () => {
+    await resourceBrowser.goto(resourceName1);
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+    await attributionDetails.assert.commentIs(preferLocallyComment);
+  });
+});
+
+test('marks and unmarks an attribution as preferred globally if user navigates away and saves', async ({
+  attributionDetails,
+  changePreferredStatusGloballyPopup,
+  notSavedPopup,
+  projectStatisticsPopup,
+  resourceBrowser,
+  resourceDetails,
+  menuBar,
+  topBar,
+}) => {
+  await projectStatisticsPopup.close();
+  await menuBar.toggleQaMode();
+  const preferLocallyCopyright = faker.lorem.sentence();
+
+  await test.step('prefer attribution locally', async () => {
+    await resourceBrowser.goto(resourceName1);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+    await attributionDetails.copyright.fill(preferLocallyCopyright);
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+    await topBar.gotoAttributionView();
+    await notSavedPopup.assert.isVisible();
+
+    await notSavedPopup.saveButton.click();
+    await changePreferredStatusGloballyPopup.assert.isHidden();
+
+    await topBar.gotoAuditView();
+    await resourceBrowser.goto(resourceName1);
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+    await attributionDetails.assert.copyrightIs(preferLocallyCopyright);
+  });
+
+  await test.step('prefer attribution globally', async () => {
+    await resourceBrowser.goto(resourceName2);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+    await resourceBrowser.goto(resourceName3);
+    await notSavedPopup.assert.isVisible();
+
+    await notSavedPopup.saveGloballyButton.click();
+    await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
+
+    await changePreferredStatusGloballyPopup.okButton.click();
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+  });
+
+  await test.step('unmark preferred globally', async () => {
+    await resourceDetails.attributionCard.assert.preferredIconIsVisible(
+      packageInfo1,
+    );
+
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.unmarkAsPreferred.click();
+    await resourceBrowser.goto(resourceName2);
+    await notSavedPopup.assert.isVisible();
+
+    await notSavedPopup.saveGloballyButton.click();
+    await changePreferredStatusGloballyPopup.assert.unmarkAsPreferredWarningIsVisible();
+
+    await changePreferredStatusGloballyPopup.okButton.click();
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+  });
+});
+
+test('popup is only shown if necessary and undo reverts preference status only', async ({
+  attributionDetails,
+  changePreferredStatusGloballyPopup,
+  notSavedPopup,
+  projectStatisticsPopup,
+  resourceBrowser,
+  resourceDetails,
+  menuBar,
+  topBar,
+}) => {
+  await projectStatisticsPopup.close();
+  await menuBar.toggleQaMode();
+
+  await test.step('popup is not shown if attribution has a single resource', async () => {
+    await resourceBrowser.goto(resourceName4);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo2,
+    );
+
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+    await attributionDetails.saveGloballyButton.isHidden();
+    await resourceBrowser.goto(resourceName3);
+    await notSavedPopup.assert.isVisible();
+
+    await notSavedPopup.saveGloballyButton.isHidden();
+    await notSavedPopup.saveButton.click();
+    await changePreferredStatusGloballyPopup.assert.isHidden();
+  });
+
+  await test.step('cancel button preserves changes and prevents navigating away', async () => {
+    const comment = faker.lorem.sentence();
+
+    await resourceBrowser.goto(resourceName3);
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.hamburgerMenu.markAsPreferred.click();
+
+    await attributionDetails.comment().fill(comment);
+    await topBar.gotoAttributionView();
+    await notSavedPopup.assert.isVisible();
+
+    await notSavedPopup.saveGloballyButton.click();
+    await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
+
+    await changePreferredStatusGloballyPopup.cancelButton.click();
+    await topBar.assert.auditViewIsActive();
+    await resourceDetails.attributionCard.assert.preferredIconIsHidden(
+      packageInfo1,
+    );
+    await attributionDetails.assert.commentIs(comment);
+
+    await attributionDetails.openHamburgerMenu();
+    await attributionDetails.assert.buttonInHamburgerMenuIsVisible(
+      'unmarkAsPreferred',
+    );
+  });
+});

--- a/src/e2e-tests/page-objects/ChangePreferredStatusGloballyPopup.ts
+++ b/src/e2e-tests/page-objects/ChangePreferredStatusGloballyPopup.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { text } from '../../shared/text';
+
+export class ChangePreferredStatusGloballyPopup {
+  private readonly window: Page;
+  private readonly node: Locator;
+  readonly okButton: Locator;
+  readonly cancelButton: Locator;
+
+  constructor(window: Page) {
+    this.window = window;
+    this.node = window.getByLabel('change preferred status globally popup');
+    this.okButton = this.node.getByRole('button', {
+      name: 'Ok',
+      exact: true,
+    });
+    this.cancelButton = this.node.getByRole('button', {
+      name: 'Cancel',
+      exact: true,
+    });
+  }
+
+  public assert = {
+    isVisible: async (): Promise<void> => {
+      await expect(this.node).toBeVisible();
+    },
+    isHidden: async (): Promise<void> => {
+      await expect(this.node).toBeHidden();
+    },
+    markAsPreferredWarningIsVisible: async (): Promise<void> => {
+      await expect(
+        this.node.getByText(
+          text.changePreferredStatusGloballyPopup.markAsPreferred,
+        ),
+      ).toBeVisible();
+    },
+    unmarkAsPreferredWarningIsVisible: async (): Promise<void> => {
+      await expect(
+        this.node.getByText(
+          text.changePreferredStatusGloballyPopup.unmarkAsPreferred,
+        ),
+      ).toBeVisible();
+    },
+  };
+
+  async close(): Promise<void> {
+    await this.window.keyboard.press('Escape');
+  }
+}

--- a/src/e2e-tests/page-objects/PackageCard.ts
+++ b/src/e2e-tests/page-objects/PackageCard.ts
@@ -89,6 +89,10 @@ export class PackageCard {
     return this.node(packageInfo).getByRole('button').getByLabel('add');
   }
 
+  public preferredIcon(packageInfo: PackageInfo): Locator {
+    return this.node(packageInfo).getByLabel('Preferred icon', { exact: true });
+  }
+
   public wasPreferredIcon(packageInfo: PackageInfo): Locator {
     return this.node(packageInfo).getByLabel('was preferred icon');
   }
@@ -114,6 +118,12 @@ export class PackageCard {
     },
     addButtonIsHidden: async (packageInfo: PackageInfo): Promise<void> => {
       await expect(this.addButton(packageInfo)).toBeHidden();
+    },
+    preferredIconIsVisible: async (packageInfo: PackageInfo): Promise<void> => {
+      await expect(this.preferredIcon(packageInfo)).toBeVisible();
+    },
+    preferredIconIsHidden: async (packageInfo: PackageInfo): Promise<void> => {
+      await expect(this.preferredIcon(packageInfo)).toBeHidden();
     },
     wasPreferredIconIsVisible: async (
       packageInfo: PackageInfo,

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -22,6 +22,7 @@ import { AttributionDetails } from '../page-objects/AttributionDetails';
 import { AttributionFilters } from '../page-objects/AttributionFilters';
 import { AttributionList } from '../page-objects/AttributionList';
 import { AttributionWizard } from '../page-objects/AttributionWizard';
+import { ChangePreferredStatusGloballyPopup } from '../page-objects/ChangePreferredStatusGloballyPopup';
 import { ConfirmationPopup } from '../page-objects/ConfirmationPopup';
 import { EditAttributionPopup } from '../page-objects/EditAttributionPopup';
 import { ErrorPopup } from '../page-objects/ErrorPopup';
@@ -58,6 +59,7 @@ export const test = base.extend<{
   attributionFilters: AttributionFilters;
   attributionList: AttributionList;
   attributionWizard: AttributionWizard;
+  changePreferredStatusGloballyPopup: ChangePreferredStatusGloballyPopup;
   confirmationPopup: ConfirmationPopup;
   editAttributionPopup: EditAttributionPopup;
   errorPopup: ErrorPopup;
@@ -143,6 +145,9 @@ export const test = base.extend<{
   },
   fileSearchPopup: async ({ window }, use) => {
     await use(new FileSearchPopup(window));
+  },
+  changePreferredStatusGloballyPopup: async ({ window }, use) => {
+    await use(new ChangePreferredStatusGloballyPopup(window));
   },
   confirmationPopup: async ({ window }, use) => {
     await use(new ConfirmationPopup(window));

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -17,4 +17,9 @@ export const text = {
       searchForPackage: 'Search for package information',
     },
   },
+  changePreferredStatusGloballyPopup: {
+    markAsPreferred: 'Do you really want to prefer the attribution globally?',
+    unmarkAsPreferred:
+      'Do you really want to remove the preferred status globally?',
+  },
 };


### PR DESCRIPTION
### Summary of changes

This PR enables preferring an attribution globally, as well as removing the preferred status again. The user is shown a warning message whenever he is about to save such a global modification of the preferred status.

The commits:
1) create the warning popup
2) enable save globally if attribution is marked or unmarked as preferred
3) open warning popup on save. There are three ways to save and that lead into the warning popup:
 - save globally button
 - via save globally button on unsaved changes warning
 - via menu and hotkey
 4) add integration tests

The warning popup gives the user the choise to proceed with the modification of the preferred status or to undo it.
Undoing it reverts the changes to the preferred status but keeps remaining changes, if there are any.

Currently, modifying the preferred status is only possible in Audit view. I.e. all this changes only take effect in audit view.

![Screenshot 2023-11-21 at 14 57 27](https://github.com/opossum-tool/OpossumUI/assets/82914459/7086304e-dfa4-40c6-a548-3a5175f9b035)
![Screenshot 2023-11-21 at 14 57 54](https://github.com/opossum-tool/OpossumUI/assets/82914459/abe0e71c-f3ed-484e-9836-bd3ed9499f73)


### Context and reason for change

We want to give the user the possibility to mark and unmark attributions as preferred globally. But since that should be handled with caution a user should be alerted and asked for confirmation if he globally saves changes that include marking or unmarking the attribution as preferred.

Closes #2290
Closes #2291 

### How can the changes be tested

Added two integration tests.
Manual testing.