### PR TITLE
Fix fix ubuntu image for e2e tests

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
           - os: macos-13

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-code-quality:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     env:

--- a/.github/workflows/check-license-compliance.yml
+++ b/.github/workflows/check-license-compliance.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-license-compliance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             FILE: release/linux/OpossumUI-for-linux.AppImage
           - os: macos-latest
             FILE: release/mac/OpossumUI-for-mac.zip

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "dpdm": "^3.14.0",
-    "electron": "33.2.1",
+    "electron": "33.3.0",
     "electron-builder": "^25.1.8",
     "electron-playwright-helpers": "^1.7.1",
     "eslint": "^9.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6020,16 +6020,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:33.2.1":
-  version: 33.2.1
-  resolution: "electron@npm:33.2.1"
+"electron@npm:33.3.0":
+  version: 33.3.0
+  resolution: "electron@npm:33.3.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^20.9.0"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/1f7e4e61fe949503a79e08c91fc6a914216868176907b0586c4d47a720f0d16c42cb0594f30efa0608c316e992426befc0b6b214702bf1c4e2bd77115959efec
+  checksum: 10/b2494b39c7a4872bb732ec6c2c0673cc6e375231d19e18708116582f709e4a1a0aea155b8d5134552e7c98872f1d1947930bf40b96f02a7cc611ffd9884256c9
   languageName: node
   linkType: hard
 
@@ -10020,7 +10020,7 @@ __metadata:
     dayjs: "npm:^1.11.13"
     dotenv: "npm:^16.4.7"
     dpdm: "npm:^3.14.0"
-    electron: "npm:33.2.1"
+    electron: "npm:33.3.0"
     electron-builder: "npm:^25.1.8"
     electron-log: "npm:^5.2.4"
     electron-playwright-helpers: "npm:^1.7.1"


### PR DESCRIPTION
### Summary of changes

Fix ubuntu image for e2e tests

### Context and reason for change

The  currently used image `ubuntu-latest` silently switched to 24.04 which has some problems with app images and especially with app images containing Electron apps

* See 
   * https://github.com/electron/electron/issues/41066
   * https://itsfoss.com/cant-run-appimage-ubuntu/ 

### How can the changes be tested

e2e tests successful

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
