### PR TITLE
Documentation update: inlcude snap to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ reporter. It uses metadata from the analyzer as well as scan results from the sc
 [oss-review-toolkit/ort](https://github.com/oss-review-toolkit/ort) and the new reporter output
 is called `Opossum`.
 
-For details of the file format, see [file formats](#file-formats).
+For details of the file format, see [file formats](docs/FileFormats.md).
 
 ## How to get and run OpossumUI
 
@@ -131,59 +131,6 @@ Run _OpossumUI-for-win.exe_ to install the OpossumUI. Then open _OpossumUI_ from
 Check out our [short video](https://youtu.be/bqGX9IQYpJY?si=BjNeCi9osPWy7z1H), which presents a basic workflow.
 
 For an in-depth explanation, please read the [Users's Guide](USER_GUIDE.md).
-
-## File formats
-
-Files with a `.opossum` extension are zip-archives which contain an `input.json` (must be provided) together with an `output.json` (optional).
-JSON schemas for both the [input](src/ElectronBackend/input/OpossumInputFileSchema.json)
-and [output](src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
-under [example files](example-files/).
-
-### Input file
-
-It has to be generated through external tools and provided to the app. Contains 5 main fields:
-
-- `metadata`: contains some project-level information,
-- `resources`: defines the file tree,
-- `externalAttributions`: contains all attributions which are provided as signals (preselected signals will be
-  automatically used by the app to create attributions in the output file),
-- `resourcesToAttributions`: links attributions to file paths,
-
-There are additional fields which are optional:
-
-- `frequentLicenses`: A list of licenses that can be selected in a dropdown when the user enters a license name.
-- `attributionBreakpoints`: a list of folder paths where attribution inference stops, e.g. `node_modules`."
-- `filesWithChildren`: a list of folders that are treated as files. This can be used to attach another file tree to
-  files like `package.json`, usually also setting an attribution breakpoint.
-- `baseUrlsForSources`: a map from paths to the respective base url. The base url should contain a {path} placeholder.
-  E.g.
-
-  ```json
-  "baseUrlsForSources": {
-    "/": "https://github.com/opossum-tool/opossumUI/blob/main/{path}"
-  }
-  ```
-
-- `externalAttributionSources`: used to store a mapping of short names for attribution sources to full names and priorities used for sorting in the PackagePanel. Entries with higher numbers have a higher priority. E.g.:
-
-  ```json
-  "externalAttributionSources": {
-    "SC": {
-      "name": "ScanCode",
-      "priority": 1
-    }
-  }
-  ```
-
-### Output file
-
-Contains four main fields:
-
-- `metadata`: contains some project-level information,
-- `manualAttributions`: contains all attributions created by the user or preselected,
-- `resourcesToAttributions`: links attributions to file paths,
-- `resolvedExternalAttributions`: used to store which signal attributions have been resolved, as they are hidden in the
-  UI.
 
 ### Exporting data
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Install the snap file locally using
 snap install ./OpossumUI-for-linux.snap --dangerous
 ```
 
-Open Opossum UI via the start menu of your distribution (should be in the `development` category) or by running
+Open OpossumUI via the start menu of your distribution (should be in the `development` category) or by running
 
 ```shell
 opossum-ui

--- a/README.md
+++ b/README.md
@@ -92,7 +92,31 @@ Download the latest release for your OS from [GitHub](https://github.com/opossum
 
 #### Linux
 
-Run the executable _OpossumUI-for-linux.AppImage_
+#### AppImage
+
+Run the executable _OpossumUI-for-linux.AppImage_.
+
+Note that for ubuntu versions 22.04+ you will run into a sandboxing issue with app images (see this [electron github issue](https://github.com/electron/electron/issues/41066) for details). This can be circumvented by opening the application with the `--no-sandbox` flag:
+
+```shell
+./OpossumUI-for-linux.AppImage --no-sandbox
+```
+
+#### snap
+
+Install the snap file locally using
+
+```shell
+snap install ./OpossumUI-for-linux.snap --dangerous
+```
+
+Open Opossum UI via the start menu of your distribution (should be in the `development` category) or by running
+
+```shell
+opossum-ui
+```
+
+from the command line
 
 #### macOS
 

--- a/docs/FileFormats.md
+++ b/docs/FileFormats.md
@@ -1,0 +1,52 @@
+# File formats
+
+Files with a `.opossum` extension are zip-archives which contain an `input.json` (must be provided) together with an `output.json` (optional).
+JSON schemas for both the [input](src/ElectronBackend/input/OpossumInputFileSchema.json)
+and [output](src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
+under [example files](example-files/).
+
+### Input file
+
+It has to be generated through external tools and provided to the app. Contains 5 main fields:
+
+- `metadata`: contains some project-level information,
+- `resources`: defines the file tree,
+- `externalAttributions`: contains all attributions which are provided as signals (preselected signals will be
+  automatically used by the app to create attributions in the output file),
+- `resourcesToAttributions`: links attributions to file paths,
+
+There are additional fields which are optional:
+
+- `frequentLicenses`: A list of licenses that can be selected in a dropdown when the user enters a license name.
+- `attributionBreakpoints`: a list of folder paths where attribution inference stops, e.g. `node_modules`."
+- `filesWithChildren`: a list of folders that are treated as files. This can be used to attach another file tree to
+  files like `package.json`, usually also setting an attribution breakpoint.
+- `baseUrlsForSources`: a map from paths to the respective base url. The base url should contain a {path} placeholder.
+  E.g.
+
+  ```json
+  "baseUrlsForSources": {
+    "/": "https://github.com/opossum-tool/opossumUI/blob/main/{path}"
+  }
+  ```
+
+- `externalAttributionSources`: used to store a mapping of short names for attribution sources to full names and priorities used for sorting in the PackagePanel. Entries with higher numbers have a higher priority. E.g.:
+
+  ```json
+  "externalAttributionSources": {
+    "SC": {
+      "name": "ScanCode",
+      "priority": 1
+    }
+  }
+  ```
+
+### Output file
+
+Contains four main fields:
+
+- `metadata`: contains some project-level information,
+- `manualAttributions`: contains all attributions created by the user or preselected,
+- `resourcesToAttributions`: links attributions to file paths,
+- `resolvedExternalAttributions`: used to store which signal attributions have been resolved, as they are hidden in the
+  UI.


### PR DESCRIPTION
### Summary of changes

Adapt the documentation to include:
* installing of the snap file
* using the AppImage on the newest ubuntu

### Context and reason for change

A bug in electron prevents using the AppImage on the latest Ubuntu

Closes https://github.com/opossum-tool/OpossumUI/issues/2735

### How can the changes be tested

* Read and follow the docs in the Running the app --> Linux section 
