### PR TITLE
feat: ignore hidden signals in project statistics

### DIFF
--- a/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
+++ b/src/Frontend/Components/CriticalLicensesTable/CriticalLicensesTable.tsx
@@ -6,16 +6,16 @@ import { sortBy } from 'lodash';
 import { ReactElement } from 'react';
 
 import { Criticality } from '../../../shared/shared-types';
+import { text } from '../../../shared/text';
 import { clickableIcon } from '../../shared-styles';
 import { LicenseNamesWithCriticality } from '../../types/types';
 import { ProjectLicensesTable } from '../ProjectLicensesTable/ProjectLicensesTable';
 
 const LICENSE_COLUMN_NAME_IN_TABLE = 'License name';
-const COUNT_COLUMN_NAME_IN_TABLE = 'Signals Count';
 const FOOTER_TITLE = 'Total';
 const TABLE_COLUMN_NAMES = [
   LICENSE_COLUMN_NAME_IN_TABLE,
-  COUNT_COLUMN_NAME_IN_TABLE,
+  text.projectStatisticsPopup.criticalLicensesSignalCountColumnName,
 ];
 
 const classes = {
@@ -93,7 +93,9 @@ export function CriticalLicensesTable(
           ({ licenseName, totalNumberOfAttributions }) => [
             licenseName,
             {
-              [COUNT_COLUMN_NAME_IN_TABLE]: totalNumberOfAttributions,
+              [text.projectStatisticsPopup
+                .criticalLicensesSignalCountColumnName]:
+                totalNumberOfAttributions,
             },
           ],
         ),

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -11,9 +11,9 @@ import { ProjectStatisticsPopupTitle } from '../../enums/enums';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
-  getExternalAttributions,
   getExternalAttributionSources,
   getManualAttributions,
+  getUnresolvedExternalAttributions,
 } from '../../state/selectors/resource-selectors';
 import { useUserSetting } from '../../state/variables/use-user-setting';
 import { AccordionWithPieChart } from '../AccordionWithPieChart/AccordionWithPieChart';
