### PR TITLE
fix: autocomplete end-icon click opens popover

### DIFF
--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -225,18 +225,17 @@ export function Autocomplete<
     }
 
     return (
-      <EndAdornmentContainer>
+      <EndAdornmentContainer
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
         {hasClearButton && (
-          <ClearButton
-            {...(getClearProps() as MuiIconButtonProps)}
-            onMouseDown={(event) => event.stopPropagation()}
-          />
+          <ClearButton {...(getClearProps() as MuiIconButtonProps)} />
         )}
         {hasPopupIndicator && (
           <PopupIndicator
             popupOpen={isPopupOpen}
             {...(getPopupIndicatorProps() as MuiIconButtonProps)}
-            onClick={undefined}
           />
         )}
         {endAdornment}

--- a/src/Frontend/Components/IconButton/IconButton.tsx
+++ b/src/Frontend/Components/IconButton/IconButton.tsx
@@ -13,7 +13,7 @@ interface IconButtonProps {
   tooltipPlacement?: TooltipProps['placement'];
   iconSx?: SxProps;
   containerSx?: SxProps;
-  onClick?(): void;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   icon: ReactElement;
   disabled?: boolean;
   hidden?: boolean;
@@ -39,7 +39,7 @@ export function IconButton(props: IconButtonProps) {
           sx={props.iconSx}
           onClick={(event) => {
             event.stopPropagation();
-            props.onClick?.();
+            props.onClick?.(event);
           }}
           disabled={props.disabled}
           data-testid={props['data-testid']}


### PR DESCRIPTION
### Summary of changes

- stop propagation of mouse-down and click events on end-adornment container

### How can the changes be tested

To reproduce issue on main:

1. Open a file that offers suggestions for repository URLs when you click into the "repository URL" input field of the attribution details.
2. Click on the "magic wand" or "open URL in browser" icon buttons at the end of the input field.
3. Notice that the suggestions popover opens.

Expected: popover should remain closed and only open when the underlying input field is clicked.