### PR TITLE
fix: shift end icons in text fiels inwards instead of scroll bar

### DIFF
--- a/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageAutocomplete.tsx
@@ -46,7 +46,7 @@ interface Props {
   attribute: AutocompleteAttribute;
   packageInfo: PackageInfo;
   highlight?: 'default' | 'dark';
-  endAdornment?: React.ReactElement;
+  endAdornment?: React.ReactElement | Array<React.ReactElement>;
   defaults?: Array<PackageInfo>;
   readOnly?: boolean;
   disabled?: boolean;

--- a/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionColumn/PackageSubPanel.tsx
@@ -209,59 +209,65 @@ export function PackageSubPanel({
         text={purl}
         disabled
         endIcon={
-          isDiff ? undefined : (
-            <>
-              <IconButton
-                tooltipTitle={
-                  text.attributionColumn.packageSubPanel.copyToClipboard
-                }
-                tooltipPlacement="left"
-                onClick={async () => {
-                  await navigator.clipboard.writeText(purl);
-                  toast.success(text.attributionColumn.copyToClipboardSuccess);
-                }}
-                icon={<ContentCopyIcon sx={clickableIcon} />}
-                hidden={!purl}
-                aria-label={
-                  text.attributionColumn.packageSubPanel.copyToClipboard
-                }
-              />
-              <IconButton
-                tooltipTitle={
-                  text.attributionColumn.packageSubPanel.pasteFromClipboard
-                }
-                hidden={!onEdit}
-                tooltipPlacement="left"
-                onClick={async () => {
-                  const parsedPurl = parsePurl(
-                    await navigator.clipboard.readText(),
-                  );
-                  if (parsedPurl) {
-                    dispatch(
-                      setTemporaryDisplayPackageInfo({
-                        ...packageInfo,
-                        packageName: parsedPurl.name,
-                        packageVersion: parsedPurl.version ?? undefined,
-                        packageType: parsedPurl.type,
-                        packageNamespace: parsedPurl.namespace ?? undefined,
-                      }),
-                    );
+          isDiff
+            ? undefined
+            : [
+                <IconButton
+                  tooltipTitle={
+                    text.attributionColumn.packageSubPanel.copyToClipboard
+                  }
+                  tooltipPlacement="left"
+                  onClick={async () => {
+                    await navigator.clipboard.writeText(purl);
                     toast.success(
                       text.attributionColumn.copyToClipboardSuccess,
                     );
-                  } else {
-                    toast.error(
-                      text.attributionColumn.pasteFromClipboardFailed,
-                    );
+                  }}
+                  icon={<ContentCopyIcon sx={clickableIcon} />}
+                  hidden={!purl}
+                  aria-label={
+                    text.attributionColumn.packageSubPanel.copyToClipboard
                   }
-                }}
-                icon={<ContentPasteIcon sx={clickableIcon} />}
-                aria-label={
-                  text.attributionColumn.packageSubPanel.pasteFromClipboard
-                }
-              />
-            </>
-          )
+                  key={text.attributionColumn.packageSubPanel.copyToClipboard}
+                />,
+                <IconButton
+                  tooltipTitle={
+                    text.attributionColumn.packageSubPanel.pasteFromClipboard
+                  }
+                  hidden={!onEdit}
+                  tooltipPlacement="left"
+                  onClick={async () => {
+                    const parsedPurl = parsePurl(
+                      await navigator.clipboard.readText(),
+                    );
+                    if (parsedPurl) {
+                      dispatch(
+                        setTemporaryDisplayPackageInfo({
+                          ...packageInfo,
+                          packageName: parsedPurl.name,
+                          packageVersion: parsedPurl.version ?? undefined,
+                          packageType: parsedPurl.type,
+                          packageNamespace: parsedPurl.namespace ?? undefined,
+                        }),
+                      );
+                      toast.success(
+                        text.attributionColumn.copyToClipboardSuccess,
+                      );
+                    } else {
+                      toast.error(
+                        text.attributionColumn.pasteFromClipboardFailed,
+                      );
+                    }
+                  }}
+                  icon={<ContentPasteIcon sx={clickableIcon} />}
+                  aria-label={
+                    text.attributionColumn.packageSubPanel.pasteFromClipboard
+                  }
+                  key={
+                    text.attributionColumn.packageSubPanel.pasteFromClipboard
+                  }
+                />,
+              ]
         }
       />
     );
@@ -279,47 +285,47 @@ export function PackageSubPanel({
         color={config?.url?.color}
         focused={config?.url?.focused}
         endAdornment={
-          config?.url?.endIcon || (
-            <>
-              <IconButton
-                tooltipTitle={text.attributionColumn.getUrlAndLegal}
-                tooltipPlacement={'left'}
-                hidden={
-                  !packageInfo.packageName ||
-                  !packageInfo.packageType ||
-                  !!(
-                    packageInfo.url &&
-                    packageInfo.copyright &&
-                    packageInfo.licenseName
-                  ) ||
-                  !onEdit
-                }
-                onClick={() =>
-                  onEdit?.(async () => {
-                    const enriched = await enrichPackageInfo({
-                      ...packageInfo,
-                      wasPreferred: undefined,
-                    });
-                    if (enriched) {
-                      dispatch(setTemporaryDisplayPackageInfo(enriched));
-                    }
-                  })
-                }
-                icon={<AutoFixHighIcon sx={clickableIcon} />}
-              />
-              <IconButton
-                tooltipTitle={
-                  text.attributionColumn.packageSubPanel.openLinkInBrowser
-                }
-                tooltipPlacement={'left'}
-                onClick={() => openUrl(packageInfo.url)}
-                hidden={!packageInfo.url}
-                icon={
-                  <OpenInNewIcon aria-label={'Url icon'} sx={clickableIcon} />
-                }
-              />
-            </>
-          )
+          config?.url?.endIcon || [
+            <IconButton
+              tooltipTitle={text.attributionColumn.getUrlAndLegal}
+              tooltipPlacement={'left'}
+              hidden={
+                !packageInfo.packageName ||
+                !packageInfo.packageType ||
+                !!(
+                  packageInfo.url &&
+                  packageInfo.copyright &&
+                  packageInfo.licenseName
+                ) ||
+                !onEdit
+              }
+              onClick={() =>
+                onEdit?.(async () => {
+                  const enriched = await enrichPackageInfo({
+                    ...packageInfo,
+                    wasPreferred: undefined,
+                  });
+                  if (enriched) {
+                    dispatch(setTemporaryDisplayPackageInfo(enriched));
+                  }
+                })
+              }
+              icon={<AutoFixHighIcon sx={clickableIcon} />}
+              key={text.attributionColumn.getUrlAndLegal}
+            />,
+            <IconButton
+              tooltipTitle={
+                text.attributionColumn.packageSubPanel.openLinkInBrowser
+              }
+              tooltipPlacement={'left'}
+              onClick={() => openUrl(packageInfo.url)}
+              hidden={!packageInfo.url}
+              icon={
+                <OpenInNewIcon aria-label={'Url icon'} sx={clickableIcon} />
+              }
+              key={text.attributionColumn.packageSubPanel.openLinkInBrowser}
+            />,
+          ]
         }
       />
     );

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -16,6 +16,7 @@ import { compact } from 'lodash';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { VirtuosoHandle } from 'react-virtuoso';
 
+import { ensureArray } from '../../util/ensure-array';
 import { ClearButton } from '../ClearButton/ClearButton';
 import { PopupIndicator } from '../PopupIndicator/PopupIndicator';
 import {
@@ -44,7 +45,7 @@ type AutocompleteProps<
     | 'renderOptionStartIcon'
   > & {
     ['aria-label']?: string;
-    endAdornment?: React.ReactNode;
+    endAdornment?: React.ReactNode | Array<React.ReactNode>;
     highlight?: 'default' | 'dark';
     inputProps?: MuiInputProps;
     onInputChange?: (
@@ -168,7 +169,11 @@ export function Autocomplete<
           label={title}
           highlight={highlight}
           numberOfEndAdornments={
-            compact([hasClearButton, hasPopupIndicator, !!endAdornment]).length
+            compact([
+              hasClearButton,
+              hasPopupIndicator,
+              ...ensureArray(endAdornment),
+            ]).length
           }
           size={'small'}
           InputLabelProps={getInputLabelProps()}
@@ -177,6 +182,9 @@ export function Autocomplete<
             startAdornment: renderStartAdornment(),
             endAdornment: renderEndAdornment(),
             readOnly,
+            inputProps: {
+              sx: { overflowX: 'hidden', textOverflow: 'ellipsis' },
+            },
           }}
           onKeyDown={(event) => {
             // https://github.com/mui/material-ui/issues/21129

--- a/src/Frontend/Components/InputElements/TextBox.tsx
+++ b/src/Frontend/Components/InputElements/TextBox.tsx
@@ -7,6 +7,7 @@ import MuiInputAdornment from '@mui/material/InputAdornment';
 import MuiTextField from '@mui/material/TextField';
 
 import { HighlightingColor } from '../../enums/enums';
+import { ensureArray } from '../../util/ensure-array';
 import { inputElementClasses, InputElementProps } from './shared';
 
 interface TextBoxProps extends InputElementProps {
@@ -55,11 +56,17 @@ export function TextBox(props: TextBoxProps) {
             sx: {
               overflowX: 'hidden',
               textOverflow: 'ellipsis',
-              padding: '8.5px 14px',
+              paddingTop: '8.5px',
+              paddingBottom: '8.5px',
+              paddingLeft: '14px',
+              paddingRight: `calc(14px + ${ensureArray(props.endIcon).length} * 28px)`,
             },
           },
           endAdornment: props.endIcon && (
-            <MuiInputAdornment sx={{ paddingRight: '14px' }} position="end">
+            <MuiInputAdornment
+              sx={inputElementClasses.endAdornmentRoot}
+              position="end"
+            >
               {props.endIcon}
             </MuiInputAdornment>
           ),

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -49,6 +49,12 @@ export const inputElementClasses = {
       padding: '1px 3px',
     },
   },
+  endAdornmentRoot: {
+    position: 'absolute',
+    right: 0,
+    marginRight: '14px',
+    height: 0,
+  },
 } satisfies SxProps;
 
 export interface InputElementProps {
@@ -63,5 +69,5 @@ export interface InputElementProps {
   isHighlighted?: boolean;
   color?: TextFieldProps['color'];
   focused?: boolean;
-  endIcon?: React.ReactElement;
+  endIcon?: React.ReactElement | Array<React.ReactElement>;
 }

--- a/src/Frontend/util/ensure-array.ts
+++ b/src/Frontend/util/ensure-array.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export function ensureArray<T>(elementOrArray: T | Array<T>): Array<T> {
+  if (Array.isArray(elementOrArray)) {
+    return elementOrArray;
+  }
+  return [elementOrArray];
+}


### PR DESCRIPTION
### Summary of changes

Render end icon left of the scroll bar and keep scroll bar aligned with right edge in multiline text fields with a scroll bar.

### Context and reason for change

Closes [#2558](https://github.com/opossum-tool/OpossumUI/issues/2558)

### How can the changes be tested

Open OpossumUI, put longer strings into the URL and fill the relevant fields to get a PURL. Shrink the window size such that end icons start overlapping with the text. The text overflowing text should be replaced by ellipsis and there should be no overlap between text and icons.
Do the same in the Diff Popup.
