### PR TITLE
feat: add button to jump through unresolved resources

### DIFF
--- a/src/Frontend/Components/ProgressBarWithButtons/ProgressBarWithButtons.tsx
+++ b/src/Frontend/Components/ProgressBarWithButtons/ProgressBarWithButtons.tsx
@@ -1,13 +1,16 @@
-// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPD-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import NextPlanIcon from '@mui/icons-material/NextPlan';
 import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import { ReactElement } from 'react';
 
 import { text } from '../../../shared/text';
+import { OpossumColors } from '../../shared-styles';
 import { ProgressBarWithButtonsData } from '../../types/types';
+import { IconButton } from '../IconButton/IconButton';
 import { ProgressBar } from '../ProgressBar/ProgressBar';
 import { useOnProgressBarClick } from '../ProgressBar/ProgressBar.util';
 import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
@@ -16,11 +19,23 @@ const classes = {
   progressBarContainer: {
     flex: 1,
     display: 'flex',
-    marginLeft: '12px',
+    marginLeft: '2px',
     marginRight: '12px',
   },
   switch: {
     margin: 'auto',
+  },
+  jumpFileIcon: {
+    margin: '8px',
+    marginRight: '4px',
+    marginLeft: '12px',
+    width: '18px',
+    height: '18px',
+    padding: '2px',
+    color: OpossumColors.white,
+    '&:hover': {
+      background: OpossumColors.middleBlue,
+    },
   },
 };
 
@@ -58,6 +73,18 @@ export function ProgressBarWithButtons({
 
   return (
     <>
+      <IconButton
+        tooltipTitle={
+          showCriticalSignals
+            ? text.progressBarButtons.jumpButtonTooltipCritical
+            : text.progressBarButtons.jumpButtonTooltipProgress
+        }
+        tooltipPlacement="right"
+        onClick={onJumpClick}
+        icon={
+          <NextPlanIcon sx={classes.jumpFileIcon} aria-label={'JumpButton'} />
+        }
+      />
       <MuiBox sx={classes.progressBarContainer}>
         <ProgressBar
           sx={classes.progressBarContainer}

--- a/src/Frontend/Components/ProgressBarWithButtons/__tests__/ProgressBarWithButtons.test.tsx
+++ b/src/Frontend/Components/ProgressBarWithButtons/__tests__/ProgressBarWithButtons.test.tsx
@@ -56,52 +56,58 @@ describe('ProgressBarWithButtons', () => {
     expect(screen.getByText(/with only signals: 1/)).toBeInTheDocument();
   });
 
-  it('click on regular progress bar goes to next resource with non-inherited external attributions only', async () => {
-    const resourceName1 = faker.opossum.resourceName();
-    const resourceId1 = faker.opossum.filePath(resourceName1);
-    const resourceName2 = faker.opossum.resourceName();
-    const resourceId2 = faker.opossum.filePath(resourceName2);
-    const { store } = renderComponent(
-      <ProgressBarWithButtons
-        showCriticalSignals={false}
-        progressBarWithButtonsData={{
-          count: {
-            files: 6,
-            filesWithHighlyCriticalExternalAttributions: 1,
-            filesWithMediumCriticalExternalAttributions: 1,
-            filesWithManualAttribution: 3,
-            filesWithOnlyExternalAttribution: 1,
-            filesWithOnlyPreSelectedAttribution: 1,
-          },
-          resources: {
-            withMediumCriticalExternalAttributions: [],
-            withNonInheritedExternalAttributionOnly: [resourceId1, resourceId2],
-            withHighlyCriticalExternalAttributions: [],
-          },
-        }}
-        onSwitchClick={() => {}}
-      />,
-      { actions: [setResources({ [resourceName1]: 1, [resourceName2]: 1 })] },
-    );
+  it.each<[string]>([['ProgressBar'], ['JumpButton']])(
+    'click on regular %s goes to next resource with non-inherited external attributions only',
+    async (ariaLabel: string) => {
+      const resourceName1 = faker.opossum.resourceName();
+      const resourceId1 = faker.opossum.filePath(resourceName1);
+      const resourceName2 = faker.opossum.resourceName();
+      const resourceId2 = faker.opossum.filePath(resourceName2);
+      const { store } = renderComponent(
+        <ProgressBarWithButtons
+          showCriticalSignals={false}
+          progressBarWithButtonsData={{
+            count: {
+              files: 6,
+              filesWithHighlyCriticalExternalAttributions: 1,
+              filesWithMediumCriticalExternalAttributions: 1,
+              filesWithManualAttribution: 3,
+              filesWithOnlyExternalAttribution: 1,
+              filesWithOnlyPreSelectedAttribution: 1,
+            },
+            resources: {
+              withMediumCriticalExternalAttributions: [],
+              withNonInheritedExternalAttributionOnly: [
+                resourceId1,
+                resourceId2,
+              ],
+              withHighlyCriticalExternalAttributions: [],
+            },
+          }}
+          onSwitchClick={() => {}}
+        />,
+        { actions: [setResources({ [resourceName1]: 1, [resourceName2]: 1 })] },
+      );
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId2);
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId2);
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
-  });
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
+    },
+  );
 
   it('renders criticality progress bar', async () => {
     renderComponent(
@@ -144,50 +150,53 @@ describe('ProgressBarWithButtons', () => {
     ).toBeInTheDocument();
   });
 
-  it('click on criticality progress bar goes to next resource with a critical attribution', async () => {
-    const resourceName1 = faker.opossum.resourceName();
-    const resourceId1 = faker.opossum.filePath(resourceName1);
-    const resourceName2 = faker.opossum.resourceName();
-    const resourceId2 = faker.opossum.filePath(resourceName2);
-    const { store } = renderComponent(
-      <ProgressBarWithButtons
-        showCriticalSignals
-        progressBarWithButtonsData={{
-          count: {
-            files: 6,
-            filesWithHighlyCriticalExternalAttributions: 1,
-            filesWithMediumCriticalExternalAttributions: 1,
-            filesWithManualAttribution: 1,
-            filesWithOnlyExternalAttribution: 3,
-            filesWithOnlyPreSelectedAttribution: 1,
-          },
-          resources: {
-            withMediumCriticalExternalAttributions: [resourceId1],
-            withNonInheritedExternalAttributionOnly: [],
-            withHighlyCriticalExternalAttributions: [resourceId2],
-          },
-        }}
-        onSwitchClick={() => {}}
-      />,
-      { actions: [setResources({ [resourceName1]: 1, [resourceName2]: 1 })] },
-    );
+  it.each<[string]>([['ProgressBar'], ['JumpButton']])(
+    'click on criticality %s goes to next resource with a critical attribution',
+    async (ariaLabel: string) => {
+      const resourceName1 = faker.opossum.resourceName();
+      const resourceId1 = faker.opossum.filePath(resourceName1);
+      const resourceName2 = faker.opossum.resourceName();
+      const resourceId2 = faker.opossum.filePath(resourceName2);
+      const { store } = renderComponent(
+        <ProgressBarWithButtons
+          showCriticalSignals
+          progressBarWithButtonsData={{
+            count: {
+              files: 6,
+              filesWithHighlyCriticalExternalAttributions: 1,
+              filesWithMediumCriticalExternalAttributions: 1,
+              filesWithManualAttribution: 1,
+              filesWithOnlyExternalAttribution: 3,
+              filesWithOnlyPreSelectedAttribution: 1,
+            },
+            resources: {
+              withMediumCriticalExternalAttributions: [resourceId1],
+              withNonInheritedExternalAttributionOnly: [],
+              withHighlyCriticalExternalAttributions: [resourceId2],
+            },
+          }}
+          onSwitchClick={() => {}}
+        />,
+        { actions: [setResources({ [resourceName1]: 1, [resourceName2]: 1 })] },
+      );
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId2);
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId2);
 
-    await userEvent.click(screen.getByLabelText('ProgressBar'), {
-      advanceTimers: jest.runOnlyPendingTimersAsync,
-    });
+      await userEvent.click(screen.getByLabelText(ariaLabel), {
+        advanceTimers: jest.runOnlyPendingTimersAsync,
+      });
 
-    expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
-  });
+      expect(getSelectedResourceId(store.getState())).toBe(resourceId1);
+    },
+  );
 });

