### PR TITLE
feat: offer multiple sorting options for attributions

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/SyncAccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/SyncAccordionPanel.tsx
@@ -7,8 +7,10 @@ import {
   Attributions,
   AttributionsToHashes,
 } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
 import { PackagePanelTitle } from '../../enums/enums';
 import { AttributionIdWithCount } from '../../types/types';
+import { useActiveSorting } from '../../util/use-active-sorting';
 import { AccordionPanel } from './AccordionPanel';
 import { getExternalDisplayPackageInfosWithCount } from './AccordionPanel.util';
 
@@ -24,12 +26,15 @@ interface SyncAccordionPanelProps {
 export function SyncAccordionPanel(
   props: SyncAccordionPanelProps,
 ): ReactElement {
+  const [activeSorting] = useActiveSorting();
+
   const [sortedPackageCardIds, displayPackageInfosWithCount] =
     getExternalDisplayPackageInfosWithCount(
       props.getAttributionIdsWithCount(),
       props.attributions,
       props.attributionsToHashes,
       props.title,
+      activeSorting === text.auditViewSorting.byCriticality,
     );
 
   return (

--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AccordionPanel.util.test.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AccordionPanel.util.test.ts
@@ -5,6 +5,7 @@
 import {
   Attributions,
   AttributionsToHashes,
+  Criticality,
   ResourcesToAttributions,
   ResourcesWithAttributedChildren,
 } from '../../../../shared/shared-types';
@@ -17,7 +18,7 @@ import { PanelAttributionData } from '../../../util/get-contained-packages';
 import {
   getContainedManualDisplayPackageInfosWithCount,
   getExternalDisplayPackageInfosWithCount,
-  sortDisplayPackageInfosWithCountByCountAndPackageName,
+  sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName,
 } from '../AccordionPanel.util';
 
 describe('getExternalDisplayPackageInfosWithCount', () => {
@@ -54,6 +55,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -92,6 +94,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -122,6 +125,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -162,6 +166,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -192,6 +197,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -240,6 +246,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testAttributions,
         testExternalAttributionsToHashes,
         testPackagePanelTitle,
+        false,
       ),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
@@ -311,13 +318,14 @@ describe('getContainedManualDisplayPackageInfosWithCount', () => {
         selectedResourceId,
         manualData,
         panelTitle: testPackagePanelTitle,
+        sortByCriticality: false,
       }),
     ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
   });
 });
 
