### PR TITLE
fix: correctly set selected ID on package checkbox click

### DIFF
--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -10,10 +10,8 @@ import { memo, ReactElement, useMemo, useState } from 'react';
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { ButtonText, PopupType, View } from '../../enums/enums';
 import { clickableIcon, disabledIcon } from '../../shared-styles';
-import {
-  setMultiSelectSelectedAttributionIds,
-  setSelectedAttributionId,
-} from '../../state/actions/resource-actions/attribution-view-simple-actions';
+import { changeSelectedAttributionIdOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
+import { setMultiSelectSelectedAttributionIds } from '../../state/actions/resource-actions/attribution-view-simple-actions';
 import {
   deleteAttributionAndSave,
   deleteAttributionGloballyAndSave,
@@ -329,7 +327,9 @@ export const PackageCard = memo(
           ),
         );
         !selectedAttributionIdAttributionView &&
-          dispatch(setSelectedAttributionId(attributionId));
+          dispatch(
+            changeSelectedAttributionIdOrOpenUnsavedPopup(attributionId),
+          );
       }
 
       return props.showCheckBox && !props.hideContextMenuAndMultiSelect ? (


### PR DESCRIPTION
### Summary of changes

- use the correct thunk action to set selected ID to ensure that temporary package info is also correctly shown

### Context and reason for change

Previously the displayed package info was not shown correctly.

### How can the changes be tested

To reproduce the bug on main:
1. Open a file.
2. Go to attribution view.
3. Click on one of the package card checkboxes without first clicking on the package card.
4. Notice that the displayed package info in the right column is completely empty although the package card is selected.