### PR TITLE
chore: simplify follow-up attribute type

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -11,7 +11,6 @@ import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import {
   Criticality,
   DiscreteConfidence,
-  FollowUp,
   ParsedFileContent,
 } from '../../../shared/shared-types';
 import { writeFile, writeOpossumFile } from '../../../shared/write-file';
@@ -244,9 +243,6 @@ describe('Test of loading function', () => {
     expect(getGlobalBackendState().projectId).toBe(
       inputFileContent.metadata.projectId,
     );
-    expect(
-      getGlobalBackendState().inputContainsCriticalExternalAttributions,
-    ).toBeTruthy();
   });
 
   it('loads .opossum file, no output.json', async () => {
@@ -354,9 +350,6 @@ describe('Test of loading function', () => {
     expect(getGlobalBackendState().projectId).toBe(
       inputFileContent.metadata.projectId,
     );
-    expect(
-      getGlobalBackendState().inputContainsCriticalExternalAttributions,
-    ).toBeTruthy();
   });
 
   it(
@@ -604,7 +597,7 @@ function assertFileLoadedCorrectly(testUuid: string): void {
           packageName: 'Package',
           packageVersion: '1.0',
           licenseText: 'MIT',
-          followUp: FollowUp,
+          followUp: true,
           id: testUuid,
         },
       },

--- a/src/ElectronBackend/input/__tests__/parseInputData.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseInputData.test.ts
@@ -7,7 +7,6 @@ import {
   AttributionsToResources,
   BaseUrlsForSources,
   Criticality,
-  FollowUp,
   FrequentLicenses,
   RawAttributions,
   Resources,
@@ -90,38 +89,37 @@ describe('cleanNonExistentResolvedExternalAttributions', () => {
 });
 
 describe('deserializeAttributions', () => {
-  it('leaves FollowUp as followUp', () => {
+  it('converts follow-up string to boolean', () => {
     const rawAttributions: RawAttributions = {
       id: {
-        followUp: FollowUp,
+        followUp: 'FOLLOW_UP',
       },
     };
     const expectedAttributions: Attributions = {
       id: {
         id: 'id',
-        followUp: FollowUp,
+        followUp: true,
       },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
 
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
-  it('removes unknown strings from followUp', () => {
+  it('removes unknown strings from follow-up', () => {
     const rawAttributions: RawAttributions = {
       id: {
-        followUp: 'UNKNOWN_STRING' as FollowUp,
+        followUp: 'UNKNOWN_STRING' as 'FOLLOW_UP',
       },
     };
     const expectedAttributions: Attributions = {
       id: { id: 'id' },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
   it('leaves non-empty comment unchanged', () => {
@@ -136,11 +134,10 @@ describe('deserializeAttributions', () => {
         comments: ['Test comment'],
       },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
 
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
   it('removes empty comment', () => {
@@ -152,11 +149,10 @@ describe('deserializeAttributions', () => {
     const expectedAttributions: Attributions = {
       id: { id: 'id' },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
 
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
   it('leaves criticality unchanged', () => {
@@ -171,11 +167,10 @@ describe('deserializeAttributions', () => {
         criticality: Criticality.High,
       },
     };
-    const expectedCriticalExternalAttributionsFlag = true;
 
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
   it('removes invalid criticality', () => {
@@ -187,11 +182,10 @@ describe('deserializeAttributions', () => {
     const expectedAttributions: Attributions = {
       id: { id: 'id' },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
 
-    expect(deserializeAttributions(rawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([expectedAttributions, expectedCriticalExternalAttributionsFlag]);
+    expect(deserializeAttributions(rawAttributions)).toEqual(
+      expectedAttributions,
+    );
   });
 
   it('merges originIds and originId if both exist', () => {
@@ -207,13 +201,10 @@ describe('deserializeAttributions', () => {
         id: 'uuid',
       },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
-    expect(deserializeAttributions(testRawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([
+
+    expect(deserializeAttributions(testRawAttributions)).toEqual(
       expectedParsedRawAttributions,
-      expectedCriticalExternalAttributionsFlag,
-    ]);
+    );
   });
 
   it('creates originIds and writes originId into it if originIds does not exist initially', () => {
@@ -228,13 +219,10 @@ describe('deserializeAttributions', () => {
         id: 'uuid',
       },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
-    expect(deserializeAttributions(testRawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([
+
+    expect(deserializeAttributions(testRawAttributions)).toEqual(
       expectedParsedRawAttributions,
-      expectedCriticalExternalAttributionsFlag,
-    ]);
+    );
   });
 
   it('leaves originIds as it is if originId does not exist', () => {
@@ -249,13 +237,10 @@ describe('deserializeAttributions', () => {
         id: 'uuid',
       },
     };
-    const expectedCriticalExternalAttributionsFlag = false;
-    expect(deserializeAttributions(testRawAttributions)).toEqual<
-      [Attributions, boolean]
-    >([
+
+    expect(deserializeAttributions(testRawAttributions)).toEqual(
       expectedParsedRawAttributions,
-      expectedCriticalExternalAttributionsFlag,
-    ]);
+    );
   });
 });
 

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -98,8 +98,10 @@ export async function loadInputAndOutputFromFilePath(
     parsedInputData = parsingResult;
   }
 
-  const [externalAttributions, inputContainsCriticalExternalAttributions] =
-    deserializeAttributions(parsedInputData.externalAttributions);
+  logger.info('Deserializing signals');
+  const externalAttributions = deserializeAttributions(
+    parsedInputData.externalAttributions,
+  );
 
   logger.info('Parsing frequent licenses from input');
   const frequentLicenses = parseFrequentLicenses(
@@ -137,7 +139,8 @@ export async function loadInputAndOutputFromFilePath(
     }
   }
 
-  const [manualAttributions] = deserializeAttributions(
+  logger.info('Deserializing attributions');
+  const manualAttributions = deserializeAttributions(
     parsedOutputData.manualAttributions,
   );
 
@@ -173,6 +176,7 @@ export async function loadInputAndOutputFromFilePath(
     externalAttributionSources:
       parsedInputData.externalAttributionSources ?? {},
   };
+
   logger.info('Sending data to user interface');
   mainWindow.webContents.send(
     AllowedFrontendChannels.FileLoaded,
@@ -182,8 +186,6 @@ export async function loadInputAndOutputFromFilePath(
   logger.info('Finalizing global state');
   getGlobalBackendState().projectTitle = parsedInputData.metadata.projectTitle;
   getGlobalBackendState().projectId = parsedInputData.metadata.projectId;
-  getGlobalBackendState().inputContainsCriticalExternalAttributions =
-    inputContainsCriticalExternalAttributions;
 }
 
 async function createOutputInOpossumFile(

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -8,7 +8,6 @@ import {
   Attributions,
   BaseUrlsForSources,
   Criticality,
-  FollowUp,
   FrequentLicenses,
   RawAttributions,
   Resources,
@@ -119,10 +118,10 @@ export function cleanNonExistentResolvedExternalAttributions(
 
 export function deserializeAttributions(
   rawAttributions: RawAttributions,
-): [Attributions, boolean] {
-  return Object.entries(rawAttributions).reduce<[Attributions, boolean]>(
+): Attributions {
+  return Object.entries(rawAttributions).reduce<Attributions>(
     (
-      [attributions, inputContainsCriticalExternalAttributions],
+      attributions,
       [
         attributionId,
         { followUp, comment, criticality, originId, originIds, ...attribution },
@@ -136,17 +135,14 @@ export function deserializeAttributions(
         ...((originId || originIds?.length) && {
           originIds: (originIds ?? []).concat(originId ?? []),
         }),
-        ...(followUp === FollowUp && { followUp }),
+        ...(followUp === 'FOLLOW_UP' && { followUp: true }),
         ...(sanitizedComment && { comments: [sanitizedComment] }),
         ...(isCritical && { criticality }),
         id: attributionId,
       };
-      return [
-        attributions,
-        inputContainsCriticalExternalAttributions || isCritical,
-      ];
+      return attributions;
     },
-    [{}, false],
+    {},
   );
 }
 
@@ -161,6 +157,7 @@ export function serializeAttributions(
         {
           comments,
           count,
+          followUp,
           id,
           linkedAttributionIds,
           resources,
@@ -179,6 +176,7 @@ export function serializeAttributions(
         ...(sanitizedComments?.length && {
           comment: sanitizedComments.join('\n'),
         }),
+        ...(followUp && { followUp: 'FOLLOW_UP' }),
       };
       return rawAttributions;
     },

--- a/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
+++ b/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
@@ -54,9 +54,7 @@ describe('getSaveFileListener', () => {
     expect(dialog.showMessageBox).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'error',
-        message:
-          'Error in app backend: Failed to save data. ' +
-          'The projectId is incorrect.\nprojectId: undefined',
+        message: 'Error in app backend: Project ID not found',
         buttons: ['Reload File', 'Quit'],
       }),
     );

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -59,11 +59,8 @@ export function getSaveFileListener(
     (_: unknown, args: SaveFileArgs) => {
       const globalBackendState = getGlobalBackendState();
 
-      if (globalBackendState.projectId === undefined) {
-        throw new Error(
-          'Failed to save data. The projectId is incorrect.' +
-            `\nprojectId: ${globalBackendState.projectId}`,
-        );
+      if (!globalBackendState.projectId) {
+        throw new Error('Project ID not found');
       }
 
       const outputFileContent: OpossumOutputFile = {

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -32,7 +32,6 @@ export interface GlobalBackendState {
   spdxYamlFilePath?: string;
   spdxJsonFilePath?: string;
   projectId?: string;
-  inputContainsCriticalExternalAttributions?: boolean;
   inputFileChecksum?: string;
   inputFileRaw?: Uint8Array;
 }

--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
@@ -13,7 +13,7 @@ import SentimentVerySatisfiedIcon from '@mui/icons-material/SentimentVerySatisfi
 import MuiRating from '@mui/material/Rating';
 import { useMemo } from 'react';
 
-import { FollowUp, PackageInfo } from '../../../shared/shared-types';
+import { PackageInfo } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { OpossumColors } from '../../shared-styles';
 import { setTemporaryDisplayPackageInfo } from '../../state/actions/resource-actions/all-views-simple-actions';
@@ -157,14 +157,14 @@ export function useAuditingOptions({
           dispatch(
             setTemporaryDisplayPackageInfo({
               ...getTemporaryDisplayPackageInfo(store.getState()),
-              followUp: FollowUp,
+              followUp: true,
             }),
           ),
         onDelete: () =>
           dispatch(
             setTemporaryDisplayPackageInfo({
               ...getTemporaryDisplayPackageInfo(store.getState()),
-              followUp: undefined,
+              followUp: false,
             }),
           ),
         interactive: isEditable,

--- a/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
+++ b/src/Frontend/Components/AttributionColumn/__tests__/AttributionColumn.test.tsx
@@ -10,7 +10,6 @@ import { noop } from 'lodash';
 import {
   Attributions,
   DiscreteConfidence,
-  FollowUp,
   FrequentLicenses,
   PackageInfo,
   ResourcesToAttributions,
@@ -337,7 +336,7 @@ describe('The AttributionColumn', () => {
     await userEvent.keyboard('{Escape}');
 
     expect(getTemporaryDisplayPackageInfo(store.getState()).followUp).toBe(
-      FollowUp,
+      true,
     );
   });
 

--- a/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
+++ b/src/Frontend/Components/AttributionCountsPanel/__tests__/AttributionCountsPanel.test.tsx
@@ -7,7 +7,6 @@ import { act } from 'react-dom/test-utils';
 
 import {
   Attributions,
-  FollowUp,
   ResourcesToAttributions,
 } from '../../../../shared/shared-types';
 import { View } from '../../../enums/enums';
@@ -38,7 +37,7 @@ describe('The Attribution Counts Panel', () => {
       packageVersion: '2.0',
       copyright: 'other Copyright John Doe',
       licenseText: 'Some other license text',
-      followUp: FollowUp,
+      followUp: true,
       id: testOtherManualUuid,
     },
   };

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -11,7 +11,7 @@ describe('BackendCommunication', () => {
     const testAttributions: Attributions = {
       genericAttrib: { id: 'genericAttrib' },
       firstPartyAttrib: { firstParty: true, id: 'firstPartyAttrib' },
-      followupAttrib: { followUp: 'FOLLOW_UP', id: 'followupAttrib' },
+      followupAttrib: { followUp: true, id: 'followupAttrib' },
       excludeAttrib: { excludeFromNotice: true, id: 'excludeAttrib' },
       firstPartyExcludeAttrib: {
         firstParty: true,

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
@@ -7,7 +7,6 @@ import {
   AttributionsToHashes,
   Criticality,
   ExternalAttributionSources,
-  FollowUp,
 } from '../../../../shared/shared-types';
 import {
   LicenseCounts,
@@ -54,7 +53,7 @@ const testAttributions_1: Attributions = {
       documentConfidence: 90,
     },
     licenseName: ' Apache license version-2.0 ',
-    followUp: FollowUp,
+    followUp: true,
     needsReview: true,
     id: 'uuid3',
   },

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.test.tsx
@@ -75,7 +75,7 @@ describe('The ReportTableItem', () => {
       uuid2: {
         packageName: 'Redux',
         resources: [],
-        followUp: 'FOLLOW_UP',
+        followUp: true,
         excludeFromNotice: true,
         id: 'uuid2',
       },

--- a/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.util.test.tsx
+++ b/src/Frontend/Components/ReportTableItem/__tests__/ReportTableItem.util.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { FollowUp, PackageInfo } from '../../../../shared/shared-types';
+import { PackageInfo } from '../../../../shared/shared-types';
 import { faker } from '../../../../testing/Faker';
 import { isImportantAttributionInformationMissing } from '../../../util/is-important-attribution-information-missing';
 import { TableConfig } from '../../Table/TableConfig';
@@ -54,7 +54,7 @@ describe('The table helpers', () => {
   it.each`
     followUp     | expected
     ${undefined} | ${'No'}
-    ${FollowUp}  | ${'Yes'}
+    ${true}      | ${'Yes'}
   `(
     'getFormattedCellData handles follow-up value $followUp',
     ({ followUp, expected }) => {

--- a/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
+++ b/src/Frontend/Components/ReportView/__tests__/ReportView.test.tsx
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event';
 
 import {
   Attributions,
-  FollowUp,
   FrequentLicenses,
   Resources,
   ResourcesToAttributions,
@@ -45,7 +44,7 @@ describe('The ReportView', () => {
     packageVersion: '2.0',
     copyright: 'other Copyright John Doe',
     licenseText: 'Some other license text',
-    followUp: FollowUp,
+    followUp: true,
     excludeFromNotice: true,
     id: testOtherManualUuid,
   };

--- a/src/Frontend/web-workers/scripts/__tests__/get-filtered-attributions.test.ts
+++ b/src/Frontend/web-workers/scripts/__tests__/get-filtered-attributions.test.ts
@@ -182,7 +182,7 @@ describe('get-filtered-attributions', () => {
 
   it('returns filtered attributions with needs-follow-up filter', () => {
     const packageInfo1 = faker.opossum.packageInfo({
-      followUp: 'FOLLOW_UP',
+      followUp: true,
     });
     const packageInfo2 = faker.opossum.packageInfo();
 

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -12,9 +12,6 @@ export interface Resources {
   [resourceName: string]: Resources | 1;
 }
 
-export type FollowUp = 'FOLLOW_UP';
-export const FollowUp = 'FOLLOW_UP';
-
 export enum Criticality {
   High = 'high',
   Medium = 'medium',
@@ -65,7 +62,7 @@ export interface PackageInfo extends EphemeralPackageInfoProps {
   criticality?: Criticality;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
-  followUp?: FollowUp;
+  followUp?: boolean;
   licenseName?: string;
   licenseText?: string;
   needsReview?: boolean;
@@ -84,9 +81,13 @@ export interface PackageInfo extends EphemeralPackageInfoProps {
 }
 
 export interface RawPackageInfo
-  extends Never<PackageInfo, keyof EphemeralPackageInfoProps> {
+  extends Never<
+    Omit<PackageInfo, 'followUp'>,
+    keyof EphemeralPackageInfoProps
+  > {
   originId?: string;
   comment?: string;
+  followUp?: 'FOLLOW_UP';
 }
 
 export interface RawAttributions {
@@ -241,7 +242,7 @@ export interface FileSupportPopupArgs {
   dotOpossumFileAlreadyExists: boolean;
 }
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Listener = (event: IpcRendererEvent, ...args: Array<any>) => void;
 
 export interface ElectronAPI {


### PR DESCRIPTION
### Summary of changes

- convert follow-up from string enum to boolean since it only contains one value
- remove unused criticality boolean calculated during deserialization

### Context and reason for change

Reduce code complexity: "followUp" behaves like a boolean and is similar to other attributes like "wasPreferred".

### How can the changes be tested

Check that the "needs follow-up" as part of the auditing options still works as expected.