### PR TITLE
feat: do not highlight missing attribution version

### DIFF
--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.util.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.util.test.tsx
@@ -118,7 +118,6 @@ describe('The table helpers', () => {
     ${'licenseName'}
     ${'packageName'}
     ${'url'}
-    ${'packageVersion'}
   `(
     'isImportantAttributionInformationMissing handles $property correctly',
     ({ property }) => {

--- a/src/Frontend/util/is-important-attribution-information-missing.ts
+++ b/src/Frontend/util/is-important-attribution-information-missing.ts
@@ -32,7 +32,6 @@ export function isImportantAttributionInformationMissing(
     case 'licenseName':
     case 'packageName':
     case 'packageType':
-    case 'packageVersion':
     case 'url':
       return !packageInfo[attributionProperty];
     case 'packageNamespace':


### PR DESCRIPTION
### Summary of changes

- remove "version" from the list of required attributes

### Context and reason for change

closes #2527

### How can the changes be tested

Create an attribution with all required fields, except version. Notice that the attribution no longer has the yellow tooth on the package card and also that the version input field is not highlighted in yellow in attribution view.