### PR TITLE
feat: trigger test runs on renovate branches

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'renovate/*'
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'renovate/*'
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'renovate/*'
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
### Summary of changes

- this is needed to enable the `automergeType: 'branch'` configuration of renovate which is waiting for green tests on branches without a PR
