### PR TITLE
Add original source field

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -156,7 +156,8 @@
     "bb61b094-b5ba-4bd0-b218-8ec96b7c5ae0": {
       "source": {
         "name": "MERGER",
-        "documentConfidence": 50.0
+        "documentConfidence": 50.0,
+        "additionalName": "ScanCode"
       },
       "attributionConfidence": 100,
       "comment": "TypeScript. \nhttps://www.npmjs.com/package/typescript",
@@ -172,7 +173,8 @@
     "bb61b094-b5ba-4bd0-b218-8ec96b7c5af0": {
       "source": {
         "name": "MERGER",
-        "documentConfidence": 50.0
+        "documentConfidence": 50.0,
+        "additionalName": "REUSER"
       },
       "attributionConfidence": 100,
       "comment": "TypeScript. \nhttps://www.npmjs.com/package/typescript",

--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -66,6 +66,10 @@
                 "description": "How much the information is trusted (0: bad, 100: good)",
                 "minimum": 0,
                 "maximum": 100
+              },
+              "additionalName": {
+                "type": "string",
+                "description": "Original source for suggested signals (e.g. a tool like ScanCode)"
               }
             },
             "required": ["name", "documentConfidence"],

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -10,6 +10,7 @@ import upath from 'upath';
 import * as zlib from 'zlib';
 
 import { EMPTY_PROJECT_METADATA } from '../../../Frontend/shared-constants';
+import { faker } from '../../../shared/Faker';
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import {
   Criticality,
@@ -566,15 +567,16 @@ describe('Test of loading function', () => {
     deleteFolder(temporaryPath);
   });
 
-  it('loads file and parses json successfully, custom metadata', async () => {
+  it('loads file and parses json successfully, origin Ids and original source', async () => {
     const inputFileContentWithOriginIds: ParsedOpossumInputFile = {
       ...inputFileContent,
       externalAttributions: {
         uuid: {
-          source: {
-            name: 'REUSER:HHC',
+          source: faker.opossum.source({
+            name: 'MERGER',
             documentConfidence: 13,
-          },
+            additionalName: 'Original Source',
+          }),
           packageName: 'react',
           originIds: ['abc', 'def'],
         },
@@ -599,10 +601,11 @@ describe('Test of loading function', () => {
       externalAttributions: {
         attributions: {
           uuid: {
-            source: {
-              name: 'REUSER:HHC',
+            source: faker.opossum.source({
+              name: 'MERGER',
               documentConfidence: 13,
-            },
+              additionalName: 'Original Source',
+            }),
             packageName: 'react',
             originIds: ['abc', 'def'],
           },

--- a/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingSubPanel.tsx
@@ -32,7 +32,8 @@ const classes = {
   },
   sourceField: {
     marginBottom: '4px',
-    flex: 0.5,
+    flex: 0,
+    flexBasis: 100,
   },
 };
 
@@ -107,7 +108,8 @@ export function AuditingSubPanel(props: AuditingSubPanelProps): ReactElement {
             sx={classes.sourceField}
             title={'Source'}
             text={prettifySource(
-              props.displayPackageInfo.source.name,
+              props.displayPackageInfo.source.additionalName ??
+                props.displayPackageInfo.source.name,
               attributionSources,
             )}
             handleChange={doNothing}

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -6,13 +6,13 @@
 import { screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
+import { faker } from '../../../../shared/Faker';
 import {
   DiscreteConfidence,
   DisplayPackageInfo,
   FollowUp,
   FrequentLicenses,
   SaveFileArgs,
-  Source,
 } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { ButtonText, CheckboxLabel } from '../../../enums/enums';
@@ -281,9 +281,9 @@ describe('The AttributionColumn', () => {
     );
   });
 
-  it('renders a TextBox for the source, if it is defined', () => {
+  it('renders a source name, if it is defined', () => {
     const testTemporaryDisplayPackageInfo: DisplayPackageInfo = {
-      source: { name: 'The Source', documentConfidence: 10 },
+      source: faker.opossum.source(),
       attributionIds: [],
     };
     const { store } = renderComponentWithStore(
@@ -305,8 +305,39 @@ describe('The AttributionColumn', () => {
     });
 
     expect(
+      screen.getByDisplayValue(testTemporaryDisplayPackageInfo.source!.name),
+    );
+  });
+
+  it('renders the name of the original source, if it is defined', () => {
+    const testTemporaryDisplayPackageInfo: DisplayPackageInfo = {
+      source: faker.opossum.source({
+        additionalName: 'Original Source',
+      }),
+      attributionIds: [],
+    };
+
+    const { store } = renderComponentWithStore(
+      <AttributionColumn
+        isEditable={true}
+        onSaveButtonClick={doNothing}
+        onSaveGloballyButtonClick={doNothing}
+        showManualAttributionData={true}
+        saveFileRequestListener={doNothing}
+        onDeleteButtonClick={doNothing}
+        onDeleteGloballyButtonClick={doNothing}
+      />,
+    );
+    act(() => {
+      store.dispatch(setSelectedResourceId('test_id'));
+      store.dispatch(
+        setTemporaryDisplayPackageInfo(testTemporaryDisplayPackageInfo),
+      );
+    });
+
+    expect(
       screen.getByDisplayValue(
-        (testTemporaryDisplayPackageInfo.source as Source).name,
+        testTemporaryDisplayPackageInfo.source!.additionalName!,
       ),
     );
   });

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -72,6 +72,7 @@ export interface DisplayPackageInfo extends PackageInfoCore {
 export interface Source {
   name: string;
   documentConfidence: number;
+  additionalName?: string;
 }
 
 export interface Attributions {


### PR DESCRIPTION
### Summary of changes

Original source name is shown in case if the additionalName is defined.

### Context and reason for change

We would like to see original source for suggested (=MERGER) signals

### How can the changes be tested

See unit tests.
Add the field to any source of any input.json file and check it in the UI.
