### PR TITLE
fix: include all resources attached to an attribution when preferring globally

### DIFF
--- a/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
+++ b/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
@@ -5,13 +5,15 @@
 import { ReactElement } from 'react';
 
 import { text } from '../../../shared/text';
-import { ButtonText } from '../../enums/enums';
+import { ButtonText, View } from '../../enums/enums';
 import {
   closePopupAndUnsetTargets,
   saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled,
 } from '../../state/actions/popup-actions/popup-actions';
+import { setOriginIdsToPreferOverGlobally } from '../../state/actions/resource-actions/preference-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getTemporaryDisplayPackageInfo } from '../../state/selectors/all-views-resource-selectors';
+import { getSelectedView } from '../../state/selectors/view-selector';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 
 export function ChangePreferredStatusGloballyPopup(): ReactElement {
@@ -19,8 +21,12 @@ export function ChangePreferredStatusGloballyPopup(): ReactElement {
   const temporaryDisplayPackageInfo = useAppSelector(
     getTemporaryDisplayPackageInfo,
   );
+  const view = useAppSelector(getSelectedView);
 
   function handleOkClick(): void {
+    if (view === View.Audit) {
+      dispatch(setOriginIdsToPreferOverGlobally(temporaryDisplayPackageInfo));
+    }
     dispatch(
       saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled(),
     );

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -6,8 +6,8 @@ import { ReactElement } from 'react';
 
 import { ButtonText, View } from '../../enums/enums';
 import {
-  checkIfWasPreferredAndShowWarningOrSave,
   checkIfWasPreferredAndShowWarningOrUnlinkAndSave,
+  checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave,
   closePopupAndUnsetTargets,
   navigateToTargetResourceOrAttribution,
 } from '../../state/actions/popup-actions/popup-actions';
@@ -43,7 +43,7 @@ export function NotSavedPopup(): ReactElement {
   }
 
   function handleSaveGloballyClick(): void {
-    dispatch(checkIfWasPreferredAndShowWarningOrSave());
+    dispatch(checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave());
   }
 
   function handleUndoClick(): void {

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -71,7 +71,7 @@ export function ResourceDetailsAttributionColumn(
     }
   }
 
-  function dispatchSavePackageInfoOrOpenWasPreferredPopup(): void {
+  function dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup(): void {
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
     } else if (showSaveGloballyButton && didPreferredFieldChange) {
@@ -208,9 +208,11 @@ export function ResourceDetailsAttributionColumn(
       onSaveButtonClick={
         showSaveGloballyButton
           ? dispatchUnlinkAttributionAndSavePackageInfoOrOpenWasPreferredPopup
-          : dispatchSavePackageInfoOrOpenWasPreferredPopup
+          : dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup
       }
-      onSaveGloballyButtonClick={dispatchSavePackageInfoOrOpenWasPreferredPopup}
+      onSaveGloballyButtonClick={
+        dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup
+      }
       saveFileRequestListener={saveFileRequestListener}
       onDeleteButtonClick={openConfirmDeletionPopup}
       onDeleteGloballyButtonClick={openConfirmDeletionGloballyPopup}

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -85,8 +85,8 @@ import {
 } from '../../view-actions/view-actions';
 import {
   changeSelectedAttributionIdOrOpenUnsavedPopup,
-  checkIfWasPreferredAndShowWarningOrSave,
   checkIfWasPreferredAndShowWarningOrUnlinkAndSave,
+  checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave,
   closePopupAndUnsetTargets,
   locateSignalsFromLocatorPopup,
   locateSignalsFromProjectStatisticsPopup,
@@ -533,7 +533,7 @@ describe('The actions called from the unsaved popup', () => {
   );
 
   describe.each(views)(
-    'checkIfWasPreferredAndShowWarningOrSave in %s View',
+    'checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave in %s View',
     (view: View) => {
       const notSelectedViews = views.filter(
         (viewCandidate) => viewCandidate !== view,
@@ -547,7 +547,9 @@ describe('The actions called from the unsaved popup', () => {
         const testStore = prepareTestStore(view, testDisplayPackageInfo);
         testStore.dispatch(setTargetView(notSelectedViews[0]));
 
-        testStore.dispatch(checkIfWasPreferredAndShowWarningOrSave());
+        testStore.dispatch(
+          checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(),
+        );
         expect(getCurrentAttributionId(testStore.getState())).toBe('id1');
         expect(getOpenPopup(testStore.getState())).toBe(
           PopupType.ModifyWasPreferredAttributionPopup,
@@ -563,7 +565,9 @@ describe('The actions called from the unsaved popup', () => {
         const testStore = prepareTestStore(view, testDisplayPackageInfo);
         testStore.dispatch(setTargetView(notSelectedViews[0]));
 
-        testStore.dispatch(checkIfWasPreferredAndShowWarningOrSave());
+        testStore.dispatch(
+          checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(),
+        );
         expect(getSelectedView(testStore.getState())).toBe(notSelectedViews[0]);
       });
     },

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -232,20 +232,17 @@ export function saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIs
   };
 }
 
-export function checkIfWasPreferredAndShowWarningOrSave(): AppThunkAction {
+export function checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const currentAttributionId = getCurrentAttributionId(getState());
     const temporaryDisplayPackageInfo =
       getTemporaryDisplayPackageInfo(getState());
     const attributionsToResources =
       getManualAttributionsToResources(getState());
-    const view = getSelectedView(getState());
-    const showSaveGloballyButton =
-      view === View.Audit &&
-      hasAttributionMultipleResources(
-        currentAttributionId,
-        attributionsToResources,
-      );
+    const attributionHasMultipleResources = hasAttributionMultipleResources(
+      currentAttributionId,
+      attributionsToResources,
+    );
 
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(closePopup());
@@ -257,7 +254,7 @@ export function checkIfWasPreferredAndShowWarningOrSave(): AppThunkAction {
           ),
         );
     } else if (
-      showSaveGloballyButton &&
+      attributionHasMultipleResources &&
       getDidPreferredFieldChange(getState())
     ) {
       dispatch(closePopup());

--- a/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { faker } from '../../../../../shared/Faker';
 import { Resources } from '../../../../../shared/shared-types';
 import { getOriginIdsToPreferOver } from '../preference-actions';
 
@@ -153,6 +154,55 @@ describe('getOriginIdsToPreferOver', () => {
     );
 
     const expectedOriginUuids = ['originUuid1'];
+    expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+
+  it('finds all origin ids for attribution with multiple root resources', () => {
+    const testSource = faker.opossum.source();
+    const file1 = faker.opossum.resourceName();
+    const file2 = faker.opossum.resourceName();
+    const pathFile1 = `/${file1}`;
+    const pathFile2 = `/${file2}`;
+    const uuid1 = faker.string.uuid();
+    const uuid2 = faker.string.uuid();
+    const resources: Resources = faker.opossum.resources({
+      [file1]: 1,
+      [file2]: 1,
+    });
+    const pathsToRootResources = [pathFile1, pathFile2];
+    const resourcesToExternalAttributions =
+      faker.opossum.resourcesToAttributions({
+        [pathFile1]: [uuid1],
+        [pathFile2]: [uuid2],
+      });
+
+    const originUuid1 = faker.string.uuid();
+    const originUuid2 = faker.string.uuid();
+    const externalAttributions = faker.opossum.externalAttributions({
+      [uuid1]: { originIds: [originUuid1], source: testSource },
+      [uuid2]: { originIds: [originUuid2], source: testSource },
+    });
+
+    const externalAttributionSource = faker.opossum.externalAttributionSource({
+      isRelevantForPreferred: true,
+    });
+    const externalAttributionsSources =
+      faker.opossum.externalAttributionSources({
+        [testSource.name]: externalAttributionSource,
+      });
+
+    const resourcesToManualAttributions = {};
+
+    const actualOriginUuids = getOriginIdsToPreferOver(
+      pathsToRootResources,
+      resources,
+      resourcesToExternalAttributions,
+      resourcesToManualAttributions,
+      externalAttributions,
+      externalAttributionsSources,
+    );
+
+    const expectedOriginUuids = [originUuid1, originUuid2];
     expect(actualOriginUuids).toEqual(expectedOriginUuids);
   });
 });


### PR DESCRIPTION
### Summary of changes

Use all resources that an attribution is attached to when computing the preferred over ids for that attribution if it gets preferred globally.


### Context and reason for change

Fixes #2370 

### How can the changes be tested

Added unit test.