### PR TITLE
No longer e2e test on macos-13

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -22,13 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             # https://github.com/microsoft/playwright/issues/11932
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
-          - os: macos-13
-            E2E: yarn test:e2e:ci
           - os: macos-latest
             E2E: yarn test:e2e:ci
           - os: windows-latest


### PR DESCRIPTION
### Summary of changes

Removed macos-13 from runners in e2e test action.

### Context and reason for change

* likely nothing to be gained from these tests when we already test on macos-latest
* macos-13 takes the most time and thus slows down our CI