### PR TITLE
fix: discard-and-proceed not working when creating new attribution

### DIFF
--- a/src/Frontend/state/actions/resource-actions/navigation-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/navigation-actions.ts
@@ -36,12 +36,12 @@ export function setSelectedResourceOrAttributionIdToTargetValue(): AppThunkActio
     const targetSelectedAttributionId =
       getTargetSelectedAttributionId(getState());
 
-    if (targetSelectedResourceId) {
+    if (targetSelectedResourceId !== null) {
       dispatch(setSelectedResourceId(targetSelectedResourceId));
       dispatch(setTargetSelectedResourceId(null));
     }
 
-    if (targetSelectedAttributionId) {
+    if (targetSelectedAttributionId !== null) {
       dispatch(setSelectedAttributionId(targetSelectedAttributionId));
       dispatch(setTargetSelectedAttributionId(null));
     }

--- a/src/e2e-tests/__tests__/updating-attributions.test.ts
+++ b/src/e2e-tests/__tests__/updating-attributions.test.ts
@@ -97,9 +97,7 @@ test('warns user of unsaved changes if user attempts to navigate away before sav
   await notSavedPopup.assert.isVisible();
 
   await notSavedPopup.discardButton.click();
-  await attributionDetails.attributionForm.assert.matchesPackageInfo(
-    packageInfo1,
-  );
+  await attributionDetails.attributionForm.assert.isEmpty();
 
   await attributionDetails.attributionForm.comment.fill(
     faker.lorem.sentences(),


### PR DESCRIPTION
### Summary of changes

- adjust check setting the selected attribution to distinguish between null and empty string

### Context and reason for change

Fixes #2635

### How can the changes be tested

Make a change to an attribution and try to create a new attribution. Notice that discard-and-proceed then works as expected and shows an empty attribution.