### PR TITLE
Prefer license name over copyright in package card

### DIFF
--- a/src/Frontend/util/__tests__/get-card-labels.test.ts
+++ b/src/Frontend/util/__tests__/get-card-labels.test.ts
@@ -76,51 +76,60 @@ describe('Test getPackageLabel', () => {
   it('finds label for package', () => {
     expect(getCardLabels(testProps)).toEqual([
       'Test package name, 1.2',
-      '(c) Test copyright',
+      'Test license name',
     ]);
   });
+
   it('finds label for package without version', () => {
     expect(getCardLabels(testPropsWithoutVersion)).toEqual([
       'Test package name',
-      '(c) Test copyright',
+      'Test license name',
     ]);
   });
+
   it('finds label for package with undefined name', () => {
     expect(getCardLabels(testPropsWithUndefinedName)).toEqual([
       'Test url',
-      '(c) Test copyright',
+      'Test license name',
     ]);
   });
+
   it('finds label for package without name', () => {
     expect(getCardLabels(testPropsWithoutName)).toEqual([
       'Test url',
-      '(c) Test copyright',
+      'Test license name',
     ]);
   });
+
   it('finds label for package with only copyright, licenseText and comment', () => {
     expect(getCardLabels(testPropsCopyrightLicenseTextAndComment)).toEqual([
       '(c) Test copyright',
       'Test license text',
     ]);
   });
+
   it('finds label for package with license text and comment', () => {
     expect(getCardLabels(testPropsWithLicenseTextAndComment)).toEqual([
       'Test license text',
       'Test comment',
     ]);
   });
+
   it('finds label for package with just comment', () => {
     expect(getCardLabels(testPropsJustComment)).toEqual(['Test comment']);
   });
+
   it('finds label for empty package', () => {
     expect(getCardLabels(EMPTY_DISPLAY_PACKAGE_INFO)).toEqual([]);
   });
+
   it('finds label for package with just url and copyright', () => {
     expect(getCardLabels(testPropsJustUrlAndCopyright)).toEqual([
       'Test url',
       '(c) Test copyright',
     ]);
   });
+
   it('finds label for package with just first party', () => {
     expect(getCardLabels(testPropsJustFirstParty)).toEqual(['First party']);
   });
@@ -156,6 +165,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['Test package name, 1.2']);
   });
+
   it('adds name without version', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
@@ -165,6 +175,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['Test package name']);
   });
+
   it('adds copyright', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(
@@ -174,6 +185,7 @@ describe('Test addFirstLineOfPackageLabelFromAttribute', () => {
     );
     expect(testPackageLabels).toEqual(['(c) Test copyright']);
   });
+
   it('adds url', () => {
     const testPackageLabels: Array<string> = [];
     addFirstLineOfPackageLabelFromAttribute(

--- a/src/Frontend/util/get-card-labels.ts
+++ b/src/Frontend/util/get-card-labels.ts
@@ -13,7 +13,7 @@ type RelevantDisplayPackageInfoAttributes =
   | 'url';
 
 const PRIORITIZED_DISPLAY_PACKAGE_INFO_ATTRIBUTES: Array<RelevantDisplayPackageInfoAttributes> =
-  ['packageName', 'copyright', 'licenseName', 'licenseText', 'comments', 'url'];
+  ['packageName', 'licenseName', 'copyright', 'licenseText', 'comments', 'url'];
 
 const FIRST_PARTY_TEXT = 'First party';
 


### PR DESCRIPTION
### Summary of changes

The license name is preferred over the copyright for display in the package card.

### Context and reason for change

Fix: #2442

### How can the changes be tested

Before:
![Screenshot 2023-12-22 at 06 58 29](https://github.com/opossum-tool/OpossumUI/assets/46576389/c1a2057a-a929-4c4d-bb91-588980c8e194)

After:
![Screenshot 2023-12-22 at 07 01 07](https://github.com/opossum-tool/OpossumUI/assets/46576389/bac6e08e-0da5-4532-af90-6d63c20865ec)

