### PR TITLE
fix: saving by hotkey in attribution popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionColumn.tsx
@@ -271,7 +271,7 @@ export function AttributionColumn(props: AttributionColumnProps): ReactElement {
 
   useIpcRenderer<ResetStateListener>(
     AllowedFrontendChannels.SaveFileRequest,
-    (resetState) => resetState && props.saveFileRequestListener(),
+    () => props.saveFileRequestListener(),
     [props.saveFileRequestListener],
   );
 

--- a/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
+++ b/src/Frontend/Components/EditAttributionPopup/EditAttributionPopup.tsx
@@ -44,7 +44,7 @@ export function EditAttributionPopup(): ReactElement {
         savePackageInfoIfSavingIsNotDisabled(
           null,
           popupAttributionId,
-          temporaryDisplayPackageInfo,
+          convertDisplayPackageInfoToPackageInfo(temporaryDisplayPackageInfo),
         ),
       );
     }


### PR DESCRIPTION
### Summary of changes

- package info was not converted before sending data to reducer

### Context and reason for change

Closes #2236 .

### How can the changes be tested

See bug task description.