### PR TITLE
fix: correct multiline textfield padding

### DIFF
--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -2,27 +2,23 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiInputAdornment from '@mui/material/InputAdornment';
 import MuiTextField from '@mui/material/TextField';
-import { ReactElement } from 'react';
 
 import { HighlightingColor } from '../../enums/enums';
-import { getSxFromPropsAndClasses } from '../../util/get-sx-from-props-and-classes';
 import { inputElementClasses, InputElementProps } from './shared';
 
 interface TextProps extends InputElementProps {
-  textFieldInputSx?: SxProps;
   minRows?: number;
   maxRows?: number;
-  endIcon?: ReactElement;
+  endIcon?: React.ReactElement;
   multiline?: boolean;
   highlightingColor?: HighlightingColor;
   error?: boolean;
 }
 
-export function TextBox(props: TextProps): ReactElement {
+export function TextBox(props: TextProps) {
   const isDefaultHighlighting =
     props.highlightingColor === HighlightingColor.LightOrange ||
     props.highlightingColor === undefined;
@@ -33,24 +29,30 @@ export function TextBox(props: TextProps): ReactElement {
       ? inputElementClasses.strongHighlightedTextField
       : {};
 
-  const textBoxSx = getSxFromPropsAndClasses({
-    sxProps: props.isHighlighted ? highlightedStyling : {},
-    styleClass: inputElementClasses.textField,
-  });
   return (
     <MuiBox sx={props.sx}>
       <MuiTextField
         disabled={!props.isEditable}
         error={props.error}
-        sx={textBoxSx}
+        sx={{
+          ...(props.isHighlighted ? highlightedStyling : {}),
+          ...inputElementClasses.textField,
+        }}
         label={props.title}
         InputProps={{
+          slotProps: {
+            root: {
+              sx: {
+                padding: 0,
+              },
+            },
+          },
           inputProps: {
             'aria-label': props.title,
             sx: {
-              ...props.textFieldInputSx,
               overflowX: 'hidden',
               textOverflow: 'ellipsis',
+              padding: '8.5px 14px',
             },
           },
           endAdornment: props.endIcon && (


### PR DESCRIPTION
### Summary of changes

- move scroll bar to edge of input field and apply padding around input element instead

BEFORE:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/6611ecae-65eb-460a-a715-f6a05fc5cc7a)

AFTER:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/4517eb1f-6e5a-4bcc-a9eb-60bbd29a8ea1)

### Context and reason for change

closes #2530

### How can the changes be tested

Check that both single and multiline textfields have the correct padding.