### PR TITLE
feat: add colours to the static diff popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
@@ -15,6 +15,7 @@ import { AttributionType } from '../../enums/enums';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch } from '../../state/hooks';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { AttributionFormConfig } from '../DiffPopup/DiffPopup';
 import { AuditingOptions } from './AuditingOptions';
 import { CommentStack } from './CommentStack';
 import { CopyrightSubPanel } from './CopyrightSubPanel';
@@ -42,31 +43,31 @@ interface AttributionFormProps {
   packageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
-  isDiffView?: boolean;
+  config?: AttributionFormConfig;
   label?: string;
 }
 
 export function AttributionForm(props: AttributionFormProps) {
   const dispatch = useAppDispatch();
   const variant = useMemo<PanelVariantProp>(() => {
-    if (!!props.isDiffView && props.packageInfo.firstParty) {
+    if (props.config?.isDiffView && props.packageInfo.firstParty) {
       return 'expanded-invisible';
     }
-    if (props.isDiffView && !props.packageInfo.firstParty) {
+    if (props.config?.isDiffView && !props.packageInfo.firstParty) {
       return 'expanded';
     }
-    if (!props.isDiffView && props.packageInfo.firstParty) {
+    if (!props.config?.isDiffView && props.packageInfo.firstParty) {
       return 'hidden';
     }
     return 'default';
-  }, [props.packageInfo.firstParty, props.isDiffView]);
+  }, [props.packageInfo.firstParty, props.config?.isDiffView]);
 
   return (
     <MuiBox sx={classes.formContainer} aria-label={props.label}>
       <AuditingOptions
         packageInfo={props.packageInfo}
         isEditable={!!props.onEdit}
-        sx={{ flex: props.isDiffView ? 1 : undefined }}
+        sx={{ flex: !!props.config ? 1 : undefined }}
       />
       <MuiDivider variant={'middle'}>
         <MuiTypography>
@@ -77,6 +78,7 @@ export function AttributionForm(props: AttributionFormProps) {
         displayPackageInfo={props.packageInfo}
         showHighlight={props.showHighlight}
         onEdit={props.onEdit}
+        config={props.config}
       />
       <MuiDivider variant={'middle'}>
         <MuiTypography>{text.attributionColumn.legalInformation}</MuiTypography>
@@ -87,14 +89,16 @@ export function AttributionForm(props: AttributionFormProps) {
         showHighlight={props.showHighlight}
         onEdit={props.onEdit}
         variant={variant}
+        configAttribute={{ colorValue: props.config?.copyright }}
       />
       <LicenseSubPanel
         displayPackageInfo={props.packageInfo}
         showHighlight={props.showHighlight}
         onEdit={props.onEdit}
         variant={variant}
+        config={props.config}
       />
-      {props.isDiffView ? null : (
+      {!!props.config ? null : (
         <CommentStack
           displayPackageInfo={props.packageInfo}
           onEdit={props.onEdit}

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.tsx
@@ -5,7 +5,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import MuiBox from '@mui/material/Box';
 import MuiChip from '@mui/material/Chip';
-import { SxProps } from '@mui/system';
+import { SxProps, Theme } from '@mui/system';
 import { useState } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
@@ -21,9 +21,10 @@ const classes = {
 interface Props {
   packageInfo: DisplayPackageInfo;
   isEditable: boolean;
+  sx?: SxProps<Theme>;
 }
 
-export function AuditingOptions({ packageInfo, isEditable }: Props) {
+export function AuditingOptions({ packageInfo, isEditable, sx }: Props) {
   const options = useAuditingOptions({ packageInfo, isEditable });
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const unselectedOptions = options.filter(
@@ -32,7 +33,7 @@ export function AuditingOptions({ packageInfo, isEditable }: Props) {
 
   return options.length ? (
     <>
-      <MuiBox sx={classes.container}>
+      <MuiBox sx={{ ...classes.container, ...sx }}>
         {renderTriggerButton()}
         {renderSelectedOptions()}
       </MuiBox>

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
@@ -123,7 +123,7 @@ export function useAuditingOptions({
               preferred: false,
             }),
           ),
-        interactive: isPreferenceFeatureEnabled && qaMode,
+        interactive: isPreferenceFeatureEnabled && qaMode && isEditable,
       },
       {
         id: 'was-preferred',
@@ -137,7 +137,7 @@ export function useAuditingOptions({
         label: text.auditingOptions.modifiedPreferred,
         icon: <ModifiedPreferredIcon noTooltip />,
         selected: !!originalPreferred,
-        interactive: !!originalPreferred,
+        interactive: !!originalPreferred && isEditable,
         deleteIcon: <ReplayIcon aria-label={'undo modified preferred'} />,
         onDelete: originalPreferred
           ? () =>

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -9,6 +9,7 @@ import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-act
 import { useAppDispatch } from '../../state/hooks';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { AttributionFormConfigAttribute } from '../DiffPopup/DiffPopup';
 import { TextBox } from '../InputElements/TextBox';
 import { PanelVariantProp } from './AttributionForm';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
@@ -18,6 +19,7 @@ interface CopyrightSubPanelProps {
   showHighlight?: boolean;
   onEdit?: Confirm;
   variant?: PanelVariantProp;
+  configAttribute?: AttributionFormConfigAttribute;
 }
 
 export function CopyrightSubPanel({
@@ -25,6 +27,7 @@ export function CopyrightSubPanel({
   onEdit,
   showHighlight,
   variant,
+  configAttribute,
 }: CopyrightSubPanelProps) {
   const dispatch = useAppDispatch();
 
@@ -62,6 +65,7 @@ export function CopyrightSubPanel({
             displayPackageInfo,
           )
         }
+        configAttribute={configAttribute}
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
-import { ReactElement } from 'react';
 
 import { DisplayPackageInfo } from '../../../shared/shared-types';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -11,30 +10,39 @@ import { useAppDispatch } from '../../state/hooks';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
 import { TextBox } from '../InputElements/TextBox';
+import { PanelVariantProp } from './AttributionForm';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
 interface CopyrightSubPanelProps {
   displayPackageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  variant?: PanelVariantProp;
 }
 
 export function CopyrightSubPanel({
   displayPackageInfo,
   onEdit,
   showHighlight,
-}: CopyrightSubPanelProps): ReactElement {
+  variant,
+}: CopyrightSubPanelProps) {
   const dispatch = useAppDispatch();
 
-  return (
-    <MuiBox sx={attributionColumnClasses.panel}>
+  return variant === 'hidden' ? null : (
+    <MuiBox
+      sx={{
+        ...attributionColumnClasses.panel,
+        ...(variant === 'expanded-invisible' ? { visibility: 'hidden' } : {}),
+      }}
+    >
       <TextBox
         isEditable={!!onEdit}
         sx={attributionColumnClasses.textBox}
         title={'Copyright'}
         text={displayPackageInfo.copyright}
-        minRows={3}
-        maxRows={10}
+        {...(variant === 'expanded' || variant === 'expanded-invisible'
+          ? { rows: 7 }
+          : { minRows: 3, maxRows: 10 })}
         multiline={true}
         handleChange={({ target: { value } }) =>
           onEdit?.(() =>

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -9,7 +9,7 @@ import MuiAccordionSummary from '@mui/material/AccordionSummary';
 import MuiBox from '@mui/material/Box';
 import MuiInputAdornment from '@mui/material/InputAdornment';
 import { sortBy } from 'lodash';
-import { ReactElement, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   AutocompleteSignal,
@@ -23,6 +23,7 @@ import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-re
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
 import { TextBox } from '../InputElements/TextBox';
 import { getLicenseTextLabelText } from './AttributionColumn.util';
+import { PanelVariantProp } from './AttributionForm';
 import { PackageAutocomplete } from './PackageAutocomplete';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
@@ -49,6 +50,9 @@ const classes = {
     padding: '0px',
     width: 'calc(100% - 36px)',
   },
+  expansionPanelDetailsDiffView: {
+    padding: '0px',
+  },
   expandMoreIcon: {
     display: 'flex',
     alignItems: 'center',
@@ -69,13 +73,15 @@ interface LicenseSubPanelProps {
   displayPackageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  variant?: PanelVariantProp;
 }
 
 export function LicenseSubPanel({
   displayPackageInfo,
   showHighlight,
   onEdit,
-}: LicenseSubPanelProps): ReactElement {
+  variant,
+}: LicenseSubPanelProps) {
   const dispatch = useAppDispatch();
   const [expanded, setExpanded] = useState(false);
   const frequentLicensesNames = useAppSelector(getFrequentLicensesNameOrder);
@@ -99,29 +105,41 @@ export function LicenseSubPanel({
     [frequentLicensesNames],
   );
 
-  return (
-    <MuiBox sx={classes.panel}>
+  return variant === 'hidden' ? null : (
+    <MuiBox
+      sx={{
+        ...classes.panel,
+        ...(variant === 'expanded-invisible' ? { visibility: 'hidden' } : {}),
+      }}
+    >
       <MuiAccordion
         sx={classes.expansionPanel}
         elevation={0}
         key={'License'}
         disableGutters
-        expanded={expanded}
+        expanded={
+          variant === 'expanded' || variant === 'expanded-invisible'
+            ? true
+            : expanded
+        }
       >
         <MuiAccordionSummary
           sx={classes.expansionPanelSummary}
           expandIcon={
-            <MuiBox
-              sx={classes.expandMoreIcon}
-              onClick={() => setExpanded((prev) => !prev)}
-            >
-              <ExpandMoreIcon aria-label={'license text toggle'} />
-            </MuiBox>
+            variant === 'default' ? (
+              <MuiBox
+                sx={classes.expandMoreIcon}
+                onClick={() => setExpanded((prev) => !prev)}
+              >
+                <ExpandMoreIcon aria-label={'license text toggle'} />
+              </MuiBox>
+            ) : null
           }
         >
           <PackageAutocomplete
             attribute={'licenseName'}
             title={text.attributionColumn.licenseName}
+            packageInfo={displayPackageInfo}
             disabled={!onEdit}
             showHighlight={showHighlight}
             onEdit={onEdit}
@@ -135,12 +153,19 @@ export function LicenseSubPanel({
             defaults={defaultLicenses}
           />
         </MuiAccordionSummary>
-        <MuiAccordionDetails sx={classes.expansionPanelDetails}>
+        <MuiAccordionDetails
+          sx={
+            variant === 'expanded' || variant === 'expanded-invisible'
+              ? classes.expansionPanelDetailsDiffView
+              : classes.expansionPanelDetails
+          }
+        >
           <TextBox
             isEditable={!!onEdit}
             sx={classes.licenseText}
-            minRows={3}
-            maxRows={10}
+            {...(variant === 'expanded' || variant === 'expanded-invisible'
+              ? { rows: 10 }
+              : { minRows: 3, maxRows: 10 })}
             multiline={true}
             title={getLicenseTextLabelText(
               displayPackageInfo.licenseName,

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -21,6 +21,7 @@ import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-act
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-resource-selectors';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { AttributionFormConfig } from '../DiffPopup/DiffPopup';
 import { TextBox } from '../InputElements/TextBox';
 import { getLicenseTextLabelText } from './AttributionColumn.util';
 import { PanelVariantProp } from './AttributionForm';
@@ -74,6 +75,7 @@ interface LicenseSubPanelProps {
   showHighlight?: boolean;
   onEdit?: Confirm;
   variant?: PanelVariantProp;
+  config?: AttributionFormConfig;
 }
 
 export function LicenseSubPanel({
@@ -81,6 +83,7 @@ export function LicenseSubPanel({
   showHighlight,
   onEdit,
   variant,
+  config,
 }: LicenseSubPanelProps) {
   const dispatch = useAppDispatch();
   const [expanded, setExpanded] = useState(false);
@@ -151,6 +154,9 @@ export function LicenseSubPanel({
               ) : undefined
             }
             defaults={defaultLicenses}
+            configAttribute={{
+              colorValue: config?.licenseName,
+            }}
           />
         </MuiAccordionSummary>
         <MuiAccordionDetails
@@ -184,6 +190,9 @@ export function LicenseSubPanel({
                 ),
               )
             }
+            configAttribute={{
+              colorValue: config?.licenseText,
+            }}
           />
         </MuiAccordionDetails>
       </MuiAccordion>

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -21,10 +21,7 @@ import { text } from '../../../shared/text';
 import { clickableIcon } from '../../shared-styles';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
-import {
-  getExternalAttributionSources,
-  getTemporaryDisplayPackageInfo,
-} from '../../state/selectors/all-views-resource-selectors';
+import { getExternalAttributionSources } from '../../state/selectors/all-views-resource-selectors';
 import { isAuditViewSelected } from '../../state/selectors/view-selector';
 import { useAutocompleteSignals } from '../../state/variables/use-autocomplete-signals';
 import { generatePurl } from '../../util/handle-purl';
@@ -51,6 +48,7 @@ type AutocompleteAttribute = Extract<
 interface Props {
   title: string;
   attribute: AutocompleteAttribute;
+  packageInfo: DisplayPackageInfo;
   highlight?: 'default' | 'dark';
   endAdornment?: React.ReactElement;
   defaults?: Array<AutocompleteSignal>;
@@ -75,6 +73,7 @@ const AddIconButton = styled(MuiIconButton)({
 export function PackageAutocomplete({
   attribute,
   title,
+  packageInfo,
   highlight = 'default',
   endAdornment,
   defaults = [],
@@ -83,8 +82,7 @@ export function PackageAutocomplete({
   onEdit,
 }: Props) {
   const dispatch = useAppDispatch();
-  const temporaryPackageInfo = useAppSelector(getTemporaryDisplayPackageInfo);
-  const attributeValue = temporaryPackageInfo[attribute] || '';
+  const attributeValue = packageInfo[attribute] || '';
   const [inputValue, setInputValue] = useState(attributeValue);
   const sources = useAppSelector(getExternalAttributionSources);
   const isAuditView = useAppSelector(isAuditViewSelected);
@@ -118,10 +116,7 @@ export function PackageAutocomplete({
       inputValue={inputValue}
       highlight={
         showHighlight &&
-        isImportantAttributionInformationMissing(
-          attribute,
-          temporaryPackageInfo,
-        )
+        isImportantAttributionInformationMissing(attribute, packageInfo)
           ? highlight
           : undefined
       }
@@ -141,7 +136,7 @@ export function PackageAutocomplete({
       }
       renderOptionStartIcon={renderOptionStartIcon}
       renderOptionEndIcon={renderOptionEndIcon}
-      value={temporaryPackageInfo}
+      value={packageInfo}
       filterOptions={createFilterOptions({
         stringify: (option) => {
           switch (attribute) {
@@ -189,11 +184,11 @@ export function PackageAutocomplete({
       }}
       onInputChange={(event, value) =>
         event &&
-        temporaryPackageInfo[attribute] !== value &&
+        packageInfo[attribute] !== value &&
         onEdit?.(() => {
           dispatch(
             setTemporaryDisplayPackageInfo({
-              ...temporaryPackageInfo,
+              ...packageInfo,
               [attribute]: value,
               wasPreferred: undefined,
             }),
@@ -269,7 +264,7 @@ export function PackageAutocomplete({
                 'source',
                 'suffix',
               ]),
-              ...pick(temporaryPackageInfo, [
+              ...pick(packageInfo, [
                 'attributionConfidence',
                 'excludeFromNotice',
                 'followUp',

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -32,6 +32,7 @@ import { openUrl } from '../../util/open-url';
 import { PackageSearchHooks } from '../../util/package-search-hooks';
 import { Autocomplete } from '../Autocomplete/Autocomplete';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { AttributionFormConfigAttribute } from '../DiffPopup/DiffPopup';
 import { IconButton } from '../IconButton/IconButton';
 import { PreferredIcon, SourceIcon, WasPreferredIcon } from '../Icons/Icons';
 
@@ -55,6 +56,7 @@ interface Props {
   disabled: boolean;
   showHighlight: boolean | undefined;
   onEdit?: Confirm;
+  configAttribute?: AttributionFormConfigAttribute;
 }
 
 const Badge = styled(MuiBadge)({
@@ -80,6 +82,7 @@ export function PackageAutocomplete({
   disabled,
   showHighlight,
   onEdit,
+  configAttribute,
 }: Props) {
   const dispatch = useAppDispatch();
   const attributeValue = packageInfo[attribute] || '';
@@ -197,6 +200,7 @@ export function PackageAutocomplete({
         })
       }
       endAdornment={endAdornment}
+      configAttribute={configAttribute}
     />
   );
 

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -25,6 +25,7 @@ import { openUrl } from '../../util/open-url';
 import { PackageSearchHooks } from '../../util/package-search-hooks';
 import { useDebouncedInput } from '../../util/use-debounced-input';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { AttributionFormConfig } from '../DiffPopup/DiffPopup';
 import { IconButton } from '../IconButton/IconButton';
 import { TextBox } from '../InputElements/TextBox';
 import { toast } from '../Toaster';
@@ -72,12 +73,14 @@ interface PackageSubPanelProps {
   displayPackageInfo: DisplayPackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  config?: AttributionFormConfig;
 }
 
 export function PackageSubPanel({
   displayPackageInfo,
   showHighlight,
   onEdit,
+  config,
 }: PackageSubPanelProps) {
   const dispatch = useAppDispatch();
   const defaultPackageTypes = useMemo(
@@ -138,6 +141,9 @@ export function PackageSubPanel({
         showHighlight={showHighlight}
         defaults={packageNames}
         onEdit={onEdit}
+        configAttribute={{
+          colorValue: config?.packageName,
+        }}
       />
     );
   }
@@ -153,6 +159,9 @@ export function PackageSubPanel({
         showHighlight={showHighlight}
         defaults={packageNamespaces}
         onEdit={onEdit}
+        configAttribute={{
+          colorValue: config?.packageNamespace,
+        }}
       />
     );
   }
@@ -167,6 +176,9 @@ export function PackageSubPanel({
         showHighlight={showHighlight}
         defaults={packageVersions}
         onEdit={onEdit}
+        configAttribute={{
+          colorValue: config?.packageVersion,
+        }}
       />
     );
   }
@@ -182,6 +194,9 @@ export function PackageSubPanel({
         showHighlight={showHighlight}
         defaults={defaultPackageTypes}
         onEdit={onEdit}
+        configAttribute={{
+          colorValue: config?.packageType,
+        }}
       />
     );
   }
@@ -257,6 +272,9 @@ export function PackageSubPanel({
         disabled={!onEdit}
         showHighlight={showHighlight}
         onEdit={onEdit}
+        configAttribute={{
+          colorValue: config?.url,
+        }}
         endAdornment={
           <>
             <IconButton

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -132,6 +132,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageName'}
         title={text.attributionColumn.packageSubPanel.packageName}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -146,6 +147,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageNamespace'}
         title={text.attributionColumn.packageSubPanel.packageNamespace}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -160,6 +162,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageVersion'}
         title={text.attributionColumn.packageSubPanel.packageVersion}
+        packageInfo={displayPackageInfo}
         disabled={!onEdit}
         showHighlight={showHighlight}
         defaults={packageVersions}
@@ -173,6 +176,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'packageType'}
         title={text.attributionColumn.packageSubPanel.packageType}
+        packageInfo={displayPackageInfo}
         highlight={'dark'}
         disabled={!onEdit}
         showHighlight={showHighlight}
@@ -249,6 +253,7 @@ export function PackageSubPanel({
       <PackageAutocomplete
         attribute={'url'}
         title={text.attributionColumn.packageSubPanel.repositoryUrl}
+        packageInfo={displayPackageInfo}
         disabled={!onEdit}
         showHighlight={showHighlight}
         onEdit={onEdit}
@@ -264,7 +269,8 @@ export function PackageSubPanel({
                   displayPackageInfo.url &&
                   displayPackageInfo.copyright &&
                   displayPackageInfo.licenseName
-                )
+                ) ||
+                !onEdit
               }
               onClick={() =>
                 onEdit?.(async () => {

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { VirtuosoHandle } from 'react-virtuoso';
 
 import { ClearButton } from '../ClearButton/ClearButton';
+import { AttributionFormConfigAttribute } from '../DiffPopup/DiffPopup';
 import { PopupIndicator } from '../PopupIndicator/PopupIndicator';
 import {
   Container,
@@ -54,6 +55,7 @@ type AutocompleteProps<
     ) => void;
     sx?: SxProps;
     title: string;
+    configAttribute?: AttributionFormConfigAttribute;
   };
 
 export function Autocomplete<
@@ -79,6 +81,7 @@ export function Autocomplete<
   renderOptionStartIcon,
   sx,
   title,
+  configAttribute,
   ...props
 }: AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>) {
   const [open, setOpen] = useState(false);
@@ -173,6 +176,17 @@ export function Autocomplete<
           InputProps={{
             startAdornment: renderStartAdornment(),
             endAdornment: renderEndAdornment(),
+            ...(configAttribute?.colorValue
+              ? {
+                  inputProps: {
+                    sx: {
+                      '&.Mui-disabled': {
+                        WebkitTextFillColor: configAttribute.colorValue,
+                      },
+                    },
+                  },
+                }
+              : {}),
           }}
           onKeyDown={(event) => {
             // https://github.com/mui/material-ui/issues/21129

--- a/src/Frontend/Components/DiffPopup/DiffPopup.style.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.style.tsx
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { styled } from '@mui/material';
+import MuiBox from '@mui/material/Box';
+
+export const DiffPopupContainer = styled(MuiBox)({
+  display: 'flex',
+  flexDirection: 'row',
+  flex: 1,
+  padding: '6px',
+  gap: '12px',
+  overflow: 'hidden auto',
+});

--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import MuiDivider from '@mui/material/Divider';
+
+import { DisplayPackageInfo } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
+import { AttributionForm } from '../AttributionColumn/AttributionForm';
+import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
+import { DiffPopupContainer } from './DiffPopup.style';
+
+interface DiffPopupProps {
+  original: DisplayPackageInfo;
+  current: DisplayPackageInfo;
+  isOpen: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function DiffPopup(props: DiffPopupProps): React.ReactElement {
+  return (
+    <NotificationPopup
+      header={text.diffPopup.title}
+      content={renderDiffView()}
+      leftButtonConfig={{
+        disabled: true,
+        buttonText: text.buttons.diffPopup.applyChanges,
+      }}
+      centerRightButtonConfig={{
+        disabled: true,
+        buttonText: text.buttons.diffPopup.revertAll,
+      }}
+      rightButtonConfig={{
+        onClick: () => props.setOpen(false),
+        buttonText: text.buttons.cancel,
+        color: 'secondary',
+      }}
+      isOpen={props.isOpen}
+      background={'lightestBlue'}
+      fullWidth={true}
+      aria-label={'diff popup'}
+    />
+  );
+
+  function renderDiffView() {
+    return (
+      <DiffPopupContainer>
+        <AttributionForm
+          packageInfo={props.original}
+          isDiffView={true}
+          label={'original'}
+        />
+        <MuiDivider
+          variant={'middle'}
+          flexItem={true}
+          orientation={'vertical'}
+        />
+        <AttributionForm
+          packageInfo={props.current}
+          isDiffView={true}
+          label={'current'}
+        />
+      </DiffPopupContainer>
+    );
+  }
+}

--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -3,9 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiDivider from '@mui/material/Divider';
+import { useMemo } from 'react';
 
-import { DisplayPackageInfo } from '../../../shared/shared-types';
+import {
+  DisplayPackageInfo,
+  PackageInfoCore,
+} from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
+import { OpossumColors } from '../../shared-styles';
 import { AttributionForm } from '../AttributionColumn/AttributionForm';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { DiffPopupContainer } from './DiffPopup.style';
@@ -17,7 +22,96 @@ interface DiffPopupProps {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+type AttributionFormConfigBase = Pick<
+  PackageInfoCore,
+  'packageName' | 'packageVersion' | 'packageNamespace' | 'packageType' | 'url'
+>;
+type AttributionFormConfigThirdParty = Pick<
+  PackageInfoCore,
+  'copyright' | 'licenseName' | 'licenseText'
+>;
+export type AttributionFormConfig = AttributionFormConfigBase &
+  AttributionFormConfigThirdParty & { isDiffView?: boolean };
+export type AttributionFormConfigAttribute = {
+  colorValue?: string;
+};
+
+function getAttributionFormConfigsForDiff(
+  originalPackageInfo: DisplayPackageInfo,
+  displayedPackageInfo: DisplayPackageInfo,
+): [AttributionFormConfig, AttributionFormConfig] {
+  const attributionFormConfigBaseOriginal: AttributionFormConfigBase = {
+    packageName: OpossumColors.black,
+    packageVersion: OpossumColors.black,
+    packageNamespace: OpossumColors.black,
+    packageType: OpossumColors.black,
+    url: OpossumColors.black,
+  };
+  const attributionFormConfigThirdPartyOriginal: AttributionFormConfigThirdParty =
+    {
+      copyright: OpossumColors.black,
+      licenseName: OpossumColors.black,
+      licenseText: OpossumColors.black,
+    };
+
+  const attributionFormConfigBaseCurrent = {
+    ...attributionFormConfigBaseOriginal,
+  };
+  const attributionFormConfigCurrentThirdParty = {
+    ...attributionFormConfigThirdPartyOriginal,
+  };
+  for (const attribute of Object.keys(attributionFormConfigBaseOriginal)) {
+    if (
+      originalPackageInfo[attribute as keyof AttributionFormConfigBase] !==
+      displayedPackageInfo[attribute as keyof AttributionFormConfigBase]
+    ) {
+      attributionFormConfigBaseOriginal[
+        attribute as keyof AttributionFormConfigBase
+      ] = OpossumColors.red;
+      attributionFormConfigBaseCurrent[
+        attribute as keyof AttributionFormConfigBase
+      ] = OpossumColors.green;
+    }
+  }
+  if (!originalPackageInfo.firstParty && !displayedPackageInfo.firstParty) {
+    for (const attribute of Object.keys(
+      attributionFormConfigThirdPartyOriginal,
+    )) {
+      if (
+        originalPackageInfo[
+          attribute as keyof AttributionFormConfigThirdParty
+        ] !==
+        displayedPackageInfo[attribute as keyof AttributionFormConfigThirdParty]
+      ) {
+        attributionFormConfigThirdPartyOriginal[
+          attribute as keyof AttributionFormConfigThirdParty
+        ] = OpossumColors.red;
+        attributionFormConfigCurrentThirdParty[
+          attribute as keyof AttributionFormConfigThirdParty
+        ] = OpossumColors.green;
+      }
+    }
+  }
+  return [
+    {
+      ...attributionFormConfigBaseOriginal,
+      ...attributionFormConfigThirdPartyOriginal,
+      isDiffView: true,
+    },
+    {
+      ...attributionFormConfigBaseCurrent,
+      ...attributionFormConfigCurrentThirdParty,
+      isDiffView: true,
+    },
+  ];
+}
+
 export function DiffPopup(props: DiffPopupProps): React.ReactElement {
+  const [originalFormConfig, currentFormConfig] = useMemo(
+    () => getAttributionFormConfigsForDiff(props.original, props.current),
+    [props],
+  );
+
   return (
     <NotificationPopup
       header={text.diffPopup.title}
@@ -47,7 +141,7 @@ export function DiffPopup(props: DiffPopupProps): React.ReactElement {
       <DiffPopupContainer>
         <AttributionForm
           packageInfo={props.original}
-          isDiffView={true}
+          config={originalFormConfig}
           label={'original'}
         />
         <MuiDivider
@@ -57,7 +151,7 @@ export function DiffPopup(props: DiffPopupProps): React.ReactElement {
         />
         <AttributionForm
           packageInfo={props.current}
-          isDiffView={true}
+          config={currentFormConfig}
           label={'current'}
         />
       </DiffPopupContainer>

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -10,6 +10,7 @@ import { HighlightingColor } from '../../enums/enums';
 import { inputElementClasses, InputElementProps } from './shared';
 
 interface TextProps extends InputElementProps {
+  rows?: number;
   minRows?: number;
   maxRows?: number;
   endIcon?: React.ReactElement;
@@ -62,6 +63,7 @@ export function TextBox(props: TextProps) {
           ),
         }}
         multiline={props.multiline}
+        rows={props.rows}
         minRows={props.minRows}
         maxRows={props.maxRows}
         variant="outlined"

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -4,9 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
 import MuiInputAdornment from '@mui/material/InputAdornment';
+import { InputBaseComponentProps as MuiInputBaseComponentProps } from '@mui/material/InputBase/InputBase';
 import MuiTextField from '@mui/material/TextField';
 
 import { HighlightingColor } from '../../enums/enums';
+import { AttributionFormConfigAttribute } from '../DiffPopup/DiffPopup';
 import { inputElementClasses, InputElementProps } from './shared';
 
 interface TextProps extends InputElementProps {
@@ -17,6 +19,8 @@ interface TextProps extends InputElementProps {
   multiline?: boolean;
   highlightingColor?: HighlightingColor;
   error?: boolean;
+  inputProps?: MuiInputBaseComponentProps;
+  configAttribute?: AttributionFormConfigAttribute;
 }
 
 export function TextBox(props: TextProps) {
@@ -54,6 +58,13 @@ export function TextBox(props: TextProps) {
               overflowX: 'hidden',
               textOverflow: 'ellipsis',
               padding: '8.5px 14px',
+              ...(props.configAttribute?.colorValue
+                ? {
+                    '&.Mui-disabled': {
+                      WebkitTextFillColor: props.configAttribute.colorValue,
+                    },
+                  }
+                : {}),
             },
           },
           endAdornment: props.endIcon && (
@@ -62,6 +73,7 @@ export function TextBox(props: TextProps) {
             </MuiInputAdornment>
           ),
         }}
+        inputProps={props.inputProps}
         multiline={props.multiline}
         rows={props.rows}
         minRows={props.minRows}

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -22,11 +22,11 @@ export const OpossumColors = {
   lightGrey: 'hsla(0, 0%, 0%, 0.09)',
   mediumGrey: 'hsla(0, 0%, 0%, 0.36)',
   darkGrey: 'hsla(0, 0%, 0%, 0.7)',
-  black: 'hsl(0, 0%, 0%)',
+  black: 'rgb(0, 0, 0)',
   pastelLightGreen: 'hsl(146, 50%, 80%)',
   pastelMiddleGreen: 'hsl(146, 50%, 68%)',
   pastelDarkGreen: 'hsl(146, 50%, 55%)',
-  green: 'hsl(146, 50%, 45%)',
+  green: 'rgb(57, 172, 107)',
   lightOrange: 'hsl(27, 100%, 94%)',
   lightOrangeOnHover: 'hsl(27, 100%, 89%)',
   mediumOrange: 'hsl(20, 100%, 72%)',
@@ -34,7 +34,7 @@ export const OpossumColors = {
   pastelRed: 'hsl(0, 70%, 70%)',
   darkOrange: 'hsl(20, 80%, 78%)',
   darkOrangeOnHover: 'hsl(20, 80%, 65%)',
-  red: 'hsl(0, 100%, 45%)',
+  red: 'rgb(230, 0, 0)',
   brown: 'hsl(33, 55%, 44%)',
 };
 

--- a/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
+++ b/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { AttributionType } from '../../Frontend/enums/enums';
+import { OpossumColors } from '../../Frontend/shared-styles';
 import { faker, test } from '../utils';
 
 const [resourceName1, resourceName2] = faker.opossum.resourceNames({
@@ -61,5 +63,75 @@ test('enables comparing attribution to origin if origin is present', async ({
   );
   await diffPopup.currentAttributionForm.assert.matchesPackageInfo(
     manualPackageInfo2,
+  );
+});
+
+test('shows modified fields in colours that indicate the change', async ({
+  attributionDetails,
+  diffPopup,
+  resourceBrowser,
+}) => {
+  await resourceBrowser.goto(resourceName2);
+  await attributionDetails.compareButton.click();
+  await diffPopup.assert.isVisible();
+  await diffPopup.currentAttributionForm.assert.nameHasColor(
+    OpossumColors.black,
+  );
+  await diffPopup.originalAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.black,
+  );
+
+  await diffPopup.cancelButton.click();
+  await diffPopup.assert.isHidden();
+
+  await attributionDetails.attributionForm.name.fill(faker.word.noun());
+  await attributionDetails.attributionForm.licenseTextToggleButton.click();
+  await attributionDetails.attributionForm.licenseText.fill(
+    faker.lorem.sentence(),
+  );
+  await attributionDetails.compareButton.click();
+  await diffPopup.originalAttributionForm.assert.nameHasColor(
+    OpossumColors.red,
+  );
+  await diffPopup.currentAttributionForm.assert.nameHasColor(
+    OpossumColors.green,
+  );
+  await diffPopup.originalAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.red,
+  );
+  await diffPopup.currentAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.green,
+  );
+
+  await diffPopup.cancelButton.click();
+  await attributionDetails.saveButton.click();
+  await attributionDetails.compareButton.click();
+  await diffPopup.originalAttributionForm.assert.nameHasColor(
+    OpossumColors.red,
+  );
+  await diffPopup.currentAttributionForm.assert.nameHasColor(
+    OpossumColors.green,
+  );
+  await diffPopup.originalAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.red,
+  );
+  await diffPopup.currentAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.green,
+  );
+});
+
+test('hides copyright and license fields if package is first party', async ({
+  attributionDetails,
+  diffPopup,
+  resourceBrowser,
+}) => {
+  await resourceBrowser.goto(resourceName2);
+  await attributionDetails.attributionForm.selectAttributionType(
+    AttributionType.FirstParty,
+  );
+  await attributionDetails.compareButton.click();
+  await diffPopup.currentAttributionForm.assert.licenseTextIsHidden();
+  await diffPopup.originalAttributionForm.assert.licenseTextHasColor(
+    OpossumColors.black,
   );
 });

--- a/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
+++ b/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { faker, test } from '../utils';
+
+const [resourceName1, resourceName2] = faker.opossum.resourceNames({
+  count: 2,
+});
+const [attributionId1, manualPackageInfo1] = faker.opossum.manualAttribution();
+const [attributionId2, manualPackageInfo2] = faker.opossum.manualAttribution({
+  originIds: [faker.opossum.attributionId()],
+  licenseText: faker.opossum.license().defaultText,
+});
+const [externalAttributionId, externalPackageInfo] =
+  faker.opossum.externalAttribution(manualPackageInfo2);
+
+test.use({
+  data: {
+    inputData: faker.opossum.inputData({
+      resources: faker.opossum.resources({
+        [resourceName1]: 1,
+        [resourceName2]: 1,
+      }),
+      externalAttributions: faker.opossum.externalAttributions({
+        [externalAttributionId]: externalPackageInfo,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName2)]: [externalAttributionId],
+      }),
+    }),
+    outputData: faker.opossum.outputData({
+      manualAttributions: faker.opossum.manualAttributions({
+        [attributionId1]: manualPackageInfo1,
+        [attributionId2]: manualPackageInfo2,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName1)]: [attributionId1],
+        [faker.opossum.filePath(resourceName2)]: [attributionId2],
+      }),
+    }),
+  },
+});
+
+test('enables comparing attribution to origin if origin is present', async ({
+  attributionDetails,
+  diffPopup,
+  resourceBrowser,
+}) => {
+  await resourceBrowser.goto(resourceName1);
+  await attributionDetails.assert.compareButtonIsHidden();
+
+  await resourceBrowser.goto(resourceName2);
+  await attributionDetails.assert.compareButtonIsEnabled();
+
+  await attributionDetails.compareButton.click();
+  await diffPopup.assert.isVisible();
+
+  await diffPopup.originalAttributionForm.assert.matchesPackageInfo(
+    externalPackageInfo,
+  );
+  await diffPopup.currentAttributionForm.assert.matchesPackageInfo(
+    manualPackageInfo2,
+  );
+});

--- a/src/e2e-tests/page-objects/AttributionDetails.ts
+++ b/src/e2e-tests/page-objects/AttributionDetails.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, Page } from '@playwright/test';
 
+import { text } from '../../shared/text';
 import { AttributionForm } from './AttributionForm';
 
 export class AttributionDetails {
@@ -32,6 +33,7 @@ export class AttributionDetails {
     readonly deleteGlobally: Locator;
   };
   readonly revertButton: Locator;
+  readonly compareButton: Locator;
   readonly showHideSignalButton: Locator;
 
   constructor(window: Page) {
@@ -93,6 +95,10 @@ export class AttributionDetails {
     };
     this.revertButton = this.node.getByRole('button', {
       name: 'Revert',
+      exact: true,
+    });
+    this.compareButton = this.node.getByRole('button', {
+      name: text.buttons.compareToOrigin,
       exact: true,
     });
     this.showHideSignalButton = this.node.getByLabel('resolve attribution');
@@ -164,6 +170,12 @@ export class AttributionDetails {
     },
     revertButtonIsHidden: async (): Promise<void> => {
       await expect(this.revertButton).toBeHidden();
+    },
+    compareButtonIsEnabled: async (): Promise<void> => {
+      await expect(this.compareButton).toBeEnabled();
+    },
+    compareButtonIsHidden: async (): Promise<void> => {
+      await expect(this.compareButton).toBeHidden();
     },
     showHideSignalButtonIsVisible: async (): Promise<void> => {
       await expect(this.showHideSignalButton).toBeVisible();

--- a/src/e2e-tests/page-objects/AttributionForm.ts
+++ b/src/e2e-tests/page-objects/AttributionForm.ts
@@ -147,8 +147,20 @@ export class AttributionForm {
     nameIs: async (name: string): Promise<void> => {
       await expect(this.name).toHaveValue(name);
     },
+    nameHasColor: async (expectedColor: string): Promise<void> => {
+      const actualColor = await this.name.evaluate((element) => {
+        return window.getComputedStyle(element).webkitTextFillColor;
+      });
+      expect(actualColor).toBe(expectedColor);
+    },
     versionIs: async (version: string): Promise<void> => {
       await expect(this.version).toHaveValue(version);
+    },
+    versionHasColor: async (expectedColor: string): Promise<void> => {
+      const actualColor = await this.version.evaluate((element) => {
+        return window.getComputedStyle(element).webkitTextFillColor;
+      });
+      expect(actualColor).toBe(expectedColor);
     },
     purlIs: async (purl: string): Promise<void> => {
       await expect(this.purl).toHaveValue(purl);
@@ -158,6 +170,12 @@ export class AttributionForm {
     },
     copyrightIs: async (copyright: string): Promise<void> => {
       await expect(this.copyright).toHaveValue(copyright);
+    },
+    copyrightHasColor: async (expectedColor: string): Promise<void> => {
+      const actualColor = await this.copyright.evaluate((element) => {
+        return window.getComputedStyle(element).webkitTextFillColor;
+      });
+      expect(actualColor).toBe(expectedColor);
     },
     confidenceIs: async (confidence: number): Promise<void> => {
       await expect(
@@ -182,6 +200,12 @@ export class AttributionForm {
     },
     licenseTextIsHidden: async (): Promise<void> => {
       await expect(this.licenseText).toBeHidden();
+    },
+    licenseTextHasColor: async (expectedColor: string): Promise<void> => {
+      const actualColor = await this.licenseText.evaluate((element) => {
+        return window.getComputedStyle(element).webkitTextFillColor;
+      });
+      expect(actualColor).toBe(expectedColor);
     },
     commentIs: async (comment: string, number = 0): Promise<void> => {
       await expect(this.comment(number)).toHaveValue(comment);

--- a/src/e2e-tests/page-objects/DiffPopup.ts
+++ b/src/e2e-tests/page-objects/DiffPopup.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { text } from '../../shared/text';
+import { AttributionForm } from './AttributionForm';
+
+export class DiffPopup {
+  private readonly node: Locator;
+  readonly originalAttributionForm: AttributionForm;
+  readonly currentAttributionForm: AttributionForm;
+  readonly applyButton: Locator;
+  readonly revertButton: Locator;
+  readonly cancelButton: Locator;
+
+  constructor(window: Page) {
+    this.node = window.getByLabel('diff popup');
+    this.originalAttributionForm = new AttributionForm(
+      this.node.getByLabel('original', { exact: true }),
+      window,
+    );
+    this.currentAttributionForm = new AttributionForm(
+      this.node.getByLabel('current', { exact: true }),
+      window,
+    );
+    this.applyButton = this.node.getByRole('button', {
+      name: text.buttons.diffPopup.applyChanges,
+      exact: true,
+    });
+    this.revertButton = this.node.getByRole('button', {
+      name: text.buttons.diffPopup.revertAll,
+      exact: true,
+    });
+    this.cancelButton = this.node.getByRole('button', {
+      name: text.buttons.cancel,
+      exact: true,
+    });
+  }
+
+  public assert = {
+    isVisible: async (): Promise<void> => {
+      await expect(this.node).toBeVisible();
+    },
+    isHidden: async (): Promise<void> => {
+      await expect(this.node).toBeHidden();
+    },
+  };
+}

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -23,6 +23,7 @@ import { AttributionList } from '../page-objects/AttributionList';
 import { ChangePreferredStatusGloballyPopup } from '../page-objects/ChangePreferredStatusGloballyPopup';
 import { ConfirmationDialog } from '../page-objects/ConfirmationDialog';
 import { ConfirmationPopup } from '../page-objects/ConfirmationPopup';
+import { DiffPopup } from '../page-objects/DiffPopup';
 import { ErrorPopup } from '../page-objects/ErrorPopup';
 import { FileSearchPopup } from '../page-objects/FileSearchPopup';
 import { FileSupportPopup } from '../page-objects/FileSupportPopup';
@@ -56,6 +57,7 @@ export const test = base.extend<{
   changePreferredStatusGloballyPopup: ChangePreferredStatusGloballyPopup;
   confirmationDialog: ConfirmationDialog;
   confirmationPopup: ConfirmationPopup;
+  diffPopup: DiffPopup;
   errorPopup: ErrorPopup;
   fileSearchPopup: FileSearchPopup;
   fileSupportPopup: FileSupportPopup;
@@ -163,6 +165,9 @@ export const test = base.extend<{
   },
   notSavedPopup: async ({ window }, use) => {
     await use(new NotSavedPopup(window));
+  },
+  diffPopup: async ({ window }, use) => {
+    await use(new DiffPopup(window));
   },
 });
 

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -54,9 +54,14 @@ export const text = {
   },
   buttons: {
     cancel: 'Cancel',
+    compareToOrigin: 'Compare to origin',
     confirm: 'Confirm',
     filter: 'Filter',
     sort: 'Sort',
+    diffPopup: {
+      applyChanges: 'Apply changes',
+      revertAll: 'Revert all',
+    },
   },
   changePreferredStatusGloballyPopup: {
     markAsPreferred: 'Do you really want to prefer the attribution globally?',
@@ -131,5 +136,8 @@ export const text = {
   resourceDetails: {
     searchTooltip: 'Search',
     sortTooltip: 'Sort',
+  },
+  diffPopup: {
+    title: 'Compare to Original Signal',
   },
 } as const;


### PR DESCRIPTION


### Summary of changes

Add colours to the package info fields that indicate change.

If there is a diff between two relevant fields the original value is displayed in red and the currently displayed value is green.
Two fields differ if they are not equal. More sophisticated diffing is kept for later efforts.

Only if original and displayed package are of type third party, we also diff the copyright and license fields.

### Context and reason for change

Closes [#2517](https://github.com/opossum-tool/OpossumUI/issues/2517)

### How can the changes be tested

Added e2e test.

Manually. Open the Diff popup and play around with changing the package info.
