### PR TITLE
feat: add browser history

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "re-resizable": "^6.9.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hotkeys-hook": "^4.4.1",
     "react-redux": "^8.1.3",
     "react-virtuoso": "^4.6.2",
     "recharts": "^2.9.3",

--- a/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/Frontend/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -14,15 +14,12 @@ const classes = {
   breadcrumbs: {
     color: OpossumColors.black,
     '.MuiBreadcrumbs-separator': {
-      margin: '0px',
+      margin: '0 2px',
     },
   },
   breadcrumbsButton: {
     padding: '1px 4px',
     backgroundColor: OpossumColors.lightestBlue,
-    '&:hover': {
-      backgroundColor: OpossumColors.lightestBlue,
-    },
     '&:loading': {
       backgroundColor: OpossumColors.lightestBlue,
     },
@@ -42,7 +39,7 @@ const classes = {
 };
 
 interface BreadcrumbsProps {
-  selectedId: string;
+  selectedId?: string;
   onClick: (id: string) => void;
   idsToDisplayValues: Array<[string, string]>;
   sx?: SxProps;
@@ -69,7 +66,9 @@ export function Breadcrumbs(props: BreadcrumbsProps): ReactElement {
           selected={props.selectedId === id}
           onClick={(): void => props.onClick(id)}
           disableRipple={true}
-          disabled={index >= ids.indexOf(props.selectedId)}
+          disabled={
+            !!props.selectedId && index >= ids.indexOf(props.selectedId)
+          }
         >
           <MuiTypography
             sx={props.selectedId === id ? classes.breadcrumbsSelected : null}

--- a/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
+++ b/src/Frontend/Components/FetchLicenseInformationButton/__tests__/FetchLicenseInformationButton.test.tsx
@@ -36,6 +36,8 @@ import {
 } from '../github-fetching-helpers';
 import { getPypiAPIUrl } from '../pypi-fetching-helpers';
 
+jest.useFakeTimers();
+
 const axiosMock = new MockAdapter(axios);
 
 describe('FetchLicenseInformationButton', () => {
@@ -82,6 +84,7 @@ describe('FetchLicenseInformationButton', () => {
 
       fireEvent.click(screen.getByRole('button'));
       fireEvent.mouseOver(screen.getByRole('button'));
+      jest.runAllTimers();
 
       expect(await screen.findByText('Network Error')).toBeInTheDocument();
     });
@@ -98,6 +101,7 @@ describe('FetchLicenseInformationButton', () => {
 
       fireEvent.click(screen.getByRole('button'));
       fireEvent.mouseOver(screen.getByRole('button'));
+      jest.runAllTimers();
 
       expect(
         await screen.findByText('Request failed with status code 404'),
@@ -121,6 +125,7 @@ describe('FetchLicenseInformationButton', () => {
 
       fireEvent.click(screen.getByRole('button'));
       fireEvent.mouseOver(screen.getByRole('button'));
+      jest.runAllTimers();
 
       expect(await screen.findByText(FETCH_DATA_TOOLTIP)).toBeInTheDocument();
     });

--- a/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
+++ b/src/Frontend/Components/GoToLinkButton/GoToLinkButton.tsx
@@ -8,7 +8,7 @@ import { ReactElement } from 'react';
 
 import { OpenLinkArgs } from '../../../shared/shared-types';
 import { PopupType } from '../../enums/enums';
-import { clickableIcon } from '../../shared-styles';
+import { clickableIcon, disabledIcon } from '../../shared-styles';
 import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { getParents } from '../../state/helpers/get-parents';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
@@ -79,16 +79,24 @@ export function GoToLinkButton(): ReactElement | null {
     });
   }
 
-  return openLinkArgs.link ? (
+  return (
     <IconButton
       tooltipTitle={
-        isLocalLink(openLinkArgs.link)
-          ? 'open file'
-          : 'open resource in browser'
+        openLinkArgs.link
+          ? isLocalLink(openLinkArgs.link)
+            ? 'Open file'
+            : 'Open resource in browser'
+          : 'No link available'
       }
       tooltipPlacement="left"
       onClick={onClick}
-      icon={<OpenInNewIcon sx={clickableIcon} aria-label={'link to open'} />}
+      icon={
+        <OpenInNewIcon
+          sx={openLinkArgs.link ? clickableIcon : disabledIcon}
+          aria-label={'link to open'}
+        />
+      }
+      disabled={!openLinkArgs.link}
     />
-  ) : null;
+  );
 }

--- a/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
+++ b/src/Frontend/Components/GoToLinkButton/__tests__/GoToLinkButton.test.tsx
@@ -39,7 +39,9 @@ describe('The GoToLinkButton', () => {
       });
 
       expect(window.electronAPI.openLink).toHaveBeenCalledTimes(0);
-      expect(screen.getByLabelText('link to open'));
+      expect(
+        screen.getByLabelText('Open resource in browser'),
+      ).toBeInTheDocument();
       clickGoToLinkIcon(screen, 'link to open');
 
       expect(window.electronAPI.openLink).toHaveBeenCalledTimes(1);
@@ -56,6 +58,6 @@ describe('The GoToLinkButton', () => {
     store.dispatch(setSelectedResourceId(parentPath));
     store.dispatch(setBaseUrlsForSources(testBaseUrlsForSources));
 
-    expect(screen.queryByLabelText('link to open')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('No link available')).toBeInTheDocument();
   });
 });

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -34,6 +34,7 @@ export function IconButton(props: IconButtonProps): ReactElement {
       disableInteractive
       title={props.hidden ? '' : props.tooltipTitle}
       placement={props.tooltipPlacement}
+      enterDelay={1500}
     >
       <MuiBox component="span" sx={props.containerSx}>
         {

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
-import { ReactElement } from 'react';
-import { Virtuoso } from 'react-virtuoso';
+import { ReactElement, useEffect, useRef } from 'react';
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
 const classes = {
   scrollChild: {
@@ -33,6 +33,7 @@ export function List({
   length,
   ...props
 }: Props): ReactElement {
+  const ref = useRef<VirtuosoHandle>(null);
   const maxHeight = ((): number | undefined => {
     if ('maxHeight' in props) {
       return props.maxHeight;
@@ -44,16 +45,19 @@ export function List({
   })();
   const currentHeight = length * cardHeight;
 
+  useEffect(() => {
+    if (indexToScrollTo && ref.current) {
+      ref.current.scrollToIndex({
+        index: indexToScrollTo,
+        align: 'center',
+        behavior: 'smooth',
+      });
+    }
+  }, [indexToScrollTo]);
+
   return (
     <Virtuoso
-      initialTopMostItemIndex={
-        window?.process?.env.JEST_WORKER_ID // https://github.com/petyosi/react-virtuoso/issues/1001
-          ? undefined
-          : {
-              index: indexToScrollTo,
-              align: 'center',
-            }
-      }
+      ref={ref}
       fixedItemHeight={cardHeight}
       totalCount={length}
       style={{

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -8,10 +8,11 @@ import MuiDialogActions from '@mui/material/DialogActions';
 import MuiDialogContent from '@mui/material/DialogContent';
 import MuiDialogContentText from '@mui/material/DialogContentText';
 import MuiDialogTitle from '@mui/material/DialogTitle';
-import { ReactElement, useEffect } from 'react';
+import { noop } from 'lodash';
+import { ReactElement } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 
 import { ButtonConfig } from '../../types/types';
-import { doNothing } from '../../util/do-nothing';
 import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 import { Button } from '../Button/Button';
 
@@ -38,29 +39,7 @@ interface NotificationPopupProps {
 }
 
 export function NotificationPopup(props: NotificationPopupProps): ReactElement {
-  const onEscapeKeyDown = props.onEscapeKeyDown
-    ? props.onEscapeKeyDown
-    : doNothing;
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        onEscapeKeyDown();
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return (): void => window.removeEventListener('keydown', onKeyDown);
-  }, [onEscapeKeyDown]);
-
-  function handleOnClose(_: unknown, reason: string): void {
-    switch (reason) {
-      case 'backdropClick':
-        if (props.onBackdropClick) {
-          props.onBackdropClick();
-        }
-        break;
-    }
-  }
+  useHotkeys('esc', props.onEscapeKeyDown || noop, [props.onEscapeKeyDown]);
 
   return (
     <MuiDialog
@@ -68,7 +47,9 @@ export function NotificationPopup(props: NotificationPopupProps): ReactElement {
       maxWidth={'xl'}
       open={props.isOpen}
       disableEscapeKeyDown={true}
-      onClose={handleOnClose}
+      onClose={(_, reason) =>
+        reason === 'backdropClick' && props.onBackdropClick?.()
+      }
       PaperProps={{ sx: props.fullHeight ? classes.fullHeightPaper : {} }}
       aria-label={props['aria-label']}
     >

--- a/src/Frontend/Components/PathBar/PathBar.tsx
+++ b/src/Frontend/Components/PathBar/PathBar.tsx
@@ -2,15 +2,24 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import MuiBox from '@mui/material/Box';
-import { compact } from 'lodash';
-import { ReactElement } from 'react';
+import { compact, uniq } from 'lodash';
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 
-import { clickableIcon } from '../../shared-styles';
+import { clickableIcon, disabledIcon } from '../../shared-styles';
 import { setSelectedResourceIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
+import { setExpandedIds } from '../../state/actions/resource-actions/audit-view-simple-actions';
+import { getParents } from '../../state/helpers/get-parents';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import { getSelectedResourceId } from '../../state/selectors/audit-view-resource-selectors';
+import {
+  getExpandedIds,
+  getSelectedResourceId,
+} from '../../state/selectors/audit-view-resource-selectors';
+import { usePrevious } from '../../util/use-previous';
 import { Breadcrumbs } from '../Breadcrumbs/Breadcrumbs';
 import { GoToLinkButton } from '../GoToLinkButton/GoToLinkButton';
 import { IconButton } from '../IconButton/IconButton';
@@ -20,46 +29,153 @@ const classes = {
     padding: '0 6px',
     display: 'flex',
     alignItems: 'center',
+    minHeight: '24px',
   },
 };
 
 export function PathBar(): ReactElement | null {
   const resourceId = useAppSelector(getSelectedResourceId);
+  const expandedIds = useAppSelector(getExpandedIds);
   const dispatch = useAppDispatch();
+  const [history, setHistory] = useState<string[]>([resourceId]);
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+  const activeResourceId = history[activeIndex];
+  const previousActiveResourceId = usePrevious(activeResourceId);
+  const isGoBackEnabled = !!activeIndex;
+  const isGoForwardEnabled = activeIndex !== history.length - 1;
 
   const pathElements = compact(resourceId.split('/'));
 
-  const getPathToResource = (resourceName: string): string => {
-    const elements = resourceId.split('/');
-    return elements
-      .slice(0, elements.indexOf(resourceName) + 1)
-      .concat('')
-      .join('/');
-  };
+  const cmdOrCtrl = useMemo(
+    () => (window.navigator.platform.match(/^Mac/) ? '⌘' : 'Ctrl'),
+    [],
+  );
 
-  return pathElements.length > 0 ? (
+  const handleGoBack = useCallback((): void => {
+    if (activeIndex > 0) {
+      setActiveIndex((prev) => prev - 1);
+      dispatch(
+        setSelectedResourceIdOrOpenUnsavedPopup(history[activeIndex - 1]),
+      );
+    }
+  }, [activeIndex, dispatch, history]);
+
+  const handleGoForward = useCallback((): void => {
+    if (activeIndex < history.length - 1) {
+      setActiveIndex((prev) => prev + 1);
+      dispatch(
+        setSelectedResourceIdOrOpenUnsavedPopup(history[activeIndex + 1]),
+      );
+    }
+  }, [activeIndex, dispatch, history]);
+
+  useHotkeys('mod+ArrowLeft', handleGoBack, { enabled: isGoBackEnabled }, [
+    activeIndex,
+    history,
+  ]);
+
+  useHotkeys(
+    'mod+ArrowRight',
+    handleGoForward,
+    { enabled: isGoForwardEnabled },
+    [activeIndex, history],
+  );
+
+  useEffect(() => {
+    if (resourceId && activeResourceId !== resourceId) {
+      setHistory((prev) => prev.slice(0, activeIndex + 1).concat(resourceId));
+      setActiveIndex((prev) => prev + 1);
+    }
+  }, [activeIndex, activeResourceId, resourceId]);
+
+  useEffect(() => {
+    if (
+      activeResourceId !== previousActiveResourceId &&
+      !expandedIds.includes(activeResourceId)
+    ) {
+      dispatch(
+        setExpandedIds(
+          uniq([
+            ...expandedIds,
+            ...getParents(activeResourceId),
+            activeResourceId,
+          ]),
+        ),
+      );
+    }
+  }, [activeResourceId, dispatch, expandedIds, previousActiveResourceId]);
+
+  return (
     <MuiBox aria-label={'path bar'} sx={classes.root}>
-      <IconButton
-        icon={<ContentCopyIcon aria-label={'copy path'} sx={clickableIcon} />}
-        onClick={async (): Promise<void> => {
-          await navigator.clipboard.writeText(pathElements.join('/'));
-        }}
-        tooltipPlacement={'left'}
-        tooltipTitle={'copy path to clipboard'}
-        aria-label={'copy path'}
-      />
-      <GoToLinkButton />
+      {renderActions()}
+      {renderBreadcrumbs()}
+    </MuiBox>
+  );
+
+  function renderActions(): ReactElement {
+    return (
+      <>
+        <IconButton
+          icon={
+            <ArrowBackIcon
+              aria-label={'go back'}
+              sx={isGoBackEnabled ? clickableIcon : disabledIcon}
+            />
+          }
+          onClick={handleGoBack}
+          tooltipPlacement={'left'}
+          tooltipTitle={`Go back (${cmdOrCtrl} + Left arrow)`}
+          disabled={!isGoBackEnabled}
+        />
+        <IconButton
+          icon={
+            <ArrowForwardIcon
+              aria-label={'go forward'}
+              sx={isGoForwardEnabled ? clickableIcon : disabledIcon}
+            />
+          }
+          onClick={handleGoForward}
+          tooltipPlacement={'left'}
+          tooltipTitle={`Go forward (${cmdOrCtrl} + Right arrow)`}
+          disabled={!isGoForwardEnabled}
+        />
+        <IconButton
+          icon={<ContentCopyIcon aria-label={'copy path'} sx={clickableIcon} />}
+          onClick={(): Promise<void> =>
+            navigator.clipboard.writeText(pathElements.join('/'))
+          }
+          tooltipPlacement={'left'}
+          tooltipTitle={'Copy path to clipboard'}
+          aria-label={'copy path'}
+        />
+        <GoToLinkButton />
+      </>
+    );
+  }
+
+  function renderBreadcrumbs(): ReactElement {
+    const getResourceId = (resourceName: string): string => {
+      const elements = resourceId.split('/');
+      return elements
+        .slice(0, elements.indexOf(resourceName) + 1)
+        .concat('')
+        .join('/');
+    };
+
+    return (
       <Breadcrumbs
         idsToDisplayValues={pathElements.map((element) => [element, element])}
         maxItems={5}
-        onClick={(id): void =>
+        onClick={(resourceName): void =>
           dispatch(
-            setSelectedResourceIdOrOpenUnsavedPopup(getPathToResource(id)),
+            setSelectedResourceIdOrOpenUnsavedPopup(
+              getResourceId(resourceName),
+            ),
           )
         }
         key={resourceId}
         selectedId={pathElements[pathElements.length - 1]}
       />
-    </MuiBox>
-  ) : null;
+    );
+  }
 }

--- a/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
+++ b/src/Frontend/Components/PathBar/__tests__/PathBar.test.tsx
@@ -65,7 +65,7 @@ describe('The PathBar', () => {
       );
     });
 
-    fireEvent.click(screen.getByLabelText('open resource in browser'));
+    fireEvent.click(screen.getByLabelText('link to open'));
 
     expect(window.electronAPI.openLink).toHaveBeenCalledTimes(1);
   });

--- a/src/Frontend/util/use-previous.ts
+++ b/src/Frontend/util/use-previous.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useRef } from 'react';
+
+export function usePrevious<T>(value: T, fallback: T): T;
+export function usePrevious<T>(value: T, fallback?: T): T | undefined;
+export function usePrevious<T>(value: T, fallback?: T): T | undefined {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current ?? fallback;
+}

--- a/src/e2e-tests/__tests__/browsing-resources.test.ts
+++ b/src/e2e-tests/__tests__/browsing-resources.test.ts
@@ -43,7 +43,7 @@ test.use({
   },
 });
 
-test('shows expected resources as user browses through resources or clicks on progress bar', async ({
+test('shows expected resources as user browses through resources', async ({
   projectStatisticsPopup,
   resourceBrowser,
 }) => {
@@ -92,4 +92,62 @@ test('cycles through resources as user clicks on progress bar', async ({
 
   await topBar.progressBar.click();
   await resourceDetails.signalCard.assert.isVisible(packageInfo2);
+});
+
+test('shows expected breadcrumbs as user navigates through path bar', async ({
+  modKey,
+  projectStatisticsPopup,
+  resourceBrowser,
+  resourceDetails,
+  window,
+}) => {
+  await projectStatisticsPopup.close();
+  await resourceBrowser.gotoRoot();
+  await resourceDetails.assert.goBackButtonIsDisabled();
+  await resourceDetails.assert.goForwardButtonIsDisabled();
+
+  await resourceBrowser.goto(resourceName1, resourceName2, resourceName3);
+  await resourceDetails.assert.goBackButtonIsEnabled();
+  await resourceDetails.assert.goForwardButtonIsDisabled();
+  await resourceDetails.assert.breadcrumbsAreVisible(
+    resourceName1,
+    resourceName2,
+    resourceName3,
+  );
+
+  await resourceDetails.goBackButton.click();
+  await resourceDetails.assert.goForwardButtonIsEnabled();
+  await resourceDetails.assert.breadcrumbsAreVisible(
+    resourceName1,
+    resourceName2,
+  );
+  await resourceDetails.assert.breadcrumbsAreHidden(resourceName3);
+
+  await resourceDetails.goForwardButton.click();
+  await resourceDetails.assert.breadcrumbsAreVisible(
+    resourceName1,
+    resourceName2,
+    resourceName3,
+  );
+
+  await resourceDetails.clickOnBreadcrumb(resourceName1);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName1);
+  await resourceDetails.assert.breadcrumbsAreHidden(
+    resourceName2,
+    resourceName3,
+  );
+
+  await window.keyboard.press(`${modKey}+ArrowLeft`);
+  await resourceDetails.assert.breadcrumbsAreVisible(
+    resourceName1,
+    resourceName2,
+    resourceName3,
+  );
+
+  await window.keyboard.press(`${modKey}+ArrowRight`);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName1);
+  await resourceDetails.assert.breadcrumbsAreHidden(
+    resourceName2,
+    resourceName3,
+  );
 });

--- a/src/e2e-tests/__tests__/opening-invalid-resource-urls.test.ts
+++ b/src/e2e-tests/__tests__/opening-invalid-resource-urls.test.ts
@@ -38,11 +38,11 @@ test('displays an error if user attempts to open invalid resource URL', async ({
 }) => {
   await projectStatisticsPopup.close();
   await resourceBrowser.goto(resourceName1, resourceName3);
-  await resourceDetails.assert.resourcePathIsVisible(
+  await resourceDetails.assert.breadcrumbsAreVisible(
     resourceName1,
     resourceName3,
   );
-  await resourceDetails.assert.openResourceUrlButtonIsVisible();
+  await resourceDetails.assert.openResourceUrlButtonIsEnabled();
 
   await resourceDetails.openResourceUrl();
   await errorPopup.assert.isVisible();
@@ -52,5 +52,5 @@ test('displays an error if user attempts to open invalid resource URL', async ({
   await errorPopup.assert.isHidden();
 
   await resourceBrowser.goto(resourceName2);
-  await resourceDetails.assert.openResourceUrlButtonIsHidden();
+  await resourceDetails.assert.openResourceUrlButtonIsDisabled();
 });

--- a/src/e2e-tests/__tests__/showing-resources-belonging-to-attributions.test.ts
+++ b/src/e2e-tests/__tests__/showing-resources-belonging-to-attributions.test.ts
@@ -63,20 +63,20 @@ test('shows resources belonging to attributions', async ({
   await resourcePathPopup.assert.titleIsVisible();
 
   await resourcePathPopup.goto(resourceName1);
-  await resourceDetails.assert.resourcePathIsVisible(resourceName1);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName1);
   await resourceDetails.signalCard.assert.isVisible(externalPackageInfo);
 
   await resourceDetails.attributionCard.openContextMenu(manualPackageInfo1);
   await resourceDetails.attributionCard.contextMenu.showResourcesButton.click();
   await resourcePathPopup.goto(resourceName4);
-  await resourceDetails.assert.resourcePathIsVisible(resourceName4);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName4);
   await attributionDetails.assert.matchesPackageInfo(manualPackageInfo1);
 
   await resourceDetails.gotoGlobalTab();
   await resourceDetails.signalCard.openContextMenu(manualPackageInfo2);
   await resourceDetails.signalCard.contextMenu.showResourcesButton.click();
   await resourcePathPopup.goto(resourceName3);
-  await resourceDetails.assert.resourcePathIsVisible(resourceName3);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName3);
   await attributionDetails.assert.matchesPackageInfo(manualPackageInfo2);
 
   await topBar.gotoAttributionView();
@@ -90,5 +90,5 @@ test('shows resources belonging to attributions', async ({
   await topBar.gotoAttributionView();
   await attributionList.attributionCard.click(manualPackageInfo1);
   await resourceBrowser.goto(resourceName1);
-  await resourceDetails.assert.resourcePathIsVisible(resourceName1);
+  await resourceDetails.assert.breadcrumbsAreVisible(resourceName1);
 });

--- a/src/e2e-tests/page-objects/ResourceDetails.ts
+++ b/src/e2e-tests/page-objects/ResourceDetails.ts
@@ -18,12 +18,15 @@ export class ResourceDetails {
   readonly attributionsInFolderContentToggle: Locator;
   readonly openResourceUrlButton: Locator;
   readonly copyPathButton: Locator;
+  readonly goBackButton: Locator;
+  readonly goForwardButton: Locator;
   readonly overrideParentButton: Locator;
   readonly addNewAttributionButton: Locator;
   readonly localTab: Locator;
   readonly globalTab: Locator;
   readonly attributionCard: PackageCard;
   readonly signalCard: PackageCard;
+  readonly pathBar: Locator;
 
   constructor(window: Page) {
     this.node = window.getByLabel('resource details');
@@ -52,6 +55,10 @@ export class ResourceDetails {
       .getByRole('button')
       .getByLabel('link to open');
     this.copyPathButton = this.node.getByRole('button').getByLabel('copy path');
+    this.goBackButton = this.node.getByRole('button').getByLabel('go back');
+    this.goForwardButton = this.node
+      .getByRole('button')
+      .getByLabel('go forward');
     this.overrideParentButton = this.attributions.getByRole('button', {
       name: 'override parent',
     });
@@ -62,23 +69,29 @@ export class ResourceDetails {
     this.globalTab = this.node.getByLabel('global tab');
     this.attributionCard = new PackageCard(window, this.attributions);
     this.signalCard = new PackageCard(window, this.signals);
+    this.pathBar = this.node.getByLabel('path bar');
   }
 
   public assert = {
-    resourcePathIsVisible: async (...elements: string[]): Promise<void> => {
+    breadcrumbsAreVisible: async (...breadcrumbs: string[]): Promise<void> => {
       await Promise.all(
-        elements.map((element) =>
-          expect(
-            this.node.getByLabel('path bar').getByText(element),
-          ).toBeVisible(),
+        breadcrumbs.map((crumb) =>
+          expect(this.pathBar.getByText(crumb)).toBeVisible(),
         ),
       );
     },
-    openResourceUrlButtonIsVisible: async (): Promise<void> => {
-      await expect(this.openResourceUrlButton).toBeVisible();
+    breadcrumbsAreHidden: async (...breadcrumbs: string[]): Promise<void> => {
+      await Promise.all(
+        breadcrumbs.map((crumb) =>
+          expect(this.pathBar.getByText(crumb)).toBeHidden(),
+        ),
+      );
     },
-    openResourceUrlButtonIsHidden: async (): Promise<void> => {
-      await expect(this.openResourceUrlButton).toBeHidden();
+    openResourceUrlButtonIsEnabled: async (): Promise<void> => {
+      await expect(this.openResourceUrlButton).toBeEnabled();
+    },
+    openResourceUrlButtonIsDisabled: async (): Promise<void> => {
+      await expect(this.openResourceUrlButton).toBeDisabled();
     },
     globalTabIsEnabled: async (): Promise<void> => {
       await expect(this.globalTab).toBeEnabled();
@@ -116,6 +129,18 @@ export class ResourceDetails {
     addNewAttributionButtonIsHidden: async (): Promise<void> => {
       await expect(this.addNewAttributionButton).toBeHidden();
     },
+    goBackButtonIsDisabled: async (): Promise<void> => {
+      await expect(this.goBackButton).toBeDisabled();
+    },
+    goBackButtonIsEnabled: async (): Promise<void> => {
+      await expect(this.goBackButton).toBeEnabled();
+    },
+    goForwardButtonIsDisabled: async (): Promise<void> => {
+      await expect(this.goForwardButton).toBeDisabled();
+    },
+    goForwardButtonIsEnabled: async (): Promise<void> => {
+      await expect(this.goForwardButton).toBeEnabled();
+    },
   };
 
   async openResourceUrl(): Promise<void> {
@@ -128,5 +153,9 @@ export class ResourceDetails {
 
   async gotoGlobalTab(): Promise<void> {
     await this.globalTab.click();
+  }
+
+  async clickOnBreadcrumb(crumb: string): Promise<void> {
+    await this.pathBar.getByText(crumb).click();
   }
 }

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -53,6 +53,7 @@ export const test = base.extend<{
   fileSearchPopup: FileSearchPopup;
   fileSupportPopup: FileSupportPopup;
   menuBar: MenuBar;
+  modKey: string;
   modifyWasPreferredAttributionPopup: ModifyWasPreferredAttributionPopup;
   notSavedPopup: NotSavedPopup;
   projectMetadataPopup: ProjectMetadataPopup;
@@ -98,6 +99,9 @@ export const test = base.extend<{
       console.log(`DEBUG: ${info.outputPath()}`);
       info.fixme();
     });
+  },
+  modKey: async ({}, use) => {
+    await use(os.platform() === 'darwin' ? 'Meta' : 'Control');
   },
   projectStatisticsPopup: async ({ window }, use) => {
     await use(new ProjectStatisticsPopup(window));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9029,6 +9029,7 @@ __metadata:
     re-resizable: "npm:^6.9.11"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-hotkeys-hook: "npm:^4.4.1"
     react-redux: "npm:^8.1.3"
     react-virtuoso: "npm:^4.6.2"
     recharts: "npm:^2.9.3"
@@ -9532,6 +9533,16 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: ca5e7762ec8c17a472a3605b6f111895c9f87ac7d43a610ab7024f68cd833d08eda0625ce02ec7178cc1f3c957cf0b9273cdc17aa2cd02da87544331c43b1d21
+  languageName: node
+  linkType: hard
+
+"react-hotkeys-hook@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "react-hotkeys-hook@npm:4.4.1"
+  peerDependencies:
+    react: ">=16.8.1"
+    react-dom: ">=16.8.1"
+  checksum: 7bffc313c6f91d595ed3ed64093462452c0086b48264aa58471339943fb324093852b3cd1a679773fc80eed58acacb6ee1d15e018fbb38008d69feeeed2546b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary of changes

- add buttons to navigate back and forth through resource browser history
- enable navigation via keyboard shortcuts
- enable/disable path bar buttons and show appropriate tooltips instead of hiding them completely
- add tooltip delay to icon buttons to make them feel less jumpy
- scroll to resource when navigating via browser or path bar
- expand resource browser to selected resource if a resource is navigated to but hidden in the browser due to file/folder collapse

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/4db27cb0-9a93-41c1-afd3-6844a9086693)

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/bfa42d9d-53da-4737-a486-8b4e8032d141)

### Context and reason for change

Closes #2299.

### How can the changes be tested

Use mouse and keyboard to navigate through the browser history. Pay special attention to edge cases such as being at the beginning or end of the history stack.