### PR TITLE
feat: improve virtualized list performance

### DIFF
--- a/src/Frontend/Components/AttributionList/AttributionList.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.tsx
@@ -7,7 +7,7 @@ import { SxProps } from '@mui/system';
 import { ReactElement } from 'react';
 
 import { checkboxClass } from '../../shared-styles';
-import { DisplayPackageInfos, PackageCardConfig } from '../../types/types';
+import { DisplayPackageInfos } from '../../types/types';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { AttributionsViewPackageList } from '../PackageList/AttributionsViewPackageList';
 import { ResizableBox } from '../ResizableBox/ResizableBox';
@@ -34,31 +34,25 @@ interface AttributionListProps {
 }
 
 export function AttributionList(props: AttributionListProps): ReactElement {
-  function getAttributionCard(packageCardId: string): ReactElement {
+  function getAttributionCard(
+    packageCardId: string,
+    { isScrolling }: { isScrolling: boolean },
+  ): ReactElement {
     const displayPackageInfo = props.displayPackageInfos[packageCardId];
-
-    function isSelected(): boolean {
-      return packageCardId === props.selectedPackageCardId;
-    }
-
-    function onClick(): void {
-      props.onCardClick(packageCardId);
-    }
-
-    const cardConfig: PackageCardConfig = {
-      isSelected: isSelected(),
-      isPreSelected: Boolean(displayPackageInfo.preSelected),
-    };
 
     return (
       <PackageCard
         cardId={`attribution-list-${packageCardId}`}
-        onClick={onClick}
-        cardConfig={cardConfig}
+        onClick={() => props.onCardClick(packageCardId)}
+        cardConfig={{
+          isSelected: packageCardId === props.selectedPackageCardId,
+          isPreSelected: displayPackageInfo.preSelected,
+        }}
         key={`AttributionCard-${displayPackageInfo.packageName}-${packageCardId}`}
         displayPackageInfo={displayPackageInfo}
         hideResourceSpecificButtons={true}
         showCheckBox={true}
+        isScrolling={isScrolling}
       />
     );
   }

--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiCheckbox from '@mui/material/Checkbox';
@@ -11,11 +13,11 @@ import { ReactElement } from 'react';
 import { OpossumColors } from '../../shared-styles';
 
 const classes = {
-  white: {
-    color: OpossumColors.white,
-  },
   disabledLabel: {
     color: OpossumColors.disabledGrey,
+  },
+  skeleton: {
+    fill: 'rgba(0, 0, 0, 0.6)',
   },
 };
 
@@ -25,35 +27,32 @@ interface CheckboxProps {
   checked: boolean;
   onChange(event: React.ChangeEvent<HTMLInputElement>): void;
   sx?: SxProps;
-  white?: boolean;
+  skeleton?: boolean;
 }
 
 export function Checkbox(props: CheckboxProps): ReactElement {
-  const whiteMode = props.white ? classes.white : {};
+  const Icon = props.checked ? CheckBoxIcon : CheckBoxOutlineBlankIcon;
 
   return (
     <MuiBox sx={props.sx}>
-      <MuiCheckbox
-        disabled={props.disabled}
-        checked={props.checked}
-        onChange={props.onChange}
-        inputProps={{
-          'aria-label': `checkbox ${props.label}`,
-        }}
-        color={'default'}
-        sx={{
-          '&.MuiCheckbox-root': whiteMode,
-          '&.MuiCheckbox-checked': whiteMode,
-        }}
-      />
-      <MuiTypography
-        sx={{
-          ...whiteMode,
-          ...(props.disabled ? classes.disabledLabel : {}),
-        }}
-      >
-        {props.label || ''}
-      </MuiTypography>
+      {props.skeleton ? (
+        <Icon sx={classes.skeleton} />
+      ) : (
+        <MuiCheckbox
+          disabled={props.disabled}
+          checked={props.checked}
+          onChange={props.onChange}
+          inputProps={{
+            'aria-label': `checkbox ${props.label}`,
+          }}
+          color={'default'}
+        />
+      )}
+      {props.label ? (
+        <MuiTypography sx={props.disabled ? classes.disabledLabel : {}}>
+          {props.label}
+        </MuiTypography>
+      ) : null}
     </MuiBox>
   );
 }

--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -3,8 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
-import { ReactElement, useEffect, useRef } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
+const NUMBER_OF_OVERSCROLL_ITEMS = 10;
 
 const classes = {
   scrollChild: {
@@ -15,10 +17,14 @@ const classes = {
 type Props = {
   cardHeight: number;
   fullHeight?: boolean;
-  getListItem(index: number): ReactElement | null;
+  getListItem(
+    index: number,
+    props: { isScrolling: boolean },
+  ): ReactElement | null;
   indexToScrollTo?: number;
   leftScrollBar?: boolean;
   length: number;
+  placeholder?: React.ReactElement;
 } & (
   | { maxHeight?: number; maxNumberOfItems?: never }
   | { maxHeight?: never; maxNumberOfItems?: number }
@@ -34,6 +40,7 @@ export function List({
   ...props
 }: Props): ReactElement {
   const ref = useRef<VirtuosoHandle>(null);
+  const [isScrolling, setIsScrolling] = useState(false);
   const maxHeight = ((): number | undefined => {
     if ('maxHeight' in props) {
       return props.maxHeight;
@@ -60,6 +67,7 @@ export function List({
       ref={ref}
       fixedItemHeight={cardHeight}
       totalCount={length}
+      isScrolling={setIsScrolling}
       style={{
         height: fullHeight ? '100%' : currentHeight,
         maxHeight,
@@ -67,6 +75,7 @@ export function List({
         overflowX: 'auto',
         overflowY: maxHeight && currentHeight < maxHeight ? 'hidden' : 'auto',
       }}
+      overscan={cardHeight * NUMBER_OF_OVERSCROLL_ITEMS}
       itemContent={(index): ReactElement => (
         <MuiBox
           sx={{
@@ -74,7 +83,7 @@ export function List({
             height: cardHeight,
           }}
         >
-          {getListItem(index)}
+          {getListItem(index, { isScrolling })}
         </MuiBox>
       )}
     />

--- a/src/Frontend/Components/ListCard/ListCard.tsx
+++ b/src/Frontend/Components/ListCard/ListCard.tsx
@@ -6,7 +6,7 @@ import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import { merge } from 'lodash';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 
 import { Criticality } from '../../../shared/shared-types';
 import { HighlightingColor } from '../../enums/enums';
@@ -164,7 +164,7 @@ interface ListCardProps {
 }
 
 export function ListCard(props: ListCardProps): ReactElement | null {
-  const displayedCount = ((): string => {
+  const displayedCount = useMemo((): string => {
     const digitsInAThousand = 4;
     const digitsInAMillion = 7;
     const count = props.count ? props.count.toString() : '';
@@ -176,19 +176,26 @@ export function ListCard(props: ListCardProps): ReactElement | null {
     } else {
       return `${count.slice(0, -(digitsInAMillion - 1))}M`;
     }
-  })();
+  }, [props.count]);
 
-  function calculateRightPadding(): number {
-    return Math.max(
-      0,
-      MAX_RIGHT_PADDING -
-        Math.ceil((props.rightIcons?.length || 0) / 2) *
-          PADDING_PER_ICON_COLUMN,
-    );
-  }
+  const paddingRight = useMemo(
+    () =>
+      Math.max(
+        0,
+        MAX_RIGHT_PADDING -
+          Math.ceil((props.rightIcons?.length || 0) / 2) *
+            PADDING_PER_ICON_COLUMN,
+      ),
+    [props.rightIcons?.length],
+  );
 
   return (
-    <MuiBox sx={getSx(props.cardConfig, props.highlighting)}>
+    <MuiBox
+      sx={useMemo(
+        () => getSx(props.cardConfig, props.highlighting),
+        [props.cardConfig, props.highlighting],
+      )}
+    >
       {props.leftElement}
       <MuiBox
         sx={{
@@ -210,7 +217,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             ...classes.textLines,
             ...(props.cardConfig.isResource ? {} : classes.longTextInFlexbox),
             ...(props.highlighting && {
-              paddingRight: `${calculateRightPadding()}px`,
+              paddingRight: `${paddingRight}px`,
             }),
           }}
         >
@@ -248,9 +255,7 @@ export function ListCard(props: ListCardProps): ReactElement | null {
             </MuiTypography>
           ) : null}
         </MuiBox>
-        {props.rightIcons ? (
-          <MuiBox sx={classes.iconColumn}>{props.rightIcons}</MuiBox>
-        ) : null}
+        <MuiBox sx={classes.iconColumn}>{props.rightIcons}</MuiBox>
       </MuiBox>
       <MuiBox
         sx={{

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -40,8 +40,13 @@ export function getRightIcons(
   cardConfig: ListCardConfig,
   cardId: string,
   openResourcesIcon?: JSX.Element,
+  isScrolling?: boolean,
 ): Array<ReactElement> {
   const rightIcons: Array<JSX.Element> = [];
+
+  if (isScrolling) {
+    return rightIcons;
+  }
 
   if (openResourcesIcon) {
     rightIcons.push(openResourcesIcon);

--- a/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
+++ b/src/Frontend/Components/PackageList/AttributionsViewPackageList.tsx
@@ -22,7 +22,10 @@ const classes = {
 interface AttributionsViewPackageListProps {
   displayPackageInfos: DisplayPackageInfos;
   sortedPackageCardIds: Array<string>;
-  getAttributionCard(packageCardId: string): ReactElement | null;
+  getAttributionCard(
+    packageCardId: string,
+    props: { isScrolling: boolean },
+  ): ReactElement | null;
 }
 
 export function AttributionsViewPackageList(
@@ -30,8 +33,8 @@ export function AttributionsViewPackageList(
 ): ReactElement {
   const [search, setSearch] = useState('');
 
-  const filteredAndSortedPackageCardIds: Array<string> = useMemo(
-    () =>
+  const filteredAndSortedPackageCardIds = useMemo(
+    (): Array<string> =>
       getFilteredPackageCardIdsFromDisplayPackageInfos(
         props.displayPackageInfos,
         props.sortedPackageCardIds,
@@ -44,8 +47,10 @@ export function AttributionsViewPackageList(
     <MuiBox sx={classes.container}>
       <SearchTextField onInputChange={setSearch} search={search} />
       <List
-        getListItem={(index: number): ReactElement | null =>
-          props.getAttributionCard(filteredAndSortedPackageCardIds[index])
+        getListItem={(index, { isScrolling }): ReactElement | null =>
+          props.getAttributionCard(filteredAndSortedPackageCardIds[index], {
+            isScrolling,
+          })
         }
         length={filteredAndSortedPackageCardIds.length}
         cardHeight={PACKAGE_CARD_HEIGHT}


### PR DESCRIPTION
### Summary of changes

- memoize expensive calculations and components
- render placeholders for or omit expensive components while scrolling is in progress (inside PackageCard, the left and right icons/elements are expensive)

LEFT = BEFORE, RIGHT = AFTER

https://github.com/opossum-tool/OpossumUI/assets/46091730/afd1c381-92c1-4ce1-8ec2-b77f443b2218

### Context and reason for change

Closes #1312.

### How can the changes be tested

Do a before/after comparison as you scroll through the attribution list in attribution view.
Also check other virtualized lists such as the resource browser.