### PR TITLE
fix: don't show original license info if signal is of type first party

### DIFF
--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -16,7 +16,10 @@ import {
 import { AttributionForm } from '../AttributionColumn/AttributionForm';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
 import { DiffPopupContainer } from './DiffPopup.style';
-import { useAttributionFormConfigs } from './DiffPopup.util';
+import {
+  stripLicenseInfoIfFirstParty,
+  useAttributionFormConfigs,
+} from './DiffPopup.util';
 
 interface DiffPopupProps {
   original: PackageInfo;
@@ -38,8 +41,8 @@ export function DiffPopup({
     bufferPackageInfo,
     setBufferPackageInfo,
   } = useAttributionFormConfigs({
-    original,
-    current,
+    original: stripLicenseInfoIfFirstParty(original),
+    current: stripLicenseInfoIfFirstParty(current),
   });
 
   function handleApplyChanges({
@@ -120,7 +123,7 @@ export function DiffPopup({
     return (
       <DiffPopupContainer>
         <AttributionForm
-          packageInfo={original}
+          packageInfo={stripLicenseInfoIfFirstParty(original)}
           variant={'diff'}
           label={'original'}
           config={originalFormConfig}

--- a/src/Frontend/Components/DiffPopup/DiffPopup.util.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.util.tsx
@@ -19,16 +19,7 @@ export function useAttributionFormConfigs({
   original: PackageInfo;
   current: PackageInfo;
 }) {
-  const [bufferPackageInfo, setBufferPackageInfo] = useState(
-    current.firstParty
-      ? {
-          ...current,
-          copyright: undefined,
-          licenseName: undefined,
-          licenseText: undefined,
-        }
-      : current,
-  );
+  const [bufferPackageInfo, setBufferPackageInfo] = useState(current);
 
   const getEndIcon = useCallback(
     ({
@@ -212,4 +203,15 @@ export function useAttributionFormConfigs({
     bufferPackageInfo,
     setBufferPackageInfo,
   };
+}
+
+export function stripLicenseInfoIfFirstParty(packageInfo: PackageInfo) {
+  return packageInfo.firstParty
+    ? {
+        ...packageInfo,
+        copyright: undefined,
+        licenseName: undefined,
+        licenseText: undefined,
+      }
+    : packageInfo;
 }


### PR DESCRIPTION


### Summary of changes

in the attribution column we don't show license info fields (name, text, copyright) if an attribution is first party. Thus, we leave this fields empty in the diff popup as well. We did so for the current attribution already, but not for the original signal since the assumption was that it shouldn't come with such info. But the fields were only removed recently and we still get first party signals with license info. Thus, we also remove them from original signals in the diff popup now.

### Context and reason for change

It can be confusing if the original signal displays license info and the current signal doesn't, but no diff is displayed.

### How can the changes be tested

Open Diff Popup for attribution that has first party license info. See that it is not displayed in the Diff Popup anymore.