### PR TITLE
feat: add incomplete-attribution filter

### DIFF
--- a/src/Frontend/Components/AttributionList/AttributionList.util.tsx
+++ b/src/Frontend/Components/AttributionList/AttributionList.util.tsx
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import Filter3Icon from '@mui/icons-material/Filter3';
+import RuleIcon from '@mui/icons-material/Rule';
 import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
 import { difference, isEqual, sortBy } from 'lodash';
 import { useEffect, useMemo } from 'react';
@@ -36,6 +37,7 @@ export const FILTER_ICONS: Record<Filter, React.ReactElement> = {
   'Currently Preferred': <PreferredIcon noTooltip />,
   'Excluded from Notice': <ExcludeFromNoticeIcon noTooltip />,
   'First Party': <FirstPartyIcon noTooltip />,
+  Incomplete: <RuleIcon color={'info'} sx={baseIcon} />,
   'Low Confidence': <SentimentDissatisfiedIcon color={'error'} sx={baseIcon} />,
   'Modified Previously Preferred': <ModifiedPreferredIcon noTooltip />,
   'Needs Follow-Up': <FollowUpIcon noTooltip />,

--- a/src/Frontend/web-workers/scripts/__tests__/get-filtered-attributions.test.ts
+++ b/src/Frontend/web-workers/scripts/__tests__/get-filtered-attributions.test.ts
@@ -261,6 +261,31 @@ describe('get-filtered-attributions', () => {
     });
   });
 
+  it('returns filtered attributions with incomplete-attribution filter', () => {
+    const [attributionId1, packageInfo1] = faker.opossum.manualAttribution({
+      packageName: undefined,
+    });
+    const [attributionId2, packageInfo2] = faker.opossum.manualAttribution();
+
+    const attributions = getFilteredAttributions({
+      selectedFilters: ['Incomplete'],
+      externalData: faker.opossum.externalAttributionData(),
+      manualData: faker.opossum.manualAttributionData({
+        attributions: faker.opossum.manualAttributions({
+          [attributionId1]: packageInfo1,
+          [attributionId2]: packageInfo2,
+        }),
+        resourcesToAttributions: faker.opossum.resourcesToAttributions({
+          [faker.opossum.filePath()]: [attributionId1, attributionId2],
+        }),
+      }),
+    });
+
+    expect(attributions).toEqual<Attributions>({
+      [attributionId1]: packageInfo1,
+    });
+  });
+
   it('returns filtered attributions with modified-preferred filter', () => {
     const originId1 = faker.string.uuid();
     const originId2 = faker.string.uuid();

--- a/src/Frontend/web-workers/scripts/get-filtered-attributions.ts
+++ b/src/Frontend/web-workers/scripts/get-filtered-attributions.ts
@@ -7,6 +7,7 @@ import { fromPairs, pickBy } from 'lodash';
 import { Attributions, PackageInfo } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { PanelAttributionData } from '../../util/get-contained-packages';
+import { isPackageInfoIncomplete } from '../../util/is-important-attribution-information-missing';
 
 export const filters = Object.values(text.attributionFilters);
 export type Filter = (typeof filters)[number];
@@ -22,6 +23,7 @@ export const FILTER_FUNCTIONS: Record<
   'Currently Preferred': (packageInfo) => !!packageInfo.preferred,
   'Excluded from Notice': (packageInfo) => !!packageInfo.excludeFromNotice,
   'First Party': (packageInfo) => !!packageInfo.firstParty,
+  Incomplete: (packageInfo) => isPackageInfoIncomplete(packageInfo),
   'Low Confidence': (packageInfo) =>
     packageInfo.attributionConfidence !== undefined &&
     packageInfo.attributionConfidence <= LOW_CONFIDENCE_THRESHOLD,

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -100,6 +100,7 @@ export const text = {
     currentlyPreferred: 'Currently Preferred',
     excludedFromNotice: 'Excluded from Notice',
     firstParty: 'First Party',
+    incomplete: 'Incomplete',
     lowConfidence: 'Low Confidence',
     modifiedPreferred: 'Modified Previously Preferred',
     needsFollowUp: 'Needs Follow-Up',


### PR DESCRIPTION
### Summary of changes

- add filter in attribution view to see only attributions that are missing information

![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/460235e6-1bf9-4ec9-998c-500e3caf750f)

### Context and reason for change

closes #2484 

### How can the changes be tested

Select new filter in attribution view.