### PR TITLE
fix: CORS headers may be duplicated

### DIFF
--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -52,7 +52,8 @@ export async function main(): Promise<void> {
         callback({
           responseHeaders: {
             ...details.responseHeaders,
-            'Access-Control-Allow-Origin': ['*'],
+            'access-control-allow-origin': ['*'],
+            'Access-Control-Allow-Origin': [],
           },
         });
       },


### PR DESCRIPTION
### Summary of changes

- due to casing, we may set the access-control-allow-origin header to "*" twice
- fix this by overwriting one of the casings

### Context and reason for change

Bug introduced in #2404.

### How can the changes be tested

Open the package search popup and notice that no errors are happening compared to the base branch.