### PR TITLE
chore(deps): ignore ubuntu dependency in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -148,5 +148,10 @@
       matchDepTypes: ['engines'],
       enabled: false,
     },
+    {
+      description: 'Ignore ubuntu dependency as ubuntu v24 does is not compatible with app image and electron',
+      matchDepTypes: ['ubuntu'],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
Ignore ubuntu dependency in renovate bot as this would currently break our e2e test
Reason: AppImages containing Electron no longer work in Ubuntu24.0+

See also 984ac318e88d49bb898bd07f5390ad9eb5eb7a50

### Summary of changes

Make renovate ignore the ubuntu dependency

### Context and reason for change

Ignore ubuntu dependency in renovate bot as this would currently break our e2e test
Reason: AppImages containing Electron no longer work in Ubuntu24.0+

See also 984ac318e88d49bb898bd07f5390ad9eb5eb7a50
### How can the changes be tested

Look at the renovate dashboard / branches to ensure that renovate no longer tries to update the ubuntu dependency

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
