### PR TITLE
feat: add static diff popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
@@ -35,16 +35,26 @@ interface AttributionFormProps {
   packageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  variant?: 'default' | 'diff';
+  label?: string;
 }
 
-export function AttributionForm(props: AttributionFormProps) {
+export function AttributionForm({
+  packageInfo,
+  label,
+  onEdit,
+  showHighlight,
+  variant = 'default',
+}: AttributionFormProps) {
   const dispatch = useAppDispatch();
+  const isDiff = variant === 'diff';
 
   return (
-    <MuiBox sx={classes.formContainer}>
+    <MuiBox sx={classes.formContainer} aria-label={label}>
       <AuditingOptions
-        packageInfo={props.packageInfo}
-        isEditable={!!props.onEdit}
+        packageInfo={packageInfo}
+        isEditable={!!onEdit}
+        sx={{ flex: isDiff ? 1 : undefined }}
       />
       <MuiDivider variant={'middle'}>
         <MuiTypography>
@@ -52,45 +62,44 @@ export function AttributionForm(props: AttributionFormProps) {
         </MuiTypography>
       </MuiDivider>
       <PackageSubPanel
-        displayPackageInfo={props.packageInfo}
-        showHighlight={props.showHighlight}
-        onEdit={props.onEdit}
+        displayPackageInfo={packageInfo}
+        showHighlight={showHighlight}
+        onEdit={onEdit}
       />
       <MuiDivider variant={'middle'}>
         <MuiTypography>{text.attributionColumn.legalInformation}</MuiTypography>
       </MuiDivider>
       {renderAttributionType()}
-      {props.packageInfo.firstParty ? null : (
-        <>
-          <CopyrightSubPanel
-            displayPackageInfo={props.packageInfo}
-            showHighlight={props.showHighlight}
-            onEdit={props.onEdit}
-          />
-          <LicenseSubPanel
-            displayPackageInfo={props.packageInfo}
-            showHighlight={props.showHighlight}
-            onEdit={props.onEdit}
-          />
-        </>
-      )}
-      <CommentStack
-        displayPackageInfo={props.packageInfo}
-        onEdit={props.onEdit}
+      <CopyrightSubPanel
+        displayPackageInfo={packageInfo}
+        showHighlight={showHighlight}
+        onEdit={onEdit}
+        expanded={isDiff}
+        hidden={packageInfo.firstParty}
       />
+      <LicenseSubPanel
+        displayPackageInfo={packageInfo}
+        showHighlight={showHighlight}
+        onEdit={onEdit}
+        expanded={isDiff}
+        hidden={packageInfo.firstParty}
+      />
+      {isDiff ? null : (
+        <CommentStack displayPackageInfo={packageInfo} onEdit={onEdit} />
+      )}
     </MuiBox>
   );
 
   function renderAttributionType() {
     return (
       <MuiToggleButtonGroup
-        value={props.packageInfo.firstParty || false}
+        value={packageInfo.firstParty || false}
         exclusive
         onChange={(_, newValue) =>
-          props.onEdit?.(() =>
+          onEdit?.(() =>
             dispatch(
               setTemporaryDisplayPackageInfo({
-                ...props.packageInfo,
+                ...packageInfo,
                 firstParty: newValue,
                 wasPreferred: undefined,
               }),
@@ -99,6 +108,7 @@ export function AttributionForm(props: AttributionFormProps) {
         }
         size={'small'}
         fullWidth
+        disabled={!onEdit}
       >
         <MuiToggleButton value={false} disableRipple>
           {AttributionType.ThirdParty}

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
@@ -5,7 +5,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import MuiBox from '@mui/material/Box';
 import MuiChip from '@mui/material/Chip';
-import { SxProps } from '@mui/system';
+import { SxProps, Theme } from '@mui/system';
 import { useState } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
@@ -21,9 +21,10 @@ const classes = {
 interface Props {
   packageInfo: DisplayPackageInfo;
   isEditable: boolean;
+  sx?: SxProps<Theme>;
 }
 
-export function AuditingOptions({ packageInfo, isEditable }: Props) {
+export function AuditingOptions({ packageInfo, isEditable, sx }: Props) {
   const options = useAuditingOptions({ packageInfo, isEditable });
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const unselectedOptions = options.filter(
@@ -32,7 +33,7 @@ export function AuditingOptions({ packageInfo, isEditable }: Props) {
 
   return options.length ? (
     <>
-      <MuiBox sx={classes.container}>
+      <MuiBox sx={{ ...classes.container, ...sx }}>
         {renderTriggerButton()}
         {renderSelectedOptions()}
       </MuiBox>

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
@@ -123,7 +123,7 @@ export function useAuditingOptions({
               preferred: false,
             }),
           ),
-        interactive: isPreferenceFeatureEnabled && qaMode,
+        interactive: isPreferenceFeatureEnabled && qaMode && isEditable,
       },
       {
         id: 'was-preferred',
@@ -137,7 +137,7 @@ export function useAuditingOptions({
         label: text.auditingOptions.modifiedPreferred,
         icon: <ModifiedPreferredIcon noTooltip />,
         selected: !!originalPreferred,
-        interactive: !!originalPreferred,
+        interactive: !!originalPreferred && isEditable,
         deleteIcon: <ReplayIcon aria-label={'undo modified preferred'} />,
         onDelete: originalPreferred
           ? () =>

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
-import { ReactElement } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -17,25 +16,35 @@ interface CopyrightSubPanelProps {
   displayPackageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  expanded?: boolean;
+  hidden?: boolean;
 }
 
 export function CopyrightSubPanel({
   displayPackageInfo,
   onEdit,
   showHighlight,
-}: CopyrightSubPanelProps): ReactElement {
+  expanded,
+  hidden,
+}: CopyrightSubPanelProps) {
   const dispatch = useAppDispatch();
 
-  return (
-    <MuiBox sx={attributionColumnClasses.panel}>
+  return hidden && !expanded ? null : (
+    <MuiBox
+      sx={{
+        ...attributionColumnClasses.panel,
+        visibility: hidden ? 'hidden' : 'visible',
+      }}
+    >
       <TextBox
         isEditable={!!onEdit}
         sx={attributionColumnClasses.textBox}
         title={'Copyright'}
         text={displayPackageInfo.copyright}
         minRows={3}
-        maxRows={10}
-        multiline={true}
+        maxRows={7}
+        multiline
+        expanded={expanded}
         handleChange={({ target: { value } }) =>
           onEdit?.(() =>
             dispatch(

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -9,7 +9,7 @@ import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import MuiBox from '@mui/material/Box';
 import MuiInputAdornment from '@mui/material/InputAdornment';
 import { sortBy } from 'lodash';
-import { ReactElement, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   AutocompleteSignal,
@@ -49,6 +49,9 @@ const classes = {
     padding: '0px',
     width: 'calc(100% - 36px)',
   },
+  expansionPanelDetailsDiffView: {
+    padding: '0px',
+  },
   expandMoreIcon: {
     display: 'flex',
     alignItems: 'center',
@@ -69,15 +72,19 @@ interface LicenseSubPanelProps {
   displayPackageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  expanded?: boolean;
+  hidden?: boolean;
 }
 
 export function LicenseSubPanel({
   displayPackageInfo,
   showHighlight,
   onEdit,
-}: LicenseSubPanelProps): ReactElement {
+  expanded: expandedOverride,
+  hidden,
+}: LicenseSubPanelProps) {
   const dispatch = useAppDispatch();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(expandedOverride);
   const frequentLicensesNames = useAppSelector(getFrequentLicensesNameOrder);
   const defaultLicenses = useMemo(
     () =>
@@ -99,8 +106,13 @@ export function LicenseSubPanel({
     [frequentLicensesNames],
   );
 
-  return (
-    <MuiBox sx={classes.panel}>
+  return hidden && !expandedOverride ? null : (
+    <MuiBox
+      sx={{
+        ...classes.panel,
+        visibility: hidden ? 'hidden' : 'visible',
+      }}
+    >
       <MuiAccordion
         sx={classes.expansionPanel}
         elevation={0}
@@ -111,17 +123,20 @@ export function LicenseSubPanel({
         <MuiAccordionSummary
           sx={classes.expansionPanelSummary}
           expandIcon={
-            <MuiBox
-              sx={classes.expandMoreIcon}
-              onClick={() => setExpanded((prev) => !prev)}
-            >
-              <ExpandMoreIcon aria-label={'license text toggle'} />
-            </MuiBox>
+            expandedOverride ? null : (
+              <MuiBox
+                sx={classes.expandMoreIcon}
+                onClick={() => setExpanded((prev) => !prev)}
+              >
+                <ExpandMoreIcon aria-label={'license text toggle'} />
+              </MuiBox>
+            )
           }
         >
           <PackageAutocomplete
             attribute={'licenseName'}
             title={text.attributionColumn.licenseName}
+            packageInfo={displayPackageInfo}
             disabled={!onEdit}
             showHighlight={showHighlight}
             onEdit={onEdit}
@@ -135,13 +150,20 @@ export function LicenseSubPanel({
             defaults={defaultLicenses}
           />
         </MuiAccordionSummary>
-        <MuiAccordionDetails sx={classes.expansionPanelDetails}>
+        <MuiAccordionDetails
+          sx={
+            expandedOverride
+              ? classes.expansionPanelDetailsDiffView
+              : classes.expansionPanelDetails
+          }
+        >
           <TextBox
             isEditable={!!onEdit}
             sx={classes.licenseText}
+            maxRows={7}
             minRows={3}
-            maxRows={10}
-            multiline={true}
+            multiline
+            expanded={expandedOverride}
             title={getLicenseTextLabelText(
               displayPackageInfo.licenseName,
               !!onEdit,

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -21,10 +21,7 @@ import { text } from '../../../shared/text';
 import { clickableIcon } from '../../shared-styles';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import {
-  getExternalAttributionSources,
-  getTemporaryDisplayPackageInfo,
-} from '../../state/selectors/all-views-resource-selectors';
+import { getExternalAttributionSources } from '../../state/selectors/all-views-resource-selectors';
 import { isAuditViewSelected } from '../../state/selectors/view-selector';
 import { useAutocompleteSignals } from '../../state/variables/use-autocomplete-signals';
 import { generatePurl } from '../../util/handle-purl';
@@ -51,6 +48,7 @@ type AutocompleteAttribute = Extract<
 interface Props {
   title: string;
   attribute: AutocompleteAttribute;
+  packageInfo: DisplayPackageInfo;
   highlight?: 'default' | 'dark';
   endAdornment?: React.ReactElement;
   defaults?: Array<AutocompleteSignal>;
@@ -75,6 +73,7 @@ const AddIconButton = styled(MuiIconButton)({
 export function PackageAutocomplete({
   attribute,
   title,
+  packageInfo,
   highlight = 'default',
   endAdornment,
   defaults = [],
@@ -83,8 +82,7 @@ export function PackageAutocomplete({
   onEdit,
 }: Props) {
   const dispatch = useAppDispatch();
-  const temporaryPackageInfo = useAppSelector(getTemporaryDisplayPackageInfo);
-  const attributeValue = temporaryPackageInfo[attribute] || '';
+  const attributeValue = packageInfo[attribute] || '';
   const [inputValue, setInputValue] = useState(attributeValue);
   const sources = useAppSelector(getExternalAttributionSources);
   const isAuditView = useAppSelector(isAuditViewSelected);
@@ -118,10 +116,7 @@ export function PackageAutocomplete({
       inputValue={inputValue}
       highlight={
         showHighlight &&
-        isImportantAttributionInformationMissing(
-          attribute,
-          temporaryPackageInfo,
-        )
+        isImportantAttributionInformationMissing(attribute, packageInfo)
           ? highlight
           : undefined
       }
@@ -141,7 +136,7 @@ export function PackageAutocomplete({
       }
       renderOptionStartIcon={renderOptionStartIcon}
       renderOptionEndIcon={renderOptionEndIcon}
-      value={temporaryPackageInfo}
+      value={packageInfo}
       filterOptions={createFilterOptions({
         stringify: (option) => {
           switch (attribute) {
@@ -189,11 +184,11 @@ export function PackageAutocomplete({
       }}
       onInputChange={(event, value) =>
         event &&
-        temporaryPackageInfo[attribute] !== value &&
+        packageInfo[attribute] !== value &&
         onEdit?.(() => {
           dispatch(
             setTemporaryDisplayPackageInfo({
-              ...temporaryPackageInfo,
+              ...packageInfo,
               [attribute]: value,
               wasPreferred: undefined,
             }),
@@ -269,7 +264,7 @@ export function PackageAutocomplete({
                 'source',
                 'suffix',
               ]),
-              ...pick(temporaryPackageInfo, [
+              ...pick(packageInfo, [
                 'attributionConfidence',
                 'excludeFromNotice',
                 'followUp',

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -132,6 +132,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageName'}
         title={text.attributionColumn.packageSubPanel.packageName}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -146,6 +147,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageNamespace'}
         title={text.attributionColumn.packageSubPanel.packageNamespace}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -160,6 +162,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageVersion'}
         title={text.attributionColumn.packageSubPanel.packageVersion}
+        packageInfo={displayPackageInfo}
         disabled={!onEdit}
         showHighlight={showHighlight}
         defaults={packageVersions}
@@ -173,6 +176,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageType'}
         title={text.attributionColumn.packageSubPanel.packageType}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -249,6 +253,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'url'}
         title={text.attributionColumn.packageSubPanel.repositoryUrl}
+        packageInfo={displayPackageInfo}
         disabled={!onEdit}
         showHighlight={showHighlight}
         onEdit={onEdit}
@@ -264,7 +269,8 @@ export function PackageSubPanel({
                   displayPackageInfo.url &&
                   displayPackageInfo.copyright &&
                   displayPackageInfo.licenseName
-                )
+                ) ||
+                !onEdit
               }
               onClick={() =>
                 onEdit?.(async () => {

--- a/src/Frontend/Components/DiffPopup/DiffPopup.style.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.style.tsx
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { styled } from '@mui/material';
+import MuiBox from '@mui/material/Box';
+
+export const DiffPopupContainer = styled(MuiBox)({
+  display: 'flex',
+  flexDirection: 'row',
+  flex: 1,
+  padding: '6px',
+  gap: '12px',
+  overflow: 'hidden auto',
+});

--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import MuiDivider from '@mui/material/Divider';
+
+import { DisplayPackageInfo } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
+import { AttributionForm } from '../AttributionColumn/AttributionForm';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { DiffPopupContainer } from './DiffPopup.style';
+
+interface DiffPopupProps {
+  original: DisplayPackageInfo;
+  current: DisplayPackageInfo;
+  isOpen: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function DiffPopup(props: DiffPopupProps): React.ReactElement {
+  return (
+    <NotificationPopup
+      header={text.diffPopup.title}
+      content={renderDiffView()}
+      leftButtonConfig={{
+        disabled: true,
+        buttonText: text.buttons.diffPopup.applyChanges,
+      }}
+      centerRightButtonConfig={{
+        disabled: true,
+        buttonText: text.buttons.diffPopup.revertAll,
+      }}
+      rightButtonConfig={{
+        onClick: () => props.setOpen(false),
+        buttonText: text.buttons.cancel,
+        color: 'secondary',
+      }}
+      isOpen={props.isOpen}
+      background={'lightestBlue'}
+      fullWidth={true}
+      aria-label={'diff popup'}
+    />
+  );
+
+  function renderDiffView() {
+    return (
+      <DiffPopupContainer>
+        <AttributionForm
+          packageInfo={props.original}
+          variant={'diff'}
+          label={'original'}
+        />
+        <MuiDivider
+          variant={'middle'}
+          flexItem={true}
+          orientation={'vertical'}
+        />
+        <AttributionForm
+          packageInfo={props.current}
+          variant={'diff'}
+          label={'current'}
+        />
+      </DiffPopupContainer>
+    );
+  }
+}

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -16,6 +16,7 @@ interface TextProps extends InputElementProps {
   multiline?: boolean;
   highlightingColor?: HighlightingColor;
   error?: boolean;
+  expanded?: boolean;
 }
 
 export function TextBox(props: TextProps) {
@@ -62,7 +63,7 @@ export function TextBox(props: TextProps) {
           ),
         }}
         multiline={props.multiline}
-        minRows={props.minRows}
+        minRows={props.expanded ? props.maxRows : props.minRows}
         maxRows={props.maxRows}
         variant="outlined"
         size="small"

--- a/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
+++ b/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { faker, test } from '../utils';
+
+const [resourceName1, resourceName2] = faker.opossum.resourceNames({
+  count: 2,
+});
+const [attributionId1, manualPackageInfo1] = faker.opossum.manualAttribution();
+const [attributionId2, manualPackageInfo2] = faker.opossum.manualAttribution({
+  originIds: [faker.opossum.attributionId()],
+  licenseText: faker.opossum.license().defaultText,
+});
+const [externalAttributionId, externalPackageInfo] =
+  faker.opossum.externalAttribution(manualPackageInfo2);
+
+test.use({
+  data: {
+    inputData: faker.opossum.inputData({
+      resources: faker.opossum.resources({
+        [resourceName1]: 1,
+        [resourceName2]: 1,
+      }),
+      externalAttributions: faker.opossum.externalAttributions({
+        [externalAttributionId]: externalPackageInfo,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName2)]: [externalAttributionId],
+      }),
+    }),
+    outputData: faker.opossum.outputData({
+      manualAttributions: faker.opossum.manualAttributions({
+        [attributionId1]: manualPackageInfo1,
+        [attributionId2]: manualPackageInfo2,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName1)]: [attributionId1],
+        [faker.opossum.filePath(resourceName2)]: [attributionId2],
+      }),
+    }),
+  },
+});
+
+test('enables comparing attribution to origin if origin is present', async ({
+  attributionDetails,
+  diffPopup,
+  resourceBrowser,
+}) => {
+  await resourceBrowser.goto(resourceName1);
+  await attributionDetails.assert.compareButtonIsHidden();
+
+  await resourceBrowser.goto(resourceName2);
+  await attributionDetails.assert.compareButtonIsEnabled();
+
+  await attributionDetails.compareButton.click();
+  await diffPopup.assert.isVisible();
+
+  await diffPopup.originalAttributionForm.assert.matchesPackageInfo(
+    externalPackageInfo,
+  );
+  await diffPopup.currentAttributionForm.assert.matchesPackageInfo(
+    manualPackageInfo2,
+  );
+});

--- a/src/e2e-tests/page-objects/AttributionDetails.ts
+++ b/src/e2e-tests/page-objects/AttributionDetails.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, Page } from '@playwright/test';
 
+import { text } from '../../shared/text';
 import { AttributionForm } from './AttributionForm';
 
 export class AttributionDetails {
@@ -32,6 +33,7 @@ export class AttributionDetails {
     readonly deleteGlobally: Locator;
   };
   readonly revertButton: Locator;
+  readonly compareButton: Locator;
   readonly showHideSignalButton: Locator;
 
   constructor(window: Page) {
@@ -93,6 +95,10 @@ export class AttributionDetails {
     };
     this.revertButton = this.node.getByRole('button', {
       name: 'Revert',
+      exact: true,
+    });
+    this.compareButton = this.node.getByRole('button', {
+      name: text.buttons.compareToOrigin,
       exact: true,
     });
     this.showHideSignalButton = this.node.getByLabel('resolve attribution');
@@ -164,6 +170,12 @@ export class AttributionDetails {
     },
     revertButtonIsHidden: async (): Promise<void> => {
       await expect(this.revertButton).toBeHidden();
+    },
+    compareButtonIsEnabled: async (): Promise<void> => {
+      await expect(this.compareButton).toBeEnabled();
+    },
+    compareButtonIsHidden: async (): Promise<void> => {
+      await expect(this.compareButton).toBeHidden();
     },
     showHideSignalButtonIsVisible: async (): Promise<void> => {
       await expect(this.showHideSignalButton).toBeVisible();

--- a/src/e2e-tests/page-objects/DiffPopup.ts
+++ b/src/e2e-tests/page-objects/DiffPopup.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { text } from '../../shared/text';
+import { AttributionForm } from './AttributionForm';
+
+export class DiffPopup {
+  private readonly node: Locator;
+  readonly originalAttributionForm: AttributionForm;
+  readonly currentAttributionForm: AttributionForm;
+  readonly applyButton: Locator;
+  readonly revertButton: Locator;
+  readonly cancelButton: Locator;
+
+  constructor(window: Page) {
+    this.node = window.getByLabel('diff popup');
+    this.originalAttributionForm = new AttributionForm(
+      this.node.getByLabel('original', { exact: true }),
+      window,
+    );
+    this.currentAttributionForm = new AttributionForm(
+      this.node.getByLabel('current', { exact: true }),
+      window,
+    );
+    this.applyButton = this.node.getByRole('button', {
+      name: text.buttons.diffPopup.applyChanges,
+      exact: true,
+    });
+    this.revertButton = this.node.getByRole('button', {
+      name: text.buttons.diffPopup.revertAll,
+      exact: true,
+    });
+    this.cancelButton = this.node.getByRole('button', {
+      name: text.buttons.cancel,
+      exact: true,
+    });
+  }
+
+  public assert = {
+    isVisible: async (): Promise<void> => {
+      await expect(this.node).toBeVisible();
+    },
+    isHidden: async (): Promise<void> => {
+      await expect(this.node).toBeHidden();
+    },
+  };
+}

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -23,6 +23,7 @@ import { AttributionList } from '../page-objects/AttributionList';
 import { ChangePreferredStatusGloballyPopup } from '../page-objects/ChangePreferredStatusGloballyPopup';
 import { ConfirmationDialog } from '../page-objects/ConfirmationDialog';
 import { ConfirmationPopup } from '../page-objects/ConfirmationPopup';
+import { DiffPopup } from '../page-objects/DiffPopup';
 import { ErrorPopup } from '../page-objects/ErrorPopup';
 import { FileSearchPopup } from '../page-objects/FileSearchPopup';
 import { FileSupportPopup } from '../page-objects/FileSupportPopup';
@@ -56,6 +57,7 @@ export const test = base.extend<{
   changePreferredStatusGloballyPopup: ChangePreferredStatusGloballyPopup;
   confirmationDialog: ConfirmationDialog;
   confirmationPopup: ConfirmationPopup;
+  diffPopup: DiffPopup;
   errorPopup: ErrorPopup;
   fileSearchPopup: FileSearchPopup;
   fileSupportPopup: FileSupportPopup;
@@ -163,6 +165,9 @@ export const test = base.extend<{
   },
   notSavedPopup: async ({ window }, use) => {
     await use(new NotSavedPopup(window));
+  },
+  diffPopup: async ({ window }, use) => {
+    await use(new DiffPopup(window));
   },
 });
 

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -54,9 +54,14 @@ export const text = {
   },
   buttons: {
     cancel: 'Cancel',
+    compareToOrigin: 'Compare to origin',
     confirm: 'Confirm',
     filter: 'Filter',
     sort: 'Sort',
+    diffPopup: {
+      applyChanges: 'Apply changes',
+      revertAll: 'Revert all',
+    },
   },
   changePreferredStatusGloballyPopup: {
     markAsPreferred: 'Do you really want to prefer the attribution globally?',
@@ -131,5 +136,8 @@ export const text = {
   resourceDetails: {
     searchTooltip: 'Search',
     sortTooltip: 'Sort',
+  },
+  diffPopup: {
+    title: 'Compare to Original Signal',
   },
 } as const;


### PR DESCRIPTION
### Summary of changes

Add popup that compares the displayed package info to the package info of its original signal if it has one. Since comments of otherwise equal package infos are merged in the UI, the comments are not diffed when comparing to the original package info.

At this stage the popup is static and can only be opened and closed. All displayed info is not editable. Colors to highlight diffs and revert buttons will be added later.  

### Context and reason for change

Closes [#2514](https://github.com/opossum-tool/OpossumUI/issues/2514). 

### How can the changes be tested

Added an e2e test.

Test manually. New "Compare to origin" is visible in the bottom right in Audit View.