### PR TITLE
fix: attribution view cards jump while scrolling

### DIFF
--- a/src/Frontend/Components/Checkbox/Checkbox.tsx
+++ b/src/Frontend/Components/Checkbox/Checkbox.tsx
@@ -15,6 +15,7 @@ import { ReactElement } from 'react';
 const classes = {
   skeleton: {
     fill: 'rgba(0, 0, 0, 0.6)',
+    width: '42px',
   },
 };
 

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -478,14 +478,8 @@ export const PackageCard = memo(
     );
 
     const rightIcons = useMemo(
-      () =>
-        getRightIcons(
-          listCardConfig,
-          props.cardId,
-          openResourcesIcon,
-          props.isScrolling,
-        ),
-      [listCardConfig, openResourcesIcon, props.cardId, props.isScrolling],
+      () => getRightIcons(listCardConfig, props.cardId, openResourcesIcon),
+      [listCardConfig, openResourcesIcon, props.cardId],
     );
 
     return (

--- a/src/Frontend/Components/PackageCard/package-card-helpers.tsx
+++ b/src/Frontend/Components/PackageCard/package-card-helpers.tsx
@@ -40,13 +40,8 @@ export function getRightIcons(
   cardConfig: ListCardConfig,
   cardId: string,
   openResourcesIcon?: JSX.Element,
-  isScrolling?: boolean,
 ): Array<ReactElement> {
   const rightIcons: Array<JSX.Element> = [];
-
-  if (isScrolling) {
-    return rightIcons;
-  }
 
   if (openResourcesIcon) {
     rightIcons.push(openResourcesIcon);


### PR DESCRIPTION
### Summary of changes

- fix checkbox skeleton width to match actual checkbox width
- re-enable right-icons computation since performance gains are not worth sacrificing the usability (it's important to see the auditing icons even while scrolling)

### Context

Bug introduced in #2313 .

### How can the changes be tested

Scroll through package cards in attribution view. Notice that performance has become worse but there is no more jumping and the right icons (auditing icons) are visible while scrolling.