### PR TITLE
feat: get URL and license for search suggestion

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -35,6 +35,7 @@ const COMMON_PACKAGE_TYPES = [
   'docker',
   'gem',
   'github',
+  'gitlab',
   'golang',
   'maven',
   'npm',

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -2,10 +2,11 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { PackageInfo } from '../../shared/shared-types';
 import PackageSearchApi from './package-search-api';
+import { tryit } from './tryit';
 
 function usePackageNames({ packageName }: PackageInfo) {
   const { data, error, isLoading } = useQuery({
@@ -33,7 +34,20 @@ function usePackageVersions({ packageType, packageName }: PackageInfo) {
   };
 }
 
+function usePackageVersion() {
+  const { mutateAsync, error, isPending } = useMutation({
+    mutationFn: (props: PackageInfo) => PackageSearchApi.getVersion(props),
+  });
+
+  return {
+    getPackageVersion: tryit(mutateAsync),
+    packageVersionError: error,
+    packageVersionLoading: isPending,
+  };
+}
+
 export const PackageSearchHooks = {
   usePackageNames,
   usePackageVersions,
+  usePackageVersion,
 };

--- a/src/Frontend/util/tryit.ts
+++ b/src/Frontend/util/tryit.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Converts a function that might throw an error into a function that returns undefined instead.
+ * @param func The function that might throw an error. It can be async.
+ * @returns
+ */
+export function tryit<A extends Array<unknown>, R>(
+  func: (...args: A) => R,
+): (
+  ...args: A
+) => R extends Promise<infer P> ? Promise<P | undefined> : R | undefined {
+  //@ts-expect-error fixing this type error would just repeat the definition above
+  return (...args) => {
+    try {
+      return func(...args);
+    } catch (error) {
+      return undefined;
+    }
+  };
+}

--- a/src/shared/Faker.ts
+++ b/src/shared/Faker.ts
@@ -14,13 +14,15 @@ import type {
 import { ensureArray } from '../Frontend/util/ensure-array';
 import { HttpClient } from '../Frontend/util/http-client';
 import {
-  RawSearchResponse,
-  SearchResponse,
+  Links,
+  PackageResponse,
+  PackagesResponse,
   System,
   systems,
   VersionKey,
   VersionResponse,
   VersionsResponse,
+  WebVersionResponse,
 } from '../Frontend/util/package-search-api';
 import { PackageSearchHooks } from '../Frontend/util/package-search-hooks';
 import {
@@ -354,9 +356,9 @@ class PackageSearchModule {
     };
   }
 
-  public static searchResponse(
-    props: Partial<SearchResponse> = {},
-  ): SearchResponse {
+  public static packageResponse(
+    props: Partial<PackageResponse> = {},
+  ): PackageResponse {
     return {
       kind: faker.datatype.boolean() ? 'PACKAGE' : 'PROJECT',
       name: faker.commerce.productName(),
@@ -365,11 +367,30 @@ class PackageSearchModule {
     };
   }
 
-  public static rawSearchResponse(
-    props: Partial<RawSearchResponse> = {},
-  ): RawSearchResponse {
+  public static packagesResponse(
+    props: Partial<PackagesResponse> = {},
+  ): PackagesResponse {
     return {
-      results: faker.helpers.multiple(PackageSearchModule.searchResponse),
+      results: faker.helpers.multiple(PackageSearchModule.packageResponse),
+      ...props,
+    };
+  }
+
+  public static links(props: Partial<Links> = {}): Links {
+    return {
+      origins: faker.helpers.multiple(faker.internet.url),
+      ...props,
+    };
+  }
+
+  public static webVersionResponse(
+    props: Partial<WebVersionResponse> = {},
+  ): WebVersionResponse {
+    return {
+      version: {
+        licenses: faker.helpers.multiple(faker.commerce.productName),
+        links: PackageSearchModule.links(),
+      },
       ...props,
     };
   }


### PR DESCRIPTION
### Summary of changes

- get URL and license from deps.dev when user adds an attribution via a version suggestion
- create "tryit" util to catch errors and convert them to undefined

### Context and reason for change

Closes #2395 

### How can the changes be tested

Click "+" when selecting a version and observe URL and license being filled in.