### PR TITLE
chore: rename linux binary to match opossum-file relase

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "pre-commit": "lint-staged",
     "install-deps": "run-script-os",
     "install-deps:darwin": "yarn node tools/downloadOpossumFile.mjs mac",
-    "install-deps:linux": "yarn node tools/downloadOpossumFile.mjs ubuntu",
+    "install-deps:linux": "yarn node tools/downloadOpossumFile.mjs linux",
     "install-deps:win32": "yarn node tools/downloadOpossumFile.mjs windows.exe"
   },
   "main": "build/ElectronBackend/app.js",

--- a/tools/downloadOpossumFile.mjs
+++ b/tools/downloadOpossumFile.mjs
@@ -14,7 +14,7 @@ async function downloadOpossumFile() {
 
   if (!osSuffix) {
     console.error(
-      'Please specify one of the following options: mac, ubuntu, windows.exe',
+      'Please specify one of the following options: mac, linux, windows.exe',
     );
     process.exit(1);
   }


### PR DESCRIPTION
### Summary of changes

changed the name of the release binary.

### Context and reason for change

We decided to rename it in [opossum-file#212](https://github.com/opossum-tool/opossum-file/pull/212) and need to match it here.

ONLY MERGE ONCE THERE IS AN ACTUAL RELEASE OF `opossum-file` WITH THAT NAMING CONVENTION.