### PR TITLE
chore: upgrade github hosted runners

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-22.04-arm, macos-latest, windows-latest]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
-          - os: macos-13
+          - os: macos-latest
             E2E: yarn test:e2e:ci
           - os: windows-latest
             E2E: yarn test:e2e:ci

--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-code-quality:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     env:

--- a/.github/workflows/check-license-compliance.yml
+++ b/.github/workflows/check-license-compliance.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-license-compliance:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             FILE: release/linux/OpossumUI-for-linux.AppImage
           - os: macos-latest
             FILE: release/mac/OpossumUI-for-mac.zip


### PR DESCRIPTION
### Summary of changes

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md