### PR TITLE
feat: add colours to the static diff popup

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
+++ b/src/Frontend/Components/AttributionColumn/AttributionForm.tsx
@@ -14,11 +14,33 @@ import { AttributionType } from '../../enums/enums';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch } from '../../state/hooks';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
+import { InputElementProps } from '../InputElements/shared';
 import { AuditingOptions } from './AuditingOptions';
 import { CommentStack } from './CommentStack';
 import { CopyrightSubPanel } from './CopyrightSubPanel';
 import { LicenseSubPanel } from './LicenseSubPanel';
 import { PackageSubPanel } from './PackageSubPanel';
+
+export const FORM_ATTRIBUTES = [
+  'packageName',
+  'packageVersion',
+  'packageNamespace',
+  'packageType',
+  'url',
+  'copyright',
+  'licenseName',
+  'licenseText',
+  'firstParty',
+] satisfies Array<keyof PackageInfo>;
+
+export type FormAttribute = (typeof FORM_ATTRIBUTES)[number];
+
+export interface AttributeConfig
+  extends Pick<InputElementProps, 'color' | 'focused'> {}
+
+export type AttributionFormConfig = Partial<
+  Record<FormAttribute, AttributeConfig>
+>;
 
 const classes = {
   formContainer: {
@@ -37,6 +59,7 @@ interface AttributionFormProps {
   onEdit?: Confirm;
   variant?: 'default' | 'diff';
   label?: string;
+  config?: AttributionFormConfig;
 }
 
 export function AttributionForm({
@@ -45,6 +68,7 @@ export function AttributionForm({
   onEdit,
   showHighlight,
   variant = 'default',
+  config,
 }: AttributionFormProps) {
   const dispatch = useAppDispatch();
   const isDiff = variant === 'diff';
@@ -65,6 +89,7 @@ export function AttributionForm({
         packageInfo={packageInfo}
         showHighlight={showHighlight}
         onEdit={onEdit}
+        config={config}
       />
       <MuiDivider variant={'middle'}>
         <MuiTypography>{text.attributionColumn.legalInformation}</MuiTypography>
@@ -76,6 +101,7 @@ export function AttributionForm({
         onEdit={onEdit}
         expanded={isDiff}
         hidden={packageInfo.firstParty}
+        config={config?.copyright}
       />
       <LicenseSubPanel
         packageInfo={packageInfo}
@@ -83,6 +109,7 @@ export function AttributionForm({
         onEdit={onEdit}
         expanded={isDiff}
         hidden={packageInfo.firstParty}
+        config={config}
       />
       {isDiff ? null : (
         <CommentStack packageInfo={packageInfo} onEdit={onEdit} />

--- a/src/Frontend/Components/AttributionColumn/CommentStack.tsx
+++ b/src/Frontend/Components/AttributionColumn/CommentStack.tsx
@@ -26,8 +26,8 @@ export function CommentStack({ packageInfo, onEdit }: Props): ReactElement {
       {comments.map((comment, index) => (
         <TextBox
           key={index}
-          isEditable={!!onEdit}
           title={`Comment ${comments.length === 1 ? '' : index + 1}`.trim()}
+          readOnly={!onEdit}
           text={comment}
           minRows={3}
           maxRows={10}

--- a/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/CopyrightSubPanel.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch } from '../../state/hooks';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
 import { TextBox } from '../InputElements/TextBox';
+import { AttributeConfig } from './AttributionForm';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
 interface CopyrightSubPanelProps {
@@ -18,6 +19,7 @@ interface CopyrightSubPanelProps {
   onEdit?: Confirm;
   expanded?: boolean;
   hidden?: boolean;
+  config?: AttributeConfig;
 }
 
 export function CopyrightSubPanel({
@@ -26,6 +28,7 @@ export function CopyrightSubPanel({
   showHighlight,
   expanded,
   hidden,
+  config,
 }: CopyrightSubPanelProps) {
   const dispatch = useAppDispatch();
 
@@ -37,12 +40,14 @@ export function CopyrightSubPanel({
       }}
     >
       <TextBox
-        isEditable={!!onEdit}
+        readOnly={!onEdit}
         sx={attributionColumnClasses.textBox}
         title={'Copyright'}
         text={packageInfo.copyright}
         minRows={3}
         maxRows={7}
+        color={config?.color}
+        focused={config?.focused}
         multiline
         expanded={expanded}
         handleChange={({ target: { value } }) =>

--- a/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/LicenseSubPanel.tsx
@@ -20,6 +20,7 @@ import { getFrequentLicensesNameOrder } from '../../state/selectors/all-views-re
 import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
 import { TextBox } from '../InputElements/TextBox';
 import { getLicenseTextLabelText } from './AttributionColumn.util';
+import { AttributionFormConfig } from './AttributionForm';
 import { PackageAutocomplete } from './PackageAutocomplete';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
@@ -71,6 +72,7 @@ interface LicenseSubPanelProps {
   onEdit?: Confirm;
   expanded?: boolean;
   hidden?: boolean;
+  config?: AttributionFormConfig;
 }
 
 export function LicenseSubPanel({
@@ -79,6 +81,7 @@ export function LicenseSubPanel({
   onEdit,
   expanded: expandedOverride,
   hidden,
+  config,
 }: LicenseSubPanelProps) {
   const dispatch = useAppDispatch();
   const [expanded, setExpanded] = useState(expandedOverride);
@@ -132,7 +135,7 @@ export function LicenseSubPanel({
             attribute={'licenseName'}
             title={text.attributionColumn.licenseName}
             packageInfo={packageInfo}
-            disabled={!onEdit}
+            readOnly={!onEdit}
             showHighlight={showHighlight}
             onEdit={onEdit}
             endAdornment={
@@ -143,6 +146,8 @@ export function LicenseSubPanel({
               ) : undefined
             }
             defaults={defaultLicenses}
+            color={config?.licenseName?.color}
+            focused={config?.licenseName?.focused}
           />
         </MuiAccordionSummary>
         <MuiAccordionDetails
@@ -153,10 +158,12 @@ export function LicenseSubPanel({
           }
         >
           <TextBox
-            isEditable={!!onEdit}
+            readOnly={!onEdit}
             sx={classes.licenseText}
             maxRows={7}
             minRows={3}
+            color={config?.licenseText?.color}
+            focused={config?.licenseText?.focused}
             multiline
             expanded={expandedOverride}
             title={getLicenseTextLabelText(

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import AddIcon from '@mui/icons-material/Add';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { createFilterOptions, styled } from '@mui/material';
+import { createFilterOptions, styled, TextFieldProps } from '@mui/material';
 import MuiBadge from '@mui/material/Badge';
 import MuiChip from '@mui/material/Chip';
 import MuiIconButton from '@mui/material/IconButton';
@@ -48,9 +48,12 @@ interface Props {
   highlight?: 'default' | 'dark';
   endAdornment?: React.ReactElement;
   defaults?: Array<PackageInfo>;
-  disabled: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
   showHighlight: boolean | undefined;
   onEdit?: Confirm;
+  color?: TextFieldProps['color'];
+  focused?: boolean;
 }
 
 const Badge = styled(MuiBadge)({
@@ -73,9 +76,12 @@ export function PackageAutocomplete({
   highlight = 'default',
   endAdornment,
   defaults = [],
+  readOnly,
   disabled,
   showHighlight,
   onEdit,
+  color,
+  focused,
 }: Props) {
   const dispatch = useAppDispatch();
   const attributeValue = packageInfo[attribute] || '';
@@ -106,10 +112,12 @@ export function PackageAutocomplete({
     <Autocomplete
       title={title}
       disabled={disabled}
+      readOnly={readOnly}
       autoHighlight
       disableClearable
       freeSolo
       inputValue={inputValue}
+      inputProps={{ color, focused }}
       highlight={
         showHighlight &&
         isImportantAttributionInformationMissing(attribute, packageInfo)

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -24,6 +24,7 @@ import { Confirm } from '../ConfirmationDialog/ConfirmationDialog';
 import { IconButton } from '../IconButton/IconButton';
 import { TextBox } from '../InputElements/TextBox';
 import { toast } from '../Toaster';
+import { AttributionFormConfig } from './AttributionForm';
 import { PackageAutocomplete } from './PackageAutocomplete';
 import { attributionColumnClasses } from './shared-attribution-column-styles';
 
@@ -68,12 +69,14 @@ interface PackageSubPanelProps {
   packageInfo: PackageInfo;
   showHighlight?: boolean;
   onEdit?: Confirm;
+  config?: AttributionFormConfig;
 }
 
 export function PackageSubPanel({
   packageInfo,
   showHighlight,
   onEdit,
+  config,
 }: PackageSubPanelProps) {
   const dispatch = useAppDispatch();
   const defaultPackageTypes = useMemo(
@@ -130,10 +133,12 @@ export function PackageSubPanel({
         title={text.attributionColumn.packageSubPanel.packageName}
         packageInfo={packageInfo}
         highlight={'dark'}
-        disabled={!onEdit}
+        readOnly={!onEdit}
         showHighlight={showHighlight}
         defaults={packageNames}
         onEdit={onEdit}
+        color={config?.packageName?.color}
+        focused={config?.packageName?.focused}
       />
     );
   }
@@ -145,10 +150,12 @@ export function PackageSubPanel({
         title={text.attributionColumn.packageSubPanel.packageNamespace}
         packageInfo={packageInfo}
         highlight={'dark'}
-        disabled={!onEdit}
+        readOnly={!onEdit}
         showHighlight={showHighlight}
         defaults={packageNamespaces}
         onEdit={onEdit}
+        color={config?.packageNamespace?.color}
+        focused={config?.packageNamespace?.focused}
       />
     );
   }
@@ -159,10 +166,12 @@ export function PackageSubPanel({
         attribute={'packageVersion'}
         title={text.attributionColumn.packageSubPanel.packageVersion}
         packageInfo={packageInfo}
-        disabled={!onEdit}
+        readOnly={!onEdit}
         showHighlight={showHighlight}
         defaults={packageVersions}
         onEdit={onEdit}
+        color={config?.packageVersion?.color}
+        focused={config?.packageVersion?.focused}
       />
     );
   }
@@ -174,10 +183,12 @@ export function PackageSubPanel({
         title={text.attributionColumn.packageSubPanel.packageType}
         packageInfo={packageInfo}
         highlight={'dark'}
-        disabled={!onEdit}
+        readOnly={!onEdit}
         showHighlight={showHighlight}
         defaults={defaultPackageTypes}
         onEdit={onEdit}
+        color={config?.packageType?.color}
+        focused={config?.packageType?.focused}
       />
     );
   }
@@ -190,7 +201,7 @@ export function PackageSubPanel({
         sx={attributionColumnClasses.textBox}
         title={text.attributionColumn.packageSubPanel.purl}
         text={purl}
-        isEditable={false}
+        disabled
         endIcon={
           <>
             <IconButton
@@ -250,9 +261,11 @@ export function PackageSubPanel({
         attribute={'url'}
         title={text.attributionColumn.packageSubPanel.repositoryUrl}
         packageInfo={packageInfo}
-        disabled={!onEdit}
+        readOnly={!onEdit}
         showHighlight={showHighlight}
         onEdit={onEdit}
+        color={config?.url?.color}
+        focused={config?.url?.focused}
         endAdornment={
           <>
             <IconButton

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -6,7 +6,7 @@ import { SxProps } from '@mui/material';
 import MuiChip from '@mui/material/Chip';
 import MuiFade from '@mui/material/Fade';
 import { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
-import { InputBaseComponentProps as MuiInputBaseComponentProps } from '@mui/material/InputBase';
+import { TextFieldProps as MuiInputProps } from '@mui/material/TextField';
 import useMuiAutocomplete, {
   AutocompleteHighlightChangeReason,
   AutocompleteInputChangeReason,
@@ -46,7 +46,7 @@ type AutocompleteProps<
     ['aria-label']?: string;
     endAdornment?: React.ReactNode;
     highlight?: 'default' | 'dark';
-    inputProps?: MuiInputBaseComponentProps;
+    inputProps?: MuiInputProps;
     onInputChange?: (
       event: React.SyntheticEvent | undefined,
       value: string,
@@ -75,6 +75,7 @@ export function Autocomplete<
   inputProps: customInputProps,
   multiple,
   optionText,
+  readOnly,
   renderOptionEndIcon,
   renderOptionStartIcon,
   sx,
@@ -137,6 +138,7 @@ export function Autocomplete<
     onHighlightChange,
     onOpen: () => setOpen(true),
     open,
+    readOnly,
     ...props,
   });
 
@@ -145,7 +147,8 @@ export function Autocomplete<
   }, [groupedOptions]);
 
   const hasPopupIndicator = !freeSolo;
-  const hasClearButton = !disableClearable && !disabled && containsValue;
+  const hasClearButton =
+    !disableClearable && !disabled && !readOnly && containsValue;
   const isPopupOpen = !!groupedOptions.length && popupOpen;
 
   const { ref, color, ...inputProps } = getInputProps();
@@ -160,6 +163,7 @@ export function Autocomplete<
       >
         <Input
           {...inputProps}
+          {...customInputProps}
           disabled={disabled}
           label={title}
           highlight={highlight}
@@ -169,10 +173,10 @@ export function Autocomplete<
           size={'small'}
           InputLabelProps={getInputLabelProps()}
           inputRef={ref}
-          inputProps={customInputProps}
           InputProps={{
             startAdornment: renderStartAdornment(),
             endAdornment: renderEndAdornment(),
+            readOnly,
           }}
           onKeyDown={(event) => {
             // https://github.com/mui/material-ui/issues/21129

--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -9,6 +9,7 @@ import { text } from '../../../shared/text';
 import { AttributionForm } from '../AttributionColumn/AttributionForm';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { DiffPopupContainer } from './DiffPopup.style';
+import { useAttributionFormConfigs } from './DiffPopup.util';
 
 interface DiffPopupProps {
   original: PackageInfo;
@@ -17,7 +18,17 @@ interface DiffPopupProps {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export function DiffPopup(props: DiffPopupProps): React.ReactElement {
+export function DiffPopup({
+  current,
+  isOpen,
+  original,
+  setOpen,
+}: DiffPopupProps) {
+  const [originalFormConfig, currentFormConfig] = useAttributionFormConfigs({
+    current,
+    original,
+  });
+
   return (
     <NotificationPopup
       header={text.diffPopup.title}
@@ -31,11 +42,11 @@ export function DiffPopup(props: DiffPopupProps): React.ReactElement {
         buttonText: text.buttons.diffPopup.revertAll,
       }}
       rightButtonConfig={{
-        onClick: () => props.setOpen(false),
+        onClick: () => setOpen(false),
         buttonText: text.buttons.cancel,
         color: 'secondary',
       }}
-      isOpen={props.isOpen}
+      isOpen={isOpen}
       background={'lightestBlue'}
       fullWidth={true}
       aria-label={'diff popup'}
@@ -46,9 +57,10 @@ export function DiffPopup(props: DiffPopupProps): React.ReactElement {
     return (
       <DiffPopupContainer>
         <AttributionForm
-          packageInfo={props.original}
+          packageInfo={original}
           variant={'diff'}
           label={'original'}
+          config={originalFormConfig}
         />
         <MuiDivider
           variant={'middle'}
@@ -56,9 +68,10 @@ export function DiffPopup(props: DiffPopupProps): React.ReactElement {
           orientation={'vertical'}
         />
         <AttributionForm
-          packageInfo={props.current}
+          packageInfo={current}
           variant={'diff'}
           label={'current'}
+          config={currentFormConfig}
         />
       </DiffPopupContainer>
     );

--- a/src/Frontend/Components/DiffPopup/DiffPopup.util.ts
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.util.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo } from 'react';
+
+import { PackageInfo } from '../../../shared/shared-types';
+import {
+  AttributionFormConfig,
+  FORM_ATTRIBUTES,
+} from '../AttributionColumn/AttributionForm';
+
+export function useAttributionFormConfigs({
+  current,
+  original,
+}: {
+  original: PackageInfo;
+  current: PackageInfo;
+}) {
+  return useMemo(
+    () =>
+      FORM_ATTRIBUTES.reduce<[AttributionFormConfig, AttributionFormConfig]>(
+        ([originalFormConfig, currentFormConfig], attribute) => {
+          switch (attribute) {
+            case 'copyright':
+            case 'licenseName':
+            case 'licenseText': {
+              const isFirstPartyChanged =
+                !!original.firstParty !== !!current.firstParty;
+              const isAttributeValueChanged =
+                original[attribute] !== current[attribute];
+              const isChanged = isFirstPartyChanged || isAttributeValueChanged;
+              originalFormConfig[attribute] = {
+                color: isChanged ? 'error' : undefined,
+                focused: isChanged,
+              };
+              currentFormConfig[attribute] = {
+                color: isChanged ? 'success' : undefined,
+                focused: isChanged,
+              };
+              break;
+            }
+            case 'packageName':
+            case 'packageNamespace':
+            case 'packageType':
+            case 'packageVersion':
+            case 'url': {
+              const isChanged =
+                (original[attribute] ?? '') !== (current[attribute] ?? '');
+              originalFormConfig[attribute] = {
+                color: isChanged ? 'error' : undefined,
+                focused: isChanged,
+              };
+              currentFormConfig[attribute] = {
+                color: isChanged ? 'success' : undefined,
+                focused: isChanged,
+              };
+              break;
+            }
+            case 'firstParty': {
+              break;
+            }
+          }
+          return [originalFormConfig, currentFormConfig];
+        },
+        [{}, {}],
+      ),
+    [current, original],
+  );
+}

--- a/src/Frontend/Components/DiffPopup/__test__/DiffPopup.util.test.tsx
+++ b/src/Frontend/Components/DiffPopup/__test__/DiffPopup.util.test.tsx
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { waitFor } from '@testing-library/react';
+import { without } from 'lodash';
+
+import { faker } from '../../../../testing/Faker';
+import { renderHook } from '../../../test-helpers/render';
+import {
+  AttributionFormConfig,
+  FORM_ATTRIBUTES,
+  FormAttribute,
+} from '../../AttributionColumn/AttributionForm';
+import { useAttributionFormConfigs } from '../DiffPopup.util';
+
+describe('useAttributionFormConfigs', () => {
+  const EMPTY_CONFIG: AttributionFormConfig = {
+    copyright: { color: undefined, focused: false },
+    licenseName: { color: undefined, focused: false },
+    licenseText: { color: undefined, focused: false },
+    packageName: { color: undefined, focused: false },
+    packageNamespace: { color: undefined, focused: false },
+    packageVersion: { color: undefined, focused: false },
+    url: { color: undefined, focused: false },
+    packageType: { color: undefined, focused: false },
+  };
+
+  it.each(
+    without(FORM_ATTRIBUTES, 'firstParty') as Array<
+      Exclude<FormAttribute, 'firstParty'>
+    >,
+  )(
+    'computes attribution form config correctly when %s changes',
+    async (attribute) => {
+      const originalPackageInfo = faker.opossum.packageInfo();
+      const currentPackageInfo = faker.opossum.packageInfo({
+        ...originalPackageInfo,
+        [attribute]: faker.internet.domainWord(),
+      });
+
+      const { result } = renderHook(() =>
+        useAttributionFormConfigs({
+          original: originalPackageInfo,
+          current: currentPackageInfo,
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current).toEqual<
+          [AttributionFormConfig, AttributionFormConfig]
+        >([
+          {
+            ...EMPTY_CONFIG,
+            [attribute]: { focused: true, color: 'error' },
+          },
+          {
+            ...EMPTY_CONFIG,
+            [attribute]: { focused: true, color: 'success' },
+          },
+        ]),
+      );
+    },
+  );
+
+  const EXPECTED_ORIGINAL_CONFIG: AttributionFormConfig = {
+    copyright: { color: 'error', focused: true },
+    licenseName: { color: 'error', focused: true },
+    licenseText: { color: 'error', focused: true },
+    packageName: { color: undefined, focused: false },
+    packageNamespace: { color: undefined, focused: false },
+    packageVersion: { color: undefined, focused: false },
+    url: { color: undefined, focused: false },
+    packageType: { color: undefined, focused: false },
+  };
+  const EXPECTED_CURRENT_CONFIG: AttributionFormConfig = {
+    copyright: { color: 'success', focused: true },
+    licenseName: { color: 'success', focused: true },
+    licenseText: { color: 'success', focused: true },
+    packageName: { color: undefined, focused: false },
+    packageNamespace: { color: undefined, focused: false },
+    packageVersion: { color: undefined, focused: false },
+    url: { color: undefined, focused: false },
+    packageType: { color: undefined, focused: false },
+  };
+
+  it.each<[boolean, boolean, [AttributionFormConfig, AttributionFormConfig]]>([
+    [true, true, [EMPTY_CONFIG, EMPTY_CONFIG]],
+    [true, false, [EXPECTED_ORIGINAL_CONFIG, EXPECTED_CURRENT_CONFIG]],
+    [false, true, [EXPECTED_ORIGINAL_CONFIG, EXPECTED_CURRENT_CONFIG]],
+    [false, false, [EMPTY_CONFIG, EMPTY_CONFIG]],
+  ])(
+    'computes attribution form config correctly if original is first party: %s and current is first party: %s',
+    async (originalFirstParty, currentFirstParty, expectedConfigs) => {
+      const originalPackageInfo = faker.opossum.packageInfo({
+        firstParty: originalFirstParty,
+      });
+      const currentPackageInfo = faker.opossum.packageInfo({
+        ...originalPackageInfo,
+        ...{ firstParty: currentFirstParty },
+      });
+
+      const { result } = renderHook(() =>
+        useAttributionFormConfigs({
+          original: originalPackageInfo,
+          current: currentPackageInfo,
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current).toEqual<
+          [AttributionFormConfig, AttributionFormConfig]
+        >(expectedConfigs),
+      );
+    },
+  );
+});

--- a/src/Frontend/Components/InputElements/Dropdown.tsx
+++ b/src/Frontend/Components/InputElements/Dropdown.tsx
@@ -40,7 +40,9 @@ export function Dropdown(props: DropdownProps): ReactElement {
   return (
     <MuiBox sx={props.sx}>
       <MuiTextField
-        disabled={!props.isEditable}
+        disabled={props.disabled}
+        color={props.color}
+        focused={props.focused}
         sx={{
           ...inputElementClasses.textField,
           ...(props.isHighlighted
@@ -54,6 +56,7 @@ export function Dropdown(props: DropdownProps): ReactElement {
           inputProps: {
             'aria-label': props.title,
           },
+          readOnly: props.readOnly,
         }}
         id={`dropdown ${props.title}`}
         value={props.value}

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -9,7 +9,7 @@ import MuiTextField from '@mui/material/TextField';
 import { HighlightingColor } from '../../enums/enums';
 import { inputElementClasses, InputElementProps } from './shared';
 
-interface TextProps extends InputElementProps {
+interface TextBoxProps extends InputElementProps {
   minRows?: number;
   maxRows?: number;
   endIcon?: React.ReactElement;
@@ -19,7 +19,7 @@ interface TextProps extends InputElementProps {
   expanded?: boolean;
 }
 
-export function TextBox(props: TextProps) {
+export function TextBox(props: TextBoxProps) {
   const isDefaultHighlighting =
     props.highlightingColor === HighlightingColor.LightOrange ||
     props.highlightingColor === undefined;
@@ -33,14 +33,17 @@ export function TextBox(props: TextProps) {
   return (
     <MuiBox sx={props.sx}>
       <MuiTextField
-        disabled={!props.isEditable}
+        disabled={props.disabled}
         error={props.error}
         sx={{
           ...(props.isHighlighted ? highlightedStyling : {}),
           ...inputElementClasses.textField,
         }}
         label={props.title}
+        focused={props.focused}
+        color={props.color}
         InputProps={{
+          readOnly: props.readOnly,
           slotProps: {
             root: {
               sx: {

--- a/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/Dropdown.test.tsx
@@ -13,7 +13,6 @@ describe('The Dropdown', () => {
   it('renders value', () => {
     render(
       <Dropdown
-        isEditable={true}
         title={'Confidence'}
         value={DiscreteConfidence.High.toString()}
         menuItems={[
@@ -40,7 +39,6 @@ describe('The Dropdown', () => {
   it('renders value not in menuItems', () => {
     render(
       <Dropdown
-        isEditable={true}
         title={'Confidence'}
         value={'10'}
         menuItems={[

--- a/src/Frontend/Components/InputElements/__tests__/TextBox.test.tsx
+++ b/src/Frontend/Components/InputElements/__tests__/TextBox.test.tsx
@@ -3,24 +3,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { render, screen } from '@testing-library/react';
-import { ChangeEvent } from 'react';
 
-import { doNothing } from '../../../util/do-nothing';
 import { TextBox } from '../TextBox';
 
 describe('The TextBox', () => {
   it('renders text and label', () => {
-    render(
-      <TextBox
-        title={'Test Title'}
-        text={'Test Content'}
-        handleChange={
-          doNothing as unknown as (
-            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-          ) => void
-        }
-      />,
-    );
+    render(<TextBox title={'Test Title'} text={'Test Content'} />);
 
     expect(screen.queryAllByText('Test Title')).toHaveLength(2);
     expect(screen.getByDisplayValue('Test Content')).toBeInTheDocument();
@@ -31,11 +19,6 @@ describe('The TextBox', () => {
       <TextBox
         title={'Test Title'}
         text={'Test Content'}
-        handleChange={
-          doNothing as unknown as (
-            event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-          ) => void
-        }
         endIcon={<div>Test Icon</div>}
       />,
     );

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { SxProps } from '@mui/material';
+import { SxProps, TextFieldProps } from '@mui/material';
 import { ChangeEvent } from 'react';
 
 import { OpossumColors } from '../../shared-styles';
@@ -52,11 +52,14 @@ export const inputElementClasses = {
 
 export interface InputElementProps {
   title?: string;
-  isEditable?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
   text?: string;
   sx?: SxProps;
   handleChange?(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ): void;
   isHighlighted?: boolean;
+  color?: TextFieldProps['color'];
+  focused?: boolean;
 }

--- a/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
+++ b/src/Frontend/Components/LocatorPopup/LocatorPopup.tsx
@@ -153,7 +153,6 @@ export function LocatorPopup(): ReactElement {
       </MuiBox>
       <Dropdown
         sx={classes.dropdown}
-        isEditable={true}
         title={'Criticality'}
         value={criticalityDropDownChoice}
         menuItems={criticalityMenuItems}

--- a/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
+++ b/src/Frontend/Components/ResourceDetailsTabs/ResourceDetailsTabs.tsx
@@ -191,7 +191,6 @@ export function ResourceDetailsTabs(props: ResourceDetailsTabsProps) {
       {showSortingSelect ? (
         <Dropdown
           sx={classes.dropdown}
-          isEditable
           title={text.buttons.sort}
           value={signalSorting}
           menuItems={sortingOptions}

--- a/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
+++ b/src/e2e-tests/__tests__/comparing-attribution-with-origin.test.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { AttributionType } from '../../Frontend/enums/enums';
 import { faker, test } from '../utils';
 
 const [resourceName1, resourceName2] = faker.opossum.resourceNames({
@@ -62,4 +63,17 @@ test('enables comparing attribution to origin if origin is present', async ({
   await diffPopup.currentAttributionForm.assert.matchesPackageInfo(
     manualPackageInfo2,
   );
+});
+
+test('hides copyright and license fields if package is first party', async ({
+  attributionDetails,
+  diffPopup,
+  resourceBrowser,
+}) => {
+  await resourceBrowser.goto(resourceName2);
+  await attributionDetails.attributionForm.selectAttributionType(
+    AttributionType.FirstParty,
+  );
+  await attributionDetails.compareButton.click();
+  await diffPopup.currentAttributionForm.assert.licenseTextIsHidden();
 });


### PR DESCRIPTION
### Summary of changes

Add colours to the package info fields that indicate change.

If there is a diff between two relevant fields the original value is displayed in red and the currently displayed value is green.
Two fields differ if they are not equal. More sophisticated diffing is kept for later efforts.

Only if original and displayed package are of type third party, we also diff the copyright and license fields.

### Context and reason for change

Closes [#2517](https://github.com/opossum-tool/OpossumUI/issues/2517)

### How can the changes be tested

Added e2e test.

Manually. Open the Diff popup and play around with changing the package info.
