### PR TITLE
fix: "license text modified" overlaps license text

### DIFF
--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -2,21 +2,22 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import EditNoteIcon from '@mui/icons-material/EditNote';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionDetails from '@mui/material/AccordionDetails';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import MuiBox from '@mui/material/Box';
-import MuiInputAdornment from '@mui/material/InputAdornment';
+import MuiTooltip from '@mui/material/Tooltip';
 import { sortBy } from 'lodash';
-import { ReactElement, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   AutocompleteSignal,
   DisplayPackageInfo,
 } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
-import { OpossumColors } from '../../shared-styles';
+import { baseIcon, OpossumColors } from '../../shared-styles';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
@@ -59,10 +60,6 @@ const classes = {
   licenseText: {
     marginTop: '12px',
   },
-  endAdornment: {
-    paddingRight: '6px',
-    paddingTop: '2px',
-  },
 };
 
 interface LicenseSubPanelProps {
@@ -75,7 +72,7 @@ export function LicenseSubPanel({
   displayPackageInfo,
   showHighlight,
   onEdit,
-}: LicenseSubPanelProps): ReactElement {
+}: LicenseSubPanelProps) {
   const dispatch = useAppDispatch();
   const [expanded, setExpanded] = useState(false);
   const frequentLicensesNames = useAppSelector(getFrequentLicensesNameOrder);
@@ -124,9 +121,12 @@ export function LicenseSubPanel({
             onEdit={onEdit}
             endAdornment={
               displayPackageInfo.licenseText ? (
-                <MuiInputAdornment position="end" sx={classes.endAdornment}>
-                  {text.attributionColumn.licenseTextModified}
-                </MuiInputAdornment>
+                <MuiTooltip title={text.attributionColumn.licenseTextModified}>
+                  <EditNoteIcon
+                    color={'warning'}
+                    sx={{ ...baseIcon, cursor: 'default' }}
+                  />
+                </MuiTooltip>
               ) : undefined
             }
             defaults={defaultLicenses}

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -31,7 +31,7 @@ export const text = {
     invalidPurl: 'INVALID PURL',
     legalInformation: 'Legal Information',
     licenseName: 'License Name',
-    licenseTextModified: '(License text modified)',
+    licenseTextModified: 'License text modified',
     manualAttributions: 'Manual Attributions',
     occurrence: 'occurrence',
     openSourceInsights: 'Open Source Insights',


### PR DESCRIPTION
### Summary of changes

- replace end adornment label by end adornment icon in order to save space

BEFORE:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/74e3f797-2e68-41ba-ba17-4ed00fc43dd8)

AFTER:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/e1a1c196-9df9-413b-b953-73184c3cbe5e)

### Context and reason for change

closes #2529

### How can the changes be tested

Inspect an attribution with a modified (non-empty-string) license text.