### PR TITLE
feat: add package description and homepage into comment field

### DIFF
--- a/src/Frontend/util/package-search-api.ts
+++ b/src/Frontend/util/package-search-api.ts
@@ -80,8 +80,9 @@ export interface Links {
 
 export interface WebVersionResponse {
   version: {
-    licenses: Array<string>;
-    links: Links;
+    description?: string;
+    licenses?: Array<string>;
+    links?: Links;
   };
 }
 
@@ -470,18 +471,33 @@ export class PackageSearchApi {
     }
 
     const {
-      version: { links, licenses },
+      version: { links, licenses, description },
     }: WebVersionResponse = await response.json();
 
     return this.enrichPackageInfoViaRepoUrl({
       ...packageInfo,
+      comments: packageInfo.comments || [
+        [
+          ...(description
+            ? [`${text.attributionColumn.description}: ${description}`]
+            : []),
+          ...(links?.homepage
+            ? [`${text.attributionColumn.homepage}: ${links.homepage}`]
+            : []),
+          ...(links?.origins?.length
+            ? links.origins.map(
+                (origin, index, origins) =>
+                  `${text.attributionColumn.origin}${
+                    origins.length > 1 ? ` #${index + 1}` : ''
+                  }: ${origin}`,
+              )
+            : []),
+        ].join('\n'),
+      ],
       licenseName:
         packageInfo.licenseName ||
-        licenses
-          .filter((license) => license !== DEPS_DEV_NON_STANDARD_LICENSE_MARKER)
-          .join(' AND '),
-      url:
-        packageInfo.url || links.repo || links.homepage || links.origins?.[0],
+        licenses?.filter((license) => license !== DEPS_DEV_NON_STANDARD_LICENSE_MARKER).join(' AND '),
+      url: packageInfo.url || links?.repo,
     });
   }
 

--- a/src/shared/Faker.ts
+++ b/src/shared/Faker.ts
@@ -479,6 +479,9 @@ class PackageSearchModule {
   public static links(props: Partial<Links> = {}): Links {
     return {
       origins: faker.helpers.multiple(faker.internet.url),
+      homepage: faker.internet.url(),
+      repo: faker.internet.url(),
+      issues: faker.internet.url(),
       ...props,
     };
   }

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -33,6 +33,9 @@ export const text = {
       'Adopt all coordinates and legal information from suggestion',
     originallyFrom: 'Originally from ',
     invalidPurl: 'INVALID PURL',
+    description: 'Description',
+    homepage: 'Homepage',
+    origin: 'Origin',
   },
   changePreferredStatusGloballyPopup: {
     markAsPreferred: 'Do you really want to prefer the attribution globally?',


### PR DESCRIPTION
### Summary of changes

- Open Source Insights (deps.dev) provides information such as description and links to homepage and origins which we add to the "comment" field of an attribution when the user selects a suggestion from one of the package comboboxes via the "+" button

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/4ffd4f51-3bab-44d8-b864-76b7080b2dc1)

### Context and reason for change

Closes #2439 

### How can the changes be tested

Only works for packages (not projects).