### PR TITLE
fix: disable suggestions loading when viewing a non-editable signal/attribution

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -98,12 +98,18 @@ export function PackageSubPanel({
 
   const debouncedPackageInfo = useDebouncedInput(displayPackageInfo);
 
-  const { packageNames } =
-    PackageSearchHooks.usePackageNames(debouncedPackageInfo);
-  const { packageNamespaces } =
-    PackageSearchHooks.usePackageNamespaces(debouncedPackageInfo);
-  const { packageVersions } =
-    PackageSearchHooks.usePackageVersions(debouncedPackageInfo);
+  const { packageNames } = PackageSearchHooks.usePackageNames(
+    debouncedPackageInfo,
+    { disabled: !isEditable },
+  );
+  const { packageNamespaces } = PackageSearchHooks.usePackageNamespaces(
+    debouncedPackageInfo,
+    { disabled: !isEditable },
+  );
+  const { packageVersions } = PackageSearchHooks.usePackageVersions(
+    debouncedPackageInfo,
+    { disabled: !isEditable },
+  );
   const { enrichPackageInfo } = PackageSearchHooks.useEnrichPackageInfo({
     showToasts: true,
   });

--- a/src/Frontend/util/package-search-hooks.ts
+++ b/src/Frontend/util/package-search-hooks.ts
@@ -11,11 +11,10 @@ import { toast } from '../Components/Toaster';
 import PackageSearchApi from './package-search-api';
 import { tryit } from './tryit';
 
-function usePackageNames({
-  packageName,
-  packageNamespace,
-  packageType,
-}: DisplayPackageInfo) {
+function usePackageNames(
+  { packageName, packageNamespace, packageType }: DisplayPackageInfo,
+  { disabled }: Partial<{ disabled: boolean }> = {},
+) {
   const { data, error, isLoading } = useQuery({
     queryKey: [
       'package-name-suggestions',
@@ -25,7 +24,7 @@ function usePackageNames({
     ],
     queryFn: () =>
       PackageSearchApi.getNames({ packageName, packageNamespace, packageType }),
-    enabled: !!packageName,
+    enabled: !!packageName && !disabled,
   });
   return {
     packageNames: data,
@@ -34,11 +33,10 @@ function usePackageNames({
   };
 }
 
-function usePackageNamespaces({
-  packageName,
-  packageNamespace,
-  packageType,
-}: DisplayPackageInfo) {
+function usePackageNamespaces(
+  { packageName, packageNamespace, packageType }: DisplayPackageInfo,
+  { disabled }: Partial<{ disabled: boolean }> = {},
+) {
   const { data, error, isLoading } = useQuery({
     queryKey: [
       'package-namespace-suggestions',
@@ -52,7 +50,7 @@ function usePackageNamespaces({
         packageNamespace,
         packageType,
       }),
-    enabled: !!packageName && !!packageType,
+    enabled: !!packageName && !!packageType && !disabled,
   });
   return {
     packageNamespaces: data,
@@ -61,12 +59,15 @@ function usePackageNamespaces({
   };
 }
 
-function usePackageVersions({
-  packageName,
-  packageNamespace,
-  packageType,
-  packageVersion,
-}: DisplayPackageInfo) {
+function usePackageVersions(
+  {
+    packageName,
+    packageNamespace,
+    packageType,
+    packageVersion,
+  }: DisplayPackageInfo,
+  { disabled }: Partial<{ disabled: boolean }> = {},
+) {
   const { data, error, isLoading } = useQuery({
     queryKey: [
       'package-version-suggestions',
@@ -82,7 +83,7 @@ function usePackageVersions({
         packageType,
         packageVersion,
       }),
-    enabled: !!packageName && !!packageType,
+    enabled: !!packageName && !!packageType && !disabled,
   });
   return {
     packageVersions: data,


### PR DESCRIPTION
### Summary of changes

- when viewing a non-editable signal or attribution it is not necessary to load any suggestions
- the input field was already correctly disabled before

### Context and reason for change

Avoid unnecessary background requests.

### How can the changes be tested

While in audit view, open the dev tools network tab. Then select once an attribution that is editable and then one that is not (for example a signal). Notice that only the editable attribution should trigger network requests.