### PR TITLE
fix: keep green or red color when hovering over fields in diff popup

### DIFF
--- a/src/Frontend/Components/Autocomplete/Autocomplete.style.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.style.tsx
@@ -60,7 +60,9 @@ export const Input = styled(MuiTextField, {
       display: 'none',
     },
   },
-  '& .Mui-readOnly:hover fieldset': { borderColor: 'rgba(0, 0, 0, 0.23)' },
+  '& .Mui-readOnly:hover :not(.Mui-focused) fieldset': {
+    borderColor: 'rgba(0, 0, 0, 0.23)',
+  },
 }));
 
 export const StyledPopper = styled((props: PopperProps) => (

--- a/src/Frontend/Components/InputElements/shared.ts
+++ b/src/Frontend/Components/InputElements/shared.ts
@@ -27,7 +27,9 @@ export const inputElementClasses = {
         display: 'none',
       },
     },
-    '& .Mui-readOnly:hover fieldset': { borderColor: 'rgba(0, 0, 0, 0.23)' },
+    '& .Mui-readOnly:hover :not(.Mui-focused) fieldset': {
+      borderColor: 'rgba(0, 0, 0, 0.23)',
+    },
   },
   defaultHighlightedTextField: {
     '& div': {


### PR DESCRIPTION
### Summary of changes

When hovering over green or red fields in the Diff Popup their color should stay the same.

### How can the changes be tested

Start Opossum, open Diff Popup with changes. Hover over colored fields.