### PR TITLE
Fix integration of @yarnpkg/plugin-spdx

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -44,29 +44,7 @@ jobs:
 
       - run: yarn ship:auto
 
-      - name: Create SPDX document
-        run: yarn spdx
-
-      - name: Verify name in SPDX document on MacOS and Ubuntu
-        if: matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
-        run: |
-          set -e
-          name=$(jq .name opossum-ui.spdx.json -r)
-          echo "name=$name"
-          if [[ "$name" != "opossum-ui" ]]; then
-            echo "Name in SPDX document is not opossum-ui"
-            exit 1
-          fi
-
-      - name: Verify name in SPDX document on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          $name=jq .name opossum-ui.spdx.json -r
-          echo "name=$name"
-          if ("$name" -ne "opossum-ui") {
-            echo "Name in SPDX document is not opossum-ui"
-            exit 1
-          }
+      - run: yarn spdx
 
       - run: ${{ matrix.E2E }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Upload SPDX document
         uses: softprops/action-gh-release@v1
         with:
-          files: opossum-up.spdx.json
+          files: opossum-ui.spdx.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ playwright-report
 # release
 /dist-electron
 /release
+opossum-ui.spdx.json
 
 # misc
 .DS_Store


### PR DESCRIPTION
- Add spdx file to .gitignore in order to avoid accidentally checking the file in when creating it locally.
- Remove verification of name in SPDX file from CI workflow. If the document creation does not work correctly, the plugin should throw an error. So, there is no need to test that here. Besides, this test would fail if the app name would be changed in the package.json.

### Summary of changes

- Add spdx file to .gitignore
- Remove verification of name in SPDX file from CI workflow

### Context and reason for change

- We add the spdx file to .gitignore in order to avoid accidentally checking the file in when creating it locally.
- If the document creation does not work correctly, the plugin should throw an error. So, there is no need to test that in the CI workflow. Besides, this test would fail if the app name would be changed in the package.json.

### How can the changes be tested

- Create an SPDX file with `yarn spdx` and verify that it's not checked in.
- Run the CI workflow.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
