### PR TITLE
chore: merge data structures counting packages

### DIFF
--- a/src/Frontend/Components/AggregatedAttributionsPanel/AccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/AccordionPanel.tsx
@@ -47,8 +47,8 @@ export function AccordionPanel(props: AccordionPanelProps): ReactElement {
   const [expanded, setExpanded] = useState<boolean>(false);
 
   useMemo(() => {
-    setExpanded(!isEmpty(props.panelData.displayPackageInfosWithCount));
-  }, [props.panelData.displayPackageInfosWithCount]);
+    setExpanded(!isEmpty(props.panelData.displayPackageInfos));
+  }, [props.panelData.displayPackageInfos]);
 
   function handleExpansionChange(
     _: React.ChangeEvent<unknown>,
@@ -68,7 +68,7 @@ export function AccordionPanel(props: AccordionPanelProps): ReactElement {
       key={`PackagePanel-${props.title}`}
       expanded={expanded}
       onChange={handleExpansionChange}
-      disabled={isEmpty(props.panelData.displayPackageInfosWithCount)}
+      disabled={isEmpty(props.panelData.displayPackageInfos)}
       aria-label={props['aria-label']}
     >
       <MuiAccordionSummary
@@ -86,9 +86,7 @@ export function AccordionPanel(props: AccordionPanelProps): ReactElement {
       >
         <PackagePanel
           title={props.title}
-          displayPackageInfosWithCount={
-            props.panelData.displayPackageInfosWithCount
-          }
+          displayPackageInfos={props.panelData.displayPackageInfos}
           sortedPackageCardIds={props.panelData.sortedPackageCardIds}
           isAddToPackageEnabled={props.isAddToPackageEnabled}
         />

--- a/src/Frontend/Components/AggregatedAttributionsPanel/SyncAccordionPanel.tsx
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/SyncAccordionPanel.tsx
@@ -37,7 +37,7 @@ export function SyncAccordionPanel(props: SyncAccordionPanelProps) {
     <AccordionPanel
       panelData={{
         sortedPackageCardIds,
-        displayPackageInfosWithCount,
+        displayPackageInfos: displayPackageInfosWithCount,
       }}
       title={props.title}
       isAddToPackageEnabled={props.isAddToPackageEnabled}

--- a/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AccordionPanel.util.test.ts
+++ b/src/Frontend/Components/AggregatedAttributionsPanel/__tests__/AccordionPanel.util.test.ts
@@ -12,7 +12,7 @@ import {
 import { PackagePanelTitle } from '../../../enums/enums';
 import {
   AttributionIdWithCount,
-  DisplayPackageInfosWithCount,
+  DisplayPackageInfos,
 } from '../../../types/types';
 import { PanelAttributionData } from '../../../util/get-contained-packages';
 import {
@@ -39,13 +39,11 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
     };
 
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
+        attributionIds: ['uuid1', 'uuid2'],
+        packageName: 'Typescript',
         count: 3,
-        displayPackageInfo: {
-          attributionIds: ['uuid1', 'uuid2'],
-          packageName: 'Typescript',
-        },
       },
     };
 
@@ -57,7 +55,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 
   it('does not merge attributions without hash', () => {
@@ -71,20 +69,16 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
       `${testPackagePanelTitle}-0`,
       `${testPackagePanelTitle}-1`,
     ];
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
         count: 3,
-        displayPackageInfo: {
-          packageName: 'Typescript',
-          attributionIds: ['uuid1'],
-        },
+        packageName: 'Typescript',
+        attributionIds: ['uuid1'],
       },
       [expectedPackageCardIds[1]]: {
         count: 2,
-        displayPackageInfo: {
-          packageName: 'Typescript',
-          attributionIds: ['uuid2'],
-        },
+        packageName: 'Typescript',
+        attributionIds: ['uuid2'],
       },
     };
 
@@ -96,7 +90,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 
   it('keeps the minimum confidence in the merged attribution', () => {
@@ -109,13 +103,11 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
       uuid2: 'a',
     };
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
         count: 3,
-        displayPackageInfo: {
-          attributionIds: ['uuid1', 'uuid2'],
-          attributionConfidence: 20,
-        },
+        attributionIds: ['uuid1', 'uuid2'],
+        attributionConfidence: 20,
       },
     };
 
@@ -127,7 +119,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 
   it('appends comments, skipping empty ones', () => {
@@ -150,13 +142,11 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
       uuid4: 'a',
     };
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
         count: 0,
-        displayPackageInfo: {
-          attributionIds: ['uuid1', 'uuid2', 'uuid3', 'uuid4'],
-          comments: ['comment A', 'comment B'],
-        },
+        attributionIds: ['uuid1', 'uuid2', 'uuid3', 'uuid4'],
+        comments: ['comment A', 'comment B'],
       },
     };
 
