### PR TITLE
fix: make content name match the name in the template

### DIFF
--- a/tools/generateNotices.mjs
+++ b/tools/generateNotices.mjs
@@ -11,7 +11,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function generateNotices() {
   const noticeDocumentFolder = join(__dirname, '..', 'notices');
-  const fileContent = readFileSync(join(noticeDocumentFolder, 'notices.txt'));
+  const noticeContent = readFileSync(join(noticeDocumentFolder, 'notices.txt'));
 
   copyFileSync(
     join(
@@ -27,7 +27,7 @@ function generateNotices() {
   writeFileSync(
     join(noticeDocumentFolder, 'notices.html'),
     nunjucks.render(join(__dirname, 'notices.template.html'), {
-      fileContent,
+      noticeContent,
     }),
   );
 }


### PR DESCRIPTION
### Summary of changes

Fixed notice generation

### Context and reason for change

Notice generation is broken in the current release

### How can the changes be tested

* Locally:
```shell
yarn generate-notice 
```
and then checking `./notices/notices.html`

or by building a release and accessing the notice via the menu
