### PR TITLE
fix: updating attribution with original signal or suggestion

### DIFF
--- a/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionColumn/AuditingOptions.util.tsx
@@ -138,7 +138,18 @@ export function useAuditingOptions({
         interactive: !!originalPreferred,
         deleteIcon: <ReplayIcon aria-label={'undo modified preferred'} />,
         onDelete: originalPreferred
-          ? () => dispatch(setTemporaryDisplayPackageInfo(originalPreferred))
+          ? () =>
+              dispatch(
+                setTemporaryDisplayPackageInfo({
+                  ...originalPreferred,
+                  id: packageInfo.id,
+                  preSelected: undefined,
+                  comments:
+                    (originalPreferred.comments?.length ?? 0) > 1
+                      ? undefined
+                      : originalPreferred.comments,
+                }),
+              )
           : undefined,
       },
       {
@@ -271,6 +282,7 @@ export function useAuditingOptions({
       packageInfo.attributionConfidence,
       packageInfo.excludeFromNotice,
       packageInfo.followUp,
+      packageInfo.id,
       packageInfo.needsReview,
       packageInfo.preSelected,
       packageInfo.preferred,

--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -25,7 +25,7 @@ import { isAuditViewSelected } from '../../state/selectors/view-selector';
 import { useAutocompleteSignals } from '../../state/variables/use-autocomplete-signals';
 import { generatePurl } from '../../util/handle-purl';
 import { isImportantAttributionInformationMissing } from '../../util/is-important-attribution-information-missing';
-import { omit, pick } from '../../util/lodash-extension-utils';
+import { omit } from '../../util/lodash-extension-utils';
 import { maybePluralize } from '../../util/maybe-pluralize';
 import { openUrl } from '../../util/open-url';
 import { PackageSearchHooks } from '../../util/package-search-hooks';
@@ -258,14 +258,12 @@ export function PackageAutocomplete({
           onClick={async (event) => {
             event.stopPropagation();
             const merged: PackageInfo = {
-              ...omit(option, ['preSelected', 'source']),
-              ...pick(temporaryPackageInfo, [
-                'attributionConfidence',
-                'excludeFromNotice',
-                'followUp',
-                'needsReview',
-                'preferred',
-              ]),
+              ...temporaryPackageInfo,
+              ...omit(option, ['preSelected', 'id']),
+              comments:
+                (option.comments?.length ?? 0) > 1
+                  ? undefined
+                  : option.comments,
             };
             dispatch(
               setTemporaryDisplayPackageInfo(


### PR DESCRIPTION
### Summary of changes

- attributes "id", "preSelected" should not be used when updating an attribution via an original signal or suggestion
- also ensure multiple comments are dropped

### How can the changes be tested

1. Modify a previously preferred and pre-selected attribution, save the changes, and then click on the chip to revert to the original state.
2. Pick a suggestion from an autocomplete via the "+" button and notice that id, pre-selected do not change while an suggested signal that had multiple comments drops these comments.