### PR TITLE
[WIP] chore: add initial opossum file to e2e test output artefacts

### DIFF
--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -7,8 +7,10 @@ import {
   _electron as electron,
   ElectronApplication,
   Page,
+  TestInfo,
 } from '@playwright/test';
 import { parseElectronApp } from 'electron-playwright-helpers';
+import { cloneDeep } from 'lodash';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -63,6 +65,7 @@ export const test = base.extend<{
   data: undefined,
   window: async ({ data }, use, info) => {
     const filePath = data && (await createOpossumFile({ data, info }));
+    data && (await saveInitialOpossumFile(data, info));
 
     const [executablePath, main] = getLaunchProps();
 
@@ -170,4 +173,14 @@ function getReleasePath(): string {
   }
 
   throw new Error('Unsupported platform');
+}
+
+async function saveInitialOpossumFile(
+  data: OpossumData,
+  info: TestInfo,
+): Promise<void> {
+  const dataInitial = cloneDeep(data);
+  dataInitial.inputData.metadata.projectId =
+    dataInitial?.inputData.metadata.projectId + '_initial';
+  await createOpossumFile({ data: dataInitial, info });
 }


### PR DESCRIPTION
[Not clear yet, if this is helpful. The debug fixture is a good and usable alternative. But if more people request it, we can consider merging.]

### Summary of changes

This PR adds the initial opossum file to e2e test output artefacts.

This is helpful because currently the opossum file is saved in the state in which the error happened. If one wants to reproduce the steps that let to the error by hand, that is not possible in all cases (because steps can't necessarily be reverted).

This is especially helpful if a bug in a release is found by the test. One can use the initial opossum file and go through the test step by step to check if the failure also happens in the released app.