### PR TITLE
feat: show license short names in autocomplete

### DIFF
--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -82,15 +82,18 @@ export function LicenseSubPanel({
   const defaultLicenses = useMemo(
     () =>
       sortBy(
-        frequentLicensesNames.map<AutocompleteSignal>(({ fullName }) => ({
-          attributionIds: [],
-          default: true,
-          licenseName: fullName,
-          source: {
-            documentConfidence: 100,
-            name: text.attributionColumn.commonLicenses,
-          },
-        })),
+        frequentLicensesNames.map<AutocompleteSignal>(
+          ({ fullName, shortName }) => ({
+            attributionIds: [],
+            default: true,
+            licenseName: fullName,
+            source: {
+              documentConfidence: 100,
+              name: text.attributionColumn.commonLicenses,
+            },
+            suffix: `(${shortName})`,
+          }),
+        ),
         ({ licenseName }) => licenseName?.toLowerCase(),
       ),
     [frequentLicensesNames],

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -143,10 +143,14 @@ export function PackageAutocomplete({
       renderOptionEndIcon={renderOptionEndIcon}
       value={temporaryPackageInfo}
       filterOptions={createFilterOptions({
-        stringify: (option) =>
-          attribute === 'packageName'
-            ? `${option.packageName || ''}${option.packageNamespace || ''}`
-            : option[attribute] || '',
+        stringify: (option) => {
+          switch (attribute) {
+            case 'packageName':
+              return `${option.packageName || ''}${option.packageNamespace || ''}`;
+            default:
+              return `${option[attribute] || ''} ${option.suffix || ''}`.trim();
+          }
+        },
       })}
       isOptionEqualToValue={(option, value) =>
         option[attribute] === value[attribute]


### PR DESCRIPTION
### Summary of changes

- display the license short name as a suffix behind actual license name

BEFORE:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/6632901d-c496-41ea-ad9b-cf432c48135c)

AFTER:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/cfa47e65-7938-48d4-aea1-97aeea080401)

### Context and reason for change

closes #2526

### How can the changes be tested

Look at the "common licenses" section of the license name autocomplete.
Note that it is still expected that the long name is the value of the input field since that is the actual name of the license and not just the SPDX identifier.