### PR TITLE
Feat: release also snap files

### DIFF
--- a/.github/workflows/check-code-quality.yml
+++ b/.github/workflows/check-code-quality.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-code-quality:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     env:

--- a/.github/workflows/check-license-compliance.yml
+++ b/.github/workflows/check-license-compliance.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-license-compliance:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: |
       !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,11 +19,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            FILE: release/linux/OpossumUI-for-linux.AppImage
+            FILES: |
+              release/linux/OpossumUI-for-linux.AppImage
+              release/linux/OpossumUI-for-linux.snap
           - os: macos-latest
-            FILE: release/mac/OpossumUI-for-mac.zip
+            FILES: release/mac/OpossumUI-for-mac.zip
           - os: windows-latest
-            FILE: release/win/OpossumUI-for-win.exe
+            FILES: release/win/OpossumUI-for-win.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +42,7 @@ jobs:
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ matrix.FILE }}
+          files: ${{ matrix.FILES }}
 
       - name: Upload user guide
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             FILE: release/linux/OpossumUI-for-linux.AppImage
           - os: macos-latest
             FILE: release/mac/OpossumUI-for-mac.zip

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ reporter. It uses metadata from the analyzer as well as scan results from the sc
 [oss-review-toolkit/ort](https://github.com/oss-review-toolkit/ort) and the new reporter output
 is called `Opossum`.
 
-For details of the file format, see [file formats](#file-formats).
+For details of the file format, see [file formats](docs/FileFormats.md).
 
 ## How to get and run OpossumUI
 
@@ -131,59 +131,6 @@ Run _OpossumUI-for-win.exe_ to install the OpossumUI. Then open _OpossumUI_ from
 Check out our [short video](https://youtu.be/bqGX9IQYpJY?si=BjNeCi9osPWy7z1H), which presents a basic workflow.
 
 For an in-depth explanation, please read the [Users's Guide](USER_GUIDE.md).
-
-## File formats
-
-Files with a `.opossum` extension are zip-archives which contain an `input.json` (must be provided) together with an `output.json` (optional).
-JSON schemas for both the [input](src/ElectronBackend/input/OpossumInputFileSchema.json)
-and [output](src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
-under [example files](example-files/).
-
-### Input file
-
-It has to be generated through external tools and provided to the app. Contains 5 main fields:
-
-- `metadata`: contains some project-level information,
-- `resources`: defines the file tree,
-- `externalAttributions`: contains all attributions which are provided as signals (preselected signals will be
-  automatically used by the app to create attributions in the output file),
-- `resourcesToAttributions`: links attributions to file paths,
-
-There are additional fields which are optional:
-
-- `frequentLicenses`: A list of licenses that can be selected in a dropdown when the user enters a license name.
-- `attributionBreakpoints`: a list of folder paths where attribution inference stops, e.g. `node_modules`."
-- `filesWithChildren`: a list of folders that are treated as files. This can be used to attach another file tree to
-  files like `package.json`, usually also setting an attribution breakpoint.
-- `baseUrlsForSources`: a map from paths to the respective base url. The base url should contain a {path} placeholder.
-  E.g.
-
-  ```json
-  "baseUrlsForSources": {
-    "/": "https://github.com/opossum-tool/opossumUI/blob/main/{path}"
-  }
-  ```
-
-- `externalAttributionSources`: used to store a mapping of short names for attribution sources to full names and priorities used for sorting in the PackagePanel. Entries with higher numbers have a higher priority. E.g.:
-
-  ```json
-  "externalAttributionSources": {
-    "SC": {
-      "name": "ScanCode",
-      "priority": 1
-    }
-  }
-  ```
-
-### Output file
-
-Contains four main fields:
-
-- `metadata`: contains some project-level information,
-- `manualAttributions`: contains all attributions created by the user or preselected,
-- `resourcesToAttributions`: links attributions to file paths,
-- `resolvedExternalAttributions`: used to store which signal attributions have been resolved, as they are hidden in the
-  UI.
 
 ### Exporting data
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Install the snap file locally using
 snap install ./OpossumUI-for-linux.snap --dangerous
 ```
 
-Open Opossum UI via the start menu of your distribution (should be in the `development` category) or by running
+Open OpossumUI via the start menu of your distribution (should be in the `development` category) or by running
 
 ```shell
 opossum-ui

--- a/README.md
+++ b/README.md
@@ -92,7 +92,31 @@ Download the latest release for your OS from [GitHub](https://github.com/opossum
 
 #### Linux
 
-Run the executable _OpossumUI-for-linux.AppImage_
+#### AppImage
+
+Run the executable _OpossumUI-for-linux.AppImage_.
+
+Note that for ubuntu versions 22.04+ you will run into a sandboxing issue with app images (see this [electron github issue](https://github.com/electron/electron/issues/41066) for details). This can be circumvented by opening the application with the `--no-sandbox` flag:
+
+```shell
+./OpossumUI-for-linux.AppImage --no-sandbox
+```
+
+#### snap
+
+Install the snap file locally using
+
+```shell
+snap install ./OpossumUI-for-linux.snap --dangerous
+```
+
+Open Opossum UI via the start menu of your distribution (should be in the `development` category) or by running
+
+```shell
+opossum-ui
+```
+
+from the command line
 
 #### macOS
 

--- a/docs/FileFormats.md
+++ b/docs/FileFormats.md
@@ -1,0 +1,52 @@
+# File formats
+
+Files with a `.opossum` extension are zip-archives which contain an `input.json` (must be provided) together with an `output.json` (optional).
+JSON schemas for both the [input](src/ElectronBackend/input/OpossumInputFileSchema.json)
+and [output](src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
+under [example files](example-files/).
+
+### Input file
+
+It has to be generated through external tools and provided to the app. Contains 5 main fields:
+
+- `metadata`: contains some project-level information,
+- `resources`: defines the file tree,
+- `externalAttributions`: contains all attributions which are provided as signals (preselected signals will be
+  automatically used by the app to create attributions in the output file),
+- `resourcesToAttributions`: links attributions to file paths,
+
+There are additional fields which are optional:
+
+- `frequentLicenses`: A list of licenses that can be selected in a dropdown when the user enters a license name.
+- `attributionBreakpoints`: a list of folder paths where attribution inference stops, e.g. `node_modules`."
+- `filesWithChildren`: a list of folders that are treated as files. This can be used to attach another file tree to
+  files like `package.json`, usually also setting an attribution breakpoint.
+- `baseUrlsForSources`: a map from paths to the respective base url. The base url should contain a {path} placeholder.
+  E.g.
+
+  ```json
+  "baseUrlsForSources": {
+    "/": "https://github.com/opossum-tool/opossumUI/blob/main/{path}"
+  }
+  ```
+
+- `externalAttributionSources`: used to store a mapping of short names for attribution sources to full names and priorities used for sorting in the PackagePanel. Entries with higher numbers have a higher priority. E.g.:
+
+  ```json
+  "externalAttributionSources": {
+    "SC": {
+      "name": "ScanCode",
+      "priority": 1
+    }
+  }
+  ```
+
+### Output file
+
+Contains four main fields:
+
+- `metadata`: contains some project-level information,
+- `manualAttributions`: contains all attributions created by the user or preselected,
+- `resourcesToAttributions`: links attributions to file paths,
+- `resolvedExternalAttributions`: used to store which signal attributions have been resolved, as they are hidden in the
+  UI.


### PR DESCRIPTION
### Summary of changes

Release also the `.snap` file generated

### Context and reason for change

The app images does have problems when being used on Ubuntu 22.04+ (depending on your settings problems might occur also for older versions)

Closes https://github.com/opossum-tool/OpossumUI/issues/2734

### How can the changes be tested

Create a test release --> Discussed: Please do **not** do so as there currently is no proper process for that