@@ -41,15 +41,19 @@ export function ProjectStatisticsPopup(): ReactElement {
   const dispatch = useAppDispatch();
 
   const manualAttributions = useAppSelector(getManualAttributions);
-  const externalAttributions = useAppSelector(getExternalAttributions);
   const attributionSources = useAppSelector(getExternalAttributionSources);
 
-  const strippedLicenseNameToAttribution =
-    getUniqueLicenseNameToAttribution(externalAttributions);
+  const unresolvedExternalAttribution = useAppSelector(
+    getUnresolvedExternalAttributions,
+  );
+
+  const strippedLicenseNameToAttribution = getUniqueLicenseNameToAttribution(
+    unresolvedExternalAttribution,
+  );
 
   const { licenseCounts, licenseNamesWithCriticality } =
     aggregateLicensesAndSourcesFromAttributions(
-      externalAttributions,
+      unresolvedExternalAttribution,
       strippedLicenseNameToAttribution,
       attributionSources,
     );

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.tsx
@@ -86,6 +86,7 @@ export function ResourcesTreeNode({ node, nodeId, nodeName }: TreeNode) {
         nodeId,
         resourcesToExternalAttributions,
         externalAttributions,
+        resolvedExternalAttributions,
       )}
       isAttributionBreakpoint={attributionBreakpoints.has(nodeId)}
       showFolderIcon={canHaveChildren && !filesWithChildren.has(nodeId)}

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
@@ -16,11 +16,19 @@ export function getCriticality(
   nodeId: string,
   resourcesToExternalAttributions: ResourcesToAttributions,
   externalAttributions: Attributions,
+  resolvedExternalAttributions: Set<string>,
 ): Criticality | undefined {
-  if (hasExternalAttribution(nodeId, resourcesToExternalAttributions)) {
+  if (
+    hasUnresolvedExternalAttribution(
+      nodeId,
+      resourcesToExternalAttributions,
+      resolvedExternalAttributions,
+    )
+  ) {
     const attributionsForResource = resourcesToExternalAttributions[nodeId];
     for (const attributionId of attributionsForResource) {
       if (
+        !resolvedExternalAttributions.has(attributionId) &&
         externalAttributions[attributionId].criticality === Criticality.High
       ) {
         return Criticality.High;
@@ -29,6 +37,7 @@ export function getCriticality(
 
     for (const attributionId of attributionsForResource) {
       if (
+        !resolvedExternalAttributions.has(attributionId) &&
         externalAttributions[attributionId].criticality === Criticality.Medium
       ) {
         return Criticality.Medium;

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
@@ -93,7 +93,7 @@ export function ResourcesTreeNodeLabel(props: Props): ReactElement {
       >
         {props.labelText}
       </MuiTypography>
-      {props.hasExternalAttribution &&
+      {props.hasUnresolvedExternalAttribution &&
         (props.criticality ? (
           <CriticalityIcon
             criticality={props.criticality}

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
@@ -80,7 +80,7 @@ describe('ResourcesTreeNodeLabel', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a folder with resolved signal and icon', () => {
+  it('renders a folder with resolved signal but without criticality icon', () => {
     render(
       <ResourcesTreeNodeLabel
         labelText={'Test label'}
@@ -99,7 +99,6 @@ describe('ResourcesTreeNodeLabel', () => {
     );
 
     expect(screen.getByText('Test label')).toBeInTheDocument();
-    expect(screen.getByLabelText('Criticality icon')).toBeInTheDocument();
     expect(
       screen.getByLabelText('Directory icon without information'),
     ).toBeInTheDocument();

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
@@ -38,6 +38,7 @@ describe('ResourcesTreeNode', () => {
         nodeId,
         resourcesToExternalAttributions,
         externalAttributions,
+        new Set(),
       );
       expect(criticality).toEqual(expectedCriticalities[nodeId]);
     }

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/__tests__/ResourcesTree.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/__tests__/ResourcesTree.test.tsx
@@ -206,7 +206,7 @@ describe('ResourcesTree', () => {
     act(() => {
       store.dispatch(addResolvedExternalAttributions([testUuid]));
     });
-    expectIconToExist(screen, 'Criticality icon', 'src', true);
+    expectIconToExist(screen, 'Criticality icon', 'src', false);
     expectResourceIconLabelToBe(
       screen,
       'src',

--- a/src/Frontend/state/selectors/resource-selectors.ts
+++ b/src/Frontend/state/selectors/resource-selectors.ts
@@ -50,6 +50,15 @@ export function getResolvedExternalAttributions(state: State): Set<string> {
   return state.resourceState.resolvedExternalAttributions;
 }
 
+export function getUnresolvedExternalAttributions(state: State): Attributions {
+  return Object.fromEntries(
+    Object.entries(state.resourceState.externalData.attributions).filter(
+      ([attributionId]) =>
+        !state.resourceState.resolvedExternalAttributions.has(attributionId),
+    ),
+  );
+}
+
 export function getExpandedIds(state: State): Array<string> {
   return state.resourceState.expandedIds;
 }

--- a/src/e2e-tests/__tests__/project-statistics.test.ts
+++ b/src/e2e-tests/__tests__/project-statistics.test.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Criticality } from '../../shared/shared-types';
+import { faker, test } from '../utils';
+
+const [resourceName1] = faker.opossum.resourceNames({ count: 1 });
+const [attributionId1, packageInfo1] = faker.opossum.rawAttribution({
+  criticality: Criticality.Medium,
+});
+const [attributionId3, packageInfo3] = faker.opossum.rawAttribution({
+  criticality: Criticality.Medium,
+});
+test.use({
+  data: {
+    inputData: faker.opossum.inputData({
+      resources: faker.opossum.resources({
+        [resourceName1]: 1,
+      }),
+      externalAttributions: faker.opossum.rawAttributions({
+        [attributionId1]: packageInfo1,
+        [attributionId3]: packageInfo3,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName1)]: [
+          attributionId1,
+          attributionId3,
+        ],
+      }),
+    }),
+    outputData: faker.opossum.outputData({}),
+  },
+});
+
+test('opens, displays, and closes project statistics', async ({
+  menuBar,
+  projectStatisticsPopup,
+}) => {
+  await menuBar.openProjectStatistics();
+  await projectStatisticsPopup.assert.titleIsVisible();
+
+  await projectStatisticsPopup.closeButton.click();
+  await projectStatisticsPopup.assert.titleIsHidden();
+});
+
+test('hidden signals are ignored for project statistics', async ({
+  menuBar,
+  projectStatisticsPopup,
+  resourcesTree,
+  signalsPanel,
+  attributionDetails,
+}) => {
+  await menuBar.openProjectStatistics();
+  await projectStatisticsPopup.assert.titleIsVisible();
+
+  await projectStatisticsPopup.assert.criticalLicenseCount(2);
+
+  await projectStatisticsPopup.closeButton.click();
+  await resourcesTree.goto(resourceName1);
+
+  await signalsPanel.packageCard.assert.isVisible(packageInfo1);
+  await signalsPanel.packageCard.assert.isVisible(packageInfo3);
+
+  await signalsPanel.packageCard.click(packageInfo3);
+  await attributionDetails.deleteButton.click();
+  await signalsPanel.packageCard.assert.isHidden(packageInfo3);
+
+  await menuBar.openProjectStatistics();
+  await projectStatisticsPopup.assert.criticalLicenseCount(1);
+});

--- a/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
+++ b/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
@@ -4,15 +4,28 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import { text } from '../../shared/text';
+
 export class ProjectStatisticsPopup {
   private readonly node: Locator;
   readonly title: Locator;
   readonly closeButton: Locator;
+  readonly totalCriticalLicensesCount: Locator;
 
   constructor(window: Page) {
     this.node = window.getByLabel('project statistics');
-    this.title = this.node.getByText('Project Statistics');
+    this.title = this.node.getByRole('heading').getByText('Project Statistics');
     this.closeButton = this.node.getByRole('button', { name: 'Close' });
+    const signalsCount = window.getByText(
+      text.projectStatisticsPopup.criticalLicensesSignalCountColumnName,
+    );
+    this.totalCriticalLicensesCount = this.node
+      .getByRole('table')
+      .filter({ has: signalsCount })
+      .getByRole('row')
+      .last()
+      .getByRole('cell')
+      .last();
   }
 
   public assert = {
@@ -21,6 +34,11 @@ export class ProjectStatisticsPopup {
     },
     titleIsHidden: async (): Promise<void> => {
       await expect(this.title).toBeHidden();
+    },
+    criticalLicenseCount: async (count: number): Promise<void> => {
+      await expect(this.totalCriticalLicensesCount).toContainText(
+        count.toString(),
+      );
     },
   };
 }

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -102,6 +102,7 @@ export const text = {
   projectStatisticsPopup: {
     title: 'Project Statistics',
     toggleStartupCheckbox: 'Show project statistics on startup',
+    criticalLicensesSignalCountColumnName: 'Signals Count',
   },
   unsavedChangesPopup: {
     title: 'Unsaved Changes',


### PR DESCRIPTION
### Summary of changes

We reverted the changes from #2617 because the performance of the project statistics popup was too bad. This PR adds the feature back in again, but we need to fix the performance issues.

### Context and reason for change

fixes issue #2227
(cherry picked from commit b50de5ff2fb08d84a4051800d058c1ff2b0c0b2c)
