### PR TITLE
fix: remove mutations of the redux state in reducers

### DIFF
--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -517,7 +517,7 @@ describe('The actions called from the unsaved popup', () => {
       return testStore.getState();
     }
 
-    it('closesPopup', () => {
+    it('closes popup', () => {
       const state: State = prepareTestState();
       expect(getOpenPopup(state)).toBeFalsy();
     });
@@ -711,7 +711,7 @@ describe('saveTemporaryDisplayPackageInfoAndNavigateToTargetViewIfSavingIsNotDis
     expect(getSelectedView(state)).toBe(View.Attribution);
   });
 
-  it('closesPopup', () => {
+  it('closes popup', () => {
     const state: State = prepareTestState();
     expect(getOpenPopup(state)).toBeFalsy();
   });

--- a/src/Frontend/state/configure-store.ts
+++ b/src/Frontend/state/configure-store.ts
@@ -19,7 +19,7 @@ export function createAppStore() {
         // TECH DEBT: we should not be putting sets into the store
         // https://redux.js.org/style-guide/#do-not-put-non-serializable-values-in-state-or-actions
         serializableCheck: false,
-        // TECH DEBT: we are mutating the redux state inside reducers
+        // We set this to false because it significantly reduces performance in development mode.
         immutableCheck: false,
       }),
   });

--- a/src/Frontend/state/helpers/action-and-reducer-helpers.ts
+++ b/src/Frontend/state/helpers/action-and-reducer-helpers.ts
@@ -228,7 +228,7 @@ export function getAttributionIdOfFirstPackageCardInManualPackagePanel(
 ): string {
   let displayedAttributionId = '';
   if (attributionIds && attributionIds.length > 0) {
-    displayedAttributionId = attributionIds.sort(
+    displayedAttributionId = [...attributionIds].sort(
       getAlphabeticalComparerForAttributions(
         state.allViews.manualData.attributions,
         false,
@@ -242,7 +242,7 @@ export function getAttributionIdOfFirstPackageCardInManualPackagePanel(
         getAttributionBreakpointCheckForResourceState(state),
       );
     if (closestParentAttributionIds.length > 0) {
-      displayedAttributionId = closestParentAttributionIds.sort(
+      displayedAttributionId = [...closestParentAttributionIds].sort(
         getAlphabeticalComparerForAttributions(
           state.allViews.manualData.attributions,
           false,

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -56,7 +56,13 @@ export function createManualAttribution(
       [newAttributionId]: [selectedResourceId],
     },
     resourcesWithAttributedChildren: {
-      ...manualData.resourcesWithAttributedChildren,
+      paths: [...manualData.resourcesWithAttributedChildren.paths],
+      pathsToIndices: {
+        ...manualData.resourcesWithAttributedChildren.pathsToIndices,
+      },
+      attributedChildren: {
+        ...manualData.resourcesWithAttributedChildren.attributedChildren,
+      },
     },
   };
 
@@ -595,7 +601,13 @@ function getAttributionDataShallowCopy(
     resourcesToAttributions: { ...attributionData.resourcesToAttributions },
     attributionsToResources: { ...attributionData.attributionsToResources },
     resourcesWithAttributedChildren: {
-      ...attributionData.resourcesWithAttributedChildren,
+      paths: [...attributionData.resourcesWithAttributedChildren.paths],
+      pathsToIndices: {
+        ...attributionData.resourcesWithAttributedChildren.pathsToIndices,
+      },
+      attributedChildren: {
+        ...attributionData.resourcesWithAttributedChildren.attributedChildren,
+      },
     },
   };
 }

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -662,7 +662,15 @@ export const resourceState = (
         new Set(state.auditView.resolvedExternalAttributions);
 
       const resourcesWithAttributedChildren = {
-        ...state.allViews.externalData.resourcesWithAttributedChildren,
+        paths:
+          state.allViews.externalData.resourcesWithAttributedChildren.paths,
+        pathsToIndices:
+          state.allViews.externalData.resourcesWithAttributedChildren
+            .pathsToIndices,
+        attributedChildren: {
+          ...state.allViews.externalData.resourcesWithAttributedChildren
+            .attributedChildren,
+        },
       };
       resolvedExternalAttributionsWithAddedAttribution.add(
         resolvedAttributionId,
@@ -718,8 +726,16 @@ export const resourceState = (
             resourcesWithAttributedChildren:
               addUnresolvedAttributionsToResourcesWithAttributedChildren(
                 {
-                  ...state.allViews.externalData
-                    .resourcesWithAttributedChildren,
+                  paths:
+                    state.allViews.externalData.resourcesWithAttributedChildren
+                      .paths,
+                  pathsToIndices:
+                    state.allViews.externalData.resourcesWithAttributedChildren
+                      .pathsToIndices,
+                  attributedChildren: {
+                    ...state.allViews.externalData
+                      .resourcesWithAttributedChildren.attributedChildren,
+                  },
                 },
                 state.allViews.externalData.attributionsToResources[
                   action.payload


### PR DESCRIPTION
### Summary of changes

This fixes some of our reducers, so that they don't mutate the state.

### Context and reason for change

Before this change, there were a few places in our code, where reducers were mutating the state. This is strongly discouraged according to [the Redux guide](https://redux.js.org/style-guide/#priority-a-rules-essential).

### How can the changes be tested

- `yarn test:unit`
- check that the app performance is still acceptable, by opening a large file in OpossumUI

Fixes https://github.com/opossum-tool/OpossumUI/issues/2412
