### PR TITLE
feat: persist QA mode

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -3,13 +3,12 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { BrowserWindow, Menu } from 'electron';
+import { BrowserWindow } from 'electron';
 import isDev from 'electron-is-dev';
 import path from 'path';
 import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
-import { createMenu } from './menu';
 
 export async function createWindow(): Promise<BrowserWindow> {
   const mainWindow = new BrowserWindow({
@@ -23,8 +22,6 @@ export async function createWindow(): Promise<BrowserWindow> {
     },
     icon: getIconPath(),
   });
-
-  Menu.setApplicationMenu(createMenu(mainWindow));
 
   if (isDev) {
     await mainWindow.loadURL('http://localhost:5173/');

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -23,9 +23,11 @@ import {
   getPathOfChromiumNoticeDocument,
   getPathOfNoticeDocument,
 } from './notice-document-helpers';
+import { UserSettings } from './user-settings';
 
-export function createMenu(mainWindow: BrowserWindow): Menu {
+export async function createMenu(mainWindow: BrowserWindow): Promise<Menu> {
   const webContents = mainWindow.webContents;
+  const qaMode = await UserSettings.get('qaMode');
 
   return Menu.buildFromTemplate([
     {
@@ -331,16 +333,17 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           ),
           label: 'QA Mode',
           id: 'disabled-qa-mode',
-          click(): void {
+          click: async () => {
             makeFirstIconVisibleAndSecondHidden(
               'enabled-qa-mode',
               'disabled-qa-mode',
             );
+            await UserSettings.set('qaMode', true);
             webContents.send(AllowedFrontendChannels.SetQAMode, {
               qaMode: true,
             });
           },
-          visible: true,
+          visible: !qaMode,
         },
         {
           icon: getIconBasedOnTheme(
@@ -349,16 +352,17 @@ export function createMenu(mainWindow: BrowserWindow): Menu {
           ),
           label: 'QA Mode',
           id: 'enabled-qa-mode',
-          click(): void {
+          click: async () => {
             makeFirstIconVisibleAndSecondHidden(
               'disabled-qa-mode',
               'enabled-qa-mode',
             );
+            await UserSettings.set('qaMode', false);
             webContents.send(AllowedFrontendChannels.SetQAMode, {
               qaMode: false,
             });
           },
-          visible: false,
+          visible: qaMode,
         },
       ],
     },

--- a/src/ElectronBackend/main/user-settings.ts
+++ b/src/ElectronBackend/main/user-settings.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import settings from 'electron-settings';
+import { isEqual } from 'lodash';
+
+import { UserSettings as IUserSettings } from '../../shared/shared-types';
+
+export class UserSettings {
+  public static async init() {
+    const current: Partial<IUserSettings> = await settings.get();
+    const reset = process.argv.includes('--reset');
+
+    const updated = {
+      ...current,
+      showProjectStatistics: reset
+        ? false
+        : current.showProjectStatistics ?? true,
+      qaMode: reset ? false : current.qaMode ?? false,
+    } satisfies IUserSettings;
+
+    if (!isEqual(current, updated)) {
+      await settings.set(updated);
+    }
+  }
+
+  public static get<T extends keyof IUserSettings>(
+    path: T,
+  ): Promise<IUserSettings[T]> {
+    return settings.get(path) as Promise<IUserSettings[T]>;
+  }
+
+  public static set<T extends keyof IUserSettings>(
+    path: T,
+    value: IUserSettings[T],
+  ): Promise<void> {
+    return settings.set(path, value);
+  }
+}

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -83,7 +83,7 @@ export const test = base.extend<{
     const filePath = data && (await createTestFile({ data, info }));
 
     const [executablePath, main] = getLaunchProps();
-    const args = ['--skip-statistics'];
+    const args = ['--reset'];
 
     const app = await electron.launch({
       args: [main, ...(!filePath ? args : args.concat([filePath]))],

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -275,6 +275,7 @@ export interface Log {
 
 export interface UserSettings {
   showProjectStatistics: boolean;
+  qaMode: boolean;
 }
 
 export type SignalWithCount = PackageInfo & {


### PR DESCRIPTION
### Summary of changes

- create class for type-safe interactions with user settings in the backend
- persist QA mode in user settings and adjust menu to display QA mode options accordingly

### Context and reason for change

Closes #2405 

### How can the changes be tested

Change QA mode, restart the app, and notice that your last setting is persisted.