### PR TITLE
test: ensure notices generated do have content

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "update-commit-hash": "run-script-os",
     "update-commit-hash:darwin:linux": "COMMIT_INFO=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD); echo \"{\\\"commitInfo\\\" : \\\"$COMMIT_INFO\\\" }\" > \"src/commitInfo.json\"",
     "update-commit-hash:win32": "tools/get_app_version_for_windows.bat",
-    "generate-notice": "mkdirp notices && yarn licenses generate-disclaimer --production > notices/notices.txt && yarn node tools/generateNotices.mjs",
+    "generate-notice": "mkdirp notices && yarn licenses generate-disclaimer --production > notices/notices.txt && yarn node tools/generateNotices.mjs && ./tools/checkNotices.sh",
     "ship-linux": "yarn install-deps:linux && yarn build && tools/build_linux_release.sh",
     "ship-win": "yarn install-deps:win32 && yarn build && electron-builder --win --x64 --publish never && mkdirp release/win && mv \"release/OpossumUI Setup 0.1.0.exe\" \"release/win/OpossumUI-for-win.exe\"",
     "ship-mac": "yarn install-deps:darwin && yarn build && electron-builder --mac --x64 --publish never && zip -r -y -q 'release/mac/OpossumUI-for-mac.zip' 'release/mac/'",

--- a/tools/checkNotices.sh
+++ b/tools/checkNotices.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+# SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+NOTICE_HEADER="THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED IN PORTIONS OF THE OPOSSUM UI PRODUCT."
+
+grep -q "${NOTICE_HEADER}" ./notices/notices.txt || {
+  echo "Error: Attributions not found in notices.txt"
+  exit 1
+}
+grep -q "${NOTICE_HEADER}" ./notices/notices.html || {
+  echo "Error: Attributions not found in notices.html"
+  exit 1
+}


### PR DESCRIPTION
### Summary of changes
Add a check in the build step to ensure that the notice document is not empty

### Context and reason for change

There was a bug where we delivered an empty notices document
https://github.com/opossum-tool/OpossumUI/issues/2760

This shall prevent a repetition of the bug

Alternative Solutions considered:
* Write a **playwright based e2e test**: Did not fly as playwright does not manage to follow the "jump" from electron to the real browser after clicking the notice menu link.
* Writing **jest unit test** would have required translating the tooling to typescript (jest support for mjs -- or to be exact the used include statements -- is currently only experimental) which was determined to be out of scope for this ticket

### How can the changes be tested

Break the notice generation (e.g. by modifying `generateNotices.mjs`) and observe `yarn build` (or `yarn generate-notice`) to fail. 

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
