### PR TITLE
feat: improve error message in case of parsing issues with the input file

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -9,6 +9,7 @@ import * as zlib from 'zlib';
 import { EMPTY_PROJECT_METADATA } from '../../../Frontend/shared-constants';
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { Criticality, ParsedFileContent } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
 import { writeFile, writeOpossumFile } from '../../../shared/write-file';
 import { faker } from '../../../testing/Faker';
 import {
@@ -631,7 +632,7 @@ describe('getMessageBoxForParsingError', () => {
       expect.objectContaining({
         type: 'error',
         message: 'Error parsing the input file.',
-        detail: 'parsingErrorMessage',
+        detail: `parsingErrorMessage\n${text.errorBoundary.outdatedAppVersion}`,
         buttons: ['OK'],
       }),
     );

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -14,6 +14,7 @@ import {
   ParsedFileContent,
   ResourcesToAttributions,
 } from '../../shared/shared-types';
+import { text } from '../../shared/text';
 import { writeFile, writeOpossumFile } from '../../shared/write-file';
 import { getGlobalBackendState } from '../main/globalBackendState';
 import logger from '../main/logger';
@@ -215,8 +216,7 @@ async function createOutputInOpossumFile(
   const parsingResult = (await parseOpossumFile(
     filePath,
   )) as ParsedOpossumInputAndOutput;
-  const parsedOutputFile = parsingResult.output as ParsedOpossumOutputFile;
-  return parsedOutputFile;
+  return parsingResult.output as ParsedOpossumOutputFile;
 }
 
 async function parseOrCreateOutputJsonFile(
@@ -238,8 +238,7 @@ async function parseOrCreateOutputJsonFile(
   }
 
   logger.info('Parsing output');
-  const parsedOutputFile = parseOutputJsonFile(filePath);
-  return parsedOutputFile;
+  return parseOutputJsonFile(filePath);
 }
 
 function createJsonOutputFile(
@@ -306,7 +305,7 @@ export async function getMessageBoxForParsingError(
     defaultId: 0,
     title: 'Parsing Error',
     message: 'Error parsing the input file.',
-    detail: errorMessage,
+    detail: `${errorMessage}\n${text.errorBoundary.outdatedAppVersion}`,
   });
 }
 

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -232,6 +232,8 @@ export const text = {
     revertAll: 'Revert all',
   },
   errorBoundary: {
+    outdatedAppVersion:
+      'This might be caused by an outdated version of the app. Make sure you are using the newest version of the app to open the file.',
     unexpectedError: "We're sorry, an unexpected error occurred!",
     relaunch: 'Relaunch App',
     quit: 'Quit App',


### PR DESCRIPTION
### Summary of changes

If the app is not able to parse the opossum file it might be that the version of the app used is outdated. This PR adds a hint to the error message to use the newest version of the app if there is a problem parsing the input file. 

### Context and reason for change

fixes issue #2099

### How can the changes be tested

See CI, I updated the correpsonding unit tests. 
