### PR TITLE
feat: offer namespace suggestions

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -86,7 +86,8 @@ export function PackageSubPanel(props: PackageSubPanelProps) {
 
   const { packageNames } =
     PackageSearchHooks.usePackageNames(debouncedPackageInfo);
-
+  const { packageNamespaces } =
+    PackageSearchHooks.usePackageNamespaces(debouncedPackageInfo);
   const { packageVersions } =
     PackageSearchHooks.usePackageVersions(debouncedPackageInfo);
 
@@ -126,6 +127,7 @@ export function PackageSubPanel(props: PackageSubPanelProps) {
         highlight={'dark'}
         disabled={!props.isEditable}
         showHighlight={props.showHighlight}
+        defaults={packageNamespaces}
       />
     );
   }

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -31,6 +31,33 @@ function usePackageNames({
   };
 }
 
+function usePackageNamespaces({
+  packageName,
+  packageNamespace,
+  packageType,
+}: PackageInfo) {
+  const { data, error, isLoading } = useQuery({
+    queryKey: [
+      'package-namespace-suggestions',
+      packageName,
+      packageNamespace,
+      packageType,
+    ],
+    queryFn: () =>
+      PackageSearchApi.getNamespaces({
+        packageName,
+        packageNamespace,
+        packageType,
+      }),
+    enabled: !!packageName && !!packageType,
+  });
+  return {
+    packageNamespaces: data,
+    packageNamespacesError: error,
+    packageNamespacesLoading: isLoading,
+  };
+}
+
 function usePackageVersions({
   packageName,
   packageNamespace,
@@ -49,7 +76,7 @@ function usePackageVersions({
         packageNamespace,
         packageType,
       }),
-    enabled: !!packageType && !!packageName,
+    enabled: !!packageName && !!packageType,
   });
   return {
     packageVersions: data,
@@ -72,7 +99,8 @@ function useGetPackageUrlAndLicense() {
 }
 
 export const PackageSearchHooks = {
-  usePackageNames,
-  usePackageVersions,
   useGetPackageUrlAndLicense,
+  usePackageNames,
+  usePackageNamespaces,
+  usePackageVersions,
 };

--- a/src/shared/Faker.ts
+++ b/src/shared/Faker.ts
@@ -321,6 +321,14 @@ class PackageSearchModule {
     });
   }
 
+  public static usePackageNamespaces() {
+    jest.spyOn(PackageSearchHooks, 'usePackageNamespaces').mockReturnValue({
+      packageNamespaces: [],
+      packageNamespacesError: null,
+      packageNamespacesLoading: false,
+    });
+  }
+
   public static usePackageVersions() {
     jest.spyOn(PackageSearchHooks, 'usePackageVersions').mockReturnValue({
       packageVersions: { default: [], other: [] },

--- a/src/shared/setupTests.ts
+++ b/src/shared/setupTests.ts
@@ -55,6 +55,7 @@ beforeAll(() => {
   mockConsoleImplementation(SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_WARN, 'warn');
   mockConsoleImplementation(SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_ERROR, 'error');
   faker.packageSearch.usePackageNames();
+  faker.packageSearch.usePackageNamespaces();
   faker.packageSearch.usePackageVersions();
 });
 


### PR DESCRIPTION
### Summary of changes

- offer namespace suggestions, when relevant, based on package name and type
- do not highlight package version and URL in attribution view since they are not essential information when determining legal information (it's rare albeit not impossible that different versions have different licenses)
- remove advisories from search results

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/ffe95bb2-cb6e-4636-a276-68a336a5e0ca)

### Context and reason for change

#2426 

### How can the changes be tested

Namespace suggestions only occur for maven, github, gitlab, bitbucket.