### PR TITLE
fix: change field "license name" to "license expression"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ SPDX-License-Identifier: CC0-1.0
 - **[Benedikt Richter](https://github.com/benedikt-richter)** (<benedikt.richter@tngtech.com>)
 - **[Benjamin Petek](https://github.com/b-petek)**
 - **[David Mundelius](https://github.com/davidmundelius)** (<david.mundelius@tngtech.com>)
+- **[Dominikus Hellgartner](https://github.com/Hellgartner)** (<dominikus.hellgartner@tngtech.com>)
 - **[Florian Schepers](https://github.com/FlorianSchepers)** (<florian.schepers@tngtech.com>)
 - **[Indira Bhatt](https://github.com/indirabhatt)** (<Indira.bhatt@gmail.com>)
 - **[Jakob Schubert](https://github.com/JakobSchubert)**

--- a/src/Frontend/Components/AttributionForm/LicenseSubPanel/LicenseSubPanel.tsx
+++ b/src/Frontend/Components/AttributionForm/LicenseSubPanel/LicenseSubPanel.tsx
@@ -77,7 +77,7 @@ export function LicenseSubPanel({
       <MuiBox display={'flex'} alignItems={'center'} gap={'8px'}>
         <PackageAutocomplete
           attribute={'licenseName'}
-          title={text.attributionColumn.licenseName}
+          title={text.attributionColumn.licenseExpression}
           packageInfo={packageInfo}
           readOnly={!onEdit}
           showHighlight={showHighlight}

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -267,6 +267,16 @@ describe('AttributionForm', () => {
     renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
     expect(screen.queryByLabelText('Copyright')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('License Name')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('License Expression'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does show copyright or license name fields when attribution is third party', () => {
+    const packageInfo = faker.opossum.packageInfo({ firstParty: false });
+    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+    expect(screen.getByLabelText('Copyright')).toBeInTheDocument();
+    expect(screen.getByLabelText('License Expression')).toBeInTheDocument();
   });
 });

--- a/src/e2e-tests/page-objects/AttributionForm.ts
+++ b/src/e2e-tests/page-objects/AttributionForm.ts
@@ -77,7 +77,7 @@ export class AttributionForm {
     this.comment = this.node.getByLabel('Comment', { exact: true });
     this.copyright = this.node.getByLabel('Copyright', { exact: true });
     this.licenseName = this.node.getByLabel(
-      text.attributionColumn.licenseName,
+      text.attributionColumn.licenseExpression,
       {
         exact: true,
       },

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -25,6 +25,7 @@ export const text = {
     invalidPurl: 'INVALID PURL',
     legalInformation: 'Legal Information',
     licenseName: 'License Name',
+    licenseExpression: 'License Expression',
     licenseText: 'License Text',
     licenseTextDefault: 'License Text (inferred from license name)',
     link: 'Link as attribution on selected resource',

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -24,7 +24,6 @@ export const text = {
     homepage: 'Homepage',
     invalidPurl: 'INVALID PURL',
     legalInformation: 'Legal Information',
-    licenseName: 'License Name',
     licenseExpression: 'License Expression',
     licenseText: 'License Text',
     licenseTextDefault: 'License Text (inferred from license name)',


### PR DESCRIPTION
### Summary of changes

Change the label for the license name field to license expression as it better describes the actual possibilities

### Context and reason for change

The field "license name" can be used to enter license expressions. Since not every license expression is a license name but the converse is true, it would be more correct to name the field "license expression".

Fixes https://github.com/opossum-tool/OpossumUI/issues/2689

### How can the changes be tested

* Open the new version of Opossum UI
* Load any file
* Check any attribution
![image](https://github.com/user-attachments/assets/8d28d1f0-a419-4813-a722-889fddf7fade)

See also 

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
