### PR TITLE
chore: improve github macos runner performance

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         include:
           - os: ubuntu-latest
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
-          - os: macos-latest
+          - os: macos-13
             E2E: yarn test:e2e:ci
           - os: windows-latest
             E2E: yarn test:e2e:ci


### PR DESCRIPTION
### Summary of changes

Use larger runner: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### Context and reason for change

MacOS runner is the slowest among Linux/Win/MacOS and we want to see if other runners perform better.

### How can the changes be tested

See pipeline output.
