### PR TITLE
feat: rank suggestions by previously/currently preferred

### DIFF
--- a/example-files/opossum_input.json
+++ b/example-files/opossum_input.json
@@ -211,6 +211,7 @@
       "attributionConfidence": 100,
       "comment": "TypeScript. \nhttps://www.npmjs.com/package/typescript",
       "packageName": "TypeScript",
+      "packageType": "github",
       "preSelected": true,
       "criticality": "medium",
       "packageVersion": "3.9.6",

--- a/src/Frontend/Components/Autocomplete/Autocomplete.style.ts
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.style.ts
@@ -14,7 +14,7 @@ export const Group = styled('div')({
   top: '-8px',
   position: 'sticky',
   padding: '4px 10px',
-  zIndex: 1,
+  zIndex: 10, // needs to be higher than that of elements rendered as start or end icon
   backgroundColor: OpossumColors.lightBlue,
 });
 


### PR DESCRIPTION
### Summary of changes

- add golden or grey star to suggestion star icon when preferred/previously preferred
- rank suggestions by preferred/previously preferred

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/ca93ba25-e19b-46db-9b83-b17516ceeb9d)

### Context and reason for change

#2345 

### How can the changes be tested

Check that preferred/previously preferred suggestions come first within their group.