### PR TITLE
Fix badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OpossumUI is a tool to
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/opossum-tool/opossumUI/blob/main/LICENSES/Apache-2.0.txt)
 [![REUSE status](https://api.reuse.software/badge/git.fsfe.org/reuse/api)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/opossum-tool/opossumUI)](https://github.com/opossum-tool/opossumUI/releases/latest)
-![build workflow](https://github.com/opossum-tool/opossumUI/actions/workflows/lint-and-test.yml/badge.svg)
+![build workflow](https://github.com/opossum-tool/opossumUI/actions/workflows/check-code-quality.yml/badge.svg)
 ![build workflow](https://github.com/opossum-tool/opossumUI/actions/workflows/build-and-e2e-test.yml/badge.svg)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 


### PR DESCRIPTION
### Summary of changes

Fix the link to the GitHub actions to correctly show the badge.
![Screenshot from 2023-12-15 07-10-26](https://github.com/opossum-tool/OpossumUI/assets/50019307/775f1ce6-e297-4eac-aa33-8bc37f5d5a33)


### Context and reason for change

Badge is not shown correctly.
![image](https://github.com/opossum-tool/OpossumUI/assets/50019307/03e16873-d8cd-4a2a-b86f-c7232365261f)

