### PR TITLE
chore: enable redux immutability check in ci

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -20,6 +20,7 @@ jobs:
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     env:
+      CI: true
       TARGET_BRANCH: origin/${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "test:changed": "jest --onlyChanged",
     "test:watch": "jest --watch",
     "test:e2e": "start-server-and-test \"tsc -p src/ElectronBackend && vite -m e2e\" http-get://localhost:5173/index.html \"yarn playwright test -c src/e2e-tests/playwright.config.ts\"",
-    "test:e2e:ci": "cross-env CI=true yarn playwright test -c src/e2e-tests/playwright.config.ts",
+    "test:e2e:ci": "yarn playwright test -c src/e2e-tests/playwright.config.ts",
     "lint": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\" --fix",
     "lint-check": "eslint -c .eslintrc.js \"src/**/*.{ts,tsx}\"",
     "lint-commits": "commitlint -f ${TARGET_BRANCH:-origin/main} --verbose",

--- a/src/Frontend/state/configure-store.ts
+++ b/src/Frontend/state/configure-store.ts
@@ -19,8 +19,8 @@ export function createAppStore() {
         // TECH DEBT: we should not be putting sets into the store
         // https://redux.js.org/style-guide/#do-not-put-non-serializable-values-in-state-or-actions
         serializableCheck: false,
-        // We set this to false because it significantly reduces performance in development mode.
-        immutableCheck: false,
+        // We only use this check in the CI because it significantly slows down the development server.
+        immutableCheck: process.env.CI === 'true',
       }),
   });
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import electron from 'vite-plugin-electron';
 import svgrPlugin from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
@@ -19,6 +19,9 @@ export default defineConfig(({ mode }) => ({
           entry: 'src/ElectronBackend/main/main.ts',
         })),
   ],
+  define: {
+    'process.env.CI': loadEnv(mode, process.cwd()).CI,
+  },
   build: {
     outDir: 'build',
   },


### PR DESCRIPTION
### Summary of changes

- conditionally enable check in CI but keep it off in development mode because of performance issues

### Context and reason for change

closes #2493

### How can the changes be tested

Run `yarn test:unit` locally and notice that the immutability check is off, so no error occurs when you mutate state inside one of the reducers. Now look at this pipeline run to see that the CI detects mutations: https://github.com/opossum-tool/OpossumUI/actions/runs/7506410149/job/20437774813?pr=2497