### PR TITLE
feat: extract copyright from license text

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -76,7 +76,7 @@ export function PackageAutocomplete({
   const isAuditView = useAppSelector(isAuditViewSelected);
 
   const { getPackageUrlAndLicense } =
-    PackageSearchHooks.useGetPackageUrlAndLicense();
+    PackageSearchHooks.useGetPackageUrlAndLegal();
 
   const autocompleteSignals = useAutocompleteSignals();
   const filteredSignals = useMemo(

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -85,10 +85,9 @@ function usePackageVersions({
   };
 }
 
-function useGetPackageUrlAndLicense() {
+function useGetPackageUrlAndLegal() {
   const { mutateAsync, error, isPending } = useMutation({
-    mutationFn: (props: PackageInfo) =>
-      PackageSearchApi.getUrlAndLicense(props),
+    mutationFn: (props: PackageInfo) => PackageSearchApi.getUrlAndLegal(props),
   });
 
   return {
@@ -99,7 +98,7 @@ function useGetPackageUrlAndLicense() {
 }
 
 export const PackageSearchHooks = {
-  useGetPackageUrlAndLicense,
+  useGetPackageUrlAndLegal,
   usePackageNames,
   usePackageNamespaces,
   usePackageVersions,


### PR DESCRIPTION
### Summary of changes

- for packages stored on GitHub or GitLab, extract copyright in addition to license name when loading the license information
- use default package version for all further requests if no package version has been provided

### Context and reason for change

Closes #2428 

### How can the changes be tested

Click the "+" button to add an attribution via any autocomplete. Notice that the copyright will be filled in automatically, if the package has a repo URL on GitHub or GitLab and the license file in the repo contains this information.
Also note, that for packages a default version will be used if no other version has been previously chosen.