@@ -168,7 +158,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 
   it('merges originIds, de-duplicating them', () => {
@@ -181,13 +171,11 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
       uuid2: 'a',
     };
     const expectedPackageCardIds = [`${testPackagePanelTitle}-0`];
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
         count: 3,
-        displayPackageInfo: {
-          attributionIds: ['uuid1', 'uuid2'],
-          originIds: ['uuid3', 'uuid4', 'uuid5'],
-        },
+        attributionIds: ['uuid1', 'uuid2'],
+        originIds: ['uuid3', 'uuid4', 'uuid5'],
       },
     };
 
@@ -199,7 +187,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 
   it('sorts ordinary and merged attributions according to the count', () => {
@@ -223,20 +211,16 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
       `${testPackagePanelTitle}-0`,
     ];
 
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
         count: 3,
-        displayPackageInfo: {
-          attributionIds: ['uuidToMerge1', 'uuidToMerge2'],
-          packageName: 'Typescript',
-        },
+        attributionIds: ['uuidToMerge1', 'uuidToMerge2'],
+        packageName: 'Typescript',
       },
       [expectedPackageCardIds[1]]: {
         count: 1,
-        displayPackageInfo: {
-          attributionIds: ['uuidNotToMerge'],
-          packageName: 'React',
-        },
+        attributionIds: ['uuidNotToMerge'],
+        packageName: 'React',
       },
     };
 
@@ -248,7 +232,7 @@ describe('getExternalDisplayPackageInfosWithCount', () => {
         testPackagePanelTitle,
         false,
       ),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 });
 
@@ -289,27 +273,21 @@ describe('getContainedManualDisplayPackageInfosWithCount', () => {
       `${testPackagePanelTitle}-0`,
     ];
 
-    const expectedDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const expectedDisplayPackageInfos: DisplayPackageInfos = {
       [expectedPackageCardIds[0]]: {
-        displayPackageInfo: {
-          packageName: 'Vue',
-          attributionIds: ['uuid_2'],
-        },
         count: 2,
+        packageName: 'Vue',
+        attributionIds: ['uuid_2'],
       },
       [expectedPackageCardIds[1]]: {
-        displayPackageInfo: {
-          packageName: 'Angular',
-          attributionIds: ['uuid_3'],
-        },
         count: 1,
+        packageName: 'Angular',
+        attributionIds: ['uuid_3'],
       },
       [expectedPackageCardIds[2]]: {
-        displayPackageInfo: {
-          packageName: 'React',
-          attributionIds: ['uuid_1'],
-        },
         count: 1,
+        packageName: 'React',
+        attributionIds: ['uuid_1'],
       },
     };
 
@@ -320,7 +298,7 @@ describe('getContainedManualDisplayPackageInfosWithCount', () => {
         panelTitle: testPackagePanelTitle,
         sortByCriticality: false,
       }),
-    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfosWithCount]);
+    ).toEqual([expectedPackageCardIds, expectedDisplayPackageInfos]);
   });
 });
 
@@ -334,31 +312,13 @@ describe('sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName', 
       'pcid5',
       'pcid6',
     ];