-describe('sortDisplayPackageInfosWithCountByCountAndPackageName', () => {
-  it('sorts items correctly', () => {
+describe('sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName', () => {
+  it('sorts items correctly, ignoring criticality', () => {
     const initialPackageCardIds: Array<string> = [
       'pcid1',
       'pcid2',
@@ -362,8 +370,102 @@ describe('sortDisplayPackageInfosWithCountByCountAndPackageName', () => {
     ];
 
     const result = initialPackageCardIds.sort(
-      sortDisplayPackageInfosWithCountByCountAndPackageName(
+      sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName(
         testDisplayPackageInfosWithCount,
+        true,
+      ),
+    );
+    expect(result).toEqual(expectedPackageCardIds);
+  });
+
+  it('sorts items correctly by criticality, package name an version', () => {
+    const initialPackageCardIds: Array<string> = [
+      'pcid1',
+      'pcid2',
+      'pcid3',
+      'pcid4',
+      'pcid5',
+      'pcid6',
+      'pcid7',
+      'pcid8',
+      'pcid9',
+      'pcid10',
+    ];
+    const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+      pcid1: {
+        displayPackageInfo: { attributionIds: ['uuid1'] },
+        count: 10,
+      },
+      pcid2: {
+        displayPackageInfo: { attributionIds: ['uuid2'], packageName: 'c' },
+        count: 11,
+      },
+      pcid3: {
+        displayPackageInfo: { attributionIds: ['uuid3'], packageName: 'b' },
+        count: 10,
+      },
+      pcid4: {
+        displayPackageInfo: { attributionIds: ['uuid4'], packageName: 'e' },
+        count: 1,
+      },
+      pcid5: {
+        displayPackageInfo: { attributionIds: ['uuid5'], packageName: 'z' },
+        count: 10,
+      },
+      pcid6: {
+        displayPackageInfo: { attributionIds: ['uuid6'], packageName: 'd' },
+        count: 1,
+      },
+      pcid7: {
+        displayPackageInfo: {
+          attributionIds: ['uuid7'],
+          packageName: 'a',
+          criticality: Criticality.Medium,
+        },
+        count: 10,
+      },
+      pcid8: {
+        displayPackageInfo: {
+          attributionIds: ['uuid7'],
+          packageName: 'a',
+          criticality: Criticality.Medium,
+        },
+        count: 11,
+      },
+      pcid9: {
+        displayPackageInfo: {
+          attributionIds: ['uuid7'],
+          packageName: 'b',
+          criticality: Criticality.Medium,
+        },
+        count: 10,
+      },
+      pcid10: {
+        displayPackageInfo: {
+          attributionIds: ['uuid7'],
+          packageName: 'a',
+          criticality: Criticality.High,
+        },
+        count: 10,
+      },
+    };
+    const expectedPackageCardIds: Array<string> = [
+      'pcid10',
+      'pcid8',
+      'pcid7',
+      'pcid9',
+      'pcid2',
+      'pcid3',
+      'pcid5',
+      'pcid1',
+      'pcid6',
+      'pcid4',
+    ];
+
+    const result = initialPackageCardIds.sort(
+      sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName(
+        testDisplayPackageInfosWithCount,
+        true,
       ),
     );
     expect(result).toEqual(expectedPackageCardIds);

--- a/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
+++ b/src/Frontend/Components/AllAttributionsPanel/AllAttributionsPanel.tsx
@@ -5,6 +5,7 @@
 import MuiPaper from '@mui/material/Paper';
 import { ReactElement } from 'react';
 
+import { text } from '../../../shared/text';
 import { PackagePanelTitle } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
 import { selectPackageCardInAuditViewOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
@@ -12,6 +13,8 @@ import { addToSelectedResource } from '../../state/actions/resource-actions/save
 import { useAppDispatch } from '../../state/hooks';
 import { DisplayPackageInfos, PackageCardConfig } from '../../types/types';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
+import { getAlphabeticalComparerForAttributions } from '../../util/get-alphabetical-comparer';
+import { useActiveSorting } from '../../util/use-active-sorting';
 import { PackageCard } from '../PackageCard/PackageCard';
 import { PackageList } from '../PackageList/PackageList';
 
@@ -35,6 +38,7 @@ export function AllAttributionsPanel(
   props: AllAttributionsPanelProps,
 ): ReactElement {
   const dispatch = useAppDispatch();
+  const [activeSorting] = useActiveSorting();
 
   function getPackageCard(packageCardId: string): ReactElement | null {
     const displayPackageInfo = props.displayPackageInfos[packageCardId];
@@ -74,11 +78,18 @@ export function AllAttributionsPanel(
     );
   }
 
+  const sortedPackageCardIds = Object.keys(props.displayPackageInfos).sort(
+    getAlphabeticalComparerForAttributions(
+      props.displayPackageInfos,
+      activeSorting === text.auditViewSorting.byCriticality,
+    ),
+  );
+
   return (
     <MuiPaper sx={classes.root} elevation={0} square={true}>
       <PackageList
         displayPackageInfos={props.displayPackageInfos}
-        sortedPackageCardIds={Object.keys(props.displayPackageInfos)}
+        sortedPackageCardIds={sortedPackageCardIds}
         getAttributionCard={getPackageCard}
         listTitle={PackagePanelTitle.AllAttributions}
         fullHeight

--- a/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
+++ b/src/Frontend/Components/AttributionList/__tests__/AttributionList.test.tsx
@@ -5,8 +5,11 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { Criticality } from '../../../../shared/shared-types';
+import { text } from '../../../../shared/text';
 import { faker } from '../../../../testing/Faker';
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
+import { setVariable } from '../../../state/actions/variables-actions/variables-actions';
 import { getSelectedAttributionIdInAttributionView } from '../../../state/selectors/attribution-view-resource-selectors';
 import {
   getParsedInputFileEnrichedWithTestData,
@@ -48,6 +51,50 @@ describe('AttributionList', () => {
           ),
         ),
     ).toBe(2);
+  });
+
+  it('sorts attributions by criticality', () => {
+    const [attributionId1, packageInfo1] = faker.opossum.manualAttribution({
+      packageName: 'A',
+    });
+    const [attributionId2, packageInfo2] = faker.opossum.manualAttribution({
+      packageName: 'B',
+      criticality: Criticality.High,
+    });
+    const [attributionId3, packageInfo3] = faker.opossum.manualAttribution({
+      packageName: 'C',
+      criticality: Criticality.Medium,
+    });
+    renderComponent(<AttributionList />, {
+      actions: [
+        loadFromFile(
+          getParsedInputFileEnrichedWithTestData({
+            manualAttributions: faker.opossum.manualAttributions({
+              [attributionId1]: packageInfo1,
+              [attributionId2]: packageInfo2,
+              [attributionId3]: packageInfo3,
+            }),
+          }),
+        ),
+        setVariable(
+          'active-sorting-attribution-view',
+          text.attributionViewSorting.byCriticality,
+        ),
+      ],
+    });
+
+    const packageDisplay1 = screen.getByText(
+      `${packageInfo1.packageName}, ${packageInfo1.packageVersion}`,
+    );
+    const packageDisplay2 = screen.getByText(
+      `${packageInfo2.packageName}, ${packageInfo2.packageVersion}`,
+    );
+    const packageDisplay3 = screen.getByText(
+      `${packageInfo3.packageName}, ${packageInfo3.packageVersion}`,
+    );
+
+    expect(packageDisplay2.compareDocumentPosition(packageDisplay3)).toBe(4);
+    expect(packageDisplay3.compareDocumentPosition(packageDisplay1)).toBe(4);
   });
 
   it('sets selected attribution ID on card click', async () => {

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -17,11 +17,13 @@ import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import RectangleIcon from '@mui/icons-material/Rectangle';
 import ReplayIcon from '@mui/icons-material/Replay';
 import SearchIcon from '@mui/icons-material/Search';
+import SortIcon from '@mui/icons-material/Sort';
 import StarIcon from '@mui/icons-material/Star';
 import WidgetsIcon from '@mui/icons-material/Widgets';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiTooltip from '@mui/material/Tooltip';
+import { ReactElement } from 'react';
 
 import { Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
@@ -245,6 +247,18 @@ export function SearchPackagesIcon(props: IconProps) {
         sxProps: props.sx,
       })}
       aria-label={'Search packages icon'}
+    />
+  );
+}
+
+export function SortAttributionsIcon(props: IconProps): ReactElement {
+  return (
+    <SortIcon
+      sx={getSxFromPropsAndClasses({
+        styleClass: classes.nonClickableIcon,
+        sxProps: props.sx,
+      })}
+      aria-label={'Sort icon'}
     />
   );
 }

--- a/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
+++ b/src/Frontend/Components/ManualPackagePanel/ManualPackagePanel.tsx
@@ -62,7 +62,6 @@ export function ManualPackagePanel(
   );
   const selectedResourceOrClosestParentAttributions: Attributions =
     useAppSelector(getAttributionsOfSelectedResourceOrClosestParent);
-
   const selectedResourceId: string = useAppSelector(getSelectedResourceId);
 
   const shownAttributionsOfResource: Attributions = props.overrideParentMode
@@ -131,7 +130,7 @@ function getSortedPackageCardIdsAndDisplayPackageInfos(
   displayPackageInfos: DisplayPackageInfos;
 } {
   const sortedAttributionIds = Object.keys(shownAttributionsOfResource).sort(
-    getAlphabeticalComparerForAttributions(shownAttributionsOfResource),
+    getAlphabeticalComparerForAttributions(shownAttributionsOfResource, false),
   );
 
   const sortedPackageCardIds: Array<string> = [];

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -6,9 +6,10 @@ import MuiBox from '@mui/material/Box';
 import MuiTab from '@mui/material/Tab';
 import MuiTabs from '@mui/material/Tabs';
 import { remove } from 'lodash';
-import { ReactElement, useEffect, useState } from 'react';
+import { ChangeEvent, ReactElement, useEffect, useState } from 'react';
 
 import { Attributions } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
 import { PackagePanelTitle } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
 import {
@@ -29,13 +30,22 @@ import {
 import { DisplayPackageInfos } from '../../types/types';
 import { createPackageCardId } from '../../util/create-package-card-id';
 import { getDisplayPackageInfoWithCountFromAttributions } from '../../util/get-display-attributions-with-count-from-attributions';
+import {
+  AuditViewSorting,
+  useActiveSorting,
+} from '../../util/use-active-sorting';
 import { AggregatedAttributionsPanel } from '../AggregatedAttributionsPanel/AggregatedAttributionsPanel';
 import { AllAttributionsPanel } from '../AllAttributionsPanel/AllAttributionsPanel';
 import { IconButton } from '../IconButton/IconButton';
-import { SearchPackagesIcon } from '../Icons/Icons';
+import { SearchPackagesIcon, SortAttributionsIcon } from '../Icons/Icons';
+import { Dropdown, MenuItem } from '../InputElements/Dropdown';
 import { SearchTextField } from '../SearchTextField/SearchTextField';
 
 const classes = {
+  dropdown: {
+    marginTop: '10px',
+    marginBottom: '8px',
+  },
   container: {
     position: 'relative',
     height: '100%',
@@ -60,7 +70,7 @@ const classes = {
       color: OpossumColors.black,
     },
   },
-  searchToggle: {
+  icons: {
     position: 'absolute',
     right: '0px',
     top: '0px',
@@ -78,10 +88,29 @@ const classes = {
       background: OpossumColors.middleBlue,
     },
   },
+  disabledLargeClickableIcon: {
+    width: '26px',
+    height: '26px',
+    padding: '2px',
+    margin: '0 2px',
+    color: OpossumColors.disabledButtonGrey,
+  },
   searchBox: {
     marginTop: '10px',
   },
 };
+
+const SORTING_ALGORITHMS: Array<MenuItem> = [
+  {
+    value: text.auditViewSorting.byOccurrence,
+    name: text.auditViewSorting.byOccurrence,
+  },
+  {
+    value: text.auditViewSorting.byCriticality,
+    name: text.auditViewSorting.byCriticality,
+  },
+];
+const defaultSorting = text.auditViewSorting.byOccurrence;
 
 interface ResourceDetailsTabsProps {
   isGlobalTabEnabled: boolean;
@@ -92,7 +121,6 @@ export function ResourceDetailsTabs(
   props: ResourceDetailsTabsProps,
 ): ReactElement | null {
   const manualData = useAppSelector(getManualData);
-
   const selectedPackage = useAppSelector(getDisplayedPackage);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const attributionIdsOfSelectedResource: Array<string> =
@@ -101,6 +129,12 @@ export function ResourceDetailsTabs(
     getIsAccordionSearchFieldDisplayed,
   );
   const searchTerm = useAppSelector(getPackageSearchTerm);
+
+  const [activeSorting, setActiveSorting] = useActiveSorting();
+  const defaultSortingIsActive = activeSorting === defaultSorting;
+  const [showSortingSelect, setShowSortingSelect] = useState<boolean>(
+    !defaultSortingIsActive,
+  );
 
   const dispatch = useAppDispatch();
 
@@ -128,6 +162,14 @@ export function ResourceDetailsTabs(
     [Tabs.Local]: 'Local',
     [Tabs.Global]: 'Global',
   };
+
+  function onSortToggleClick(): void {
+    setShowSortingSelect(!showSortingSelect);
+  }
+
+  function onSortInputChange(event: ChangeEvent<HTMLInputElement>): void {
+    setActiveSorting(event.target.value as AuditViewSorting);
+  }
 
   function onSearchToggleClick(): void {
     dispatch(toggleAccordionSearchField());
@@ -165,13 +207,39 @@ export function ResourceDetailsTabs(
           sx={classes.tab}
         />
       </MuiTabs>
-      <IconButton
-        tooltipTitle="Search signals by name, license name, copyright text and version"
-        tooltipPlacement="right"
-        onClick={onSearchToggleClick}
-        icon={<SearchPackagesIcon sx={classes.largeClickableIcon} />}
-        iconSx={classes.searchToggle}
-      />
+      <MuiBox sx={classes.icons}>
+        <IconButton
+          tooltipTitle="Choose sorting algorithm for the displayed signals"
+          tooltipPlacement="right"
+          onClick={onSortToggleClick}
+          disabled={!defaultSortingIsActive}
+          icon={
+            <SortAttributionsIcon
+              sx={
+                !defaultSortingIsActive
+                  ? classes.disabledLargeClickableIcon
+                  : classes.largeClickableIcon
+              }
+            />
+          }
+        />
+        <IconButton
+          tooltipTitle="Search signals by name, license name, copyright text and version"
+          tooltipPlacement="right"
+          onClick={onSearchToggleClick}
+          icon={<SearchPackagesIcon sx={classes.largeClickableIcon} />}
+        />
+      </MuiBox>
+      {showSortingSelect ? (
+        <Dropdown
+          sx={classes.dropdown}
+          isEditable={true}
+          title={'Sorting Algorithm'}
+          value={activeSorting}
+          menuItems={SORTING_ALGORITHMS}
+          handleChange={onSortInputChange}
+        />
+      ) : null}
       {isAccordionSearchFieldDisplayed ? (
         <SearchTextField
           onInputChange={onSearchInputChange}

--- a/src/Frontend/enums/enums.ts
+++ b/src/Frontend/enums/enums.ts
@@ -81,6 +81,11 @@ export enum ButtonText {
   UnmarkForReplacement = 'Unmark current for replacement',
 }
 
+export enum AuditViewSortingType {
+  ByOccurrence = 'By Occurrence',
+  ByCriticality = 'By Criticality',
+}
+
 export enum ProjectStatisticsPopupTitle {
   LicenseCountsTable = 'Signals per Sources',
   AttributionPropertyCountTable = 'Attributions Overview',

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -231,6 +231,7 @@ export function getAttributionIdOfFirstPackageCardInManualPackagePanel(
     displayedAttributionId = attributionIds.sort(
       getAlphabeticalComparerForAttributions(
         state.allViews.manualData.attributions,
+        false,
       ),
     )[0];
   } else {
@@ -244,6 +245,7 @@ export function getAttributionIdOfFirstPackageCardInManualPackagePanel(
       displayedAttributionId = closestParentAttributionIds.sort(
         getAlphabeticalComparerForAttributions(
           state.allViews.manualData.attributions,
+          false,
         ),
       )[0];
     }
@@ -264,7 +266,7 @@ export function getIndexOfAttributionInManualPackagePanel(
   }
 
   const sortedAttributionIds = manualAttributionIdsOnResource.sort(
-    getAlphabeticalComparerForAttributions(manualData.attributions),
+    getAlphabeticalComparerForAttributions(manualData.attributions, false),
   );
 
   const packageCardIndex = sortedAttributionIds.findIndex(

--- a/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
+++ b/src/Frontend/util/__tests__/get-alphabetical-comparer.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Attributions } from '../../../shared/shared-types';
+import { Attributions, Criticality } from '../../../shared/shared-types';
+import { faker } from '../../../testing/Faker';
 import {
   compareAlphabeticalStrings,
   getAlphabeticalComparerForAttributions,
@@ -36,7 +37,7 @@ describe('getAlphabeticalComparerForAttributions', () => {
       },
     };
     const sortedAttributionIds = Object.keys(testAttributions).sort(
-      getAlphabeticalComparerForAttributions(testAttributions),
+      getAlphabeticalComparerForAttributions(testAttributions, false),
     );
 
     expect(sortedAttributionIds).toEqual(['3', '5', '4', '2', '1']);
@@ -56,7 +57,7 @@ describe('getAlphabeticalComparerForAttributions', () => {
       },
     };
     const sortedAttributionIds = Object.keys(testAttributions).sort(
-      getAlphabeticalComparerForAttributions(testAttributions),
+      getAlphabeticalComparerForAttributions(testAttributions, false),
     );
 
     expect(sortedAttributionIds).toEqual(['2', '3', '1']);
@@ -79,10 +80,39 @@ describe('getAlphabeticalComparerForAttributions', () => {
       },
     };
     const sortedAttributionIds = Object.keys(testAttributions).sort(
-      getAlphabeticalComparerForAttributions(testAttributions),
+      getAlphabeticalComparerForAttributions(testAttributions, false),
     );
 
     expect(sortedAttributionIds).toEqual(['2', '1', '3']);
+  });
+
+  it('sorts by criticality', () => {
+    const testAttributions: Attributions = {
+      '1': faker.opossum.manualPackageInfo({
+        packageName: 'Test package 1',
+        packageVersion: '1.0',
+      }),
+      '2': faker.opossum.manualPackageInfo({
+        attributionConfidence: 0,
+        comment: 'Some comment',
+        copyright: 'Copyright John Doe',
+        licenseText: 'Some license text',
+        criticality: Criticality.Medium,
+      }),
+      '3': faker.opossum.manualPackageInfo({
+        copyright: 'John Doe',
+        criticality: Criticality.High,
+      }),
+      '4': faker.opossum.manualPackageInfo({
+        packageName: 'Test package 2',
+        copyright: 'John Doe',
+      }),
+    };
+    const sortedAttributionIds = Object.keys(testAttributions).sort(
+      getAlphabeticalComparerForAttributions(testAttributions, true),
+    );
+
+    expect(sortedAttributionIds).toEqual(['3', '2', '1', '4']);
   });
 });
 

--- a/src/Frontend/util/get-alphabetical-comparer.ts
+++ b/src/Frontend/util/get-alphabetical-comparer.ts
@@ -3,18 +3,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Attributions } from '../../shared/shared-types';
+import { getNumericalCriticalityValue } from '../Components/AggregatedAttributionsPanel/AccordionPanel.util';
+import { DisplayPackageInfos } from '../types/types';
 import { convertPackageInfoToDisplayPackageInfo } from './convert-package-info';
 import { getCardLabels } from './get-card-labels';
 
 const DEFAULT_NAME = '\u10FFFF'; // largest unicode character
 
 export function getAlphabeticalComparerForAttributions(
-  attributions: Attributions,
+  attributions: Attributions | DisplayPackageInfos,
+  compareCriticality: boolean,
 ) {
   return function compareFunction(
     element: string,
     otherElement: string,
   ): number {
+    if (
+      compareCriticality &&
+      attributions[element]?.criticality !==
+        attributions[otherElement]?.criticality
+    ) {
+      return (
+        getNumericalCriticalityValue(attributions[otherElement]?.criticality) -
+        getNumericalCriticalityValue(attributions[element]?.criticality)
+      );
+    }
+
     const elementCardLabels = getCardLabels(
       convertPackageInfoToDisplayPackageInfo(
         {

--- a/src/Frontend/util/use-active-sorting.ts
+++ b/src/Frontend/util/use-active-sorting.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { text } from '../../shared/text';
+import { useVariable } from './use-variable';
+
+export const auditViewSorting = Object.values(text.auditViewSorting);
+export const attributionViewSorting = Object.values(
+  text.attributionViewSorting,
+);
+export type AuditViewSorting = (typeof auditViewSorting)[number];
+export type AttributionViewSorting = (typeof attributionViewSorting)[number];
+
+export function useActiveSorting(): [
+  AuditViewSorting,
+  (
+    newValue: AuditViewSorting | ((prev: AuditViewSorting) => AuditViewSorting),
+  ) => void,
+] {
+  const [activeSorting, setActiveSorting] = useVariable<AuditViewSorting>(
+    'active-sorting-audit-view',
+    text.auditViewSorting.byOccurrence,
+  );
+
+  return [activeSorting, setActiveSorting];
+}
+
+export function useActiveSortingInAttributionView(): [
+  AttributionViewSorting,
+  (
+    newValue:
+      | AttributionViewSorting
+      | ((prev: AttributionViewSorting) => AttributionViewSorting),
+  ) => void,
+] {
+  const [activeSorting, setActiveSorting] = useVariable<AttributionViewSorting>(
+    'active-sorting-attribution-view',
+    text.attributionViewSorting.alphabetical,
+  );
+
+  return [activeSorting, setActiveSorting];
+}

--- a/src/Frontend/web-workers/__tests__/signals-worker.test.ts
+++ b/src/Frontend/web-workers/__tests__/signals-worker.test.ts
@@ -45,6 +45,7 @@ describe('SignalsWorker', () => {
     const dispatch = jest.fn();
     const worker = new SignalsWorker(dispatch, {
       manualData: faker.opossum.manualAttributionData(),
+      sortByCriticality: false,
     });
 
     worker.processInput({
@@ -76,6 +77,7 @@ describe('SignalsWorker', () => {
       externalData: faker.opossum.externalAttributionData(),
       resolvedExternalAttributions: new Set<string>(),
       attributionsToHashes: {},
+      sortByCriticality: false,
     });
 
     worker.processInput({

--- a/src/Frontend/web-workers/scripts/get-attributions-in-folder-content.ts
+++ b/src/Frontend/web-workers/scripts/get-attributions-in-folder-content.ts
@@ -10,17 +10,20 @@ import { PanelAttributionData } from '../../util/get-contained-packages';
 interface Props {
   manualData: PanelAttributionData;
   resourceId: string;
+  sortByCriticality: boolean;
 }
 
 export function getAttributionsInFolderContent({
   manualData,
   resourceId,
+  sortByCriticality,
 }: Props): PanelData {
   const [sortedPackageCardIds, displayPackageInfosWithCount] =
     getContainedManualDisplayPackageInfosWithCount({
       selectedResourceId: resourceId,
       manualData,
       panelTitle: PackagePanelTitle.ContainedManualPackages,
+      sortByCriticality,
     });
 
   return {

--- a/src/Frontend/web-workers/scripts/get-signals-in-folder-content.ts
+++ b/src/Frontend/web-workers/scripts/get-signals-in-folder-content.ts
@@ -13,6 +13,7 @@ interface Props {
   attributionsToHashes: AttributionsToHashes;
   resolvedExternalAttributions: Set<string>;
   resourceId: string;
+  sortByCriticality: boolean;
 }
 
 export function getSignalsInFolderContent({
@@ -20,6 +21,7 @@ export function getSignalsInFolderContent({
   attributionsToHashes,
   resolvedExternalAttributions,
   resourceId,
+  sortByCriticality,
 }: Props): PanelData {
   const [sortedPackageCardIds, displayAttributionIdsWithCount] =
     getContainedExternalDisplayPackageInfosWithCount({
@@ -28,6 +30,7 @@ export function getSignalsInFolderContent({
       resolvedExternalAttributions,
       attributionsToHashes,
       panelTitle: PackagePanelTitle.ContainedExternalPackages,
+      sortByCriticality,
     });
 
   return {

--- a/src/Frontend/web-workers/use-signals-worker.ts
+++ b/src/Frontend/web-workers/use-signals-worker.ts
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react';
 
 import { AutocompleteSignal } from '../../shared/shared-types';
+import { text } from '../../shared/text';
 import { useAppSelector } from '../state/hooks';
 import {
   getAttributionBreakpoints,
@@ -23,6 +24,7 @@ import {
 import { isAuditViewSelected } from '../state/selectors/view-selector';
 import { PanelData, ProgressBarData } from '../types/types';
 import { shouldNotBeCalled } from '../util/should-not-be-called';
+import { useActiveSorting } from '../util/use-active-sorting';
 import { useVariable } from '../util/use-variable';
 import { SignalsWorkerInput, SignalsWorkerOutput } from './signals-worker';
 
@@ -99,6 +101,7 @@ export function useSignalsWorker() {
   const filesWithChildren = useAppSelector(getFilesWithChildren);
   const isAuditView = useAppSelector(isAuditViewSelected);
   const { projectId } = useAppSelector(getProjectMetadata);
+  const [activeSorting] = useActiveSorting();
 
   const [worker, setWorker] = useState<Worker>();
   const [, setAutocompleteSignals] = useVariable<Array<AutocompleteSignal>>(
@@ -248,4 +251,11 @@ export function useSignalsWorker() {
       } satisfies SignalsWorkerInput);
     }
   }, [resources, worker]);
+
+  useEffect(() => {
+    worker?.postMessage({
+      name: 'sortByCriticality',
+      data: activeSorting === text.auditViewSorting.byCriticality,
+    } satisfies SignalsWorkerInput);
+  }, [activeSorting, worker]);
 }

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -96,4 +96,12 @@ export const text = {
     previouslyPreferred: 'Previously Preferred',
     thirdParty: 'Third Party',
   },
+  attributionViewSorting: {
+    alphabetical: 'Alphabetical',
+    byCriticality: 'By Criticality',
+  },
+  auditViewSorting: {
+    byOccurrence: 'By Occurrence',
+    byCriticality: 'By Criticality',
+  },
 } as const;


### PR DESCRIPTION
### Summary of changes

- add toggle state for critical signals progress bar to store
- extend sorting algorithm to consider criticality
- extend test of sorting

### Context and reason for change

There is highlighting for critical signals but before this change it was still hard to find critical signals in long lists of signals coming from e.g. ScanCode.

### How can the changes be tested

Open an input file that contains critical signals and look at the sorting.
