### PR TITLE
feat: offer project search suggestions

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -25,20 +25,36 @@ import { TextBox } from '../InputElements/TextBox';
 import { PackageAutocomplete } from './PackageAutocomplete';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
+/** https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst */
 const COMMON_PACKAGE_TYPES = [
   'bitbucket',
   'cargo',
+  'composer',
+  'conan',
+  'conda',
+  'cran',
   'deb',
   'docker',
   'gem',
+  'generic',
   'github',
   'gitlab',
   'golang',
+  'hackage',
+  'hex',
+  'huggingface',
   'maven',
+  'mlflow',
   'npm',
   'nuget',
+  'oci',
+  'pub',
   'pypi',
+  'qpkg',
   'rpm',
+  'rpm',
+  'swid',
+  'swift',
 ];
 
 const DisplayRow = styled('div')({
@@ -71,9 +87,8 @@ export function PackageSubPanel(props: PackageSubPanelProps) {
   const { packageNames } =
     PackageSearchHooks.usePackageNames(debouncedPackageInfo);
 
-  const { packageVersions } = PackageSearchHooks.usePackageVersions(
-    props.displayPackageInfo,
-  );
+  const { packageVersions } =
+    PackageSearchHooks.usePackageVersions(debouncedPackageInfo);
 
   return (
     <MuiBox sx={attributionColumnClasses.panel}>

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -9,6 +9,7 @@ import { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton'
 import { InputBaseComponentProps as MuiInputBaseComponentProps } from '@mui/material/InputBase';
 import useMuiAutocomplete, {
   AutocompleteHighlightChangeReason,
+  AutocompleteInputChangeReason,
   UseAutocompleteProps as MuiUseAutocompleteProps,
 } from '@mui/material/useAutocomplete';
 import { compact } from 'lodash';
@@ -32,12 +33,12 @@ type AutocompleteProps<
   FreeSolo extends boolean | undefined,
 > = Omit<
   MuiUseAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>,
-  'onClose' | 'onOpen' | 'open' | 'onHighlightChange'
+  'onClose' | 'onOpen' | 'open' | 'onHighlightChange' | 'onInputChange'
 > &
   Pick<
     ListboxProps<Value, FreeSolo>,
     | 'getOptionKey'
-    | 'groupIcon'
+    | 'groupProps'
     | 'optionText'
     | 'renderOptionEndIcon'
     | 'renderOptionStartIcon'
@@ -45,6 +46,11 @@ type AutocompleteProps<
     endAdornment?: React.ReactNode;
     highlight?: 'default' | 'dark';
     inputProps?: MuiInputBaseComponentProps;
+    onInputChange?: (
+      event: React.SyntheticEvent | undefined,
+      value: string,
+      reason: AutocompleteInputChangeReason,
+    ) => void;
     sx?: SxProps;
     title: string;
   };
@@ -63,7 +69,7 @@ export function Autocomplete<
   getOptionKey,
   getOptionLabel,
   groupBy,
-  groupIcon,
+  groupProps,
   highlight,
   inputProps,
   multiple,
@@ -223,7 +229,7 @@ export function Autocomplete<
               optionText={optionText}
               options={groupedOptions as Array<Value>}
               groupBy={groupBy}
-              groupIcon={groupIcon}
+              groupProps={groupProps}
               getOptionKey={getOptionKey}
               getOptionProps={getOptionProps}
               renderOptionStartIcon={renderOptionStartIcon}

--- a/src/Frontend/Components/Autocomplete/Listbox/Listbox.tsx
+++ b/src/Frontend/Components/Autocomplete/Listbox/Listbox.tsx
@@ -22,7 +22,10 @@ export type ListboxProps<
 > = React.HTMLAttributes<HTMLElement> & {
   virtuosoRef: React.RefObject<VirtuosoHandle>;
   options: Array<Value>;
-  groupIcon?: React.ReactNode;
+  groupProps?: {
+    icon?: React.FC<{ name: string }>;
+    action?: React.FC<{ name: string }>;
+  };
   closePopper: () => void;
   groupBy?: (option: Value) => string;
   getOptionKey?: (
@@ -64,7 +67,7 @@ export const Listbox = forwardRef(
       getOptionKey,
       getOptionProps,
       groupBy,
-      groupIcon,
+      groupProps,
       optionText,
       options,
       renderOptionEndIcon,
@@ -126,16 +129,22 @@ export const Listbox = forwardRef(
           }
           totalListHeightChanged={setHeight}
           groupCounts={groupCounts}
-          groupContent={(index) => (
-            <GroupContainer role={'group'}>
-              {groupIcon}
-              <MuiTypography
-                sx={{ ...styles.overflowEllipsis, paddingTop: '2px' }}
-              >
-                {groupNames[index]}
-              </MuiTypography>
-            </GroupContainer>
-          )}
+          groupContent={(index) => {
+            const IconComp = groupProps?.icon || (() => null);
+            const ActionComp = groupProps?.action || (() => null);
+
+            return (
+              <GroupContainer role={'group'}>
+                <IconComp name={groupNames[index]} />
+                <MuiTypography
+                  sx={{ ...styles.overflowEllipsis, paddingTop: '2px' }}
+                >
+                  {groupNames[index]}
+                </MuiTypography>
+                <ActionComp name={groupNames[index]} />
+              </GroupContainer>
+            );
+          }}
           itemContent={(index) =>
             renderOption({ index, option: options[index] })
           }

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -9,8 +9,8 @@ const TYPES_REQUIRING_NAMESPACE = [
   'bitbucket',
   'composer',
   'deb',
-  'golang',
   'github',
+  'gitlab',
   'maven',
 ];
 

--- a/src/Frontend/util/package-search-api.ts
+++ b/src/Frontend/util/package-search-api.ts
@@ -2,14 +2,18 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { compareVersions } from 'compare-versions';
-import { mapValues, partition, pick } from 'lodash';
+import { compareVersions, validate } from 'compare-versions';
+import { compact, mapValues, partition, pick } from 'lodash';
 
-import { AutocompleteSignal, PackageInfo } from '../../shared/shared-types';
+import {
+  AutocompleteSignal,
+  PackageInfo,
+  Source,
+} from '../../shared/shared-types';
 import { text } from '../../shared/text';
 import { HttpClient } from './http-client';
 
-export const systems = [
+export const packageSystems = [
   'GO',
   'NPM',
   'CARGO',
@@ -17,20 +21,47 @@ export const systems = [
   'PYPI',
   'NUGET',
 ] as const;
-export type System = (typeof systems)[number];
+export type PackageSystem = (typeof packageSystems)[number];
 
-export interface PackageResponse {
-  kind: 'PACKAGE' | 'PROJECT';
+export const projectTypes = ['GITHUB', 'GITLAB', 'BITBUCKET'] as const;
+export type ProjectType = (typeof projectTypes)[number];
+
+export interface PackageSuggestion {
+  kind: 'PACKAGE';
   name: string;
-  system: string;
+  system: PackageSystem;
+  projectType?: never;
 }
 
-export interface PackagesResponse {
-  results: Array<PackageResponse>;
+export interface ProjectSuggestion {
+  kind: 'PROJECT';
+  name: string;
+  system?: never;
+  projectType: ProjectType;
+}
+
+export interface AdvisorySuggestion {
+  kind: 'ADVISORY';
+  name: string;
+  system?: never;
+  projectType?: never;
+}
+
+export type SearchSuggestion =
+  | PackageSuggestion
+  | ProjectSuggestion
+  | AdvisorySuggestion;
+
+export interface SearchSuggestionResponse {
+  results: Array<SearchSuggestion>;
+}
+
+export interface ProjectResponse {
+  license: string;
 }
 
 export interface VersionKey {
-  system: System;
+  system: PackageSystem;
   name: string;
   version: string;
 }
@@ -64,80 +95,169 @@ export interface Versions {
   other: Array<AutocompleteSignal>;
 }
 
-export interface Version {
-  url: string | undefined;
-  license: string;
-}
+export type UrlAndLicense = Pick<PackageInfo, 'url' | 'licenseName'>;
 
 export class PackageSearchApi {
   private readonly baseUrlApi = 'https://api.deps.dev';
   private readonly baseUrlWeb = 'https://deps.dev';
+  private readonly projectTypeDomains: Record<ProjectType, string> = {
+    GITHUB: 'github.com',
+    GITLAB: 'gitlab.com',
+    BITBUCKET: 'bitbucket.org',
+  };
 
   constructor(private readonly httpClient: HttpClient) {}
 
-  private sanitize<T extends object, K extends Array<keyof T>>(
-    input: T,
-    keys: K,
-  ): Pick<T, (typeof keys)[number]> {
-    return mapValues(pick(input, keys), (value, key) => {
-      const sanitized = value?.toString().trim().toLowerCase();
-      return key === 'packageType' && sanitized === 'golang' ? 'go' : sanitized;
-    }) as Pick<T, (typeof keys)[number]>;
+  private deserialize(input: PackageInfo): Partial<SearchSuggestion> {
+    const { packageName, packageNamespace, packageType } = mapValues(
+      pick(input, ['packageName', 'packageNamespace', 'packageType']),
+      (value) => value?.trim().toLowerCase(),
+    );
+
+    if (
+      packageType &&
+      [...packageSystems, 'golang'].some(
+        (system) => system.toLowerCase() === packageType,
+      )
+    ) {
+      return {
+        kind: 'PACKAGE',
+        name:
+          packageType === 'maven'
+            ? compact([packageNamespace, packageName]).join(':')
+            : packageName,
+        system:
+          packageType === 'golang'
+            ? 'GO'
+            : (packageType.toUpperCase() as PackageSystem),
+        projectType: undefined,
+      };
+    }
+
+    if (
+      packageType &&
+      projectTypes.some((type) => type.toLowerCase() === packageType)
+    ) {
+      return {
+        kind: 'PROJECT',
+        name: compact([packageNamespace, packageName]).join('/'),
+        system: undefined,
+        projectType: packageType.toUpperCase() as ProjectType,
+      };
+    }
+
+    return {
+      kind: undefined,
+      name: packageName,
+      system: undefined,
+      projectType: undefined,
+    };
   }
 
-  public async getPackages(
+  private serialize({
+    name,
+    system,
+    projectType,
+    version,
+  }: {
+    name: string;
+    version?: string;
+    system?: PackageSystem;
+    projectType?: ProjectType;
+  }): PackageInfo {
+    const type = system || projectType;
+    const source: Source = {
+      name: text.attributionColumn.openSourceInsights,
+      documentConfidence: 100,
+    };
+    switch (type) {
+      case 'MAVEN': {
+        const [packageNamespace, packageName] = name.split(':');
+        return {
+          packageName,
+          packageNamespace,
+          packageType: 'maven',
+          packageVersion: version,
+          source,
+        };
+      }
+      case 'GITHUB':
+      case 'GITLAB':
+      case 'BITBUCKET': {
+        const [packageNamespace, packageName] = name.split('/');
+        return {
+          packageName,
+          packageNamespace,
+          packageType: type.toLowerCase(),
+          packageVersion: version,
+          source,
+          url: `https://${this.projectTypeDomains[type]}/${name}`,
+        };
+      }
+      case 'GO': {
+        return {
+          packageName: name,
+          packageNamespace: undefined,
+          packageType: 'golang',
+          packageVersion: version,
+          source,
+        };
+      }
+      default: {
+        return {
+          packageName: name,
+          packageNamespace: undefined,
+          packageType: type?.toLowerCase(),
+          packageVersion: version,
+          source,
+        };
+      }
+    }
+  }
+
+  public async getNames(
     props: PackageInfo,
   ): Promise<Array<AutocompleteSignal>> {
-    const { packageName } = this.sanitize(props, ['packageName']);
-    if (!packageName) {
+    const { name } = this.deserialize(props);
+    if (!name) {
       return [];
     }
     const response = await this.httpClient.request({
-      baseUrl: this.baseUrlWeb,
+      baseUrl: this.baseUrlWeb, // endpoint not available via API
       path: '/_/search/suggest',
       params: {
-        q: packageName,
+        q: name,
       },
     });
-    const data: PackagesResponse = await response.json();
+    const data: SearchSuggestionResponse = await response.json();
 
     return data.results
-      .filter((searchResponse) => searchResponse.kind === 'PACKAGE')
-      .map<AutocompleteSignal>(({ name, system }) => ({
-        packageName: name,
-        packageType: system.toLowerCase(),
-        source: {
-          name: text.attributionColumn.depsDev,
-          documentConfidence: 100,
-        },
-      }));
+      .filter(({ kind }) => kind !== 'ADVISORY')
+      .map<AutocompleteSignal>(({ name, system, projectType }) =>
+        this.serialize({ name, system, projectType }),
+      );
   }
 
   public async getVersions(props: PackageInfo): Promise<Versions> {
-    const { packageName, packageType } = this.sanitize(props, [
-      'packageName',
-      'packageType',
-    ]);
+    const { name, system } = this.deserialize(props);
 
-    if (
-      !packageType ||
-      !packageName ||
-      !systems.some((type) => type === packageType.toUpperCase())
-    ) {
+    if (!system || !name) {
       return { default: [], other: [] };
     }
 
     const response = await this.httpClient.request({
       baseUrl: this.baseUrlApi,
-      path: `/v3alpha/systems/${packageType}/packages/${packageName}`,
+      path: `/v3alpha/systems/${system}/packages/${encodeURIComponent(name)}`,
     });
     const { versions }: VersionsResponse = await response.json();
 
     const [defaultVersions, otherVersions] = partition(
       versions
-        .sort((a, b) =>
-          compareVersions(a.versionKey.version, b.versionKey.version),
-        )
+        .sort((a, b) => {
+          const v1 = a.versionKey.version;
+          const v2 = b.versionKey.version;
+          return validate(v1) && validate(v2) ? compareVersions(v1, v2) : 0;
+        })
         .reverse(),
       ({ isDefault }) => isDefault,
     );
@@ -145,57 +265,108 @@ export class PackageSearchApi {
     return {
       default: defaultVersions.map<AutocompleteSignal>(
         ({ versionKey: { name, system, version } }) => ({
-          packageName: name,
-          packageType: system.toLowerCase(),
-          packageVersion: version,
-          source: {
-            name: text.attributionColumn.depsDev,
-            documentConfidence: 100,
-          },
+          ...this.serialize({ name, system, version }),
           suffix: '(default)',
         }),
       ),
       other: otherVersions.map<AutocompleteSignal>(
-        ({ versionKey: { name, system, version } }) => ({
-          packageName: name,
-          packageType: system.toLowerCase(),
-          packageVersion: version,
-          source: {
-            name: text.attributionColumn.depsDev,
-            documentConfidence: 100,
-          },
-        }),
+        ({ versionKey: { name, system, version } }) =>
+          this.serialize({ name, system, version }),
       ),
     };
   }
 
-  public async getVersion(props: PackageInfo): Promise<Version> {
-    const { packageName, packageType, packageVersion } = this.sanitize(props, [
-      'packageName',
-      'packageType',
-      'packageVersion',
-    ]);
+  public async getUrlAndLicense({
+    url,
+    licenseName,
+    packageVersion,
+    ...props
+  }: PackageInfo): Promise<UrlAndLicense> {
+    const { name, projectType, system, kind } = this.deserialize(props);
 
-    if (
-      !packageType ||
-      !packageName ||
-      !packageVersion ||
-      !systems.some((type) => type === packageType.toUpperCase())
-    ) {
-      return { url: undefined, license: '' };
+    if (kind && name && system && packageVersion) {
+      return this.getPackageUrlAndLicense({
+        kind,
+        name,
+        system,
+        url,
+        licenseName,
+        packageVersion,
+      });
+    }
+
+    if (kind && name && projectType) {
+      return this.getProjectUrlAndLicense({
+        kind,
+        name,
+        projectType,
+        url,
+        licenseName,
+      });
+    }
+
+    return { url, licenseName };
+  }
+
+  private async getPackageUrlAndLicense({
+    name,
+    system,
+    url,
+    licenseName,
+    packageVersion,
+  }: PackageSuggestion &
+    UrlAndLicense & { packageVersion: string }): Promise<UrlAndLicense> {
+    if ((url && licenseName) || !packageVersion) {
+      return { url, licenseName };
     }
 
     const response = await this.httpClient.request({
-      baseUrl: this.baseUrlWeb,
-      path: `_/s/${packageType}/p/${packageName}/v/${packageVersion}`,
+      baseUrl: this.baseUrlWeb, // website provides source repo URL in a better format than API
+      path: `/_/s/${system}/p/${encodeURIComponent(
+        name,
+      )}/v/${encodeURIComponent(packageVersion)}`,
     });
+
+    if (!response.ok) {
+      return { url, licenseName };
+    }
+
     const {
       version: { links, licenses },
     }: WebVersionResponse = await response.json();
 
     return {
-      url: links.repo || links.homepage || links.origins?.[0],
-      license: licenses.join(' AND '),
+      url: url || links.repo || links.homepage || links.origins?.[0],
+      licenseName: licenseName || licenses.join(' AND '),
+    };
+  }
+
+  private async getProjectUrlAndLicense({
+    name,
+    projectType,
+    url,
+    licenseName,
+  }: ProjectSuggestion & UrlAndLicense): Promise<UrlAndLicense> {
+    if (url && licenseName) {
+      return { url, licenseName };
+    }
+
+    const projectId = `${this.projectTypeDomains[projectType]}/${name}`;
+
+    const response = await this.httpClient.request({
+      baseUrl: this.baseUrlApi,
+      path: `/v3alpha/projects/${encodeURIComponent(projectId)}`,
+    });
+
+    if (!response.ok) {
+      return { url, licenseName };
+    }
+
+    const data: ProjectResponse = await response.json();
+
+    return {
+      url: url || `https://${projectId}`,
+      licenseName: licenseName || data.license,
     };
   }
 }

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -8,10 +8,20 @@ import { PackageInfo } from '../../shared/shared-types';
 import PackageSearchApi from './package-search-api';
 import { tryit } from './tryit';
 
-function usePackageNames({ packageName }: PackageInfo) {
+function usePackageNames({
+  packageName,
+  packageNamespace,
+  packageType,
+}: PackageInfo) {
   const { data, error, isLoading } = useQuery({
-    queryKey: ['package-name-suggestions', packageName],
-    queryFn: () => PackageSearchApi.getPackages({ packageName }),
+    queryKey: [
+      'package-name-suggestions',
+      packageName,
+      packageNamespace,
+      packageType,
+    ],
+    queryFn: () =>
+      PackageSearchApi.getNames({ packageName, packageNamespace, packageType }),
     enabled: !!packageName,
   });
   return {
@@ -21,10 +31,24 @@ function usePackageNames({ packageName }: PackageInfo) {
   };
 }
 
-function usePackageVersions({ packageType, packageName }: PackageInfo) {
+function usePackageVersions({
+  packageName,
+  packageNamespace,
+  packageType,
+}: PackageInfo) {
   const { data, error, isLoading } = useQuery({
-    queryKey: ['package-version-suggestions', packageType, packageName],
-    queryFn: () => PackageSearchApi.getVersions({ packageName, packageType }),
+    queryKey: [
+      'package-version-suggestions',
+      packageName,
+      packageNamespace,
+      packageType,
+    ],
+    queryFn: () =>
+      PackageSearchApi.getVersions({
+        packageName,
+        packageNamespace,
+        packageType,
+      }),
     enabled: !!packageType && !!packageName,
   });
   return {
@@ -34,20 +58,21 @@ function usePackageVersions({ packageType, packageName }: PackageInfo) {
   };
 }
 
-function usePackageVersion() {
+function useGetPackageUrlAndLicense() {
   const { mutateAsync, error, isPending } = useMutation({
-    mutationFn: (props: PackageInfo) => PackageSearchApi.getVersion(props),
+    mutationFn: (props: PackageInfo) =>
+      PackageSearchApi.getUrlAndLicense(props),
   });
 
   return {
-    getPackageVersion: tryit(mutateAsync),
-    packageVersionError: error,
-    packageVersionLoading: isPending,
+    getPackageUrlAndLicense: tryit(mutateAsync),
+    getPackageUrlAndLicenseError: error,
+    getPackageUrlAndLicenseLoading: isPending,
   };
 }
 
 export const PackageSearchHooks = {
   usePackageNames,
   usePackageVersions,
-  usePackageVersion,
+  useGetPackageUrlAndLicense,
 };

--- a/src/Frontend/web-workers/scripts/__tests__/get-autocomplete-signals.test.ts
+++ b/src/Frontend/web-workers/scripts/__tests__/get-autocomplete-signals.test.ts
@@ -64,6 +64,49 @@ describe('getAutocompleteSignals', () => {
     ]);
   });
 
+  it('does not offer preferred attributions as suggestions', () => {
+    const [resourceName1, resourceName2] = faker.opossum.resourceNames({
+      count: 2,
+    });
+    const [attributionId1, attribution1] = faker.opossum.externalAttribution({
+      preferred: true,
+    });
+
+    const signals = getAutocompleteSignals({
+      externalData: faker.opossum.externalAttributionData({
+        resourcesToAttributions: faker.opossum.resourcesToAttributions({
+          [faker.opossum.folderPath(resourceName1)]: [attributionId1],
+          [faker.opossum.filePath(resourceName1, resourceName2)]: [
+            attributionId1,
+          ],
+        }),
+        attributions: faker.opossum.externalAttributions({
+          [attributionId1]: attribution1,
+        }),
+        resourcesWithAttributedChildren:
+          faker.opossum.resourcesWithAttributedChildren({
+            attributedChildren: {
+              '0': new Set([1]),
+            },
+            pathsToIndices: {
+              [faker.opossum.folderPath(resourceName1)]: 0,
+              [faker.opossum.filePath(resourceName1, resourceName2)]: 1,
+            },
+            paths: [
+              faker.opossum.folderPath(resourceName1),
+              faker.opossum.filePath(resourceName1, resourceName2),
+            ],
+          }),
+      }),
+      manualData: faker.opossum.manualAttributionData(),
+      resolvedExternalAttributions: new Set(),
+      resourceId: faker.opossum.folderPath(resourceName1),
+      sources: faker.opossum.externalAttributionSources(),
+    });
+
+    expect(signals).toHaveLength(0);
+  });
+
   it('ranks data by count', () => {
     const [resourceName1, resourceName2, resourceName3] =
       faker.opossum.resourceNames({
@@ -117,61 +160,41 @@ describe('getAutocompleteSignals', () => {
     ]);
   });
 
-  it('ranks data by preferred and then was-preferred', () => {
-    const [resourceName1, resourceName2, resourceName3] =
-      faker.opossum.resourceNames({
-        count: 3,
-      });
+  it('ranks data by was-preferred', () => {
+    const [resourceName1, resourceName2] = faker.opossum.resourceNames({
+      count: 2,
+    });
     const [attributionId1, attribution1] = faker.opossum.externalAttribution({
-      preferred: false,
       wasPreferred: false,
     });
     const [attributionId2, attribution2] = faker.opossum.externalAttribution({
-      preferred: false,
       wasPreferred: true,
-    });
-    const [attributionId3, attribution3] = faker.opossum.externalAttribution({
-      preferred: true,
-      wasPreferred: undefined,
     });
 
     const signals = getAutocompleteSignals({
       externalData: faker.opossum.externalAttributionData({
         resourcesToAttributions: faker.opossum.resourcesToAttributions({
           [faker.opossum.folderPath(resourceName1)]: [attributionId1],
-          [faker.opossum.folderPath(resourceName1, resourceName2)]: [
+          [faker.opossum.filePath(resourceName1, resourceName2)]: [
             attributionId2,
           ],
-          [faker.opossum.filePath(resourceName1, resourceName2, resourceName3)]:
-            [attributionId3],
         }),
         attributions: faker.opossum.externalAttributions({
           [attributionId1]: attribution1,
           [attributionId2]: attribution2,
-          [attributionId3]: attribution3,
         }),
         resourcesWithAttributedChildren:
           faker.opossum.resourcesWithAttributedChildren({
             attributedChildren: {
-              '0': new Set([1, 2]),
+              '0': new Set([1]),
             },
             pathsToIndices: {
               [faker.opossum.folderPath(resourceName1)]: 0,
-              [faker.opossum.folderPath(resourceName1, resourceName2)]: 1,
-              [faker.opossum.filePath(
-                resourceName1,
-                resourceName2,
-                resourceName3,
-              )]: 2,
+              [faker.opossum.filePath(resourceName1, resourceName2)]: 1,
             },
             paths: [
               faker.opossum.folderPath(resourceName1),
-              faker.opossum.folderPath(resourceName1, resourceName2),
-              faker.opossum.filePath(
-                resourceName1,
-                resourceName2,
-                resourceName3,
-              ),
+              faker.opossum.filePath(resourceName1, resourceName2),
             ],
           }),
       }),
@@ -181,9 +204,8 @@ describe('getAutocompleteSignals', () => {
       sources: faker.opossum.externalAttributionSources(),
     });
 
-    expect(signals).toHaveLength(3);
+    expect(signals).toHaveLength(2);
     expect(signals).toEqual<Array<AutocompleteSignal>>([
-      { ...attribution3, count: 1 },
       { ...attribution2, count: 1 },
       { ...attribution1, count: 1 },
     ]);

--- a/src/Frontend/web-workers/scripts/get-autocomplete-signals.ts
+++ b/src/Frontend/web-workers/scripts/get-autocomplete-signals.ts
@@ -58,7 +58,7 @@ export function getAutocompleteSignals({
     ...signalsOnChildren,
     ...attributionsOnChildren,
   ].reduce<Array<AutocompleteSignal>>((acc, signal) => {
-    if (!generatePurl(signal)) {
+    if (!generatePurl(signal) || signal.preferred) {
       return acc;
     }
 
@@ -74,9 +74,7 @@ export function getAutocompleteSignals({
       acc[dupeIndex] = {
         ...acc[dupeIndex],
         count: (acc[dupeIndex].count ?? 0) + 1,
-        preferred: acc[dupeIndex].preferred || signal.preferred,
         wasPreferred: acc[dupeIndex].wasPreferred || signal.wasPreferred,
-        preSelected: acc[dupeIndex].preSelected || signal.preSelected,
       };
     }
 
@@ -87,10 +85,9 @@ export function getAutocompleteSignals({
     signals,
     [
       ({ source }) => (source && sources[source.name])?.priority ?? 0,
-      ({ preferred }) => (preferred ? 1 : 0),
       ({ wasPreferred }) => (wasPreferred ? 1 : 0),
       ({ count }) => count ?? 0,
     ],
-    ['desc', 'desc', 'desc', 'desc'],
+    ['desc', 'desc', 'desc'],
   );
 }

--- a/src/shared/Faker.ts
+++ b/src/shared/Faker.ts
@@ -14,11 +14,17 @@ import type {
 import { ensureArray } from '../Frontend/util/ensure-array';
 import { HttpClient } from '../Frontend/util/http-client';
 import {
+  AdvisorySuggestion,
   Links,
-  PackageResponse,
-  PackagesResponse,
-  System,
-  systems,
+  PackageSuggestion,
+  PackageSystem,
+  packageSystems,
+  ProjectResponse,
+  ProjectSuggestion,
+  ProjectType,
+  projectTypes,
+  SearchSuggestion,
+  SearchSuggestionResponse,
   VersionKey,
   VersionResponse,
   VersionsResponse,
@@ -307,10 +313,6 @@ class OpossumModule {
 }
 
 class PackageSearchModule {
-  public static system(): System {
-    return faker.helpers.arrayElement(systems);
-  }
-
   public static usePackageNames() {
     jest.spyOn(PackageSearchHooks, 'usePackageNames').mockReturnValue({
       packageNames: [],
@@ -327,10 +329,18 @@ class PackageSearchModule {
     });
   }
 
+  public static packageSystem(): PackageSystem {
+    return faker.helpers.arrayElement(packageSystems);
+  }
+
+  public static projectType(): ProjectType {
+    return faker.helpers.arrayElement(projectTypes);
+  }
+
   public static versionKey(props: Partial<VersionKey> = {}): VersionKey {
     return {
       name: faker.commerce.productName(),
-      system: PackageSearchModule.system(),
+      system: 'NPM',
       version: faker.system.semver(),
       ...props,
     };
@@ -356,22 +366,59 @@ class PackageSearchModule {
     };
   }
 
-  public static packageResponse(
-    props: Partial<PackageResponse> = {},
-  ): PackageResponse {
+  public static projectResponse(
+    props: Partial<ProjectResponse> = {},
+  ): ProjectResponse {
     return {
-      kind: faker.datatype.boolean() ? 'PACKAGE' : 'PROJECT',
-      name: faker.commerce.productName(),
-      system: PackageSearchModule.system(),
+      license: faker.commerce.productName(),
       ...props,
     };
   }
 
-  public static packagesResponse(
-    props: Partial<PackagesResponse> = {},
-  ): PackagesResponse {
+  public static packageSuggestion(
+    props: Partial<PackageSuggestion> = {},
+  ): PackageSuggestion {
     return {
-      results: faker.helpers.multiple(PackageSearchModule.packageResponse),
+      kind: 'PACKAGE',
+      name: faker.internet.domainWord(),
+      system: PackageSearchModule.packageSystem(),
+      ...props,
+    };
+  }
+
+  public static projectSuggestion(
+    props: Partial<ProjectSuggestion> = {},
+  ): ProjectSuggestion {
+    return {
+      kind: 'PROJECT',
+      name: `${faker.internet.domainWord()}/${faker.internet.domainWord()}`,
+      projectType: PackageSearchModule.projectType(),
+      ...props,
+    };
+  }
+
+  public static advisorySuggestion(
+    props: Partial<AdvisorySuggestion> = {},
+  ): AdvisorySuggestion {
+    return {
+      kind: 'ADVISORY',
+      name: faker.internet.domainWord(),
+      ...props,
+    };
+  }
+
+  public static searchSuggestion(): SearchSuggestion {
+    return faker.helpers.arrayElement([
+      PackageSearchModule.packageSuggestion,
+      PackageSearchModule.projectSuggestion,
+    ])();
+  }
+
+  public static searchSuggestionResponse(
+    props: Partial<SearchSuggestionResponse> = {},
+  ): SearchSuggestionResponse {
+    return {
+      results: faker.helpers.multiple(PackageSearchModule.searchSuggestion),
       ...props,
     };
   }

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -26,7 +26,7 @@ export const text = {
     amongSignals: 'among signals',
     commonEcosystems: 'Common Ecosystems',
     commonLicenses: 'Common Licenses',
-    depsDev: 'Open Source Insights (deps.dev)',
+    openSourceInsights: 'Open Source Insights',
     legalInformation: 'Legal Information',
     licenseName: 'License Name',
     licenseTextModified: '(License text modified)',


### PR DESCRIPTION
### Summary of changes

- offer suggestions for projects (github, gitlab, bitbucket) when user searches by package name
- immediately get URL and license when user selects a project via the plus button
- include both name and namespace when searching by package name
- extend list of common package types
- remove golang from list of types that are requiring namespaces because there is debate in the community about this
- do not include preferred attributions in autocomplete suggestions because they are meant for a specific resource-attribution combination
- add optional group action to autocomplete component

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/ef92510b-2679-494a-821a-6684c8e3076d)

### Context and reason for change

Closes #2396 

### How can the changes be tested

Test all possible systems for which we offer suggestions. Here a list with search terms that will have at least one suggestion for the given system.

PROJECTS:
- github: "radash"
- bitbucket: "kde"
- gitlab: "gitlab-runner"

Note that repo URL and license are filled in immediately when clicking "+".
There are never any version suggestions for projects.

PACKAGES:
- npm: "react" or "lodash"
- maven: "jgiven" or "spring"
- golang: "authboss"
- pypi: "numpy"
- nuget: "serilog"
- cargo: "tokio"

Note that repo URL and license are filled in only after you choose a version in a second step after choosing a name.