--- a/src/e2e-tests/__tests__/interacting-with-resources.test.ts
+++ b/src/e2e-tests/__tests__/interacting-with-resources.test.ts
@@ -90,6 +90,35 @@ test('cycles through resources as user clicks on progress bar', async ({
   await signalsPanel.packageCard.assert.isVisible(packageInfo1);
 });
 
+test('cycles through resources as user clicks on jump button next to progress bar', async ({
+  signalsPanel,
+  topBar,
+}) => {
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo1);
+  await signalsPanel.packageCard.click(packageInfo1);
+
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo2);
+  await signalsPanel.packageCard.click(packageInfo2);
+
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo3);
+  await signalsPanel.packageCard.click(packageInfo3);
+
+  await signalsPanel.linkButton.click();
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo1);
+  await signalsPanel.packageCard.click(packageInfo1);
+
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo2);
+  await signalsPanel.packageCard.click(packageInfo2);
+
+  await topBar.jumpButton.click();
+  await signalsPanel.packageCard.assert.isVisible(packageInfo1);
+});
+
 test('shows expected breadcrumbs as user navigates through browser history', async ({
   modKey,
   resourcesTree,

--- a/src/e2e-tests/page-objects/TopBar.ts
+++ b/src/e2e-tests/page-objects/TopBar.ts
@@ -14,6 +14,8 @@ export class TopBar {
   readonly progressBar: Locator;
   readonly openFileButton: Locator;
   readonly tooltip: Locator;
+  readonly jumpButton: Locator;
+
   constructor(window: Page) {
     this.window = window;
     this.node = window.getByLabel('top bar');
@@ -22,6 +24,10 @@ export class TopBar {
     this.progressBar = this.node.getByLabel('ProgressBar');
     this.openFileButton = this.node.getByRole('button', { name: 'open file' });
     this.tooltip = this.window.getByRole('tooltip');
+    this.jumpButton = this.node.getByRole('button', {
+      name: 'jump to next',
+      exact: false,
+    });
   }
 
   public assert = {


### PR DESCRIPTION
### Summary of changes

This diff adds a button next to the progress bar, that performs the same action as the progress bar if it is clicked: jumping to the next resource with unresolved signals or critical signals, depending on the setting of the progress bar.

### Context and reason for change

Closes #2069.

### How can the changes be tested

Unit tests.
Added e2e test.
Manually.
