### PR TITLE
Testing move to ubunut latest again

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
           - os: macos-13

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -79,6 +79,9 @@ export const test = base.extend<{
 
     const [executablePath, main] = getLaunchProps();
     const args = ['--reset'];
+    if (os.platform() === 'linux') {
+      args.push('--no-sandbox');
+    }
 
     const app = await electron.launch({
       args: [main, ...(!filePath ? args : args.concat([filePath]))],


### PR DESCRIPTION
### Summary of changes

Make the tests run against ubuntu latest

### Context and reason for change

This has been stopped for a while as ubuntu latest does not work with an app image without further command line arguments
Closes https://github.com/opossum-tool/OpossumUI/issues/2733

### How can the changes be tested

Should be covered by ci

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
