### PR TITLE
fix: QA mode not hydrated on restart

### DIFF
--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -88,7 +88,7 @@ export async function main(): Promise<void> {
       UserSettings.get(key),
     );
     ipcMain.handle(IpcChannel.SetUserSettings, (_, { key, value }) =>
-      UserSettings.set(key, value),
+      UserSettings.set(key, value, { skipNotification: true }),
     );
 
     await openFileFromCliOrEnvVariableIfProvided(mainWindow);

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -333,15 +333,12 @@ export async function createMenu(mainWindow: BrowserWindow): Promise<Menu> {
           ),
           label: 'QA Mode',
           id: 'disabled-qa-mode',
-          click: async () => {
+          click: () => {
             makeFirstIconVisibleAndSecondHidden(
               'enabled-qa-mode',
               'disabled-qa-mode',
             );
-            await UserSettings.set('qaMode', true);
-            webContents.send(AllowedFrontendChannels.SetQAMode, {
-              qaMode: true,
-            });
+            void UserSettings.set('qaMode', true);
           },
           visible: !qaMode,
         },
@@ -352,15 +349,12 @@ export async function createMenu(mainWindow: BrowserWindow): Promise<Menu> {
           ),
           label: 'QA Mode',
           id: 'enabled-qa-mode',
-          click: async () => {
+          click: () => {
             makeFirstIconVisibleAndSecondHidden(
               'disabled-qa-mode',
               'enabled-qa-mode',
             );
-            await UserSettings.set('qaMode', false);
-            webContents.send(AllowedFrontendChannels.SetQAMode, {
-              qaMode: false,
-            });
+            void UserSettings.set('qaMode', false);
           },
           visible: qaMode,
         },

