### PR TITLE
Build all MacOS releases on macos-latest runners

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,6 +51,7 @@ jobs:
           files: ${{ matrix.FILES }}
 
       - name: Upload user guide
+        continue-on-error: true
         uses: softprops/action-gh-release@v2
         with:
           files: USER_GUIDE.md
@@ -59,6 +60,7 @@ jobs:
         run: yarn spdx
 
       - name: Upload SPDX document
+        continue-on-error: true
         uses: softprops/action-gh-release@v2
         with:
           files: opossum-ui.spdx.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             build-command: yarn ship:auto

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,17 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
+            build-command: yarn ship:auto
             FILES: |
               release/linux/OpossumUI-for-linux.AppImage
               release/linux/OpossumUI-for-linux.snap
-          - os: macos-13
+          - os: macos-latest
+            build-command: yarn ship-mac:x64
             FILES: release/mac/OpossumUI-for-mac-intel.zip
           - os: macos-latest
+            build-command: yarn ship:auto
             FILES: release/mac-arm64/OpossumUI-for-mac-arm64.zip
           - os: windows-latest
+            build-command: yarn ship:auto
             FILES: release/win/OpossumUI-for-win.exe
 
     steps:
@@ -40,7 +44,7 @@ jobs:
 
       - run: yarn install --immutable
 
-      - run: yarn ship:auto
+      - run: ${{ matrix.build-command }}
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Summary of changes

On release, the build for macos with intel architecture is now also executed on a macos-latest runner.

### Context and reason for change

Electron-builder is capable of cross-compilation and building on maco-latest runners is faster on potentially more future proof than macos-13 runners.

### How can the changes be tested

Create a temporary release targeting this branch.
