### PR TITLE
fix: disable list scroll animation on first render

### DIFF
--- a/src/Frontend/Components/List/List.tsx
+++ b/src/Frontend/Components/List/List.tsx
@@ -71,6 +71,15 @@ export function List({
     <Virtuoso
       ref={ref}
       fixedItemHeight={cardHeight}
+      initialTopMostItemIndex={
+        window?.process?.env.JEST_WORKER_ID // https://github.com/petyosi/react-virtuoso/issues/1001
+          ? undefined
+          : {
+              index: indexToScrollTo,
+              behavior: 'auto',
+              align: 'center',
+            }
+      }
       totalCount={length}
       isScrolling={setIsScrolling}
       style={{


### PR DESCRIPTION
### Summary of changes

- do not animate list on initial render
- use work-around because of react-virtuoso issue https://github.com/petyosi/react-virtuoso/issues/1001

### Context and reason for change

closes #2489

### How can the changes be tested

See task description.