-    const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
-      pcid1: {
-        displayPackageInfo: { attributionIds: ['uuid1'] },
-        count: 10,
-      },
-      pcid2: {
-        displayPackageInfo: { attributionIds: ['uuid2'], packageName: 'c' },
-        count: 11,
-      },
-      pcid3: {
-        displayPackageInfo: { attributionIds: ['uuid3'], packageName: 'b' },
-        count: 10,
-      },
-      pcid4: {
-        displayPackageInfo: { attributionIds: ['uuid4'], packageName: 'e' },
-        count: 1,
-      },
-      pcid5: {
-        displayPackageInfo: { attributionIds: ['uuid5'], packageName: 'z' },
-        count: 10,
-      },
-      pcid6: {
-        displayPackageInfo: { attributionIds: ['uuid6'], packageName: 'd' },
-        count: 1,
-      },
+    const testDisplayPackageInfosWithCount: DisplayPackageInfos = {
+      pcid1: { attributionIds: ['uuid1'], count: 10 },
+      pcid2: { attributionIds: ['uuid2'], packageName: 'c', count: 11 },
+      pcid3: { attributionIds: ['uuid3'], packageName: 'b', count: 10 },
+      pcid4: { attributionIds: ['uuid4'], packageName: 'e', count: 1 },
+      pcid5: { attributionIds: ['uuid5'], packageName: 'z', count: 10 },
+      pcid6: { attributionIds: ['uuid6'], packageName: 'd', count: 1 },
     };
     const expectedPackageCardIds: Array<string> = [
       'pcid2',
@@ -391,61 +351,35 @@ describe('sortDisplayPackageInfosWithCountByCriticalityAndCountAndPackageName', 
       'pcid9',
       'pcid10',
     ];
-    const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
-      pcid1: {
-        displayPackageInfo: { attributionIds: ['uuid1'] },
-        count: 10,
-      },
-      pcid2: {
-        displayPackageInfo: { attributionIds: ['uuid2'], packageName: 'c' },
-        count: 11,
-      },
-      pcid3: {
-        displayPackageInfo: { attributionIds: ['uuid3'], packageName: 'b' },
-        count: 10,
-      },
-      pcid4: {
-        displayPackageInfo: { attributionIds: ['uuid4'], packageName: 'e' },
-        count: 1,
-      },
-      pcid5: {
-        displayPackageInfo: { attributionIds: ['uuid5'], packageName: 'z' },
-        count: 10,
-      },
-      pcid6: {
-        displayPackageInfo: { attributionIds: ['uuid6'], packageName: 'd' },
-        count: 1,
-      },
+    const testDisplayPackageInfosWithCount: DisplayPackageInfos = {
+      pcid1: { attributionIds: ['uuid1'], count: 10 },
+      pcid2: { attributionIds: ['uuid2'], packageName: 'c', count: 11 },
+      pcid3: { attributionIds: ['uuid3'], packageName: 'b', count: 10 },
+      pcid4: { attributionIds: ['uuid4'], packageName: 'e', count: 1 },
+      pcid5: { attributionIds: ['uuid5'], packageName: 'z', count: 10 },
+      pcid6: { attributionIds: ['uuid6'], packageName: 'd', count: 1 },
       pcid7: {
-        displayPackageInfo: {
-          attributionIds: ['uuid7'],
-          packageName: 'a',
-          criticality: Criticality.Medium,
-        },
+        attributionIds: ['uuid7'],
+        packageName: 'a',
+        criticality: Criticality.Medium,
         count: 10,
       },
       pcid8: {
-        displayPackageInfo: {
-          attributionIds: ['uuid7'],
-          packageName: 'a',
-          criticality: Criticality.Medium,
-        },
+        attributionIds: ['uuid7'],
+        packageName: 'a',
+        criticality: Criticality.Medium,
         count: 11,
       },
       pcid9: {
-        displayPackageInfo: {
-          attributionIds: ['uuid7'],
-          packageName: 'b',
-          criticality: Criticality.Medium,
-        },
+        attributionIds: ['uuid7'],
+        packageName: 'b',
+        criticality: Criticality.Medium,
         count: 10,
       },
       pcid10: {
-        displayPackageInfo: {
-          attributionIds: ['uuid7'],
-          packageName: 'a',
-          criticality: Criticality.High,
-        },
+        attributionIds: ['uuid7'],
+        packageName: 'a',
+        criticality: Criticality.High,
         count: 10,
       },
     };

--- a/src/Frontend/Components/PackagePanel/PackagePanel.tsx
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.tsx
@@ -19,10 +19,7 @@ import {
   getResolvedExternalAttributions,
   getSelectedResourceId,
 } from '../../state/selectors/audit-view-resource-selectors';
-import {
-  DisplayPackageInfosWithCount,
-  PackageCardConfig,
-} from '../../types/types';
+import { DisplayPackageInfos, PackageCardConfig } from '../../types/types';
 import { convertDisplayPackageInfoToPackageInfo } from '../../util/convert-package-info';
 import { prettifySource } from '../../util/prettify-source';
 import { PackageCard } from '../PackageCard/PackageCard';
@@ -40,7 +37,7 @@ const classes = {
 };
 
 interface PackagePanelProps {
-  displayPackageInfosWithCount: DisplayPackageInfosWithCount;
+  displayPackageInfos: DisplayPackageInfos;
   sortedPackageCardIds: Array<string>;
   title: PackagePanelTitle;
   isAddToPackageEnabled: boolean;
@@ -82,14 +79,13 @@ export function PackagePanel(
       selectPackageCardInAuditViewOrOpenUnsavedPopup(
         props.title,
         packageCardId,
-        props.displayPackageInfosWithCount[packageCardId].displayPackageInfo,
+        props.displayPackageInfos[packageCardId],
       ),
     );
   }
 
   function onAddAttributionClick(packageCardId: string): void {
-    const displayPackageInfo =
-      props.displayPackageInfosWithCount[packageCardId].displayPackageInfo;
+    const displayPackageInfo = props.displayPackageInfos[packageCardId];
     const packageInfoToAdd =
       convertDisplayPackageInfoToPackageInfo(displayPackageInfo);
 
@@ -97,11 +93,9 @@ export function PackagePanel(
   }
 
   function getPackageCard(packageCardId: string): ReactElement {
-    const displayPackageInfo =
-      props.displayPackageInfosWithCount[packageCardId].displayPackageInfo;
+    const displayPackageInfo = props.displayPackageInfos[packageCardId];
 
-    const packageCount =
-      props.displayPackageInfosWithCount[packageCardId].count;
+    const packageCount = props.displayPackageInfos[packageCardId].count;
 
     const isExternalAttribution =
       props.title === PackagePanelTitle.ExternalPackages ||
@@ -146,14 +140,14 @@ export function PackagePanel(
   }
 
   const sortedSources = getSortedSourcesFromDisplayPackageInfosWithCount(
-    props.displayPackageInfosWithCount,
+    props.displayPackageInfos,
     attributionSources,
   );
 
   function getPackageListForSource(sourceName: string | null): ReactElement {
     const [sortedPackageCardIdsForSource, displayPackageInfosForSource] =
       getPackageCardIdsAndDisplayPackageInfosForSource(
-        props.displayPackageInfosWithCount,
+        props.displayPackageInfos,
         props.sortedPackageCardIds,
         sourceName,
       );

--- a/src/Frontend/Components/PackagePanel/PackagePanel.util.ts
+++ b/src/Frontend/Components/PackagePanel/PackagePanel.util.ts
@@ -3,13 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { ExternalAttributionSources } from '../../../shared/shared-types';
-import {
-  DisplayPackageInfos,
-  DisplayPackageInfosWithCount,
-} from '../../types/types';
+import { DisplayPackageInfos } from '../../types/types';
 
 export function getPackageCardIdsAndDisplayPackageInfosForSource(
-  displayPackageInfosWithCount: DisplayPackageInfosWithCount,
+  displayPackageInfos: DisplayPackageInfos,
   sortedPackageCardIds: Array<string>,
   sourceName: string | null,
 ): [Array<string>, DisplayPackageInfos] {
@@ -18,13 +15,11 @@ export function getPackageCardIdsAndDisplayPackageInfosForSource(
 
   sortedPackageCardIds.forEach((packageCardId) => {
     if (
-      sourceName ===
-      (displayPackageInfosWithCount[packageCardId].displayPackageInfo?.source
-        ?.name || null)
+      sourceName === (displayPackageInfos[packageCardId]?.source?.name || null)
     ) {
       filteredAndSortedPackageCardIds.push(packageCardId);
       filteredDisplayPackageInfos[packageCardId] =
-        displayPackageInfosWithCount[packageCardId].displayPackageInfo;
+        displayPackageInfos[packageCardId];
     }
   });
 
@@ -32,16 +27,13 @@ export function getPackageCardIdsAndDisplayPackageInfosForSource(
 }
 
 export function getSortedSourcesFromDisplayPackageInfosWithCount(
-  displayPackageInfosWithCount: DisplayPackageInfosWithCount,
+  displayPackageInfos: DisplayPackageInfos,
   attributionSources: ExternalAttributionSources,
 ): Array<string | null> {
   const sourceNames = new Set<string | null>();
-  Object.values(displayPackageInfosWithCount).forEach(
-    ({ displayPackageInfo }) => {
-      sourceNames.add(displayPackageInfo?.source?.name || null);
-    },
-    sourceNames,
-  );
+  Object.values(displayPackageInfos).forEach((displayPackageInfo) => {
+    sourceNames.add(displayPackageInfo?.source?.name || null);
+  }, sourceNames);
   return sortSources(Array.from(sourceNames), attributionSources);
 }
 

--- a/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
+++ b/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.test.tsx
@@ -13,7 +13,7 @@ import { setExternalAttributionSources } from '../../../state/actions/resource-a
 import { loadFromFile } from '../../../state/actions/resource-actions/load-actions';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
 import { renderComponent } from '../../../test-helpers/render';
-import { DisplayPackageInfosWithCount } from '../../../types/types';
+import { DisplayPackageInfos } from '../../../types/types';
 import { PackagePanel } from '../PackagePanel';
 
 describe('The PackagePanel', () => {
@@ -24,29 +24,23 @@ describe('The PackagePanel', () => {
       'Contained Signals-1',
       'Contained Signals-2',
     ];
-    const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const testDisplayPackageInfos: DisplayPackageInfos = {
       [testSortedPackageCardIds[0]]: {
-        displayPackageInfo: {
-          source: testSource,
-          packageName: 'React',
-          packageVersion: '16.5.0',
-          attributionIds: ['uuid1'],
-        },
+        source: testSource,
+        packageName: 'React',
+        packageVersion: '16.5.0',
+        attributionIds: ['uuid1'],
         count: 1,
       },
       [testSortedPackageCardIds[1]]: {
-        displayPackageInfo: {
-          source: testSource,
-          packageName: 'JQuery',
-          attributionIds: ['uuid2'],
-        },
+        source: testSource,
+        packageName: 'JQuery',
+        attributionIds: ['uuid2'],
         count: 1,
       },
       [testSortedPackageCardIds[2]]: {
-        displayPackageInfo: {
-          source: testSource,
-          attributionIds: ['uuid3'],
-        },
+        source: testSource,
+        attributionIds: ['uuid3'],
         count: 1,
       },
     };
@@ -65,7 +59,7 @@ describe('The PackagePanel', () => {
     };
     renderComponent(
       <PackagePanel
-        displayPackageInfosWithCount={testDisplayPackageInfosWithCount}
+        displayPackageInfos={testDisplayPackageInfos}
         sortedPackageCardIds={testSortedPackageCardIds}
         title={PackagePanelTitle.ContainedExternalPackages}
         isAddToPackageEnabled={true}
@@ -92,29 +86,23 @@ describe('The PackagePanel', () => {
       'Contained Signals-1',
       'Contained Signals-2',
     ];
-    const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+    const testDisplayPackageInfos: DisplayPackageInfos = {
       [testSortedPackageCardIds[0]]: {
-        displayPackageInfo: {
-          source: { name: 'other', documentConfidence: 1 },
-          packageName: 'React',
-          packageVersion: '16.5.0',
-          attributionIds: ['uuid1'],
-        },
+        source: { name: 'other', documentConfidence: 1 },
+        packageName: 'React',
+        packageVersion: '16.5.0',
+        attributionIds: ['uuid1'],
         count: 1,
       },
       [testSortedPackageCardIds[1]]: {
-        displayPackageInfo: {
-          source: { name: 'SC', documentConfidence: 1 },
-          packageName: 'JQuery',
-          attributionIds: ['uuid2'],
-        },
+        source: { name: 'SC', documentConfidence: 1 },
+        packageName: 'JQuery',
+        attributionIds: ['uuid2'],
         count: 1,
       },
       [testSortedPackageCardIds[2]]: {
-        displayPackageInfo: {
-          packageName: 'JQuery 2',
-          attributionIds: ['uuid3'],
-        },
+        packageName: 'JQuery 2',
+        attributionIds: ['uuid3'],
         count: 1,
       },
     };
@@ -138,7 +126,7 @@ describe('The PackagePanel', () => {
     };
     renderComponent(
       <PackagePanel
-        displayPackageInfosWithCount={testDisplayPackageInfosWithCount}
+        displayPackageInfos={testDisplayPackageInfos}
         sortedPackageCardIds={testSortedPackageCardIds}
         title={PackagePanelTitle.ContainedExternalPackages}
         isAddToPackageEnabled={true}

--- a/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.util.test.ts
+++ b/src/Frontend/Components/PackagePanel/__tests__/PackagePanel.util.test.ts
@@ -2,11 +2,10 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { pick } from 'lodash';
+
 import { ExternalAttributionSources } from '../../../../shared/shared-types';
-import {
-  DisplayPackageInfos,
-  DisplayPackageInfosWithCount,
-} from '../../../types/types';
+import { DisplayPackageInfos } from '../../../types/types';
 import {
   getPackageCardIdsAndDisplayPackageInfosForSource,
   getSortedSourcesFromDisplayPackageInfosWithCount,
@@ -22,83 +21,60 @@ const testSortedPackageCardIds = [
   'Signals-6',
 ];
 
-const testDisplayPackageInfosWithCount: DisplayPackageInfosWithCount = {
+const testDisplayPackageInfos: DisplayPackageInfos = {
   [testSortedPackageCardIds[0]]: {
+    source: { name: 'MERGER', documentConfidence: 100 },
+    packageName: 'React',
+    packageVersion: '16.5.0',
+    attributionIds: ['react'],
     count: 5,
-    displayPackageInfo: {
-      source: { name: 'MERGER', documentConfidence: 100 },
-      packageName: 'React',
-      packageVersion: '16.5.0',
-      attributionIds: ['react'],
-    },
   },
   [testSortedPackageCardIds[1]]: {
+    source: { name: 'HC', documentConfidence: 100 },
+    packageName: 'JQuery',
+    attributionIds: ['jquery'],
     count: 1,
-    displayPackageInfo: {
-      source: { name: 'HC', documentConfidence: 100 },
-      packageName: 'JQuery',
-      attributionIds: ['jquery'],
-    },
   },
   [testSortedPackageCardIds[2]]: {
+    source: { name: 'HINT', documentConfidence: 10 },
+    packageName: 'Blub',
+    attributionIds: ['blub'],
     count: 1,
-    displayPackageInfo: {
-      source: { name: 'HINT', documentConfidence: 10 },
-      packageName: 'Blub',
-      attributionIds: ['blub'],
-    },
   },
   [testSortedPackageCardIds[3]]: {
+    source: { name: 'a_unknown', documentConfidence: 100 },
+    attributionIds: ['b_unknown'],
     count: 5,
-    displayPackageInfo: {
-      source: { name: 'a_unknown', documentConfidence: 100 },
-      attributionIds: ['b_unknown'],
-    },
   },
   [testSortedPackageCardIds[4]]: {
+    source: { name: 'SC', documentConfidence: 100 },
+    packageName: 'Vue',
+    attributionIds: ['vue'],
     count: 500,
-    displayPackageInfo: {
-      source: { name: 'SC', documentConfidence: 100 },
-      packageName: 'Vue',
-      attributionIds: ['vue'],
-    },
   },
   [testSortedPackageCardIds[5]]: {
+    source: { name: 'b_unknown', documentConfidence: 100 },
+    attributionIds: ['a_unknown'],
     count: 3,
-    displayPackageInfo: {
-      source: { name: 'b_unknown', documentConfidence: 100 },
-      attributionIds: ['a_unknown'],
-    },
   },
   [testSortedPackageCardIds[6]]: {
+    source: { name: 'REUSER:HHC', documentConfidence: 100 },
+    attributionIds: ['reuser'],
     count: 3,
-    displayPackageInfo: {
-      source: { name: 'REUSER:HHC', documentConfidence: 100 },
-      attributionIds: ['reuser'],
-    },
   },
 };
-// eslint-enable @typescript-eslint/no-magic-numbers
 
 describe('getPackageCardIdsAndDisplayPackageInfosForSource', () => {
   it('filters for source correctly', () => {
     const sourceName = 'MERGER';
     const expectedPackageCardIdsForSource = [testSortedPackageCardIds[0]];
-    const expectedDisplayPackageInfosForSource: DisplayPackageInfos = {
-      [expectedPackageCardIdsForSource[0]]: {
-        source: {
-          name: 'MERGER',
-          documentConfidence: 100,
-        },
-        packageName: 'React',
-        packageVersion: '16.5.0',
-        attributionIds: ['react'],
-      },
-    };
+    const expectedDisplayPackageInfosForSource = pick(testDisplayPackageInfos, [
+      testSortedPackageCardIds[0],
+    ]);
 
     expect(
       getPackageCardIdsAndDisplayPackageInfosForSource(
-        testDisplayPackageInfosWithCount,
+        testDisplayPackageInfos,
         testSortedPackageCardIds,
         sourceName,
       ),
@@ -112,7 +88,7 @@ describe('getPackageCardIdsAndDisplayPackageInfosForSource', () => {
     const sourceName = 'something';
     expect(
       getPackageCardIdsAndDisplayPackageInfosForSource(
-        testDisplayPackageInfosWithCount,
+        testDisplayPackageInfos,
         testSortedPackageCardIds,
         sourceName,
       ),
@@ -146,7 +122,7 @@ describe('getSortedSourcesFromDisplayPackageInfosWithCount', () => {
     ];
     expect(
       getSortedSourcesFromDisplayPackageInfosWithCount(
-        testDisplayPackageInfosWithCount,
+        testDisplayPackageInfos,
         testAttributionSources,
       ),
     ).toEqual(expectedSortedSources);
@@ -176,7 +152,7 @@ describe('getSortedSourcesFromDisplayPackageInfosWithCount', () => {
     };
     expect(
       getSortedSourcesFromDisplayPackageInfosWithCount(
-        testDisplayPackageInfosWithCount,
+        testDisplayPackageInfos,
         testAttributionSourcesEqualPrio,
       ),
     ).toEqual([

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -263,7 +263,7 @@ function getAssignableManualAttributionIdsAndDisplayPackageInfos(
     displayPackageInfos[packageCardId] =
       getDisplayPackageInfoWithCountFromAttributions([
         [attributionId, manualAttributions[attributionId], undefined],
-      ]).displayPackageInfo;
+      ]);
   });
 
   return { assignableManualAttributionIds, displayPackageInfos };

--- a/src/Frontend/state/variables/use-panel-data.ts
+++ b/src/Frontend/state/variables/use-panel-data.ts
@@ -15,11 +15,11 @@ interface WorkerPanelData {
 const initialWorkerPanelData: WorkerPanelData = {
   attributionsInFolderContent: {
     sortedPackageCardIds: [],
-    displayPackageInfosWithCount: {},
+    displayPackageInfos: {},
   },
   signalsInFolderContent: {
     sortedPackageCardIds: [],
-    displayPackageInfosWithCount: {},
+    displayPackageInfos: {},
   },
 };
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -76,13 +76,13 @@ export interface PopupInfo {
 
 export interface PanelData {
   sortedPackageCardIds: Array<string>;
-  displayPackageInfosWithCount: DisplayPackageInfosWithCount;
+  displayPackageInfos: DisplayPackageInfos;
 }
 
 export interface DisplayPackageInfosWithCountAndResourceId {
   resourceId: string;
   sortedPackageCardIds: Array<string>;
-  displayPackageInfosWithCount: DisplayPackageInfosWithCount;
+  displayPackageInfos: DisplayPackageInfos;
 }
 
 export interface ProgressBarDataAndResourceId {
@@ -116,17 +116,8 @@ export interface AttributionIdWithCount {
   count?: number;
 }
 
-export interface DisplayPackageInfoWithCount {
-  displayPackageInfo: DisplayPackageInfo;
-  count: number;
-}
-
 export interface DisplayPackageInfos {
-  [packageCardId: string]: DisplayPackageInfo;
-}
-
-export interface DisplayPackageInfosWithCount {
-  [packageCardId: string]: DisplayPackageInfoWithCount;
+  [id: string]: DisplayPackageInfo;
 }
 
 export interface LocatePopupFilters {

--- a/src/Frontend/util/__tests__/get-display-attributions-with-count-from-attributions.test.ts
+++ b/src/Frontend/util/__tests__/get-display-attributions-with-count-from-attributions.test.ts
@@ -2,8 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { PackageInfo } from '../../../shared/shared-types';
-import { DisplayPackageInfoWithCount } from '../../types/types';
+import { DisplayPackageInfo, PackageInfo } from '../../../shared/shared-types';
 import { getDisplayPackageInfoWithCountFromAttributions } from '../get-display-attributions-with-count-from-attributions';
 
 describe('getDisplayAttributionWithCountFromAttributions', () => {
@@ -28,12 +27,10 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         2,
       ],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        comments: ['comment A'],
-        attributionIds: ['uuid_1', 'uuid_2'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      comments: ['comment A'],
+      attributionIds: ['uuid_1', 'uuid_2'],
       count: 2,
     };
     const testDisplayAttributionWithCount =
@@ -67,12 +64,10 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         2,
       ],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        attributionConfidence: 20,
-        attributionIds: ['uuid_1', 'uuid_2'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionConfidence: 20,
+      attributionIds: ['uuid_1', 'uuid_2'],
       count: 2,
     };
     const testDisplayAttributionWithCount =
@@ -106,12 +101,10 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         2,
       ],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        attributionIds: ['uuid_1', 'uuid_2'],
-        originIds: ['id_1', 'id_2', 'id_3'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionIds: ['uuid_1', 'uuid_2'],
+      originIds: ['id_1', 'id_2', 'id_3'],
       count: 2,
     };
     const testDisplayAttributionWithCount =
@@ -137,11 +130,9 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
       ],
       ['uuid_2', { packageName: 'React' }, undefined],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        attributionIds: ['uuid_1', 'uuid_2'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionIds: ['uuid_1', 'uuid_2'],
       count: 1,
     };
     const testDisplayAttributionWithCount =
@@ -173,11 +164,9 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         2,
       ],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        attributionIds: ['uuid_1', 'uuid_2'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      attributionIds: ['uuid_1', 'uuid_2'],
       count: 2,
     };
     const testDisplayAttributionWithCount =
@@ -216,14 +205,12 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
       ],
       ['uuid_3', { packageName: 'React', comment: '' }, undefined],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        comments: ['comment A', 'comment B'],
-        attributionConfidence: 20,
-        attributionIds: ['uuid_1', 'uuid_2', 'uuid_3'],
-        originIds: ['id_1', 'id_2', 'id_3'],
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      comments: ['comment A', 'comment B'],
+      attributionConfidence: 20,
+      attributionIds: ['uuid_1', 'uuid_2', 'uuid_3'],
+      originIds: ['id_1', 'id_2', 'id_3'],
       count: 2,
     };
     const testDisplayAttributionWithCount =
@@ -273,15 +260,13 @@ describe('getDisplayAttributionWithCountFromAttributions', () => {
         1,
       ],
     ];
-    const expectedDisplayAttributionWithCount: DisplayPackageInfoWithCount = {
-      displayPackageInfo: {
-        packageName: 'React',
-        comments: ['comment A', 'comment B', 'comment C'],
-        attributionConfidence: 20,
-        attributionIds: ['uuid_1', 'uuid_2', 'uuid_3'],
-        originIds: ['id_1', 'id_2', 'id_3'],
-        wasPreferred: true,
-      },
+    const expectedDisplayAttributionWithCount: DisplayPackageInfo = {
+      packageName: 'React',
+      comments: ['comment A', 'comment B', 'comment C'],
+      attributionConfidence: 20,
+      attributionIds: ['uuid_1', 'uuid_2', 'uuid_3'],
+      originIds: ['id_1', 'id_2', 'id_3'],
+      wasPreferred: true,
       count: 2,
     };
     const testDisplayAttributionWithCount =

--- a/src/Frontend/util/get-display-attributions-with-count-from-attributions.ts
+++ b/src/Frontend/util/get-display-attributions-with-count-from-attributions.ts
@@ -3,13 +3,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { DisplayPackageInfo, PackageInfo } from '../../shared/shared-types';
-import { DisplayPackageInfoWithCount } from '../types/types';
 
 export function getDisplayPackageInfoWithCountFromAttributions(
   attributionsWithIdsAndCounts: Array<
     [string, PackageInfo, number | undefined]
   >,
-): DisplayPackageInfoWithCount {
+): DisplayPackageInfo {
   const displayAttributionConfidences: Array<number> =
     attributionsWithIdsAndCounts.reduce(
       (filteredConfidences, attributionWithIdAndCount) => {
@@ -86,7 +85,7 @@ export function getDisplayPackageInfoWithCountFromAttributions(
   }
 
   return {
+    ...attributionToShow,
     count: Math.max(...counts, 0),
-    displayPackageInfo: attributionToShow,
   };
 }

--- a/src/Frontend/util/get-stripped-package-info.ts
+++ b/src/Frontend/util/get-stripped-package-info.ts
@@ -79,6 +79,7 @@ const strippedDisplayPackageInfoTemplate: {
   [P in keyof Required<DisplayPackageInfo>]: boolean;
 } = {
   ...strippedPackageInfoCoreTemplate,
+  count: false,
   attributionIds: true,
   comments: true,
 };

--- a/src/Frontend/web-workers/scripts/get-attributions-in-folder-content.ts
+++ b/src/Frontend/web-workers/scripts/get-attributions-in-folder-content.ts
@@ -18,7 +18,7 @@ export function getAttributionsInFolderContent({
   resourceId,
   sortByCriticality,
 }: Props): PanelData {
-  const [sortedPackageCardIds, displayPackageInfosWithCount] =
+  const [sortedPackageCardIds, displayPackageInfos] =
     getContainedManualDisplayPackageInfosWithCount({
       selectedResourceId: resourceId,
       manualData,
@@ -28,6 +28,6 @@ export function getAttributionsInFolderContent({
 
   return {
     sortedPackageCardIds,
-    displayPackageInfosWithCount,
+    displayPackageInfos,
   };
 }

--- a/src/Frontend/web-workers/scripts/get-signals-in-folder-content.ts
+++ b/src/Frontend/web-workers/scripts/get-signals-in-folder-content.ts
@@ -23,7 +23,7 @@ export function getSignalsInFolderContent({
   resourceId,
   sortByCriticality,
 }: Props): PanelData {
-  const [sortedPackageCardIds, displayAttributionIdsWithCount] =
+  const [sortedPackageCardIds, displayPackageInfos] =
     getContainedExternalDisplayPackageInfosWithCount({
       selectedResourceId: resourceId,
       externalData,
@@ -35,6 +35,6 @@ export function getSignalsInFolderContent({
 
   return {
     sortedPackageCardIds,
-    displayPackageInfosWithCount: displayAttributionIdsWithCount,
+    displayPackageInfos,
   };
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -65,6 +65,7 @@ export interface PackageInfo extends PackageInfoCore {
 }
 
 export interface DisplayPackageInfo extends PackageInfoCore {
+  count?: number;
   comments?: Array<string>;
   attributionIds: Array<string>;
 }
@@ -275,7 +276,6 @@ export interface UserSettings {
 }
 
 export type AutocompleteSignal = DisplayPackageInfo & {
-  count?: number;
   suffix?: string;
   default?: boolean;
 };


### PR DESCRIPTION
### Summary of changes

- remove DisplayPackageInfoWithCount in favor of "count" attribute on DisplayPackageInfo

### Context and reason for change

Avoid multiple data structures for similar tasks.

### How can the changes be tested

Check that counters in audit view and sorting by occurrence still work.