### PR TITLE
fix: textbox end icon padding

### DIFF
--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -56,7 +56,7 @@ export function TextBox(props: TextProps) {
             },
           },
           endAdornment: props.endIcon && (
-            <MuiInputAdornment position="end">
+            <MuiInputAdornment sx={{ paddingRight: '14px' }} position="end">
               {props.endIcon}
             </MuiInputAdornment>
           ),

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -8,11 +8,6 @@ import { ChangeEvent } from 'react';
 import { OpossumColors } from '../../shared-styles';
 
 export const inputElementClasses = {
-  textFieldBoldText: {
-    '& input': {
-      fontWeight: 'bold',
-    },
-  },
   textField: {
     width: '100%',
     '& div': {
@@ -33,11 +28,6 @@ export const inputElementClasses = {
       },
     },
   },
-  textFieldMultiple: {
-    '& span': {
-      padding: '0px 6px',
-    },
-  },
   defaultHighlightedTextField: {
     '& div': {
       backgroundColor: OpossumColors.lightOrange,
@@ -56,13 +46,6 @@ export const inputElementClasses = {
     '& label': {
       backgroundColor: OpossumColors.darkOrange,
       padding: '1px 3px',
-    },
-  },
-  popper: {
-    '& popper': {
-      '& div': {
-        fontWeight: 'bold',
-      },
     },
   },
 };


### PR DESCRIPTION
### Summary of changes

In a previous PR, the TextBox padding was adjusted to align the scroll bar to the right. However, this broke the padding when end icons are present.

BEFORE:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/aaebd928-9b5c-499c-9dd3-b8d3e1aebf21)

AFTER:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/19cfec8d-17cc-40fd-b361-dbc1ba0f4efc)

### Context and reason for change

related to  #2533

### How can the changes be tested

Look at the PURL input field, for example.