### PR TITLE
 fix: include all resources attached to an attribution when preferring globally

### DIFF
--- a/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
+++ b/src/Frontend/Components/ChangePreferredStatusGloballyPopup/ChangePreferredStatusGloballyPopup.tsx
@@ -10,6 +10,7 @@ import {
   closePopupAndUnsetTargets,
   saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled,
 } from '../../state/actions/popup-actions/popup-actions';
+import { setOriginIdsToPreferOverGlobally } from '../../state/actions/resource-actions/preference-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getTemporaryDisplayPackageInfo } from '../../state/selectors/all-views-resource-selectors';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
@@ -21,6 +22,7 @@ export function ChangePreferredStatusGloballyPopup(): ReactElement {
   );
 
   function handleOkClick(): void {
+    dispatch(setOriginIdsToPreferOverGlobally(temporaryDisplayPackageInfo));
     dispatch(
       saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDisabled(),
     );

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -6,8 +6,8 @@ import { ReactElement } from 'react';
 
 import { ButtonText, View } from '../../enums/enums';
 import {
-  checkIfWasPreferredAndShowWarningOrSave,
   checkIfWasPreferredAndShowWarningOrUnlinkAndSave,
+  checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave,
   closePopupAndUnsetTargets,
   navigateToTargetResourceOrAttribution,
 } from '../../state/actions/popup-actions/popup-actions';
@@ -43,7 +43,7 @@ export function NotSavedPopup(): ReactElement {
   }
 
   function handleSaveGloballyClick(): void {
-    dispatch(checkIfWasPreferredAndShowWarningOrSave());
+    dispatch(checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave());
   }
 
   function handleUndoClick(): void {

--- a/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
+++ b/src/Frontend/Components/ResourceDetailsAttributionColumn/ResourceDetailsAttributionColumn.tsx
@@ -71,7 +71,7 @@ export function ResourceDetailsAttributionColumn(
     }
   }
 
-  function dispatchSavePackageInfoOrOpenWasPreferredPopup(): void {
+  function dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup(): void {
     if (temporaryDisplayPackageInfo.wasPreferred) {
       dispatch(openPopup(PopupType.ModifyWasPreferredAttributionPopup));
     } else if (showSaveGloballyButton && didPreferredFieldChange) {
@@ -208,9 +208,11 @@ export function ResourceDetailsAttributionColumn(
       onSaveButtonClick={
         showSaveGloballyButton
           ? dispatchUnlinkAttributionAndSavePackageInfoOrOpenWasPreferredPopup
-          : dispatchSavePackageInfoOrOpenWasPreferredPopup
+          : dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup
       }
-      onSaveGloballyButtonClick={dispatchSavePackageInfoOrOpenWasPreferredPopup}
+      onSaveGloballyButtonClick={
+        dispatchSavePackageInfoOrOpenPreferGloballyOrWasPreferredPopup
+      }
       saveFileRequestListener={saveFileRequestListener}
       onDeleteButtonClick={openConfirmDeletionPopup}
       onDeleteGloballyButtonClick={openConfirmDeletionGloballyPopup}

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -85,8 +85,8 @@ import {
 } from '../../view-actions/view-actions';
 import {
   changeSelectedAttributionIdOrOpenUnsavedPopup,
-  checkIfWasPreferredAndShowWarningOrSave,
   checkIfWasPreferredAndShowWarningOrUnlinkAndSave,
+  checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave,
   closePopupAndUnsetTargets,
   locateSignalsFromLocatorPopup,
   locateSignalsFromProjectStatisticsPopup,
@@ -533,7 +533,7 @@ describe('The actions called from the unsaved popup', () => {
   );
 
   describe.each(views)(
-    'checkIfWasPreferredAndShowWarningOrSave in %s View',
+    'checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave in %s View',
     (view: View) => {
       const notSelectedViews = views.filter(
         (viewCandidate) => viewCandidate !== view,
@@ -547,7 +547,9 @@ describe('The actions called from the unsaved popup', () => {
         const testStore = prepareTestStore(view, testDisplayPackageInfo);
         testStore.dispatch(setTargetView(notSelectedViews[0]));
 
-        testStore.dispatch(checkIfWasPreferredAndShowWarningOrSave());
+        testStore.dispatch(
+          checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(),
+        );
         expect(getCurrentAttributionId(testStore.getState())).toBe('id1');
         expect(getOpenPopup(testStore.getState())).toBe(
           PopupType.ModifyWasPreferredAttributionPopup,
@@ -563,7 +565,9 @@ describe('The actions called from the unsaved popup', () => {
         const testStore = prepareTestStore(view, testDisplayPackageInfo);
         testStore.dispatch(setTargetView(notSelectedViews[0]));
 
-        testStore.dispatch(checkIfWasPreferredAndShowWarningOrSave());
+        testStore.dispatch(
+          checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(),
+        );
         expect(getSelectedView(testStore.getState())).toBe(notSelectedViews[0]);
       });
     },

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -232,7 +232,7 @@ export function saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIs
   };
 }
 
-export function checkIfWasPreferredAndShowWarningOrSave(): AppThunkAction {
+export function checkIfWasPreferredOrPreferredStatusChangedAndShowWarningOrSave(): AppThunkAction {
   return (dispatch: AppThunkDispatch, getState: () => State): void => {
     const currentAttributionId = getCurrentAttributionId(getState());
     const temporaryDisplayPackageInfo =

--- a/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/preference-actions.test.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { faker } from '../../../../../shared/Faker';
 import { Resources } from '../../../../../shared/shared-types';
 import { getOriginIdsToPreferOver } from '../preference-actions';
 
@@ -154,5 +155,53 @@ describe('getOriginIdsToPreferOver', () => {
 
     const expectedOriginUuids = ['originUuid1'];
     expect(actualOriginUuids).toEqual(expectedOriginUuids);
+  });
+
+  it('finds all origin ids for attribution with multiple root resources', () => {
+    const attributionSource = faker.opossum.source();
+    const file1 = faker.opossum.resourceName();
+    const file2 = faker.opossum.resourceName();
+    const pathFile1 = faker.opossum.filePath(file1);
+    const pathFile2 = faker.opossum.filePath(file2);
+    const uuid1 = faker.string.uuid();
+    const uuid2 = faker.string.uuid();
+    const resources = faker.opossum.resources({
+      [file1]: 1,
+      [file2]: 1,
+    });
+    const pathsToRootResources = [pathFile1, pathFile2];
+    const resourcesToExternalAttributions =
+      faker.opossum.resourcesToAttributions({
+        [pathFile1]: [uuid1],
+        [pathFile2]: [uuid2],
+      });
+
+    const originUuid1 = faker.string.uuid();
+    const originUuid2 = faker.string.uuid();
+    const externalAttributions = faker.opossum.externalAttributions({
+      [uuid1]: { originIds: [originUuid1], source: attributionSource },
+      [uuid2]: { originIds: [originUuid2], source: attributionSource },
+    });
+
+    const externalAttributionSource = faker.opossum.externalAttributionSource({
+      isRelevantForPreferred: true,
+    });
+    const externalAttributionsSources =
+      faker.opossum.externalAttributionSources({
+        [attributionSource.name]: externalAttributionSource,
+      });
+
+    const resourcesToManualAttributions = {};
+
+    expect(
+      getOriginIdsToPreferOver(
+        pathsToRootResources,
+        resources,
+        resourcesToExternalAttributions,
+        resourcesToManualAttributions,
+        externalAttributions,
+        externalAttributionsSources,
+      ),
+    ).toEqual([originUuid1, originUuid2]);
   });
 });

--- a/src/Frontend/state/actions/resource-actions/preference-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/preference-actions.ts
@@ -25,6 +25,7 @@ import {
   getResourcesToExternalAttributions,
   getResourcesToManualAttributions,
 } from '../../selectors/all-views-resource-selectors';
+import { getResourceIdsOfSelectedAttribution } from '../../selectors/attribution-view-resource-selectors';
 import { getSelectedResourceId } from '../../selectors/audit-view-resource-selectors';
 import { AppThunkAction, AppThunkDispatch } from '../../types';
 import { setTemporaryDisplayPackageInfo } from './all-views-simple-actions';
@@ -57,35 +58,66 @@ export function toggleIsSelectedPackagePreferred(
   };
 }
 
+export function setOriginIdsToPreferOverGlobally(
+  packageInfo: DisplayPackageInfo,
+): AppThunkAction {
+  return (dispatch, getState): void => {
+    const state = getState();
+
+    dispatch(
+      setTemporaryDisplayPackageInfo({
+        ...packageInfo,
+        preferredOverOriginIds: getOriginIdsToPreferOver(
+          getResourceIdsOfSelectedAttribution(state) ?? [],
+          getResources(state) ?? {},
+          getResourcesToExternalAttributions(state),
+          getResourcesToManualAttributions(state),
+          getExternalAttributions(state),
+          getExternalAttributionSources(state),
+        ),
+      }),
+    );
+  };
+}
+
 export function getOriginIdsToPreferOver(
-  pathToRootResource: string,
+  pathsToRootResources: string | Array<string>,
   resources: Resources,
   resourcesToExternalAttributions: ResourcesToAttributions,
   resourcesToManualAttributions: ResourcesToAttributions,
   externalAttributions: Attributions,
   externalAttributionSources: ExternalAttributionSources,
 ): Array<string> {
-  const rootResource = getSubtree(resources, pathToRootResource);
-
+  let originIds: Array<string> = [];
   const isBreakpoint: PathPredicate = (path: string) =>
     path in resourcesToManualAttributions;
 
-  const subtreeResourcesIds = getResourceIdsInSubtreeWithBreakpoints(
-    pathToRootResource,
-    rootResource,
-    isBreakpoint,
-  );
+  if (typeof pathsToRootResources === 'string') {
+    pathsToRootResources = [pathsToRootResources];
+  }
 
-  const packageInfos = getPackageInfosFromResources(
-    subtreeResourcesIds,
-    resourcesToExternalAttributions,
-    externalAttributions,
-  );
+  for (const pathToRootResource of pathsToRootResources) {
+    const rootResource = getSubtree(resources, pathToRootResource);
 
-  const originIds = getOriginIdsToPreferOverFromPackageInfos(
-    packageInfos,
-    externalAttributionSources,
-  );
+    const subtreeResourcesIds = getResourceIdsInSubtreeWithBreakpoints(
+      pathToRootResource,
+      rootResource,
+      isBreakpoint,
+    );
+
+    const packageInfos = getPackageInfosFromResources(
+      subtreeResourcesIds,
+      resourcesToExternalAttributions,
+      externalAttributions,
+    );
+
+    const originIdsForResource = getOriginIdsToPreferOverFromPackageInfos(
+      packageInfos,
+      externalAttributionSources,
+    );
+
+    originIds = originIds.concat(originIdsForResource);
+  }
 
   return originIds;
 }


### PR DESCRIPTION
### Summary of changes

Use all resources that an attribution is attached to when computing the preferred over ids for that attribution if it gets preferred globally.


### Context and reason for change

Fixes #2370 

### How can the changes be tested

Added unit test.