### PR TITLE
feat: offer project tags as versions

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -139,11 +139,7 @@ export function PackageSubPanel(props: PackageSubPanelProps) {
         title={text.attributionColumn.packageSubPanel.packageVersion}
         disabled={!props.isEditable}
         showHighlight={props.showHighlight}
-        defaults={
-          packageVersions
-            ? [...packageVersions.default, ...packageVersions.other]
-            : []
-        }
+        defaults={packageVersions}
       />
     );
   }

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -62,6 +62,7 @@ function usePackageVersions({
   packageName,
   packageNamespace,
   packageType,
+  packageVersion,
 }: PackageInfo) {
   const { data, error, isLoading } = useQuery({
     queryKey: [
@@ -69,12 +70,14 @@ function usePackageVersions({
       packageName,
       packageNamespace,
       packageType,
+      packageVersion,
     ],
     queryFn: () =>
       PackageSearchApi.getVersions({
         packageName,
         packageNamespace,
         packageType,
+        packageVersion,
       }),
     enabled: !!packageName && !!packageType,
   });

--- a/src/shared/Faker.ts
+++ b/src/shared/Faker.ts
@@ -18,6 +18,7 @@ import {
   GitHubLicenseResponse,
   GitLabLicenseResponse,
   GitLabProjectResponse,
+  LatestReleaseResponse,
   Links,
   PackageSuggestion,
   PackageSystem,
@@ -27,6 +28,7 @@ import {
   projectTypes,
   SearchSuggestion,
   SearchSuggestionResponse,
+  TagResponse,
   VersionKey,
   VersionResponse,
   VersionsResponse,
@@ -337,7 +339,7 @@ class PackageSearchModule {
 
   public static usePackageVersions() {
     jest.spyOn(PackageSearchHooks, 'usePackageVersions').mockReturnValue({
-      packageVersions: { default: [], other: [] },
+      packageVersions: [],
       packageVersionsError: null,
       packageVersionsLoading: false,
     });
@@ -489,6 +491,22 @@ class PackageSearchModule {
         licenses: faker.helpers.multiple(faker.commerce.productName),
         links: PackageSearchModule.links(),
       },
+      ...props,
+    };
+  }
+
+  public static tagResponse(props: Partial<TagResponse> = {}): TagResponse {
+    return {
+      name: faker.system.semver(),
+      ...props,
+    };
+  }
+
+  public static latestReleaseResponse(
+    props: Partial<LatestReleaseResponse> = {},
+  ): LatestReleaseResponse {
+    return {
+      tag_name: faker.system.semver(),
       ...props,
     };
   }


### PR DESCRIPTION
### Summary of changes

- offer GitHub and GitLab project tags as version suggestions
- GitLab narrows down suggestions by taking current version value as search param while GitHub API has no such feature and thus always returns the latest 100 tags
- take latest tag as default version for GitHub and GitLab packages
- always re-compute legal and URL to ensure that a new choice of version also updates legal information

### Context and reason for change

Closes #2429 

### How can the changes be tested

Search for a GitHub package or GitLab package (e.g. `gitlab-runner`) and click on the "+" button. Notice that the version field is immediately filled with the latest tag. Also notice that the version autocomplete offers other suggestions based on tags.