### PR TITLE
feat: reset license text

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,6 +5,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn commitlint --edit ${1}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Please note, that there seem to be some issues with this plugin. It can help to 
 
 ### Debugging the end-to-end tests
 
-Each executed end-to-end test creates artifacts in the folder `src/e2e-tests/artifacts`. The artifacts contain the auto-generated .opossum file that the test was run against and, in case the test failed, a Playwright trace file.
+Each executed end-to-end test creates artifacts in the folder `src/e2e-tests/artifacts`. The artifacts contain the auto-generated .opossum file that the test was run against and a Playwright trace file.
 
 The trace file includes screenshots and DOM snapshots at each step of the test up to the failure. You can open this file (do not unzip it!) in your browser by going to the [Playwright Trace Viewer](https://trace.playwright.dev/).
 

--- a/src/Frontend/Components/AttributionForm/PackageAutocomplete/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionForm/PackageAutocomplete/PackageAutocomplete.tsx
@@ -129,7 +129,7 @@ export function PackageAutocomplete({
   }, [attributeValue, inputValue]);
 
   return (
-    <Autocomplete
+    <Autocomplete<PackageInfo, false, true, true>
       title={title}
       disabled={disabled}
       readOnly={readOnly}
@@ -200,6 +200,20 @@ export function PackageAutocomplete({
         secondary: (option) =>
           typeof option === 'string' ? option : generatePurl(option),
       }}
+      onChange={(_, value) =>
+        typeof value !== 'string' &&
+        value[attribute] !== packageInfo[attribute] &&
+        onEdit?.(() => {
+          dispatch(
+            setTemporaryDisplayPackageInfo({
+              ...packageInfo,
+              [attribute]: value[attribute],
+              ...(attribute === 'licenseName' ? { licenseText: '' } : null),
+              wasPreferred: undefined,
+            }),
+          );
+        })
+      }
       onInputChange={(event, value) =>
         event &&
         packageInfo[attribute] !== value &&

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -187,24 +187,26 @@ export function Autocomplete<
             ]).length
           }
           size={'small'}
-          InputLabelProps={getInputLabelProps()}
           inputRef={ref}
-          inputProps={{
-            'aria-label': props['aria-label'],
-            sx: {
-              overflowX: 'hidden',
-              textOverflow: 'ellipsis',
-              '&::placeholder': {
-                opacity: 1,
+          slotProps={{
+            input: {
+              startAdornment: startAdornment || renderStartAdornment(),
+              endAdornment: renderEndAdornment(),
+              readOnly,
+              sx,
+              ...(variant === 'filled' && { disableUnderline: true }),
+            },
+            inputLabel: getInputLabelProps(),
+            htmlInput: {
+              'aria-label': props['aria-label'],
+              sx: {
+                overflowX: 'hidden',
+                textOverflow: 'ellipsis',
+                '&::placeholder': {
+                  opacity: 1,
+                },
               },
             },
-          }}
-          InputProps={{
-            startAdornment: startAdornment || renderStartAdornment(),
-            endAdornment: renderEndAdornment(),
-            readOnly,
-            sx,
-            ...(variant === 'filled' && { disableUnderline: true }),
           }}
           onKeyDown={(event) => {
             // https://github.com/mui/material-ui/issues/21129

--- a/src/e2e-tests/__tests__/updating-attributions.test.ts
+++ b/src/e2e-tests/__tests__/updating-attributions.test.ts
@@ -285,3 +285,20 @@ test('switches correctly between previously-preferred and modified previously pr
   await attributionDetails.attributionForm.comment.fill(faker.lorem.sentence());
   await confirmationDialog.assert.isVisible();
 });
+
+test('resets custom license text when user selects suggested license expression', async ({
+  attributionDetails,
+  resourcesTree,
+}) => {
+  const licenseText = faker.lorem.sentences();
+
+  await resourcesTree.goto(resourceName1);
+
+  await attributionDetails.attributionForm.licenseTextToggleButton.click();
+  await attributionDetails.attributionForm.licenseText.fill(licenseText);
+  await attributionDetails.attributionForm.assert.licenseTextIs(licenseText);
+
+  await attributionDetails.attributionForm.licenseName.click();
+  await attributionDetails.attributionForm.selectLicense(license1);
+  await attributionDetails.attributionForm.assert.licenseTextIs('');
+});

--- a/src/e2e-tests/page-objects/AttributionForm.ts
+++ b/src/e2e-tests/page-objects/AttributionForm.ts
@@ -85,10 +85,7 @@ export class AttributionForm {
     this.licenseTextToggleButton = this.node.getByLabel(
       'license-text-toggle-button',
     );
-    this.licenseText = this.node.getByLabel(
-      text.attributionColumn.licenseText,
-      { exact: true },
-    );
+    this.licenseText = this.node.getByLabel(text.attributionColumn.licenseText);
     this.auditingLabels = {
       criticalityLabel: this.node.getByTestId('auditing-option-criticality'),
       confidenceLabel: this.node.getByTestId('auditing-option-confidence'),

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -95,11 +95,9 @@ export const test = base.extend<{
     await use(Object.assign(window, { app }));
 
     await window.context().tracing.stop({
-      path: info.error
-        ? info.outputPath(
-            `${data?.inputData.metadata.projectId || 'app'}.trace.zip`,
-          )
-        : undefined,
+      path: info.outputPath(
+        `${data?.inputData.metadata.projectId || 'app'}.trace.zip`,
+      ),
     });
     await app.close();
   },


### PR DESCRIPTION
### Summary of changes

- ensure that the license text is reset whenever a new license expression is selected
- reset does not occur if a new license expression is typed instead of selected from the available options
- new behavior prevents accidental mismatches between expression and text

### Context and reason for change

Closes #2724 

### How can the changes be tested

Open an opossum file that has a license with custom license text. Then select another suggested license from the autocomplete and notice that the custom license text disappears.