### PR TITLE
feat: sort common licenses to top

### DIFF
--- a/src/Frontend/Components/AttributionForm/PackageAutocomplete/PackageAutocomplete.tsx
+++ b/src/Frontend/Components/AttributionForm/PackageAutocomplete/PackageAutocomplete.tsx
@@ -83,6 +83,7 @@ export function PackageAutocomplete({
 
   const options = useMemo(
     () => [
+      ...defaults,
       ...sortBy(
         Object.entries(
           groupBy(attributions, (attribution) =>
@@ -117,7 +118,6 @@ export function PackageAutocomplete({
           })),
         ({ count }) => -(count ?? 0),
       ),
-      ...defaults,
     ],
     [attribute, attributions, defaults, signals],
   );


### PR DESCRIPTION
### Summary of changes
In the license panel, first show the common licenses

### Context and reason for change

The common licenses should be the default choice for using a license 
--> sort to the top
![image](https://github.com/user-attachments/assets/2f9753c9-2d2a-49b6-a311-3c857e3f7f32)

closes: https://github.com/opossum-tool/OpossumUI/issues/2755

### How can the changes be tested

open any attribution in opossum-ui

