### PR TITLE
feat: show origin source on attributions

### DIFF
--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -34,6 +34,7 @@ export const text = {
     packageCoordinates: 'Package Coordinates',
     useAutocompleteSuggestion:
       'Adopt all coordinates and legal information from suggestion',
+    originallyFrom: 'Originally from ',
   },
   changePreferredStatusGloballyPopup: {
     markAsPreferred: 'Do you really want to prefer the attribution globally?',


### PR DESCRIPTION
### Summary of changes

Add chips showing the origin source of of manual attributions in the attribution column

### Context and reason for change

See #2327 

### How can the changes be tested

- run 'yarn start'
- open 'opossum_input.json' or  'opossum_input.opossum'
- navigate to '/index.tsx'
- click through the different attributions
- check that each attribution has an 'origin source' chip

![origin_source_chip](https://github.com/opossum-tool/OpossumUI/assets/89708272/1df7c510-b27a-4c37-b2a9-d2fb621c432d)
