### PR TITLE
chore: simplify unit test setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,8 @@ const sharedRules = {
     { allowBoolean: true, allowNumber: true, allowNever: true },
   ],
   '@typescript-eslint/switch-exhaustiveness-check': 'error',
+  'jest/consistent-test-it': 'error',
+  'jest/prefer-spy-on': 'error',
   'filenames/match-regex': [
     'error',
     '^[a-zA-Z0-9\\-]+(.d|.test|.style)?$',

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   transformIgnorePatterns: ['/node_modules/(?!d3-*|internmap|axios)'],
   setupFilesAfterEnv: ['./src/shared/setupTests.ts'],
   watchAll: false,
+  clearMocks: true,
   setupFiles: ['whatwg-fetch'],
   roots: ['<rootDir>/src/Frontend', '<rootDir>/src/ElectronBackend'],
   modulePathIgnorePatterns: ['<rootDir>/build/'],

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -192,7 +192,7 @@ describe('Test of loading function', () => {
     const jsonPath = path.join(upath.toUnix(temporaryPath), 'test.json');
     await writeFile({ path: jsonPath, content: inputFileContent });
 
-    Date.now = jest.fn(() => 1);
+    jest.spyOn(Date, 'now').mockReturnValue(1);
 
     (dialog.showMessageBox as jest.Mock).mockImplementationOnce(
       jest.fn(() => {
@@ -242,7 +242,7 @@ describe('Test of loading function', () => {
       path: opossumPath,
     });
 
-    Date.now = jest.fn(() => 1);
+    jest.spyOn(Date, 'now').mockReturnValue(1);
 
     const globalBackendState = {
       resourceFilePath: '/previous/file.opossum',
@@ -275,7 +275,7 @@ describe('Test of loading function', () => {
       path: opossumPath,
     });
 
-    Date.now = jest.fn(() => 1691761892037);
+    jest.spyOn(Date, 'now').mockReturnValue(1691761892037);
 
     setGlobalBackendState({});
     await loadInputAndOutputFromFilePath(mainWindow, opossumPath);
@@ -296,7 +296,7 @@ describe('Test of loading function', () => {
       const jsonPath = path.join(upath.toUnix(temporaryPath), 'test.json');
       await writeFile({ path: jsonPath, content: inputFileContent });
 
-      Date.now = jest.fn(() => 1);
+      jest.spyOn(Date, 'now').mockReturnValue(1);
 
       setGlobalBackendState({});
       await loadInputAndOutputFromFilePath(mainWindow, jsonPath);
@@ -319,7 +319,7 @@ describe('Test of loading function', () => {
         zlib.gzipSync(JSON.stringify(inputFileContent)),
       );
 
-      Date.now = jest.fn(() => 1);
+      jest.spyOn(Date, 'now').mockReturnValue(1);
 
       setGlobalBackendState({});
       await loadInputAndOutputFromFilePath(mainWindow, jsonPath);
@@ -357,7 +357,7 @@ describe('Test of loading function', () => {
     };
     await writeFile({ path: attributionJsonPath, content: attributions });
 
-    Date.now = jest.fn(() => 1);
+    jest.spyOn(Date, 'now').mockReturnValue(1);
 
     const globalBackendState = {
       resourceFilePath: '/previous/file.json',
@@ -438,7 +438,7 @@ describe('Test of loading function', () => {
         content: inputFileContentWithPreselectedAttribution,
       });
 
-      Date.now = jest.fn(() => 1);
+      jest.spyOn(Date, 'now').mockReturnValue(1);
 
       const globalBackendState = {
         resourceFilePath: '/previous/file.json',
@@ -547,7 +547,7 @@ describe('Test of loading function', () => {
       content: inputFileContentWithCustomMetadata,
     });
 
-    Date.now = jest.fn(() => 1);
+    jest.spyOn(Date, 'now').mockReturnValue(1);
 
     setGlobalBackendState({});
     await loadInputAndOutputFromFilePath(mainWindow, jsonPath);
@@ -589,7 +589,7 @@ describe('Test of loading function', () => {
 
     await writeFile({ path: jsonPath, content: inputFileContentWithOriginIds });
 
-    Date.now = jest.fn(() => 1);
+    jest.spyOn(Date, 'now').mockReturnValue(1);
 
     setGlobalBackendState({});
     await loadInputAndOutputFromFilePath(mainWindow, jsonPath);

--- a/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowDev.test.ts
@@ -37,8 +37,6 @@ jest.mock('electron', () => ({
 jest.mock('electron-is-dev', () => true);
 
 describe('createWindow', () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it('returns correct BrowserWindow in devMode', async () => {
     const browserWindow = await createWindow();
     expect(browserWindow.webContents.openDevTools).toHaveBeenCalled();

--- a/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
+++ b/src/ElectronBackend/main/__tests__/createWindowProd.test.ts
@@ -45,8 +45,6 @@ jest.mock('../iconHelpers', () => ({
 }));
 
 describe('createWindow', () => {
-  beforeEach(() => jest.clearAllMocks());
-
   it('returns correct BrowserWindow in production', async () => {
     const browserWindow = await createWindow();
     expect(browserWindow.webContents.openDevTools).not.toHaveBeenCalled();

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -566,10 +566,6 @@ describe('getSelectBaseURLListener', () => {
 });
 
 describe('getSaveFileListener', () => {
-  beforeEach(() => {
-    (writeFile as jest.Mock).mockReset();
-  });
-
   it('throws error when projectId is not set', async () => {
     const mockCallback = jest.fn();
     const mainWindow = {
@@ -830,10 +826,6 @@ describe('getExportBomListener', () => {
 });
 
 describe('getExportSpdxDocumentListener', () => {
-  beforeEach(() => {
-    (writeSpdxFile as jest.Mock).mockReset();
-  });
-
   it('throws if path is not set', async () => {
     const mainWindow = await prepareBomSPdxAndFollowUpit();
 
@@ -897,10 +889,6 @@ describe('getOpenLinkListener', () => {
 });
 
 describe('_exportFileAndOpenFolder', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('calls the createFile function', async () => {
     const mainWindow = await prepareBomSPdxAndFollowUpit();
     const testSpdxDocumentYamlFilePath = '/some/path.json';

--- a/src/ElectronBackend/main/__tests__/openFileFromCliOrEnvVariableIfProvided.test.ts
+++ b/src/ElectronBackend/main/__tests__/openFileFromCliOrEnvVariableIfProvided.test.ts
@@ -23,8 +23,6 @@ describe('openFileFromCli', () => {
     process.argv = oldProcessArgv;
   });
 
-  beforeEach(() => jest.clearAllMocks());
-
   it.each`
     inputFileName          | extraParameter
     ${'inputFile.json'}    | ${null}
@@ -80,7 +78,6 @@ describe('openFileFromEnvVariable', () => {
   const oldProcessArgv = process.argv;
 
   beforeEach(() => {
-    jest.resetModules();
     process.env = cloneDeep(oldEnvVariables);
     process.argv = cloneDeep(oldProcessArgv);
   });

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -53,9 +53,6 @@ describe('The AttributionList', () => {
   const mockCallback = jest.fn((attributionId: string) => {
     return attributionId;
   });
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
 
   it('renders', () => {
     renderComponent(

--- a/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
+++ b/src/Frontend/Components/ManualAttributionList/__tests__/ManualAttributionList.test.tsx
@@ -54,9 +54,6 @@ describe('The ManualAttributionList', () => {
   const mockCallback = jest.fn((attributionId: string) => {
     return attributionId;
   });
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
 
   it('renders', () => {
     renderComponent(

--- a/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
+++ b/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
@@ -32,7 +32,6 @@ const electronAPI: {
 
 describe('ProcessPopup', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
     electronAPI.events = {};
     global.window.electronAPI = electronAPI as unknown as ElectronAPI;
   });

--- a/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/report-table-item-helpers.test.tsx
@@ -85,7 +85,7 @@ describe('The table helpers', () => {
     ).toBe('No');
   });
 
-  test.each`
+  it.each`
     followUp     | expected
     ${undefined} | ${'No'}
     ${FollowUp}  | ${'Yes'}
@@ -112,7 +112,7 @@ describe('The table helpers', () => {
     },
   );
 
-  test.each`
+  it.each`
     property
     ${'copyright'}
     ${'licenseName'}

--- a/src/Frontend/Components/ResourcesTree/__tests__/resources-tree-helpers.test.ts
+++ b/src/Frontend/Components/ResourcesTree/__tests__/resources-tree-helpers.test.ts
@@ -34,63 +34,33 @@ describe('splitResourceItToCurrentAndOtherFolder', () => {
     );
   });
 
-  const testResourcesList: Array<string> = [
-    '/OpossumUI/DCO.md',
-    '/OpossumUI/src/Frontend/test.txt',
-    '/OpossumUI/src/Frontend/Components/file.tsx',
-    '/OpossumUI/src/abc.test.tsx',
-    '/OpossumUI/.idea/',
-  ];
-
-  const expectedResources: Resources = {
-    OpossumUI: {
-      '.idea': {},
-      src: {
-        Frontend: {
-          'test.txt': 1,
-          Components: {
-            'file.tsx': 1,
-          },
-        },
-        'abc.test.tsx': 1,
-      },
-      'DCO.md': 1,
-    },
-  };
-
   it('correctly converts a list of resource ids (paths) into a Resources object', () => {
+    const testResourcesList: Array<string> = [
+      '/OpossumUI/DCO.md',
+      '/OpossumUI/src/Frontend/test.txt',
+      '/OpossumUI/src/Frontend/Components/file.tsx',
+      '/OpossumUI/src/abc.test.tsx',
+      '/OpossumUI/.idea/',
+    ];
+
+    const expectedResources: Resources = {
+      OpossumUI: {
+        '.idea': {},
+        src: {
+          Frontend: {
+            'test.txt': 1,
+            Components: {
+              'file.tsx': 1,
+            },
+          },
+          'abc.test.tsx': 1,
+        },
+        'DCO.md': 1,
+      },
+    };
+
     expect(getResourcesFromResourcePaths(testResourcesList)).toEqual(
       expectedResources,
     );
   });
-});
-
-const testResourcesList: Array<string> = [
-  '/OpossumUI/DCO.md',
-  '/OpossumUI/src/Frontend/test.txt',
-  '/OpossumUI/src/Frontend/Components/file.tsx',
-  '/OpossumUI/src/abc.test.tsx',
-  '/OpossumUI/.idea/',
-];
-
-const expectedResources: Resources = {
-  OpossumUI: {
-    '.idea': {},
-    src: {
-      Frontend: {
-        'test.txt': 1,
-        Components: {
-          'file.tsx': 1,
-        },
-      },
-      'abc.test.tsx': 1,
-    },
-    'DCO.md': 1,
-  },
-};
-
-it('correctly converts a list of resource ids (paths) into a Resources object', () => {
-  expect(getResourcesFromResourcePaths(testResourcesList)).toEqual(
-    expectedResources,
-  );
 });

--- a/src/shared/setupTests.ts
+++ b/src/shared/setupTests.ts
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom';
+import { noop } from 'lodash';
 
 import { faker } from './Faker';
 import { ElectronAPI } from './shared-types';
@@ -20,63 +21,45 @@ const SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_ERROR = [
 
 jest.mock('../ElectronBackend/main/logger.ts');
 
-const originalResizeObserver = window.ResizeObserver;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalConsoleInfo = console.info;
 
-function mockResizeObserver(): void {
-  window.ResizeObserver = jest.fn().mockImplementation(() => ({
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-    disconnect: jest.fn(),
-  }));
+class ResizeObserver {
+  observe = noop;
+  unobserve = noop;
+  disconnect = noop;
 }
 
-beforeAll(() => {
-  global.window.electronAPI = {
-    openLink: jest.fn().mockReturnValue(Promise.resolve()),
-    openFile: jest.fn(),
-    deleteFile: jest.fn(),
-    keepFile: jest.fn(),
-    convertInputFileToDotOpossum: jest.fn(),
-    useOutdatedInputFileFormat: jest.fn(),
-    openDotOpossumFile: jest.fn(),
-    sendErrorInformation: jest.fn(),
-    exportFile: jest.fn(),
-    saveFile: jest.fn(),
-    on: jest.fn().mockReturnValue(jest.fn()),
-    getUserSetting: jest.fn().mockReturnValue(undefined),
-    setUserSetting: jest.fn(),
-  } satisfies ElectronAPI;
+global.window.electronAPI = {
+  openLink: jest.fn().mockReturnValue(Promise.resolve()),
+  openFile: jest.fn(),
+  deleteFile: jest.fn(),
+  keepFile: jest.fn(),
+  convertInputFileToDotOpossum: jest.fn(),
+  useOutdatedInputFileFormat: jest.fn(),
+  openDotOpossumFile: jest.fn(),
+  sendErrorInformation: jest.fn(),
+  exportFile: jest.fn(),
+  saveFile: jest.fn(),
+  on: jest.fn().mockReturnValue(jest.fn()),
+  getUserSetting: jest.fn().mockReturnValue(undefined),
+  setUserSetting: jest.fn(),
+} satisfies ElectronAPI;
 
-  mockResizeObserver();
+window.ResizeObserver = ResizeObserver;
 
-  mockConsoleImplementation(SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_WARN, 'warn');
-  mockConsoleImplementation(SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_ERROR, 'error');
-  faker.packageSearch.usePackageNames();
-  faker.packageSearch.usePackageNamespaces();
-  faker.packageSearch.usePackageVersions();
-});
-
-beforeEach(() => jest.clearAllMocks());
-
-afterAll(() => {
-  window.ResizeObserver = originalResizeObserver;
-  console.error = originalConsoleError;
-  console.warn = originalConsoleWarn;
-  console.info = originalConsoleInfo;
-  jest.restoreAllMocks();
-});
-
-function mockConsoleImplementation(
-  selectors: Array<string>,
-  type: 'info' | 'warn' | 'error',
-): void {
-  jest
-    .spyOn(console, type)
-    .mockImplementation(getMockConsoleImplementation(selectors, type));
-}
+console.warn = getMockConsoleImplementation(
+  SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_WARN,
+  'warn',
+);
+console.error = getMockConsoleImplementation(
+  SUBSTRINGS_TO_SUPPRESS_IN_CONSOLE_ERROR,
+  'error',
+);
+faker.packageSearch.usePackageNames();
+faker.packageSearch.usePackageNamespaces();
+faker.packageSearch.usePackageVersions();
 
 function getMockConsoleImplementation(
   selectors: Array<string>,


### PR DESCRIPTION
### Summary of changes

- remove unnecessary test blocks and setup from setupTests.ts
- add linter rules to ensure that it/test and jest.spyon is correctly used

### Context and reason for change

More test consistency and transparency.

### How can the changes be tested

Run unit tests.