### PR TITLE
feat: add path breadcrumbs

### DIFF
--- a/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
+++ b/src/Frontend/Components/AttributionWizardPopup/AttributionWizardPopup.tsx
@@ -2,13 +2,16 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import MuiNavigateNextIcon from '@mui/icons-material/NavigateNext';
 import MuiBox from '@mui/material/Box';
+import MuiTooltip from '@mui/material/Tooltip';
+import MuiTypography from '@mui/material/Typography';
 import { ReactElement, useState } from 'react';
 import { v4 as uuid4 } from 'uuid';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { ButtonText } from '../../enums/enums';
-import { OpossumColors } from '../../shared-styles';
+import { OpossumColors, tooltipStyle } from '../../shared-styles';
 import { closeAttributionWizardPopup } from '../../state/actions/popup-actions/popup-actions';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import {
@@ -18,6 +21,7 @@ import {
   setAttributionWizardSelectedPackageIds,
 } from '../../state/actions/resource-actions/attribution-wizard-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
+import { getFilesWithChildren } from '../../state/selectors/all-views-resource-selectors';
 import {
   getAttributionWizardPackageNames,
   getAttributionWizardPackageNamespaces,
@@ -26,12 +30,14 @@ import {
   getAttributionWizardTotalAttributionCount,
   getAttributionWizarOriginalDisplayPackageInfo,
 } from '../../state/selectors/attribution-wizard-selectors';
+import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
 import { ButtonConfig } from '../../types/types';
+import { getFileWithChildrenCheck } from '../../util/is-file-with-children';
+import { removeTrailingSlashIfFileWithChildren } from '../../util/remove-trailing-slash-if-file-with-children';
 import { AttributionWizardPackageStep } from '../AttributionWizardPackageStep/AttributionWizardPackageStep';
 import { AttributionWizardVersionStep } from '../AttributionWizardVersionStep/AttributionWizardVersionStep';
 import { Breadcrumbs } from '../Breadcrumbs/Breadcrumbs';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
-import { PathBar } from '../PathBar/PathBar';
 import {
   getAttributionWizardListItems,
   getSelectedPackageAttributes,
@@ -59,10 +65,6 @@ const classes = {
     marginTop: '15px',
     height: `calc(100% - ${PATH_BAR_TOTAL_HEIGHT}px - ${BREADCRUMBS_TOTAL_HEIGHT}px)`,
   },
-  pathBar: {
-    margin: '24px 0px 12px 0px',
-    padding: '1px 0px 1px 5px',
-  },
   breadcrumbs: {
     height: `calc(${BREADCRUMBS_TOTAL_HEIGHT}px - 20px)`,
     marginBottom: '20px',
@@ -73,6 +75,22 @@ const classes = {
   list: {
     width: `${TABLE_WIDTH}px`,
   },
+  pathBar: {
+    margin: '24px 0px 12px 0px',
+    padding: '1px 0px 1px 5px',
+    height: '24px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    background: OpossumColors.white,
+  },
+  leftEllipsis: {
+    textOverflow: 'ellipsis',
+    overflowX: 'hidden',
+    whiteSpace: 'nowrap',
+    direction: 'rtl',
+  },
+  tooltip: tooltipStyle,
 };
 
 export function AttributionWizardPopup(): ReactElement {
@@ -90,6 +108,9 @@ export function AttributionWizardPopup(): ReactElement {
   const totalAttributionCount = useAppSelector(
     getAttributionWizardTotalAttributionCount,
   );
+  const path = useAppSelector(getSelectedResourceId);
+  const filesWithChildren = useAppSelector(getFilesWithChildren);
+  const isFileWithChildren = getFileWithChildrenCheck(filesWithChildren);
 
   const {
     selectedPackageNamespace,
@@ -266,11 +287,23 @@ export function AttributionWizardPopup(): ReactElement {
       contentSx={classes.dialogContent}
       content={
         <>
-          <PathBar sx={classes.pathBar} />
+          <MuiBox sx={classes.pathBar}>
+            <MuiTooltip sx={classes.tooltip} title={path}>
+              <MuiTypography sx={classes.leftEllipsis} variant={'subtitle1'}>
+                <bdi>
+                  {removeTrailingSlashIfFileWithChildren(
+                    path,
+                    isFileWithChildren,
+                  )}
+                </bdi>
+              </MuiTypography>
+            </MuiTooltip>
+          </MuiBox>
           <Breadcrumbs
             selectedId={selectedWizardStepId}
             onClick={handleBreadcrumbsClick}
             idsToDisplayValues={wizardStepIdsToDisplayValues}
+            separator={<MuiNavigateNextIcon fontSize="inherit" />}
             sx={classes.breadcrumbs}
           />
           <MuiBox sx={classes.mainContentBox}>

--- a/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import MuiNavigateNextIcon from '@mui/icons-material/NavigateNext';
 import MuiBreadcrumbs from '@mui/material/Breadcrumbs';
 import MuiListItemButton from '@mui/material/ListItemButton';
 import MuiTypography from '@mui/material/Typography';
@@ -47,6 +46,8 @@ interface BreadcrumbsProps {
   onClick: (id: string) => void;
   idsToDisplayValues: Array<[string, string]>;
   sx?: SxProps;
+  maxItems?: number;
+  separator?: React.ReactNode;
 }
 
 export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
@@ -57,7 +58,9 @@ export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
   return (
     <MuiBreadcrumbs
       sx={{ ...classes.breadcrumbs, ...props.sx }}
-      separator={<MuiNavigateNextIcon fontSize="inherit" />}
+      separator={props.separator}
+      maxItems={props.maxItems}
+      itemsAfterCollapse={3}
     >
       {ids.map((id, index) => (
         <MuiListItemButton

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -20,7 +20,7 @@ import { getSelectedResourceId } from '../../state/selectors/audit-view-resource
 import { getAttributionBreakpointCheck } from '../../util/is-attribution-breakpoint';
 import { IconButton } from '../IconButton/IconButton';
 
-export function GoToLinkButton(): ReactElement {
+export function GoToLinkButton(): ReactElement | null {
   const path = useAppSelector(getSelectedResourceId);
   const baseUrlsForSources = useAppSelector(getBaseUrlsForSources);
   const attributionBreakpoints = useAppSelector(getAttributionBreakpoints);
@@ -79,17 +79,16 @@ export function GoToLinkButton(): ReactElement {
     });
   }
 
-  return (
+  return openLinkArgs.link ? (
     <IconButton
       tooltipTitle={
         isLocalLink(openLinkArgs.link)
           ? 'open file'
           : 'open resource in browser'
       }
-      tooltipPlacement="right"
+      tooltipPlacement="left"
       onClick={onClick}
-      hidden={!openLinkArgs.link}
       icon={<OpenInNewIcon sx={clickableIcon} aria-label={'link to open'} />}
     />
-  );
+  ) : null;
 }

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -56,8 +56,6 @@ describe('The GoToLinkButton', () => {
     store.dispatch(setSelectedResourceId(parentPath));
     store.dispatch(setBaseUrlsForSources(testBaseUrlsForSources));
 
-    expect(screen.getByLabelText('link to open')).toHaveStyle(
-      'visibility: hidden',
-    );
+    expect(screen.queryByLabelText('link to open')).not.toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -31,6 +31,7 @@ export function IconButton(props: IconButtonProps): ReactElement {
   return (
     <MuiTooltip
       describeChild={true}
+      disableInteractive
       title={props.hidden ? '' : props.tooltipTitle}
       placement={props.tooltipPlacement}
     >

--- a/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
+++ b/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
@@ -2,26 +2,41 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { act, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { compact } from 'lodash';
 
-import { setFilesWithChildren } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  setBaseUrlsForSources,
+  setFilesWithChildren,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { setSelectedResourceId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { renderComponentWithStore } from '../../../test-helpers/render-component-with-store';
 import { PathBar } from '../PathBar';
 
+const writeText = jest.fn();
+
 describe('The PathBar', () => {
+  beforeAll(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+  });
+
   it('renders a path', () => {
-    const testPath = '/test_path';
+    const testPath = '/test/path/foo/bar/';
+    const pathElements = compact(testPath.split('/'));
 
     const { store } = renderComponentWithStore(<PathBar />);
     act(() => {
       store.dispatch(setSelectedResourceId(testPath));
     });
 
-    expect(screen.getByText(testPath));
+    pathElements.forEach((element) => {
+      expect(screen.getByText(element));
+    });
   });
 
-  it('renders a path of a file with children', () => {
+  it('copies path to clipboard', () => {
     const testPath = '/test_path/';
 
     const { store } = renderComponentWithStore(<PathBar />);
@@ -30,6 +45,28 @@ describe('The PathBar', () => {
       store.dispatch(setFilesWithChildren(new Set<string>().add(testPath)));
     });
 
-    expect(screen.getByText(testPath.slice(0, -1)));
+    fireEvent.click(screen.getByLabelText('copy path'));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith('test_path');
+  });
+
+  it('opens path URL in browser', () => {
+    const testPath = '/test_path/';
+
+    const { store } = renderComponentWithStore(<PathBar />);
+    act(() => {
+      store.dispatch(setSelectedResourceId(testPath));
+      store.dispatch(setFilesWithChildren(new Set<string>().add(testPath)));
+      store.dispatch(
+        setBaseUrlsForSources({
+          [testPath]: 'https://www.othertesturl.com/code/{path}',
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByLabelText('open resource in browser'));
+
+    expect(window.electronAPI.openLink).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/Frontend/test-helpers/attribution-column-test-helpers.ts
+++ b/src/Frontend/test-helpers/attribution-column-test-helpers.ts
@@ -120,13 +120,11 @@ function getGoToLinkIcon(screen: Screen, label: string): HTMLElement {
 }
 
 export function expectGoToLinkIconIsVisible(screen: Screen): void {
-  expect(getGoToLinkIcon(screen, 'link to open').parentElement).toBeVisible();
+  expect(getGoToLinkIcon(screen, 'link to open')).toBeInTheDocument();
 }
 
 export function expectGoToLinkIconIsNotVisible(screen: Screen): void {
-  expect(
-    getGoToLinkIcon(screen, 'link to open').parentElement,
-  ).not.toBeVisible();
+  expect(screen.queryByLabelText('link to open')).not.toBeInTheDocument();
 }
 
 export function clickGoToLinkIcon(screen: Screen, label: string): void {

--- a/src/e2e-tests/page-objects/ResourceDetails.ts
+++ b/src/e2e-tests/page-objects/ResourceDetails.ts
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import { faker } from '../../shared/Faker';
 import { PackageCard } from './PackageCard';
 
 export class ResourceDetails {
@@ -18,6 +17,7 @@ export class ResourceDetails {
   readonly attributionsInFolderContentPanel: Locator;
   readonly attributionsInFolderContentToggle: Locator;
   readonly openResourceUrlButton: Locator;
+  readonly copyPathButton: Locator;
   readonly overrideParentButton: Locator;
   readonly addNewAttributionButton: Locator;
   readonly localTab: Locator;
@@ -51,6 +51,7 @@ export class ResourceDetails {
     this.openResourceUrlButton = this.node
       .getByRole('button')
       .getByLabel('link to open');
+    this.copyPathButton = this.node.getByRole('button').getByLabel('copy path');
     this.overrideParentButton = this.attributions.getByRole('button', {
       name: 'override parent',
     });
@@ -65,9 +66,13 @@ export class ResourceDetails {
 
   public assert = {
     resourcePathIsVisible: async (...elements: string[]): Promise<void> => {
-      await expect(
-        this.node.getByText(faker.opossum.filePath(...elements)),
-      ).toBeVisible();
+      await Promise.all(
+        elements.map((element) =>
+          expect(
+            this.node.getByLabel('path bar').getByText(element),
+          ).toBeVisible(),
+        ),
+      );
     },
     globalTabIsEnabled: async (): Promise<void> => {
       await expect(this.globalTab).toBeEnabled();

--- a/src/e2e-tests/playwright.config.ts
+++ b/src/e2e-tests/playwright.config.ts
@@ -5,7 +5,7 @@
 import { PlaywrightTestConfig } from '@playwright/test';
 
 const CI_SINGLE_TEST_TIMEOUT = 60000;
-const GLOBAL_TIMEOUT = 300000;
+const GLOBAL_TIMEOUT = 3000000;
 
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,11 @@ export default defineConfig(({ mode }) => ({
   build: {
     outDir: 'build',
   },
+  resolve: {
+    alias: {
+      path: 'path-browserify',
+    },
+  },
   optimizeDeps: {
     include: ['@mui/material/Tooltip'], // https://github.com/mui/material-ui/issues/32727
   },


### PR DESCRIPTION
### Summary of changes

- convert path bar to a component that renders clickable breadcrumbs instead of a static path
- add button to copy path to clipboard which works on all OS
- keep path in Attribution Wizard unchanged

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/8c2b5c0d-9c52-49ea-8ad1-a98cce958c90)

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/82e768b9-dddc-4285-b9cd-bc4c8e8db5cf)

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/0e700511-d49f-4c70-bc16-4ed60a4d330b)

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/15ee27ab-80d5-4860-a79a-0ea5dc574bdf)

### Context and reason for change

Closes #1501.

### How can the changes be tested

File with resources which are nested 10 levels deep:
[input.json](https://github.com/opossum-tool/OpossumUI/files/13333743/input.json)