### PR TITLE
feat: remove "keep deprecated file" feature

### DIFF
--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -16,7 +16,6 @@ import {
   getOpenDotOpossumFileInsteadListener,
   getOpenFileListener,
   getOpenLinkListener,
-  getOpenOutdatedInputFileListener,
   getSaveFileListener,
   getSendErrorInformationListener,
 } from './listeners';
@@ -62,10 +61,6 @@ export async function main(): Promise<void> {
     ipcMain.handle(
       IpcChannel.ConvertInputFile,
       getConvertInputFileToDotOpossumAndOpenListener(mainWindow),
-    );
-    ipcMain.handle(
-      IpcChannel.UseOutdatedInputFile,
-      getOpenOutdatedInputFileListener(mainWindow),
     );
     ipcMain.handle(
       IpcChannel.OpenDotOpossumFile,

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -15,8 +15,6 @@ const electronAPI: ElectronAPI = {
   keepFile: () => ipcRenderer.invoke(IpcChannel.KeepFile),
   convertInputFileToDotOpossum: () =>
     ipcRenderer.invoke(IpcChannel.ConvertInputFile),
-  useOutdatedInputFileFormat: () =>
-    ipcRenderer.invoke(IpcChannel.UseOutdatedInputFile),
   openDotOpossumFile: () => ipcRenderer.invoke(IpcChannel.OpenDotOpossumFile),
   sendErrorInformation: (errorInformationArgs) =>
     ipcRenderer.invoke(IpcChannel.SendErrorInformation, errorInformationArgs),

--- a/src/Frontend/Components/ChangedInputFilePopup/__tests__/ChangedInputFilePopup.test.tsx
+++ b/src/Frontend/Components/ChangedInputFilePopup/__tests__/ChangedInputFilePopup.test.tsx
@@ -23,18 +23,4 @@ describe('ChangedInputFilePopup', () => {
     expect(window.electronAPI.deleteFile).toHaveBeenCalledTimes(1);
     expect(getOpenPopup(store.getState())).toBeNull();
   });
-
-  it('renders a ChangedInputFilePopup and clicks Keep', () => {
-    const content =
-      'The input file has changed. Do you want to keep the old attribution file or delete it?';
-
-    const { store } = renderComponent(<ChangedInputFilePopup />);
-    expect(screen.getByText('Warning')).toBeInTheDocument();
-    expect(screen.getByText(content)).toBeInTheDocument();
-
-    expect(screen.getByText(ButtonText.Keep)).toBeInTheDocument();
-    fireEvent.click(screen.getByText(ButtonText.Keep));
-    expect(window.electronAPI.keepFile).toHaveBeenCalledTimes(1);
-    expect(getOpenPopup(store.getState())).toBeNull();
-  });
 });

--- a/src/Frontend/Components/FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup.tsx
+++ b/src/Frontend/Components/FileSupportDotOpossumAlreadyExistsPopup/FileSupportDotOpossumAlreadyExistsPopup.tsx
@@ -14,9 +14,7 @@ import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 const HEADER = 'Warning: Outdated input file format';
 const INFO_TEXT_PART_1 =
   'You are trying to open a file with an outdated extension (".json" or ".json.gz"). \
-    OpossumUI now reads files with a ".opossum" extension by default. \
-    However, older file formats can still be opened but support may be \
-    discontinued in the future.';
+    OpossumUI now reads files with a ".opossum" extension by default.';
 const INFO_TEXT_PART_2 =
   'A ".opossum" file with the same name of the current input file \
   was found. This file will be opened instead.';

--- a/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
+++ b/src/Frontend/Components/FileSupportPopup/FileSupportPopup.tsx
@@ -14,12 +14,10 @@ import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 const HEADER = 'Warning: Outdated input file format';
 const INFO_TEXT_PART_1 =
   'You are trying to open a file with an outdated extension (".json" or ".json.gz"). \
-    OpossumUI now reads files with a ".opossum" extension by default. \
-    However, older file formats can still be opened but support may be \
-    discontinued in the future.';
+    OpossumUI now reads files with a ".opossum" extension by default.';
 const INFO_TEXT_PART_2 =
   'Would you like to create a new file with a ".opossum" extension from the current \
-    input file and proceed (recommended), or keep working with the old format?';
+    input file and proceed?';
 
 const classes = {
   content: {
@@ -41,10 +39,6 @@ export function FileSupportPopup(): ReactElement {
     window.electronAPI.convertInputFileToDotOpossum();
     close();
   };
-  const handleKeepButtonClick = (): void => {
-    window.electronAPI.useOutdatedInputFileFormat();
-    close();
-  };
 
   return (
     <NotificationPopup
@@ -52,11 +46,6 @@ export function FileSupportPopup(): ReactElement {
       leftButtonConfig={{
         onClick: handleCreateAndProceedButtonClick,
         buttonText: ButtonText.CreateAndProceed,
-      }}
-      rightButtonConfig={{
-        onClick: handleKeepButtonClick,
-        buttonText: ButtonText.Keep,
-        color: 'secondary',
       }}
       isOpen={true}
       content={

--- a/src/Frontend/Components/FileSupportPopup/__tests__/FileSupportPopup.test.tsx
+++ b/src/Frontend/Components/FileSupportPopup/__tests__/FileSupportPopup.test.tsx
@@ -24,12 +24,4 @@ describe('FileSupportPopup', () => {
       global.window.electronAPI.convertInputFileToDotOpossum,
     ).toHaveBeenCalled();
   });
-
-  it('sends correct signal to backend when clicking keepButton', () => {
-    renderComponent(<FileSupportPopup />);
-    fireEvent.click(screen.getByRole('button', { name: ButtonText.Keep }));
-    expect(
-      global.window.electronAPI.useOutdatedInputFileFormat,
-    ).toHaveBeenCalled();
-  });
 });

--- a/src/e2e-tests/__tests__/handling-file-deprecation-warnings.test.ts
+++ b/src/e2e-tests/__tests__/handling-file-deprecation-warnings.test.ts
@@ -11,14 +11,6 @@ test.use({
   },
 });
 
-test('allows user to keep outdated extension when user opens deprecated file', async ({
-  fileSupportPopup,
-}) => {
-  await fileSupportPopup.assert.titleIsVisible();
-  await fileSupportPopup.keepOutdated();
-  await fileSupportPopup.assert.titleIsHidden();
-});
-
 test('allows user to switch to .opossum extension when user opens deprecated file', async ({
   fileSupportPopup,
 }) => {

--- a/src/e2e-tests/page-objects/FileSupportPopup.ts
+++ b/src/e2e-tests/page-objects/FileSupportPopup.ts
@@ -28,10 +28,6 @@ export class FileSupportPopup {
     },
   };
 
-  async keepOutdated(): Promise<void> {
-    await this.keepButton.click();
-  }
-
   async convertToNew(): Promise<void> {
     await this.convertButton.click();
   }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -245,7 +245,6 @@ export interface ElectronAPI {
   deleteFile: () => Promise<unknown>;
   keepFile: () => Promise<unknown>;
   convertInputFileToDotOpossum: () => void;
-  useOutdatedInputFileFormat: () => void;
   openDotOpossumFile: () => void;
   sendErrorInformation: (
     errorInformationArgs: SendErrorInformationArgs,

--- a/src/testing/setup-tests.ts
+++ b/src/testing/setup-tests.ts
@@ -37,7 +37,6 @@ global.window.electronAPI = {
   deleteFile: jest.fn(),
   keepFile: jest.fn(),
   convertInputFileToDotOpossum: jest.fn(),
-  useOutdatedInputFileFormat: jest.fn(),
   openDotOpossumFile: jest.fn(),
   sendErrorInformation: jest.fn(),
   exportFile: jest.fn(),


### PR DESCRIPTION

### Summary of changes

The feature to continue working with deprecated file format is dropped. It is now required to convert it to the new format first.

Before:
![Screenshot 2024-01-29 at 14 58 28](https://github.com/opossum-tool/OpossumUI/assets/46576389/47b422f8-02b5-4fff-8c19-5a89507eddbc)


After:
![Screenshot 2024-01-29 at 14 57 46](https://github.com/opossum-tool/OpossumUI/assets/46576389/1a8f868f-86bd-4f46-80d0-c0ba71a35110)

### Context and reason for change

Fix: #2536

### How can the changes be tested

Open `example-files/opossum_input.json` (make sure there is no file called `example-files/opossum_input.opossum`).