--- a/src/ElectronBackend/main/user-settings.ts
+++ b/src/ElectronBackend/main/user-settings.ts
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { BrowserWindow } from 'electron';
 import settings from 'electron-settings';
 import { isEqual } from 'lodash';
 
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import { UserSettings as IUserSettings } from '../../shared/shared-types';
 
 export class UserSettings {
@@ -31,10 +33,20 @@ export class UserSettings {
     return settings.get(path) as Promise<IUserSettings[T]>;
   }
 
-  public static set<T extends keyof IUserSettings>(
+  public static async set<T extends keyof IUserSettings>(
     path: T,
     value: IUserSettings[T],
+    { skipNotification }: { skipNotification?: boolean } = {},
   ): Promise<void> {
-    return settings.set(path, value);
+    await settings.set(path, value);
+
+    if (!skipNotification) {
+      BrowserWindow.getAllWindows().forEach((window) => {
+        window.webContents.send(AllowedFrontendChannels.UserSettingsChanged, {
+          path,
+          value,
+        });
+      });
+    }
   }
 }

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
@@ -31,8 +31,8 @@ import {
   getIsPreferenceFeatureEnabled,
   getTemporaryDisplayPackageInfo,
 } from '../../state/selectors/all-views-resource-selectors';
-import { getQAMode } from '../../state/selectors/view-selector';
 import { prettifySource } from '../../util/prettify-source';
+import { useUserSetting } from '../../util/use-user-setting';
 import {
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -203,7 +203,7 @@ function useChips({
 }) {
   const dispatch = useAppDispatch();
   const store = useAppStore();
-  const qaMode = useAppSelector(getQAMode);
+  const [qaMode] = useUserSetting({ defaultValue: false, key: 'qaMode' });
   const attributionSources = useAppSelector(getExternalAttributionSources);
   const isPreferenceFeatureEnabled = useAppSelector(
     getIsPreferenceFeatureEnabled,

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -17,7 +17,6 @@ import {
   ExportType,
   FileSupportPopupArgs,
   ParsedFileContent,
-  QAModeArgs,
 } from '../../../shared/shared-types';
 import { PopupType } from '../../enums/enums';
 import {
@@ -25,10 +24,7 @@ import {
   setBaseUrlsForSources,
 } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { loadFromFile } from '../../state/actions/resource-actions/load-actions';
-import {
-  openPopup,
-  setQAMode,
-} from '../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getAttributionBreakpoints,
@@ -269,15 +265,6 @@ export function BackendCommunication(): ReactElement | null {
     }
   }
 
-  function setQAModeListener(
-    _: IpcRendererEvent,
-    qaModeArgs: QAModeArgs,
-  ): void {
-    if (qaModeArgs) {
-      dispatch(setQAMode(qaModeArgs.qaMode));
-    }
-  }
-
   useIpcRenderer(AllowedFrontendChannels.FileLoaded, fileLoadedListener, [
     dispatch,
   ]);
@@ -342,9 +329,6 @@ export function BackendCommunication(): ReactElement | null {
     showUpdateAppPopupListener,
     [dispatch],
   );
-  useIpcRenderer(AllowedFrontendChannels.SetQAMode, setQAModeListener, [
-    dispatch,
-  ]);
 
   return null;
 }

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -3,65 +3,10 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { Attributions, ExportType } from '../../../../shared/shared-types';
-import { renderComponent } from '../../../test-helpers/render';
-import {
-  BackendCommunication,
-  getBomAttributions,
-} from '../BackendCommunication';
+import { getBomAttributions } from '../BackendCommunication';
 
 describe('BackendCommunication', () => {
-  it('renders an Open file icon', () => {
-    renderComponent(<BackendCommunication />);
-    const expectedNumberOfCalls = 13;
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(expectedNumberOfCalls);
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.FileLoaded,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.Logging,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ResetLoadedFile,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ExportFileRequest,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowSearchPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowProjectMetadataPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowChangedInputFilePopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowProjectStatisticsPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.SetBaseURLForRoot,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowLocatorPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.SetQAMode,
-      expect.anything(),
-    );
-  });
-
   it('filters the correct BOM attributions', () => {
     const testAttributions: Attributions = {
       genericAttrib: {},

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { fireEvent, screen } from '@testing-library/react';
 
-import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { setResources } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { initialResourceState } from '../../../state/reducers/resource-reducer';
 import {
@@ -19,54 +18,9 @@ import { TopBar } from '../TopBar';
 describe('TopBar', () => {
   it('renders an Open file icon', () => {
     const { store } = renderComponent(<TopBar />);
-    const totalNumberOfCalls = 13;
-    expect(window.electronAPI.on).toHaveBeenCalledTimes(totalNumberOfCalls);
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.FileLoaded,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.Logging,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ResetLoadedFile,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ExportFileRequest,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowSearchPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowProjectMetadataPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowChangedInputFilePopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowProjectStatisticsPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.SetBaseURLForRoot,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.ShowLocatorPopup,
-      expect.anything(),
-    );
-    expect(window.electronAPI.on).toHaveBeenCalledWith(
-      AllowedFrontendChannels.SetQAMode,
-      expect.anything(),
-    );
 
     fireEvent.click(screen.queryByLabelText('open file') as Element);
+
     expect(store.getState().resourceState).toMatchObject(initialResourceState);
     expect(window.electronAPI.openFile).toHaveBeenCalledTimes(1);
   });

--- a/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
+++ b/src/Frontend/state/actions/view-actions/__tests__/view-actions.test.ts
@@ -8,7 +8,6 @@ import { createAppStore } from '../../../configure-store';
 import {
   getOpenPopup,
   getPopupAttributionId,
-  getQAMode,
   getSelectedView,
   getTargetView,
   isAttributionViewSelected,
@@ -20,7 +19,6 @@ import {
   navigateToView,
   openPopup,
   resetViewState,
-  setQAMode,
   setTargetView,
 } from '../view-actions';
 
@@ -108,15 +106,6 @@ describe('view actions', () => {
     expect(isAttributionViewSelected(testStore.getState())).toBe(false);
     expect(getTargetView(testStore.getState())).toBeNull();
     expect(getOpenPopup(testStore.getState())).toBeNull();
-  });
-
-  it('sets and gets QA mode state', () => {
-    const testStore = createAppStore();
-    expect(getQAMode(testStore.getState())).toBe(false);
-    testStore.dispatch(setQAMode(true));
-    expect(getQAMode(testStore.getState())).toBe(true);
-    testStore.dispatch(setQAMode(false));
-    expect(getQAMode(testStore.getState())).toBe(false);
   });
 });
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -12,9 +12,6 @@ export const ACTION_CLOSE_POPUP = 'ACTION_CLOSE_POPUP';
 export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
 export const ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE =
   'ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE';
-
-export const ACTION_SET_QA_MODE = 'ACTION_SET_QA_MODE';
-
 export const ACTION_SET_OPEN_FILE_REQUEST = 'ACTION_SET_OPEN_FILE_REQUEST';
 
 export type ViewAction =
@@ -24,7 +21,6 @@ export type ViewAction =
   | ResetViewStateAction
   | OpenPopupAction
   | SetShowNoSignalsLocatedMessage
-  | SetQAModeAction
   | SetOpenFileRequestAction;
 
 export interface ResetViewStateAction {
@@ -52,11 +48,6 @@ export interface OpenPopupAction {
 
 export interface SetShowNoSignalsLocatedMessage {
   type: typeof ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE;
-  payload: boolean;
-}
-
-export interface SetQAModeAction {
-  type: typeof ACTION_SET_QA_MODE;
   payload: boolean;
 }
 

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -19,7 +19,6 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_OPEN_FILE_REQUEST,
-  ACTION_SET_QA_MODE,
   ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -27,7 +26,6 @@ import {
   OpenPopupAction,
   ResetViewStateAction,
   SetOpenFileRequestAction,
-  SetQAModeAction,
   SetShowNoSignalsLocatedMessage,
   SetTargetView,
   SetView,
@@ -97,10 +95,6 @@ export function setShowNoSignalsLocatedMessage(
     type: ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
     payload: showMessage,
   };
-}
-
-export function setQAMode(qaMode: boolean): SetQAModeAction {
-  return { type: ACTION_SET_QA_MODE, payload: qaMode };
 }
 
 export function setOpenFileRequest(

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -10,7 +10,6 @@ import {
   ACTION_OPEN_POPUP,
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_OPEN_FILE_REQUEST,
-  ACTION_SET_QA_MODE,
   ACTION_SET_SHOW_NO_SIGNALS_LOCATED_MESSAGE,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -22,7 +21,6 @@ export interface ViewState {
   targetView: View | null;
   popupInfo: Array<PopupInfo>;
   showNoSignalsLocatedMessage: boolean;
-  qaMode: boolean;
   openFileRequest: boolean;
 }
 
@@ -31,7 +29,6 @@ export const initialViewState: ViewState = {
   targetView: null,
   popupInfo: [],
   showNoSignalsLocatedMessage: false,
-  qaMode: false,
   openFileRequest: false,
 };
 
@@ -70,11 +67,6 @@ export function viewState(
       return {
         ...state,
         showNoSignalsLocatedMessage: action.payload,
-      };
-    case ACTION_SET_QA_MODE:
-      return {
-        ...state,
-        qaMode: action.payload,
       };
     case ACTION_SET_OPEN_FILE_REQUEST:
       return {

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -38,10 +38,6 @@ export function getPopupAttributionId(state: State): string | null {
   return (popup.length === 1 && popup[0].attributionId) || null;
 }
 
-export function getQAMode(state: State): boolean {
-  return state.viewState.qaMode;
-}
-
 export function getOpenFileRequest(state: State): boolean {
   return state.viewState.openFileRequest;
 }

--- a/src/Frontend/util/__tests__/use-user-setting.test.ts
+++ b/src/Frontend/util/__tests__/use-user-setting.test.ts
@@ -12,9 +12,13 @@ import { useUserSetting } from '../use-user-setting';
 const mockGetUserSetting = jest.fn();
 const mockSetUserSetting = jest.fn();
 
-const electronAPI: Pick<ElectronAPI, 'setUserSetting' | 'getUserSetting'> = {
+const electronAPI: Pick<
+  ElectronAPI,
+  'setUserSetting' | 'getUserSetting' | 'on'
+> = {
   getUserSetting: mockGetUserSetting,
   setUserSetting: mockSetUserSetting,
+  on: jest.fn().mockReturnValue(jest.fn()),
 };
 
 describe('useUserSetting', () => {

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -14,7 +14,6 @@ import {
   IsLoadingArgs,
   Log,
   ParsedFileContent,
-  QAModeArgs,
 } from '../../shared/shared-types';
 
 export type ResetStateListener = (
@@ -49,11 +48,6 @@ export type ShowFileSupportPopupListener = (
   fileSupportPopupArgs: FileSupportPopupArgs,
 ) => void;
 
-export type SetQAModeListener = (
-  event: IpcRendererEvent,
-  qaModeArgs: QAModeArgs,
-) => void;
-
 export type Listener =
   | ResetStateListener
   | SetStateListener
@@ -61,8 +55,7 @@ export type Listener =
   | ExportFileRequestListener
   | SetBaseURLForRootListener
   | IsLoadingListener
-  | ShowFileSupportPopupListener
-  | SetQAModeListener;
+  | ShowFileSupportPopupListener;
 
 export function useIpcRenderer<T extends Listener>(
   channel: AllowedFrontendChannels,

--- a/src/Frontend/util/use-user-setting.ts
+++ b/src/Frontend/util/use-user-setting.ts
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DependencyList, useCallback, useEffect } from 'react';
 
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import { UserSettings } from '../../shared/shared-types';
+import { useIpcRenderer } from './use-ipc-renderer';
 import { useVariable } from './use-variable';
 
 /**
@@ -41,6 +43,16 @@ export const useUserSetting = <T extends keyof UserSettings>(
   useEffect(() => {
     void (async (): Promise<void> => setStoredValue(await readStoredValue()))();
   }, [readStoredValue, setStoredValue]);
+
+  useIpcRenderer(
+    AllowedFrontendChannels.UserSettingsChanged,
+    async () =>
+      setVariable({
+        hydrated: true,
+        storedValue: (await readStoredValue()) ?? defaultValue,
+      }),
+    [readStoredValue],
+  );
 
   return [storedValue, setStoredValue, hydrated];
 };

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -35,5 +35,5 @@ export enum AllowedFrontendChannels {
   ShowProjectStatisticsPopup = 'show-project-statistics-pop-up',
   ShowUpdateAppPopup = 'show-update-app-pop-up',
   ShowLocatorPopup = 'show-locator-pop-up',
-  SetQAMode = 'set-qa-mode',
+  UserSettingsChanged = 'user-settings-changed',
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -216,10 +216,6 @@ export interface IsLoadingArgs {
   isLoading: boolean;
 }
 
-export interface QAModeArgs {
-  qaMode: boolean;
-}
-
 export interface ExternalAttributionSource {
   name: string;
   priority: number;


### PR DESCRIPTION
### Summary of changes

- notify all renderers of user setting changes when they occur
- ensure that use-user-setting hook listens to updates from the main process
- add option to opt out of notification (e.g. when frontend performs update via channel)
- use use-user-setting hook instead of redux for QA mode

### Context and reason for change

closes #2476 

### How can the changes be tested

Check that QA mode not only shows up correctly in the app menu but that you can also take/not take QA actions depending on the value you last set before restarting the app.