### PR TITLE
chore: auto-update minor/patch versions of node

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -75,6 +75,11 @@
       automerge: true,
     },
     {
+      matchPackageNames: ['node'],
+      matchUpdateTypes: ['minor', 'patch'],
+      automerge: true,
+    },
+    {
       matchPackagePrefixes: ['@typescript-eslint/'],
       groupName: 'TypeScript ESLint dependencies',
       groupSlug: 'typescript-eslint',


### PR DESCRIPTION
### Summary of changes

Auto-update minor/patch versions of node, without touching the engine field.

### Context and reason for change

Node was not in the list of packages that we let Renovate automerge for minor versions and patches. I've added an extra field for it, insterad of including it in the main list, as like yarn it isn't just a package pulled in by the package manager.

