### PR TITLE
Improve error reporting for import with opossum-file

### DIFF
--- a/src/ElectronBackend/opossum-file/convertScancodeToOpossum.ts
+++ b/src/ElectronBackend/opossum-file/convertScancodeToOpossum.ts
@@ -19,11 +19,15 @@ export async function convertScancodeToOpossum(
   pathToScanCode: string,
   pathToOpossum: string,
 ): Promise<void> {
-  await execFile(OPOSSUM_FILE_EXECUTABLE, [
-    'generate',
-    '-o',
-    pathToOpossum,
-    '--scan-code-json',
-    pathToScanCode,
-  ]);
+  try {
+    await execFile(OPOSSUM_FILE_EXECUTABLE, [
+      'generate',
+      '-o',
+      pathToOpossum,
+      '--scan-code-json',
+      pathToScanCode,
+    ]);
+  } catch (error) {
+    throw new Error('Conversion of ScanCode file to .opossum file failed');
+  }
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -248,13 +248,13 @@ export interface ElectronAPI {
   relaunch: () => void;
   openLink: (link: string) => Promise<unknown>;
   openFile: () => Promise<unknown>;
-  importFileSelectInput: (fileFormat: FileFormatInfo) => Promise<string | null>;
-  importFileSelectSaveLocation: (defaultPath: string) => Promise<string | null>;
+  importFileSelectInput: (fileFormat: FileFormatInfo) => Promise<string>;
+  importFileSelectSaveLocation: (defaultPath: string) => Promise<string>;
   importFileConvertAndLoad: (
     inputFilePath: string,
     fileType: FileType,
     opossumFilePath: string,
-  ) => Promise<boolean | null>;
+  ) => Promise<boolean>;
   exportFile: (args: ExportArgsType) => void;
   saveFile: (saveFileArgs: SaveFileArgs) => void;
   on: (channel: AllowedFrontendChannels, listener: Listener) => () => void;


### PR DESCRIPTION
### Summary of changes

Clean up error reporting in import dialog and report errors occurring during file conversion with opossum-file.

### Context and reason for change

Users should be properly informed about potential errors that occurr during the import process.

### How can the changes be tested

Try to import an invalid file through the import ScanCode Json functionality.

closes #2719