### PR TITLE
chore: refactor attribution column e2e tests

### DIFF
--- a/src/e2e-tests/__tests__/adding-attributions.test.ts
+++ b/src/e2e-tests/__tests__/adding-attributions.test.ts
@@ -115,14 +115,14 @@ test('adds attribution and displays it correctly on parent and children', async 
   });
 
   await resourceDetails.signalCard.click(packageInfo4a);
-  await attributionDetails.assert.matchesPackageInfo({
+  await attributionDetails.attributionForm.assert.matchesPackageInfo({
     ...packageInfo4a,
     comment: undefined,
     comments: [packageInfo4a.comment!, packageInfo4b.comment!],
   });
 
   await resourceDetails.signalCard.addButton(packageInfo4a).click();
-  await attributionDetails.assert.matchesPackageInfo({
+  await attributionDetails.attributionForm.assert.matchesPackageInfo({
     ...packageInfo4a,
     attributionConfidence: DiscreteConfidence.High,
     comment: undefined,
@@ -139,7 +139,9 @@ test('adds attribution to child via parent override', async ({
 
   await resourceBrowser.goto(resourceName2);
   await resourceDetails.attributionCard.assert.isVisible(packageInfo1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
   await resourceDetails.assert.globalTabIsDisabled();
   await resourceDetails.assert.overrideParentButtonIsVisible();
   await attributionDetails.assert.deleteButtonIsHidden();
@@ -149,13 +151,15 @@ test('adds attribution to child via parent override', async ({
   await resourceDetails.attributionCard.assert.isHidden(packageInfo1);
 
   await resourceDetails.gotoGlobalTab();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await resourceDetails.signalCard.assert.isVisible(packageInfo1);
   await resourceDetails.signalCard.assert.isVisible(packageInfo2);
   await resourceDetails.signalCard.assert.isVisible(packageInfo3);
 
   await resourceDetails.signalCard.click(packageInfo1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   await resourceDetails.signalCard.addButton(packageInfo1).click();
   await resourceDetails.attributionCard.assert.isVisible(packageInfo1);
@@ -163,7 +167,7 @@ test('adds attribution to child via parent override', async ({
   await resourceDetails.signalCard.assert.isVisible(packageInfo2);
   await resourceDetails.signalCard.assert.isVisible(packageInfo3);
 
-  await attributionDetails.assert.matchesPackageInfo({
+  await attributionDetails.attributionForm.assert.matchesPackageInfo({
     ...packageInfo1,
     attributionConfidence: DiscreteConfidence.High,
   });

--- a/src/e2e-tests/__tests__/confirming-preselected-attributions.test.ts
+++ b/src/e2e-tests/__tests__/confirming-preselected-attributions.test.ts
@@ -45,14 +45,18 @@ test('updates progress bar when user confirms preselected attributions in audit 
   topBar,
 }) => {
   await resourceBrowser.goto(resourceName1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 4,
     filesWithOnlyPreSelectedAttributions: 4,
   });
   await attributionDetails.assert.confirmButtonIsVisible();
   await attributionDetails.assert.confirmGloballyButtonIsHidden();
-  await attributionDetails.assert.auditingLabelIsVisible('preselectedLabel');
+  await attributionDetails.attributionForm.assert.auditingLabelIsVisible(
+    'preselectedLabel',
+  );
 
   await resourceDetails.attributionCard.click(packageInfo1);
   await attributionDetails.confirmButton.click();
@@ -63,10 +67,14 @@ test('updates progress bar when user confirms preselected attributions in audit 
   });
   await attributionDetails.assert.confirmButtonIsHidden();
   await attributionDetails.assert.confirmGloballyButtonIsHidden();
-  await attributionDetails.assert.auditingLabelIsHidden('preselectedLabel');
+  await attributionDetails.attributionForm.assert.auditingLabelIsHidden(
+    'preselectedLabel',
+  );
 
   await resourceBrowser.goto(resourceName2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   await attributionDetails.selectConfirmMenuOption('confirmGlobally');
   await attributionDetails.confirmGloballyButton.click();

--- a/src/e2e-tests/__tests__/deleting-attributions.test.ts
+++ b/src/e2e-tests/__tests__/deleting-attributions.test.ts
@@ -59,7 +59,9 @@ test('deletes attributions in audit view', async ({
 }) => {
   await resourceBrowser.goto(resourceName1);
   await resourceDetails.attributionCard.click(packageInfo3);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo3);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo3,
+  );
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithAttributions: 5,
@@ -70,18 +72,20 @@ test('deletes attributions in audit view', async ({
   await confirmationPopup.assert.isVisible();
 
   await confirmationPopup.confirm();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithAttributions: 5,
   });
 
   await resourceDetails.attributionCard.click(packageInfo1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   await attributionDetails.deleteButton.click();
   await confirmationPopup.confirm();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithAttributions: 4,
@@ -97,7 +101,7 @@ test('deletes attributions in audit view', async ({
   });
 
   await resourceBrowser.goto(resourceName3);
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await attributionDetails.assert.deleteButtonIsHidden();
   await attributionDetails.assert.deleteGloballyButtonIsHidden();
 
@@ -105,7 +109,9 @@ test('deletes attributions in audit view', async ({
   await resourceBrowser.assert.isHidden();
 
   await attributionList.attributionCard.click(packageInfo2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo2);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo2,
+  );
   await attributionDetails.assert.deleteButtonIsVisible();
   await attributionDetails.assert.deleteGloballyButtonIsHidden();
 

--- a/src/e2e-tests/__tests__/deleting-preselected-attributions.test.ts
+++ b/src/e2e-tests/__tests__/deleting-preselected-attributions.test.ts
@@ -65,7 +65,9 @@ test('deletes pre-selected attributions', async ({
 }) => {
   await resourceBrowser.goto(resourceName1);
   await resourceDetails.attributionCard.click(packageInfo3);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo3);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo3,
+  );
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithOnlyPreSelectedAttributions: 5,
@@ -74,17 +76,19 @@ test('deletes pre-selected attributions', async ({
   await attributionDetails.selectDeleteMenuOption('deleteGlobally');
   await attributionDetails.deleteGloballyButton.click();
   await confirmationPopup.assert.isHidden();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithOnlyPreSelectedAttributions: 5,
   });
 
   await resourceDetails.attributionCard.click(packageInfo1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   await attributionDetails.deleteButton.click();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await topBar.assert.progressBarTooltipShowsValues({
     numberOfFiles: 5,
     filesWithOnlyPreSelectedAttributions: 4,
@@ -99,7 +103,7 @@ test('deletes pre-selected attributions', async ({
   });
 
   await resourceBrowser.goto(resourceName3);
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
   await attributionDetails.assert.deleteButtonIsHidden();
   await attributionDetails.assert.deleteGloballyButtonIsHidden();
 
@@ -107,7 +111,9 @@ test('deletes pre-selected attributions', async ({
   await resourceBrowser.assert.isHidden();
 
   await attributionList.attributionCard.click(packageInfo2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo2);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo2,
+  );
   await attributionDetails.assert.deleteButtonIsVisible();
   await attributionDetails.assert.deleteGloballyButtonIsHidden();
 

--- a/src/e2e-tests/__tests__/open-file-warnings.test.ts
+++ b/src/e2e-tests/__tests__/open-file-warnings.test.ts
@@ -41,13 +41,13 @@ test('warns user of unsaved changes if user attempts to open new file before sav
 }) => {
   const comment = faker.lorem.sentences();
   await resourceBrowser.goto(resourceName1);
-  await attributionDetails.comment().fill(comment);
+  await attributionDetails.attributionForm.comment().fill(comment);
 
   await topBar.openFileButton.click();
   await notSavedPopup.assert.isVisible();
 
   await notSavedPopup.cancelButton.click();
-  await attributionDetails.assert.commentIs(comment);
+  await attributionDetails.attributionForm.assert.commentIs(comment);
 
   await topBar.openFileButton.click();
   await notSavedPopup.assert.isVisible();

--- a/src/e2e-tests/__tests__/preferring-attributions.test.ts
+++ b/src/e2e-tests/__tests__/preferring-attributions.test.ts
@@ -50,43 +50,47 @@ test('allows QA user to mark and unmark attributions as preferred in audit view'
   resourceBrowser,
 }) => {
   await resourceBrowser.goto(resourceName1);
-  await attributionDetails.assert.matchesPackageInfo(manualPackageInfo);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    manualPackageInfo,
+  );
   await attributionDetails.assert.saveButtonIsDisabled();
   await attributionDetails.assert.saveGloballyButtonIsHidden();
-  await attributionDetails.assert.auditingLabelIsHidden(
+  await attributionDetails.attributionForm.assert.auditingLabelIsHidden(
     'currentlyPreferredLabel',
   );
 
-  await attributionDetails.openAuditingOptionsMenu();
-  await attributionDetails.assert.auditingMenuOptionIsHidden(
+  await attributionDetails.attributionForm.openAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsHidden(
     'currentlyPreferredOption',
   );
 
   await menuBar.toggleQaMode();
-  await attributionDetails.assert.auditingMenuOptionIsVisible(
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsVisible(
     'currentlyPreferredOption',
   );
 
-  await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-  await attributionDetails.closeAuditingOptionsMenu();
-  await attributionDetails.assert.auditingLabelIsVisible(
+  await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+  await attributionDetails.attributionForm.closeAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingLabelIsVisible(
     'currentlyPreferredLabel',
   );
   await attributionDetails.assert.saveButtonIsEnabled();
   await attributionDetails.assert.saveGloballyButtonIsHidden();
 
-  await attributionDetails.openAuditingOptionsMenu();
-  await attributionDetails.assert.auditingMenuOptionIsHidden(
+  await attributionDetails.attributionForm.openAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsHidden(
     'currentlyPreferredOption',
   );
 
-  await attributionDetails.closeAuditingOptionsMenu();
-  await attributionDetails.removeAuditingLabel('currentlyPreferredLabel');
+  await attributionDetails.attributionForm.closeAuditingOptionsMenu();
+  await attributionDetails.attributionForm.removeAuditingLabel(
+    'currentlyPreferredLabel',
+  );
   await attributionDetails.assert.saveButtonIsDisabled();
   await attributionDetails.assert.saveGloballyButtonIsHidden();
 
-  await attributionDetails.openAuditingOptionsMenu();
-  await attributionDetails.assert.auditingMenuOptionIsVisible(
+  await attributionDetails.attributionForm.openAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsVisible(
     'currentlyPreferredOption',
   );
 });
@@ -100,39 +104,45 @@ test('allows QA user to mark and unmark attributions as preferred in attribution
 }) => {
   await topBar.gotoAttributionView();
   await attributionList.attributionCard.click(manualPackageInfo);
-  await attributionDetails.assert.matchesPackageInfo(manualPackageInfo);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    manualPackageInfo,
+  );
   await attributionDetails.assert.saveButtonIsDisabled();
 
-  await attributionDetails.comment().fill(faker.lorem.sentence());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentence());
   await attributionDetails.assert.saveButtonIsEnabled();
 
-  await attributionDetails.openAuditingOptionsMenu();
-  await attributionDetails.assert.auditingMenuOptionIsHidden(
+  await attributionDetails.attributionForm.openAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsHidden(
     'currentlyPreferredOption',
   );
 
   await menuBar.toggleQaMode();
-  await attributionDetails.assert.auditingMenuOptionIsVisible(
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsVisible(
     'currentlyPreferredOption',
   );
 
-  await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-  await attributionDetails.closeAuditingOptionsMenu();
+  await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+  await attributionDetails.attributionForm.closeAuditingOptionsMenu();
   await attributionDetails.assert.saveButtonIsEnabled();
 
   await attributionDetails.saveButton.click();
   await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
 
   await changePreferredStatusGloballyPopup.okButton.click();
-  await attributionDetails.assert.auditingLabelIsVisible(
+  await attributionDetails.attributionForm.assert.auditingLabelIsVisible(
     'currentlyPreferredLabel',
   );
 
-  await attributionDetails.removeAuditingLabel('currentlyPreferredLabel');
+  await attributionDetails.attributionForm.removeAuditingLabel(
+    'currentlyPreferredLabel',
+  );
   await attributionDetails.assert.saveButtonIsEnabled();
 
-  await attributionDetails.openAuditingOptionsMenu();
-  await attributionDetails.assert.auditingMenuOptionIsVisible(
+  await attributionDetails.attributionForm.openAuditingOptionsMenu();
+  await attributionDetails.attributionForm.assert.auditingMenuOptionIsVisible(
     'currentlyPreferredOption',
   );
 });

--- a/src/e2e-tests/__tests__/replacing-attributions.test.ts
+++ b/src/e2e-tests/__tests__/replacing-attributions.test.ts
@@ -63,7 +63,9 @@ test('replaces attributions in attribution view', async ({
   await resourceBrowser.assert.isHidden();
 
   await attributionList.attributionCard.click(packageInfo1);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
   await resourceBrowser.assert.resourceIsVisible(resourceName3);
   await resourceBrowser.assert.resourceIsHidden(resourceName4);
 
@@ -80,7 +82,9 @@ test('replaces attributions in attribution view', async ({
   await attributionList.attributionCard.assert.isHidden(packageInfo1);
 
   await attributionList.attributionCard.click(packageInfo2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo2);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo2,
+  );
   await resourceBrowser.assert.resourceIsVisible(resourceName3);
   await resourceBrowser.assert.resourceIsVisible(resourceName4);
 });

--- a/src/e2e-tests/__tests__/saving-attributions.test.ts
+++ b/src/e2e-tests/__tests__/saving-attributions.test.ts
@@ -68,18 +68,28 @@ test('adds a new third-party attribution in audit view', async ({
   });
   await resourceBrowser.goto(resourceName1);
   await resourceDetails.addNewAttributionButton.click({ button: 'right' });
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   await resourceDetails.addNewAttributionButton.click();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
 
-  await attributionDetails.name.fill(newPackageInfo.packageName!);
-  await attributionDetails.version.fill(newPackageInfo.packageVersion!);
-  await attributionDetails.url.fill(newPackageInfo.url!);
-  await attributionDetails.copyright.fill(newPackageInfo.copyright!);
-  await attributionDetails.licenseName.click();
-  await attributionDetails.selectLicense(license1);
-  await attributionDetails.assert.matchesPackageInfo(newPackageInfo);
+  await attributionDetails.attributionForm.name.fill(
+    newPackageInfo.packageName!,
+  );
+  await attributionDetails.attributionForm.version.fill(
+    newPackageInfo.packageVersion!,
+  );
+  await attributionDetails.attributionForm.url.fill(newPackageInfo.url!);
+  await attributionDetails.attributionForm.copyright.fill(
+    newPackageInfo.copyright!,
+  );
+  await attributionDetails.attributionForm.licenseName.click();
+  await attributionDetails.attributionForm.selectLicense(license1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    newPackageInfo,
+  );
 
   await resourceBrowser.goto(resourceName2);
   await notSavedPopup.assert.isVisible();
@@ -101,35 +111,53 @@ test('allows user to edit an existing attribution locally and globally in audit 
     packageType: undefined,
   });
   await resourceBrowser.goto(resourceName1);
-  await attributionDetails.assert.licenseTextIsHidden();
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.licenseTextIsHidden();
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
   await attributionDetails.assert.saveButtonIsDisabled();
   await attributionDetails.assert.saveGloballyButtonIsHidden();
   await attributionDetails.assert.revertButtonIsDisabled();
 
-  await attributionDetails.toggleLicenseTextVisibility();
-  await attributionDetails.assert.licenseTextIsVisible();
+  await attributionDetails.attributionForm.toggleLicenseTextVisibility();
+  await attributionDetails.attributionForm.assert.licenseTextIsVisible();
 
-  await attributionDetails.licenseText.fill(newPackageInfo.licenseText!);
-  await attributionDetails.assert.licenseTextIs(newPackageInfo.licenseText!);
+  await attributionDetails.attributionForm.licenseText.fill(
+    newPackageInfo.licenseText!,
+  );
+  await attributionDetails.attributionForm.assert.licenseTextIs(
+    newPackageInfo.licenseText!,
+  );
 
-  await attributionDetails.toggleLicenseTextVisibility();
-  await attributionDetails.assert.licenseTextIsHidden();
+  await attributionDetails.attributionForm.toggleLicenseTextVisibility();
+  await attributionDetails.attributionForm.assert.licenseTextIsHidden();
 
-  await attributionDetails.selectAttributionType('First Party');
-  await attributionDetails.assert.matchesPackageInfo({
+  await attributionDetails.attributionForm.selectAttributionType('First Party');
+  await attributionDetails.attributionForm.assert.matchesPackageInfo({
     ...packageInfo1,
     firstParty: true,
   });
 
-  await attributionDetails.selectAttributionType('Third Party');
-  await attributionDetails.name.fill(newPackageInfo.packageName!);
-  await attributionDetails.version.fill(newPackageInfo.packageVersion!);
-  await attributionDetails.url.fill(newPackageInfo.url!);
-  await attributionDetails.copyright.fill(newPackageInfo.copyright!);
-  await attributionDetails.licenseName.fill(newPackageInfo.licenseName!);
-  await attributionDetails.comment().fill(newPackageInfo.comment!);
-  await attributionDetails.assert.matchesPackageInfo(newPackageInfo);
+  await attributionDetails.attributionForm.selectAttributionType('Third Party');
+  await attributionDetails.attributionForm.name.fill(
+    newPackageInfo.packageName!,
+  );
+  await attributionDetails.attributionForm.version.fill(
+    newPackageInfo.packageVersion!,
+  );
+  await attributionDetails.attributionForm.url.fill(newPackageInfo.url!);
+  await attributionDetails.attributionForm.copyright.fill(
+    newPackageInfo.copyright!,
+  );
+  await attributionDetails.attributionForm.licenseName.fill(
+    newPackageInfo.licenseName!,
+  );
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(newPackageInfo.comment!);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    newPackageInfo,
+  );
   await attributionDetails.assert.saveButtonIsEnabled();
   await attributionDetails.assert.revertButtonIsEnabled();
 
@@ -138,18 +166,20 @@ test('allows user to edit an existing attribution locally and globally in audit 
   await attributionDetails.assert.revertButtonIsDisabled();
 
   await resourceBrowser.goto(resourceName2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
 
   const newPackageName = faker.internet.domainWord();
   await resourceBrowser.goto(resourceName3);
-  await attributionDetails.name.fill(newPackageName);
+  await attributionDetails.attributionForm.name.fill(newPackageName);
   await attributionDetails.selectSaveMenuOption('saveGlobally');
   await attributionDetails.assert.saveButtonIsHidden();
   await attributionDetails.assert.saveGloballyButtonIsVisible();
 
   await attributionDetails.saveGloballyButton.click();
   await resourceBrowser.goto(resourceName4);
-  await attributionDetails.assert.nameIs(newPackageName);
+  await attributionDetails.attributionForm.assert.nameIs(newPackageName);
 });
 
 test('displays and edits an existing attribution in attribution view', async ({
@@ -175,27 +205,45 @@ test('displays and edits an existing attribution in attribution view', async ({
   await resourceBrowser.assert.resourceIsVisible(resourceName2);
   await resourceBrowser.assert.resourceIsHidden(resourceName3);
   await resourceBrowser.assert.resourceIsHidden(resourceName4);
-  await attributionDetails.assert.licenseTextIsHidden();
-  await attributionDetails.assert.matchesPackageInfo(packageInfo1);
+  await attributionDetails.attributionForm.assert.licenseTextIsHidden();
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo1,
+  );
   await attributionDetails.assert.saveButtonIsDisabled();
   await attributionDetails.assert.revertButtonIsDisabled();
 
-  await attributionDetails.toggleLicenseTextVisibility();
-  await attributionDetails.assert.licenseTextIsVisible();
+  await attributionDetails.attributionForm.toggleLicenseTextVisibility();
+  await attributionDetails.attributionForm.assert.licenseTextIsVisible();
 
-  await attributionDetails.licenseText.fill(newPackageInfo.licenseText!);
-  await attributionDetails.assert.licenseTextIs(newPackageInfo.licenseText!);
+  await attributionDetails.attributionForm.licenseText.fill(
+    newPackageInfo.licenseText!,
+  );
+  await attributionDetails.attributionForm.assert.licenseTextIs(
+    newPackageInfo.licenseText!,
+  );
 
-  await attributionDetails.toggleLicenseTextVisibility();
-  await attributionDetails.assert.licenseTextIsHidden();
+  await attributionDetails.attributionForm.toggleLicenseTextVisibility();
+  await attributionDetails.attributionForm.assert.licenseTextIsHidden();
 
-  await attributionDetails.name.fill(newPackageInfo.packageName!);
-  await attributionDetails.version.fill(newPackageInfo.packageVersion!);
-  await attributionDetails.url.fill(newPackageInfo.url!);
-  await attributionDetails.copyright.fill(newPackageInfo.copyright!);
-  await attributionDetails.licenseName.fill(newPackageInfo.licenseName!);
-  await attributionDetails.comment().fill(newPackageInfo.comment!);
-  await attributionDetails.assert.matchesPackageInfo(newPackageInfo);
+  await attributionDetails.attributionForm.name.fill(
+    newPackageInfo.packageName!,
+  );
+  await attributionDetails.attributionForm.version.fill(
+    newPackageInfo.packageVersion!,
+  );
+  await attributionDetails.attributionForm.url.fill(newPackageInfo.url!);
+  await attributionDetails.attributionForm.copyright.fill(
+    newPackageInfo.copyright!,
+  );
+  await attributionDetails.attributionForm.licenseName.fill(
+    newPackageInfo.licenseName!,
+  );
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(newPackageInfo.comment!);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    newPackageInfo,
+  );
   await attributionDetails.assert.saveButtonIsEnabled();
   await attributionDetails.assert.revertButtonIsEnabled();
 
@@ -213,15 +261,19 @@ test('warns user of unsaved changes if user attempts to navigate away before sav
   topBar,
 }) => {
   await resourceBrowser.goto(resourceName1);
-  await attributionDetails.comment().fill(faker.lorem.sentences());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentences());
 
   await resourceDetails.addNewAttributionButton.click();
   await notSavedPopup.assert.isVisible();
 
   await notSavedPopup.discardButton.click();
-  await attributionDetails.assert.isEmpty();
+  await attributionDetails.attributionForm.assert.isEmpty();
 
-  await attributionDetails.comment().fill(faker.lorem.sentences());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentences());
   await topBar.gotoReportView();
   await notSavedPopup.assert.isVisible();
 
@@ -231,7 +283,9 @@ test('warns user of unsaved changes if user attempts to navigate away before sav
 
   await notSavedPopup.discardButton.click();
   await attributionList.attributionCard.click(packageInfo1);
-  await attributionDetails.comment().fill(faker.lorem.sentences());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentences());
   await topBar.gotoAuditView();
   await notSavedPopup.assert.isVisible();
 });
@@ -246,11 +300,13 @@ test('removes was-preferred status from attribution when user saves changes', as
   await resourceDetails.attributionCard.assert.wasPreferredIconIsVisible(
     wasPreferredPackageInfo,
   );
-  await attributionDetails.assert.auditingLabelIsVisible(
+  await attributionDetails.attributionForm.assert.auditingLabelIsVisible(
     'previouslyPreferredLabel',
   );
 
-  await attributionDetails.comment().fill(faker.lorem.sentence());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentence());
   await confirmationDialog.assert.isVisible();
 
   await confirmationDialog.cancelButton.click();
@@ -258,12 +314,14 @@ test('removes was-preferred status from attribution when user saves changes', as
     wasPreferredPackageInfo,
   );
 
-  await attributionDetails.comment().fill(faker.lorem.sentence());
+  await attributionDetails.attributionForm
+    .comment()
+    .fill(faker.lorem.sentence());
   await confirmationDialog.okButton.click();
   await resourceDetails.attributionCard.assert.wasPreferredIconIsVisible(
     wasPreferredPackageInfo,
   );
-  await attributionDetails.assert.auditingLabelIsHidden(
+  await attributionDetails.attributionForm.assert.auditingLabelIsHidden(
     'previouslyPreferredLabel',
   );
 

--- a/src/e2e-tests/__tests__/saving-preferred-attributions-globally.test.ts
+++ b/src/e2e-tests/__tests__/saving-preferred-attributions-globally.test.ts
@@ -68,17 +68,21 @@ test('marks and unmarks an attribution as preferred globally if user saves globa
       packageInfo1,
     );
 
-    await attributionDetails.comment().fill(preferLocallyComment);
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm
+      .comment()
+      .fill(preferLocallyComment);
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await attributionDetails.saveButton.click();
     await changePreferredStatusGloballyPopup.assert.isHidden();
 
     await resourceDetails.attributionCard.assert.preferredIconIsVisible(
       packageInfo1,
     );
-    await attributionDetails.assert.commentIs(preferLocallyComment);
+    await attributionDetails.attributionForm.assert.commentIs(
+      preferLocallyComment,
+    );
   });
 
   await test.step('prefer attribution globally', async () => {
@@ -87,9 +91,9 @@ test('marks and unmarks an attribution as preferred globally if user saves globa
       packageInfo1,
     );
 
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await attributionDetails.selectSaveMenuOption('saveGlobally');
     await attributionDetails.saveGloballyButton.click();
     await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
@@ -106,7 +110,9 @@ test('marks and unmarks an attribution as preferred globally if user saves globa
   });
 
   await test.step('unmark preferred globally', async () => {
-    await attributionDetails.removeAuditingLabel('currentlyPreferredLabel');
+    await attributionDetails.attributionForm.removeAuditingLabel(
+      'currentlyPreferredLabel',
+    );
     await attributionDetails.selectSaveMenuOption('saveGlobally');
     await attributionDetails.saveGloballyButton.click();
     await changePreferredStatusGloballyPopup.assert.unmarkAsPreferredWarningIsVisible();
@@ -134,7 +140,9 @@ test('marks and unmarks an attribution as preferred globally if user saves globa
     await resourceDetails.attributionCard.assert.preferredIconIsVisible(
       packageInfo1,
     );
-    await attributionDetails.assert.commentIs(preferLocallyComment);
+    await attributionDetails.attributionForm.assert.commentIs(
+      preferLocallyComment,
+    );
   });
 });
 
@@ -155,10 +163,12 @@ test('marks and unmarks an attribution as preferred globally if user navigates a
     await resourceDetails.attributionCard.assert.preferredIconIsHidden(
       packageInfo1,
     );
-    await attributionDetails.copyright.fill(preferLocallyCopyright);
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.copyright.fill(
+      preferLocallyCopyright,
+    );
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await topBar.gotoAttributionView();
     await notSavedPopup.assert.isVisible();
 
@@ -170,7 +180,9 @@ test('marks and unmarks an attribution as preferred globally if user navigates a
     await resourceDetails.attributionCard.assert.preferredIconIsVisible(
       packageInfo1,
     );
-    await attributionDetails.assert.copyrightIs(preferLocallyCopyright);
+    await attributionDetails.attributionForm.assert.copyrightIs(
+      preferLocallyCopyright,
+    );
   });
 
   await test.step('prefer attribution globally', async () => {
@@ -178,9 +190,9 @@ test('marks and unmarks an attribution as preferred globally if user navigates a
     await resourceDetails.attributionCard.assert.preferredIconIsHidden(
       packageInfo1,
     );
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await resourceBrowser.goto(resourceName3);
     await notSavedPopup.assert.isVisible();
 
@@ -198,7 +210,9 @@ test('marks and unmarks an attribution as preferred globally if user navigates a
       packageInfo1,
     );
 
-    await attributionDetails.removeAuditingLabel('currentlyPreferredLabel');
+    await attributionDetails.attributionForm.removeAuditingLabel(
+      'currentlyPreferredLabel',
+    );
     await resourceBrowser.goto(resourceName2);
     await notSavedPopup.assert.isVisible();
 
@@ -229,9 +243,9 @@ test('show prefer globally warning only if necessary and do nothing on cancel', 
       packageInfo2,
     );
 
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await attributionDetails.assert.saveGloballyButtonIsHidden();
     await resourceBrowser.goto(resourceName3);
     await notSavedPopup.assert.isVisible();
@@ -249,11 +263,11 @@ test('show prefer globally warning only if necessary and do nothing on cancel', 
       packageInfo1,
     );
 
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
 
-    await attributionDetails.comment().fill(comment);
+    await attributionDetails.attributionForm.comment().fill(comment);
     await topBar.gotoAttributionView();
     await notSavedPopup.assert.isVisible();
 
@@ -265,8 +279,8 @@ test('show prefer globally warning only if necessary and do nothing on cancel', 
     await resourceDetails.attributionCard.assert.preferredIconIsHidden(
       packageInfo1,
     );
-    await attributionDetails.assert.commentIs(comment);
-    await attributionDetails.assert.auditingLabelIsVisible(
+    await attributionDetails.attributionForm.assert.commentIs(comment);
+    await attributionDetails.attributionForm.assert.auditingLabelIsVisible(
       'currentlyPreferredLabel',
     );
   });
@@ -288,9 +302,9 @@ test('show prefer globally warning if attribution is marked as preferred and sav
       packageInfo1,
     );
 
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await attributionDetails.saveButton.click();
     await changePreferredStatusGloballyPopup.assert.markAsPreferredWarningIsVisible();
 
@@ -301,7 +315,9 @@ test('show prefer globally warning if attribution is marked as preferred and sav
   });
 
   await test.step('prefer attribution with multiple resources and save via menu', async () => {
-    await attributionDetails.removeAuditingLabel('currentlyPreferredLabel');
+    await attributionDetails.attributionForm.removeAuditingLabel(
+      'currentlyPreferredLabel',
+    );
     await menuBar.saveChanges();
     await changePreferredStatusGloballyPopup.assert.unmarkAsPreferredWarningIsVisible();
 
@@ -317,9 +333,9 @@ test('show prefer globally warning if attribution is marked as preferred and sav
       packageInfo2,
     );
 
-    await attributionDetails.openAuditingOptionsMenu();
-    await attributionDetails.auditingOptionsMenu.currentlyPreferredOption.click();
-    await attributionDetails.closeAuditingOptionsMenu();
+    await attributionDetails.attributionForm.openAuditingOptionsMenu();
+    await attributionDetails.attributionForm.auditingOptionsMenu.currentlyPreferredOption.click();
+    await attributionDetails.attributionForm.closeAuditingOptionsMenu();
     await menuBar.saveChanges();
     await changePreferredStatusGloballyPopup.assert.isHidden();
     await attributionList.attributionCard.assert.preferredIconIsVisible(

--- a/src/e2e-tests/__tests__/searching-resources.test.ts
+++ b/src/e2e-tests/__tests__/searching-resources.test.ts
@@ -48,5 +48,7 @@ test('opens resource search popup which closes and displays resource details whe
   );
 
   await fileSearchPopup.gotoHit(resourceName1, resourceName2);
-  await attributionDetails.assert.matchesPackageInfo(packageInfo);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    packageInfo,
+  );
 });

--- a/src/e2e-tests/__tests__/showing-resources-belonging-to-attributions.test.ts
+++ b/src/e2e-tests/__tests__/showing-resources-belonging-to-attributions.test.ts
@@ -70,7 +70,9 @@ test('shows resources belonging to attributions', async ({
     .click();
   await resourcePathPopup.goto(resourceName4);
   await resourceDetails.assert.breadcrumbsAreVisible(resourceName4);
-  await attributionDetails.assert.matchesPackageInfo(manualPackageInfo1);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    manualPackageInfo1,
+  );
 
   await resourceDetails.gotoGlobalTab();
   await resourceDetails.signalCard
@@ -78,7 +80,9 @@ test('shows resources belonging to attributions', async ({
     .click();
   await resourcePathPopup.goto(resourceName3);
   await resourceDetails.assert.breadcrumbsAreVisible(resourceName3);
-  await attributionDetails.assert.matchesPackageInfo(manualPackageInfo2);
+  await attributionDetails.attributionForm.assert.matchesPackageInfo(
+    manualPackageInfo2,
+  );
 
   await topBar.gotoAttributionView();
   await resourceBrowser.assert.isHidden();

--- a/src/e2e-tests/page-objects/AttributionDetails.ts
+++ b/src/e2e-tests/page-objects/AttributionDetails.ts
@@ -4,24 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, Page } from '@playwright/test';
 
-import { RawFrequentLicense } from '../../ElectronBackend/types/types';
-import { DiscreteConfidence, PackageInfo } from '../../shared/shared-types';
-import { text } from '../../shared/text';
+import { AttributionForm } from './AttributionForm';
 
 export class AttributionDetails {
   private readonly window: Page;
   private readonly node: Locator;
-  readonly type: Locator;
-  readonly namespace: Locator;
-  readonly name: Locator;
-  readonly version: Locator;
-  readonly purl: Locator;
-  readonly url: Locator;
-  readonly copyright: Locator;
-  readonly licenseName: Locator;
-  readonly licenseText: Locator;
-  readonly licenseTextToggleButton: Locator;
-  readonly attributionType: Locator;
+  readonly attributionForm: AttributionForm;
   readonly saveButton: Locator;
   readonly saveGloballyButton: Locator;
   readonly saveMenuButton: Locator;
@@ -45,66 +33,11 @@ export class AttributionDetails {
   };
   readonly revertButton: Locator;
   readonly showHideSignalButton: Locator;
-  readonly addAuditingOptionButton: Locator;
-  readonly auditingOptionsMenu: {
-    readonly currentlyPreferredOption: Locator;
-    readonly needsFollowUpOption: Locator;
-    readonly needsReviewOption: Locator;
-    readonly excludedFromNoticeOption: Locator;
-  };
-  readonly auditingLabels: {
-    readonly confidenceLabel: Locator;
-    readonly currentlyPreferredLabel: Locator;
-    readonly excludedFromNoticeLabel: Locator;
-    readonly followUpLabel: Locator;
-    readonly needsReviewLabel: Locator;
-    readonly preselectedLabel: Locator;
-    readonly previouslyPreferredLabel: Locator;
-    readonly sourceLabel: Locator;
-  };
 
   constructor(window: Page) {
     this.window = window;
     this.node = window.getByLabel('attribution column');
-    this.type = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.packageType,
-      { exact: true },
-    );
-    this.namespace = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.packageNamespace,
-      {
-        exact: true,
-      },
-    );
-    this.attributionType = this.node.getByRole('group');
-    this.name = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.packageName,
-      { exact: true },
-    );
-    this.version = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.packageVersion,
-      { exact: true },
-    );
-    this.purl = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.purl,
-      { exact: true },
-    );
-    this.url = this.node.getByLabel(
-      text.attributionColumn.packageSubPanel.repositoryUrl,
-      { exact: true },
-    );
-    this.copyright = this.node.getByLabel('Copyright', { exact: true });
-    this.licenseName = this.node.getByLabel(
-      text.attributionColumn.licenseName,
-      {
-        exact: true,
-      },
-    );
-    this.licenseText = this.node.getByLabel(
-      'License Text (to appear in attribution document)',
-      { exact: true },
-    );
-    this.licenseTextToggleButton = this.node.getByLabel('license text toggle');
+    this.attributionForm = new AttributionForm(this.node, window);
     this.confirmButton = this.node.getByRole('button', {
       name: 'Confirm',
       exact: true,
@@ -163,45 +96,6 @@ export class AttributionDetails {
       exact: true,
     });
     this.showHideSignalButton = this.node.getByLabel('resolve attribution');
-    this.auditingLabels = {
-      sourceLabel: this.node.getByTestId('auditing-option-source'),
-      confidenceLabel: this.node.getByTestId('auditing-option-confidence'),
-      preselectedLabel: this.node.getByTestId('auditing-option-pre-selected'),
-      currentlyPreferredLabel: this.node.getByTestId(
-        'auditing-option-preferred',
-      ),
-      previouslyPreferredLabel: this.node.getByTestId(
-        'auditing-option-was-preferred',
-      ),
-      followUpLabel: this.node.getByTestId('auditing-option-follow-up'),
-      needsReviewLabel: this.node.getByTestId('auditing-option-needs-review'),
-      excludedFromNoticeLabel: this.node.getByTestId(
-        'auditing-option-excluded-from-notice',
-      ),
-    };
-    this.addAuditingOptionButton = this.node.getByRole('button', {
-      name: text.auditingOptions.add,
-    });
-    this.auditingOptionsMenu = {
-      currentlyPreferredOption: window
-        .getByRole('menuitem')
-        .getByText(text.auditingOptions.currentlyPreferred),
-      needsFollowUpOption: window
-        .getByRole('menuitem')
-        .getByText(text.auditingOptions.followUp),
-      needsReviewOption: window
-        .getByRole('menuitem')
-        .getByText(text.auditingOptions.needsReview),
-      excludedFromNoticeOption: window
-        .getByRole('menuitem')
-        .getByText(text.auditingOptions.excludedFromNotice),
-    };
-  }
-
-  public comment(number = 0): Locator {
-    return this.node.getByLabel(number ? `Comment ${number}` : 'Comment', {
-      exact: true,
-    });
   }
 
   public assert = {
@@ -210,113 +104,6 @@ export class AttributionDetails {
     },
     isHidden: async (): Promise<void> => {
       await expect(this.node).toBeHidden();
-    },
-    isEmpty: async (): Promise<void> => {
-      await expect(this.name).toBeEmpty();
-      await expect(this.version).toBeEmpty();
-      await expect(this.purl).toBeEmpty();
-      await expect(this.url).toBeEmpty();
-      await expect(this.comment()).toBeEmpty();
-      await expect(this.licenseName).toBeEmpty();
-      await this.assert.confidenceIs(DiscreteConfidence.High);
-      await this.assert.attributionTypeIs('Third Party');
-    },
-    typeIs: async (type: string): Promise<void> => {
-      await expect(this.type).toHaveValue(type);
-    },
-    namespaceIs: async (namespace: string): Promise<void> => {
-      await expect(this.namespace).toHaveValue(namespace);
-    },
-    nameIs: async (name: string): Promise<void> => {
-      await expect(this.name).toHaveValue(name);
-    },
-    versionIs: async (version: string): Promise<void> => {
-      await expect(this.version).toHaveValue(version);
-    },
-    purlIs: async (purl: string): Promise<void> => {
-      await expect(this.purl).toHaveValue(purl);
-    },
-    urlIs: async (url: string): Promise<void> => {
-      await expect(this.url).toHaveValue(url);
-    },
-    copyrightIs: async (copyright: string): Promise<void> => {
-      await expect(this.copyright).toHaveValue(copyright);
-    },
-    confidenceIs: async (confidence: number): Promise<void> => {
-      await expect(
-        this.auditingLabels.confidenceLabel.getByLabel(
-          `confidence of ${Math.round((confidence / 100) * 5)}`,
-        ),
-      ).toHaveAttribute('aria-disabled', 'false');
-    },
-    attributionTypeIs: async (type: string): Promise<void> => {
-      await expect(
-        this.attributionType.getByRole('button', { name: type, exact: true }),
-      ).toHaveAttribute('aria-pressed', 'true');
-    },
-    licenseNameIs: async (licenseName: string): Promise<void> => {
-      await expect(this.licenseName).toHaveValue(licenseName);
-    },
-    licenseTextIs: async (licenseText: string): Promise<void> => {
-      await expect(this.licenseText).toHaveValue(licenseText);
-    },
-    licenseTextIsVisible: async (): Promise<void> => {
-      await expect(this.licenseText).toBeVisible();
-    },
-    licenseTextIsHidden: async (): Promise<void> => {
-      await expect(this.licenseText).toBeHidden();
-    },
-    commentIs: async (comment: string, number = 0): Promise<void> => {
-      await expect(this.comment(number)).toHaveValue(comment);
-    },
-    matchesPackageInfo: async ({
-      attributionConfidence,
-      comment,
-      comments,
-      copyright,
-      firstParty,
-      licenseName,
-      licenseText,
-      packageName,
-      packageNamespace,
-      packageType,
-      packageVersion,
-      url,
-    }: PackageInfo & { comments?: Array<string> }): Promise<void> => {
-      await Promise.all([
-        ...(packageType ? [this.assert.typeIs(packageType)] : []),
-        ...(packageNamespace
-          ? [this.assert.namespaceIs(packageNamespace)]
-          : []),
-        ...(packageName ? [this.assert.nameIs(packageName)] : []),
-        ...(packageVersion ? [this.assert.versionIs(packageVersion)] : []),
-        ...(url ? [this.assert.urlIs(url)] : []),
-        ...(copyright
-          ? [
-              firstParty
-                ? await expect(this.copyright).toBeHidden()
-                : this.assert.copyrightIs(copyright),
-            ]
-          : []),
-        ...(firstParty ? [this.assert.attributionTypeIs('First Party')] : []),
-        ...(licenseName
-          ? [
-              firstParty
-                ? await expect(this.licenseName).toBeHidden()
-                : this.assert.licenseNameIs(licenseName),
-            ]
-          : []),
-        ...(licenseText ? [this.assert.licenseTextIs(licenseText)] : []),
-        ...(comment ? [this.assert.commentIs(comment)] : []),
-        ...(comments
-          ? comments.map((item, index) =>
-              this.assert.commentIs(item, index + 1),
-            )
-          : []),
-        ...(attributionConfidence
-          ? [this.assert.confidenceIs(attributionConfidence)]
-          : []),
-      ]);
     },
     saveButtonIsVisible: async (): Promise<void> => {
       await expect(this.saveButton).toBeVisible();
@@ -384,55 +171,7 @@ export class AttributionDetails {
     showHideSignalButtonIsHidden: async (): Promise<void> => {
       await expect(this.showHideSignalButton).toBeHidden();
     },
-    auditingMenuOptionIsVisible: async (
-      option: keyof typeof this.auditingOptionsMenu,
-    ): Promise<void> => {
-      await expect(this.auditingOptionsMenu[option]).toBeVisible();
-    },
-    auditingMenuOptionIsHidden: async (
-      option: keyof typeof this.auditingOptionsMenu,
-    ): Promise<void> => {
-      await expect(this.auditingOptionsMenu[option]).toBeHidden();
-    },
-    auditingLabelIsVisible: async (
-      label: keyof typeof this.auditingLabels,
-    ): Promise<void> => {
-      await expect(this.auditingLabels[label]).toBeVisible();
-    },
-    auditingLabelIsHidden: async (
-      label: keyof typeof this.auditingLabels,
-    ): Promise<void> => {
-      await expect(this.auditingLabels[label]).toBeHidden();
-    },
   };
-
-  async openAuditingOptionsMenu(): Promise<void> {
-    await this.addAuditingOptionButton.click();
-  }
-
-  async closeAuditingOptionsMenu(): Promise<void> {
-    await this.window.keyboard.press('Escape');
-  }
-
-  async toggleLicenseTextVisibility(): Promise<void> {
-    await this.licenseTextToggleButton.click();
-  }
-
-  async selectLicense(license: RawFrequentLicense): Promise<void> {
-    await this.window.getByText(license.fullName).click();
-  }
-
-  async removeAuditingLabel(
-    label: keyof typeof this.auditingLabels,
-  ): Promise<void> {
-    await this.auditingLabels[label].getByTestId('CancelIcon').click();
-  }
-
-  async selectAttributionType(type: string): Promise<void> {
-    await this.attributionType
-      .getByRole('button', { name: type, exact: true })
-      .click();
-  }
 
   async selectSaveMenuOption(
     option: keyof typeof this.saveMenuOptions,

--- a/src/e2e-tests/page-objects/AttributionForm.ts
+++ b/src/e2e-tests/page-objects/AttributionForm.ts
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, Locator, Page } from '@playwright/test';
+
+import { RawFrequentLicense } from '../../ElectronBackend/types/types';
+import { DiscreteConfidence, PackageInfo } from '../../shared/shared-types';
+import { text } from '../../shared/text';
+
+export class AttributionForm {
+  private readonly window: Page;
+  private readonly node: Locator;
+  readonly type: Locator;
+  readonly namespace: Locator;
+  readonly name: Locator;
+  readonly version: Locator;
+  readonly purl: Locator;
+  readonly url: Locator;
+  readonly copyright: Locator;
+  readonly licenseName: Locator;
+  readonly licenseText: Locator;
+  readonly licenseTextToggleButton: Locator;
+  readonly attributionType: Locator;
+  readonly addAuditingOptionButton: Locator;
+  readonly auditingOptionsMenu: {
+    readonly currentlyPreferredOption: Locator;
+    readonly needsFollowUpOption: Locator;
+    readonly needsReviewOption: Locator;
+    readonly excludedFromNoticeOption: Locator;
+  };
+  readonly auditingLabels: {
+    readonly confidenceLabel: Locator;
+    readonly currentlyPreferredLabel: Locator;
+    readonly excludedFromNoticeLabel: Locator;
+    readonly followUpLabel: Locator;
+    readonly needsReviewLabel: Locator;
+    readonly preselectedLabel: Locator;
+    readonly previouslyPreferredLabel: Locator;
+    readonly sourceLabel: Locator;
+  };
+
+  constructor(context: Locator, window: Page) {
+    this.window = window;
+    this.node = context;
+    this.type = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.packageType,
+      { exact: true },
+    );
+    this.namespace = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.packageNamespace,
+      {
+        exact: true,
+      },
+    );
+    this.attributionType = this.node.getByRole('group');
+    this.name = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.packageName,
+      { exact: true },
+    );
+    this.version = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.packageVersion,
+      { exact: true },
+    );
+    this.purl = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.purl,
+      { exact: true },
+    );
+    this.url = this.node.getByLabel(
+      text.attributionColumn.packageSubPanel.repositoryUrl,
+      { exact: true },
+    );
+    this.copyright = this.node.getByLabel('Copyright', { exact: true });
+    this.licenseName = this.node.getByLabel(
+      text.attributionColumn.licenseName,
+      {
+        exact: true,
+      },
+    );
+    this.licenseText = this.node.getByLabel(
+      'License Text (to appear in attribution document)',
+      { exact: true },
+    );
+    this.licenseTextToggleButton = this.node.getByLabel('license text toggle');
+    this.auditingLabels = {
+      sourceLabel: this.node.getByTestId('auditing-option-source'),
+      confidenceLabel: this.node.getByTestId('auditing-option-confidence'),
+      preselectedLabel: this.node.getByTestId('auditing-option-pre-selected'),
+      currentlyPreferredLabel: this.node.getByTestId(
+        'auditing-option-preferred',
+      ),
+      previouslyPreferredLabel: this.node.getByTestId(
+        'auditing-option-was-preferred',
+      ),
+      followUpLabel: this.node.getByTestId('auditing-option-follow-up'),
+      needsReviewLabel: this.node.getByTestId('auditing-option-needs-review'),
+      excludedFromNoticeLabel: this.node.getByTestId(
+        'auditing-option-excluded-from-notice',
+      ),
+    };
+    this.addAuditingOptionButton = this.node.getByRole('button', {
+      name: text.auditingOptions.add,
+    });
+    this.auditingOptionsMenu = {
+      currentlyPreferredOption: window
+        .getByRole('menuitem')
+        .getByText(text.auditingOptions.currentlyPreferred),
+      needsFollowUpOption: window
+        .getByRole('menuitem')
+        .getByText(text.auditingOptions.followUp),
+      needsReviewOption: window
+        .getByRole('menuitem')
+        .getByText(text.auditingOptions.needsReview),
+      excludedFromNoticeOption: window
+        .getByRole('menuitem')
+        .getByText(text.auditingOptions.excludedFromNotice),
+    };
+  }
+
+  public comment(number = 0): Locator {
+    return this.node.getByLabel(number ? `Comment ${number}` : 'Comment', {
+      exact: true,
+    });
+  }
+
+  public assert = {
+    isEmpty: async (): Promise<void> => {
+      await expect(this.name).toBeEmpty();
+      await expect(this.version).toBeEmpty();
+      await expect(this.purl).toBeEmpty();
+      await expect(this.url).toBeEmpty();
+      await expect(this.comment()).toBeEmpty();
+      await expect(this.licenseName).toBeEmpty();
+      await this.assert.confidenceIs(DiscreteConfidence.High);
+      await this.assert.attributionTypeIs('Third Party');
+    },
+    typeIs: async (type: string): Promise<void> => {
+      await expect(this.type).toHaveValue(type);
+    },
+    namespaceIs: async (namespace: string): Promise<void> => {
+      await expect(this.namespace).toHaveValue(namespace);
+    },
+    nameIs: async (name: string): Promise<void> => {
+      await expect(this.name).toHaveValue(name);
+    },
+    versionIs: async (version: string): Promise<void> => {
+      await expect(this.version).toHaveValue(version);
+    },
+    purlIs: async (purl: string): Promise<void> => {
+      await expect(this.purl).toHaveValue(purl);
+    },
+    urlIs: async (url: string): Promise<void> => {
+      await expect(this.url).toHaveValue(url);
+    },
+    copyrightIs: async (copyright: string): Promise<void> => {
+      await expect(this.copyright).toHaveValue(copyright);
+    },
+    confidenceIs: async (confidence: number): Promise<void> => {
+      await expect(
+        this.auditingLabels.confidenceLabel.getByLabel(
+          `confidence of ${Math.round((confidence / 100) * 5)}`,
+        ),
+      ).toHaveAttribute('aria-disabled', 'false');
+    },
+    attributionTypeIs: async (type: string): Promise<void> => {
+      await expect(
+        this.attributionType.getByRole('button', { name: type, exact: true }),
+      ).toHaveAttribute('aria-pressed', 'true');
+    },
+    licenseNameIs: async (licenseName: string): Promise<void> => {
+      await expect(this.licenseName).toHaveValue(licenseName);
+    },
+    licenseTextIs: async (licenseText: string): Promise<void> => {
+      await expect(this.licenseText).toHaveValue(licenseText);
+    },
+    licenseTextIsVisible: async (): Promise<void> => {
+      await expect(this.licenseText).toBeVisible();
+    },
+    licenseTextIsHidden: async (): Promise<void> => {
+      await expect(this.licenseText).toBeHidden();
+    },
+    commentIs: async (comment: string, number = 0): Promise<void> => {
+      await expect(this.comment(number)).toHaveValue(comment);
+    },
+    matchesPackageInfo: async ({
+      attributionConfidence,
+      comment,
+      comments,
+      copyright,
+      firstParty,
+      licenseName,
+      licenseText,
+      packageName,
+      packageNamespace,
+      packageType,
+      packageVersion,
+      url,
+    }: PackageInfo & { comments?: Array<string> }): Promise<void> => {
+      await Promise.all([
+        ...(packageType ? [this.assert.typeIs(packageType)] : []),
+        ...(packageNamespace
+          ? [this.assert.namespaceIs(packageNamespace)]
+          : []),
+        ...(packageName ? [this.assert.nameIs(packageName)] : []),
+        ...(packageVersion ? [this.assert.versionIs(packageVersion)] : []),
+        ...(url ? [this.assert.urlIs(url)] : []),
+        ...(copyright
+          ? [
+              firstParty
+                ? await expect(this.copyright).toBeHidden()
+                : this.assert.copyrightIs(copyright),
+            ]
+          : []),
+        ...(firstParty ? [this.assert.attributionTypeIs('First Party')] : []),
+        ...(licenseName
+          ? [
+              firstParty
+                ? await expect(this.licenseName).toBeHidden()
+                : this.assert.licenseNameIs(licenseName),
+            ]
+          : []),
+        ...(licenseText ? [this.assert.licenseTextIs(licenseText)] : []),
+        ...(comment ? [this.assert.commentIs(comment)] : []),
+        ...(comments
+          ? comments.map((item, index) =>
+              this.assert.commentIs(item, index + 1),
+            )
+          : []),
+        ...(attributionConfidence
+          ? [this.assert.confidenceIs(attributionConfidence)]
+          : []),
+      ]);
+    },
+    auditingMenuOptionIsVisible: async (
+      option: keyof typeof this.auditingOptionsMenu,
+    ): Promise<void> => {
+      await expect(this.auditingOptionsMenu[option]).toBeVisible();
+    },
+    auditingMenuOptionIsHidden: async (
+      option: keyof typeof this.auditingOptionsMenu,
+    ): Promise<void> => {
+      await expect(this.auditingOptionsMenu[option]).toBeHidden();
+    },
+    auditingLabelIsVisible: async (
+      label: keyof typeof this.auditingLabels,
+    ): Promise<void> => {
+      await expect(this.auditingLabels[label]).toBeVisible();
+    },
+    auditingLabelIsHidden: async (
+      label: keyof typeof this.auditingLabels,
+    ): Promise<void> => {
+      await expect(this.auditingLabels[label]).toBeHidden();
+    },
+  };
+
+  async openAuditingOptionsMenu(): Promise<void> {
+    await this.addAuditingOptionButton.click();
+  }
+
+  async closeAuditingOptionsMenu(): Promise<void> {
+    await this.window.keyboard.press('Escape');
+  }
+
+  async toggleLicenseTextVisibility(): Promise<void> {
+    await this.licenseTextToggleButton.click();
+  }
+
+  async selectLicense(license: RawFrequentLicense): Promise<void> {
+    await this.window.getByText(license.fullName).click();
+  }
+
+  async removeAuditingLabel(
+    label: keyof typeof this.auditingLabels,
+  ): Promise<void> {
+    await this.auditingLabels[label].getByTestId('CancelIcon').click();
+  }
+
+  async selectAttributionType(type: string): Promise<void> {
+    await this.attributionType
+      .getByRole('button', { name: type, exact: true })
+      .click();
+  }
+}


### PR DESCRIPTION
### Summary of changes

Introduce object model for newly introduced attribution form and refactor existing attributions details model to use it.

### Context and reason for change

In #2516 we factored the `AttributionForm` out of the `AttributionColumn` into a separate component. In this PR we refactor the corresponding object models in e2e tests.

### How can the changes be tested

Run e2e tests locally and in CI.
