### PR TITLE
fix: broken links to JSON schemas in FileFormats.md

### DIFF
--- a/docs/FileFormats.md
+++ b/docs/FileFormats.md
@@ -1,8 +1,8 @@
 # File formats
 
 Files with a `.opossum` extension are zip-archives which contain an `input.json` (must be provided) together with an `output.json` (optional).
-JSON schemas for both the [input](src/ElectronBackend/input/OpossumInputFileSchema.json)
-and [output](src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
+JSON schemas for both the [input](../src/ElectronBackend/input/OpossumInputFileSchema.json)
+and [output](../src/ElectronBackend/input/OpossumOutputFileSchema.json) files are available. Example files can be found
 under [example files](example-files/).
 
 ### Input file


### PR DESCRIPTION
Noticed that the links in FileFormats.md were broken
