### PR TITLE
Restyle license search in Locator Popup

### DIFF
--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import MuiAutocomplete from '@mui/material/Autocomplete';
 import MuiBox from '@mui/material/Box';
+import MuiTextField from '@mui/material/TextField';
 import MuiTypography from '@mui/material/Typography';
 import { ChangeEvent, ReactElement, useState } from 'react';
 
@@ -26,16 +28,28 @@ import {
 } from '../../state/selectors/locate-popup-selectors';
 import { compareAlphabeticalStrings } from '../../util/get-alphabetical-comparer';
 import { Checkbox } from '../Checkbox/Checkbox';
-import { AutoComplete } from '../InputElements/AutoComplete';
 import { Dropdown, menuItem } from '../InputElements/Dropdown';
+import { inputElementClasses } from '../InputElements/shared';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { SearchTextField } from '../SearchTextField/SearchTextField';
 
 const classes = {
+  ...inputElementClasses,
   dropdown: {
     marginTop: '8px',
   },
   autocomplete: { marginTop: '12px' },
+  autocompleteInput: {
+    '& .MuiInputLabel-root': {
+      top: '2px',
+    },
+    '& .MuiInputBase-input': {
+      height: '24px',
+    },
+    '& .MuiInputBase-root': {
+      borderRadius: '0px',
+    },
+  },
   noSignalsMessage: { color: OpossumColors.red, marginTop: '8px' },
   dialogContent: {
     width: '25vw',
@@ -166,25 +180,28 @@ export function LocatorPopup(): ReactElement {
         menuItems={criticalityMenuItems}
         handleChange={updateCriticalityDropdownChoice}
       />
-      <AutoComplete
-        isEditable={true}
-        sx={classes.autocomplete}
+      <MuiAutocomplete
         title={'License'}
-        handleChange={(event: ChangeEvent<HTMLInputElement>): void => {
-          const values =
-            typeof event.target.value === 'string'
-              ? new Set([event.target.value])
-              : new Set(event.target.value as Array<string>);
-          setSearchedLicenses(values);
-        }}
-        isHighlighted={false}
+        sx={classes.autocomplete}
+        multiple
         options={licenseNameOptions.sort((a, b) =>
           compareAlphabeticalStrings(a, b),
         )}
+        size={'small'}
+        filterSelectedOptions
+        aria-label={'auto complete'}
+        getOptionLabel={(option): string => option}
         value={[...searchedLicenses]}
-        showTextBold={false}
-        multiple={true}
-        formatOptionForDisplay={(option: string): string => option}
+        onChange={(_event, searchedLicenses): void => {
+          setSearchedLicenses(new Set(searchedLicenses));
+        }}
+        renderInput={(params): ReactElement => (
+          <MuiTextField
+            {...params}
+            label="License"
+            sx={classes.autocompleteInput}
+          />
+        )}
       />
       {showNoSignalsLocatedMessage ? (
         <MuiTypography variant={'subtitle2'} sx={classes.noSignalsMessage}>


### PR DESCRIPTION
### Summary of changes
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/250c7d84-ae58-4b03-8c65-396c3039d730)
### Context and reason for change

Fixes #2266

### How can the changes be tested

Only style changes, green CI shows that the functionality to filter for licenses didn't break.

