### PR TITLE
fix: correctly display dates in project metadata popup

### DIFF
--- a/src/Frontend/Components/AppContainer/AppContainer.tsx
+++ b/src/Frontend/Components/AppContainer/AppContainer.tsx
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 import { ReactElement, StrictMode } from 'react';
 import { Provider } from 'react-redux';
 
@@ -13,6 +15,8 @@ import {
   AccordionWorkersContextProvider,
   ProgressBarWorkersContextProvider,
 } from '../WorkersContextProvider/WorkersContextProvider';
+
+dayjs.extend(localizedFormat);
 
 const store = createAppStore();
 const queryClient = new QueryClient();

--- a/src/Frontend/Components/ProjectMetadataTable/ProjectMetadataTable.tsx
+++ b/src/Frontend/Components/ProjectMetadataTable/ProjectMetadataTable.tsx
@@ -9,7 +9,8 @@ import MuiTableCell from '@mui/material/TableCell';
 import MuiTableContainer from '@mui/material/TableContainer';
 import MuiTableRow from '@mui/material/TableRow';
 import MuiTypography from '@mui/material/Typography';
-import { ReactElement } from 'react';
+import dayjs from 'dayjs';
+import React, { ReactElement } from 'react';
 
 import { OpossumColors } from '../../shared-styles';
 import { useAppSelector } from '../../state/hooks';
@@ -36,47 +37,46 @@ export const projectMetadataTableClasses = {
   },
 };
 
-const keyToDisplayName: { [key: string]: string } = {
-  projectTitle: 'Project Title',
-  projectId: 'Project ID',
-  fileCreationDate: 'File Creation Date',
+const values: { [key: string]: { title: string; date: boolean } } = {
+  buildDate: { title: 'Build Date', date: true },
+  expectedReleaseDate: { title: 'Expected Release Date', date: true },
+  fileCreationDate: { title: 'File Creation Date', date: true },
+  projectId: { title: 'Project ID', date: false },
+  projectTitle: { title: 'Project Title', date: false },
+  projectVersion: { title: 'Project Version', date: false },
 };
 
 export function ProjectMetadataTable(): ReactElement {
   const projectMetadata = useAppSelector(getProjectMetadata);
 
-  function mapKeyToDisplayName(key: string): string {
-    return key in keyToDisplayName ? keyToDisplayName[key] : key;
-  }
-
-  function getTableRow(key: string): ReactElement {
-    return (
-      <MuiTableRow key={key}>
-        <MuiTableCell sx={projectMetadataTableClasses.firstColumn}>
-          {mapKeyToDisplayName(key)}
-        </MuiTableCell>
-        <MuiTableCell sx={projectMetadataTableClasses.secondColumn}>
-          <pre>
-            <MuiTypography fontFamily="default">
-              {typeof projectMetadata[key] === 'string'
-                ? (projectMetadata[key] as string)
-                : JSON.stringify(projectMetadata[key], null, 2)}
-            </MuiTypography>
-          </pre>
-        </MuiTableCell>
-      </MuiTableRow>
-    );
-  }
-
   return (
     <MuiBox>
       <MuiTableContainer sx={projectMetadataTableClasses.container}>
         <MuiTable>
-          <MuiTableBody>
-            {Object.keys(projectMetadata).map((key) => getTableRow(key))}
-          </MuiTableBody>
+          <MuiTableBody>{renderRows()}</MuiTableBody>
         </MuiTable>
       </MuiTableContainer>
     </MuiBox>
   );
+
+  function renderRows(): React.ReactNode {
+    return Object.entries(projectMetadata).map(([key, value]) => (
+      <MuiTableRow key={key}>
+        <MuiTableCell sx={projectMetadataTableClasses.firstColumn}>
+          {values[key]?.title ?? key}
+        </MuiTableCell>
+        <MuiTableCell sx={projectMetadataTableClasses.secondColumn}>
+          <pre>
+            <MuiTypography fontFamily="default">
+              {typeof value === 'string'
+                ? values[key]?.date
+                  ? dayjs(value).format('lll')
+                  : value
+                : JSON.stringify(value, null, 2)}
+            </MuiTypography>
+          </pre>
+        </MuiTableCell>
+      </MuiTableRow>
+    ));
+  }
 }


### PR DESCRIPTION
### Summary of changes
- use dayjs to display dates in a user-friendly way
- extend list of expected attributes (automatically trying to parse all strings as dates may lead to false positives)

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/4730c68a-51f0-4df6-a893-1455c05d05a7)

### Context and reason for change

Closes #2328.

### How can the changes be tested

Open the project metadata popup.