### PR TITLE
test: fix resolution to reduce flakiness of e2e tests

### DIFF
--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -86,6 +86,10 @@ export const test = base.extend<{
     });
 
     const window = await app.firstWindow();
+    await window.setViewportSize({
+      width: 1920,
+      height: 1080,
+    });
     // eslint-disable-next-line playwright/no-networkidle
     await window.waitForLoadState('networkidle', { timeout: LOAD_TIMEOUT });
     await window


### PR DESCRIPTION
### Summary of changes

Fixed resolution for e2e tests

### Context and reason for change

Some tests where found to be flaky and one difference of local test (passing) and remote tests (failing) was the difference in resolution.

### How can the changes be tested

Testing should be covered by ci
