### PR TITLE
fix: enable menu items if .gz or .json is opened

### DIFF
--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -140,7 +140,6 @@ export async function handleOpeningFile(
   }
 
   await openFile(mainWindow, filePath);
-  activateMenuItems();
 }
 
 function initializeGlobalBackendState(
@@ -241,6 +240,7 @@ export async function openFile(
   try {
     await loadInputAndOutputFromFilePath(mainWindow, filePath);
     setTitle(mainWindow, filePath);
+    activateMenuItems();
   } finally {
     setLoadingState(mainWindow.webContents, false);
   }


### PR DESCRIPTION
### Summary of changes

Enable menu items in `openFile` function.

### Context and reason for change

Fix  #2621. If .gz or .json files are opened it doesn't enable menu items.

### How can the changes be tested

manually.
