### PR TITLE
fix: zero-sized element in virtualized list

### DIFF
--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
@@ -34,6 +34,7 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
       aria-label={text.packageLists.linkAsAttribution}
       disabled={
         isSelectedResourceBreakpoint ||
+        !selectedAttributionIds.length ||
         isPackageInfoModified ||
         activeRelation === 'resource' ||
         !!attributionIdsForReplacement.length

--- a/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
@@ -117,9 +117,9 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
           })}
         </MuiTypography>
         <CardList
-          data={attributionIdsToDelete}
+          data={attributionIdsToDelete.filter((id) => id in attributions)}
           renderItemContent={(attributionId, { index }) => {
-            if (!attributionId || !(attributionId in attributions)) {
+            if (!attributions[attributionId]) {
               return null;
             }
 

--- a/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
+++ b/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
@@ -96,10 +96,10 @@ export const ConfirmReplacePopup = ({
           )}
         </MuiTypography>
         <CardList
-          data={attributionIdsForReplacement}
+          data={attributionIdsForReplacement.filter((id) => id in attributions)}
           data-testid={'removed-attributions'}
           renderItemContent={(attributionId, { index }) => {
-            if (!attributionId || !(attributionId in attributions)) {
+            if (!attributions[attributionId]) {
               return null;
             }
 

--- a/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
+++ b/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
@@ -146,9 +146,9 @@ export const ConfirmSavePopup: React.FC<Props> = ({
           })}
         </MuiTypography>
         <CardList
-          data={attributionIdsToSave}
+          data={attributionIdsToSave.filter((id) => id in attributions)}
           renderItemContent={(attributionId, { index }) => {
-            if (!attributionId || !(attributionId in attributions)) {
+            if (!attributions[attributionId]) {
               return null;
             }
 


### PR DESCRIPTION
### Summary of changes

- filter IDs passed as data to virtuoso for existence among attribution IDs

### Context and reason for change

When you delete all attributions at once you get the following console error:
![image](https://github.com/opossum-tool/OpossumUI/assets/46091730/a27efe79-0570-43fd-a879-a9e335f08b70)

This happens because for a few render cycles we're still passing attribution IDs to virtuoso whose corresponding attributions have already been deleted.

### How can the changes be tested

Delete all attributions at once and notice that no console error occurs.