### PR TITLE
feat: create .snap and app image for linux

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
           - os: macos-13

--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
         "snap",
         "AppImage"
       ],
-      "icon": "public/icons/icon_512x512.png"
+      "icon": "public/icons/icon_512x512.png",
+      "category": "Development"
     },
     "extraMetadata": {
       "main": "build/ElectronBackend/app.js"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "update-commit-hash:darwin:linux": "COMMIT_INFO=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD); echo \"{\\\"commitInfo\\\" : \\\"$COMMIT_INFO\\\" }\" > \"src/commitInfo.json\"",
     "update-commit-hash:win32": "tools/get_app_version_for_windows.bat",
     "generate-notice": "mkdirp notices && yarn licenses generate-disclaimer --production > notices/notices.txt && yarn node tools/generateNotices.mjs",
-    "ship-linux": "yarn install-deps:linux && yarn build && electron-builder --linux --x64 --publish never && mkdir -p release/linux && mv 'release/OpossumUI-0.1.0.AppImage' 'release/linux/OpossumUI-for-linux.AppImage'",
+    "ship-linux": "yarn install-deps:linux && yarn build && tools/build_linux_release.sh",
     "ship-win": "yarn install-deps:win32 && yarn build && electron-builder --win --x64 --publish never && mkdirp release/win && mv \"release/OpossumUI Setup 0.1.0.exe\" \"release/win/OpossumUI-for-win.exe\"",
     "ship-mac": "yarn install-deps:darwin && yarn build && electron-builder --mac --x64 --publish never && zip -r -y -q 'release/mac/OpossumUI-for-mac.zip' 'release/mac/'",
     "ship": "yarn ship-linux && yarn ship-win && yarn ship-mac",
@@ -170,7 +170,10 @@
       "icon": "public/icons/icon_512x512.png"
     },
     "linux": {
-      "target": "AppImage",
+      "target": [
+        "snap",
+        "AppImage"
+      ],
       "icon": "public/icons/icon_512x512.png"
     },
     "extraMetadata": {

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -79,6 +79,9 @@ export const test = base.extend<{
 
     const [executablePath, main] = getLaunchProps();
     const args = ['--reset'];
+    if (os.platform() === 'linux') {
+      args.push('--no-sandbox');
+    }
 
     const app = await electron.launch({
       args: [main, ...(!filePath ? args : args.concat([filePath]))],

--- a/tools/build_linux_release.sh
+++ b/tools/build_linux_release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH<https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+electron-builder --linux --x64 --publish never
+mkdir -p release/linux
+mv 'release/opossum-ui_0.1.0_amd64.snap' 'release/linux/OpossumUI-for-linux.snap'
+mv 'release/OpossumUI-0.1.0.AppImage' 'release/linux/OpossumUI-for-linux.AppImage'


### PR DESCRIPTION
### Summary of changes

Build process now builds a '.snap' image additionally to the appImage

### Context and reason for change

* The app image no longer probably works on ubuntu 24.04 and newer so we need an alternative
* Closes https://github.com/opossum-tool/OpossumUI/issues/2732


### How can the changes be tested
run `yarn ship:auto` on a linux machine

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
