### PR TITLE
fix: repair E2E test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "test:unit": "jest",
     "test:changed": "jest --onlyChanged",
     "test:watch": "jest --watch",
-    "test:e2e": "start-server-and-test \"tsc -p src/ElectronBackend && vite -m e2e\" \"http://localhost:5173/\" \"yarn playwright test -c src/e2e-tests/playwright.config.ts\"",
+    "test:e2e": "start-server-and-test \"tsc -p src/ElectronBackend && vite -m e2e\" http://localhost:5173/index.html \"yarn playwright test -c src/e2e-tests/playwright.config.ts\"",
     "test:e2e:ci": "cross-env CI=true yarn playwright test -c src/e2e-tests/playwright.config.ts",
     "lint": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
     "lint-check": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\"",

--- a/src/e2e-tests/playwright.config.ts
+++ b/src/e2e-tests/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? 'github' : 'list',
   timeout: process.env.CI ? CI_SINGLE_TEST_TIMEOUT : undefined,
-  workers: process.env.WORKERS ?? 1,
+  workers: process.env.CI ? 1 : process.env.WORKERS ?? 1,
   globalTimeout: process.env.CI ? GLOBAL_TIMEOUT : undefined,
 };
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -22,11 +22,6 @@ export default defineConfig(({ mode }) => ({
   build: {
     outDir: 'build',
   },
-  resolve: {
-    alias: {
-      path: 'path-browserify',
-    },
-  },
   optimizeDeps: {
     include: ['@mui/material/Tooltip'], // https://github.com/mui/material-ui/issues/32727
   },


### PR DESCRIPTION
### Summary of changes

- since Vite 5.0, it seems necessary to specify a specific resource in order for `start-server-and-test` to receive a 200 response when waiting for the Vite server to start up

### Context and reason for change

Upgrade to Vite 5.0 broke the E2E script (only affected local execution because pipeline uses a release instead of relying on the Vite dev server).

### How can the changes be tested

Run `yarn test:e2e`.