### PR TITLE
refactor : split up main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For details of the file format, see [file formats](docs/FileFormats.md).
 The following additional file types can be directly imported from inside OpossumUI:
 
 - ScanCode JSON files (`.json`)
+- OWASP Dependency check (`.json`)
 - more to come
 
 Result files (yaml/json) from the OSS Review Toolkit can be converted into opossum files via a reporter and then imported as described above. The implementation of this reporter can be found in the [official OSS Review Toolkit repository](https://github.com/oss-review-toolkit/ort/tree/main/plugins/reporters/opossum).

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -33,7 +33,10 @@ import {
 } from '../errorHandling/errorHandling';
 import { loadInputAndOutputFromFilePath } from '../input/importFromFile';
 import { serializeAttributions } from '../input/parseInputData';
-import { convertScancodeToOpossum } from '../opossum-file/convertScancodeToOpossum';
+import {
+  convertOwaspToOpossum,
+  convertScancodeToOpossum,
+} from '../opossum-file/convertToOpossum';
 import { writeCsvToFile } from '../output/writeCsvToFile';
 import { writeSpdxFile } from '../output/writeSpdxFile';
 import { GlobalBackendState, OpossumOutputFile } from '../types/types';
@@ -226,6 +229,9 @@ export function getImportFileConvertAndLoadListener(
           break;
         case FileType.SCANCODE_JSON:
           await convertScancodeToOpossum(resourceFilePath, opossumFilePath);
+          break;
+        case FileType.OWASP_JSON:
+          await convertOwaspToOpossum(resourceFilePath, opossumFilePath);
           break;
       }
 

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -96,6 +96,11 @@ export const importFileFormats: Array<FileFormatInfo> = [
     name: 'ScanCode File',
     extensions: ['json'],
   },
+  {
+    fileType: FileType.OWASP_JSON,
+    name: 'OWASP Dependency-Check',
+    extensions: ['json'],
+  },
 ];
 
 export async function createMenu(mainWindow: BrowserWindow): Promise<Menu> {

--- a/src/ElectronBackend/opossum-file/__tests__/convertToOpossum.test.ts
+++ b/src/ElectronBackend/opossum-file/__tests__/convertToOpossum.test.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 
 import { parseOpossumFile } from '../../input/parseFile';
 import { isOpossumFileFormat } from '../../utils/isOpossumFileFormat';
-import { convertScancodeToOpossum } from '../convertScancodeToOpossum';
+import { convertScancodeToOpossum } from '../convertToOpossum';
 
 describe('successfulConversionOfScanCodeFile', () => {
   const SCANCODE_TEST_FILE = join(__dirname, 'scancode.json');

--- a/src/ElectronBackend/opossum-file/__tests__/convertToOpossum.test.ts
+++ b/src/ElectronBackend/opossum-file/__tests__/convertToOpossum.test.ts
@@ -9,14 +9,28 @@ import { join } from 'path';
 
 import { parseOpossumFile } from '../../input/parseFile';
 import { isOpossumFileFormat } from '../../utils/isOpossumFileFormat';
-import { convertScancodeToOpossum } from '../convertToOpossum';
+import {
+  convertOwaspToOpossum,
+  convertScancodeToOpossum,
+} from '../convertToOpossum';
 
 describe('successfulConversionOfScanCodeFile', () => {
   const SCANCODE_TEST_FILE = join(__dirname, 'scancode.json');
+  const OWASP_TEST_FILE = join(__dirname, 'owasp-dependency-check-report.json');
 
   it('should convert the ScanCode file and return a path to a valid .opossum file', async () => {
     const opossumPath = join(tmpdir(), `${uniqueId('opossum_')}.opossum`);
     await convertScancodeToOpossum(SCANCODE_TEST_FILE, opossumPath);
+    expect(existsSync(opossumPath)).toBe(true);
+    expect(isOpossumFileFormat(opossumPath)).toBe(true);
+
+    const parsingResult = await parseOpossumFile(opossumPath);
+    expect(parsingResult).toHaveProperty('input');
+  });
+
+  it('should convert the owasp file and return a path to a valid .opossum file', async () => {
+    const opossumPath = join(tmpdir(), `${uniqueId('opossum_')}.opossum`);
+    await convertOwaspToOpossum(OWASP_TEST_FILE, opossumPath);
     expect(existsSync(opossumPath)).toBe(true);
     expect(isOpossumFileFormat(opossumPath)).toBe(true);
 

--- a/src/ElectronBackend/opossum-file/__tests__/owasp-dependency-check-report.json
+++ b/src/ElectronBackend/opossum-file/__tests__/owasp-dependency-check-report.json
@@ -1,0 +1,301 @@
+{
+  "reportSchema": "1.1",
+  "scanInfo": {
+    "engineVersion": "6.2.2",
+    "dataSource": [
+      {
+        "name": "NVD CVE Checked",
+        "timestamp": "2021-09-20T12:10:45"
+      },
+      {
+        "name": "NVD CVE Modified",
+        "timestamp": "2021-09-20T12:00:01"
+      },
+      {
+        "name": "VersionCheckOn",
+        "timestamp": "2021-09-19T13:55:55"
+      }
+    ]
+  },
+  "projectInfo": {
+    "name": "",
+    "reportDate": "2021-09-20T12:10:51.304633Z",
+    "credits": {
+      "NVD": "This report contains data retrieved from the National Vulnerability Database: http://nvd.nist.gov",
+      "NPM": "This report may contain data retrieved from the NPM Public Advisories: https://www.npmjs.com/advisories",
+      "RETIREJS": "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX": "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies": [
+    {
+      "isVirtual": false,
+      "fileName": "DotZLib.csproj",
+      "filePath": "contrib/dotzlib/DotZLib/DotZLib.csproj",
+      "md5": "1549ce82a2662e77a22625f68c0a5d36",
+      "sha1": "99238c2ad633a641687d722e8c80aaa0a8c8bdd2",
+      "sha256": "21606db31dfef6410dd438b73f1db68856eacabcce6c0f0411fc4f17e17001f3",
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "DotZLib"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "DotZLib"
+          }
+        ],
+        "versionEvidence": []
+      }
+    },
+    {
+      "isVirtual": true,
+      "fileName": "async:2.6.3",
+      "filePath": "/home/hellgartner/workspace/meta_oss/code/old-opossumUI/yarn.lock?async",
+      "projectReferences": ["yarn.lock: transitive"],
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "package.json",
+            "name": "name",
+            "value": "async"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "name",
+            "value": "async"
+          }
+        ],
+        "versionEvidence": [
+          {
+            "type": "version",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "version",
+            "value": "2.6.3"
+          }
+        ]
+      },
+      "packages": [
+        {
+          "id": "pkg:npm/async@2.6.3",
+          "confidence": "HIGHEST",
+          "url": "https://ossindex.sonatype.org/component/pkg:npm/async@2.6.3?utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2"
+        }
+      ],
+      "vulnerabilities": [
+        {
+          "source": "OSSINDEX",
+          "name": "CVE-2021-43138",
+          "severity": "HIGH",
+          "cvssv3": {
+            "baseScore": 7.800000190734863,
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseSeverity": "HIGH",
+            "version": "3.1"
+          },
+          "cwes": ["CWE-1321"],
+          "description": "In Async before 2.6.4 and 3.x before 3.2.2, a malicious user can obtain privileges via the mapValues() method, aka lib/internal/iterator.js createObjectIterator prototype pollution.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2021-43138 for details",
+          "notes": "",
+          "references": [
+            {
+              "source": "OSSIndex",
+              "url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43138",
+              "name": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43138"
+            },
+            {
+              "source": "OSSINDEX",
+              "url": "https://ossindex.sonatype.org/vulnerability/CVE-2021-43138?component-type=npm&component-name=async&utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2",
+              "name": "[CVE-2021-43138] CWE-1321"
+            },
+            {
+              "source": "OSSIndex",
+              "url": "https://github.com/caolan/async/pull/1828",
+              "name": "https://github.com/caolan/async/pull/1828"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:2.6.3:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true"
+              }
+            }
+          ]
+        },
+        {
+          "source": "NPM",
+          "name": "GHSA-fwr7-v2mv-hh25",
+          "unscored": "true",
+          "severity": "high",
+          "cvssv3": {
+            "baseScore": 7.800000190734863,
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseSeverity": "HIGH",
+            "version": "3.1"
+          },
+          "cwes": ["CWE-1321"],
+          "description": "A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the `mapValues()` method.",
+          "notes": "",
+          "references": [
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md#v264",
+              "name": "https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md#v264"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://jsfiddle.net/oz5twjd9",
+              "name": "https://jsfiddle.net/oz5twjd9"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/commit/e1ecdbf79264f9ab488c7799f4c76996d5dca66d",
+              "name": "https://github.com/caolan/async/commit/e1ecdbf79264f9ab488c7799f4c76996d5dca66d"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/master/lib/mapValuesLimit.js",
+              "name": "https://github.com/caolan/async/blob/master/lib/mapValuesLimit.js"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/compare/v2.6.3...v2.6.4",
+              "name": "https://github.com/caolan/async/compare/v2.6.3...v2.6.4"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/commit/8f7f90342a6571ba1c197d747ebed30c368096d2",
+              "name": "https://github.com/caolan/async/commit/8f7f90342a6571ba1c197d747ebed30c368096d2"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://security.netapp.com/advisory/ntap-20240621-0006",
+              "name": "https://security.netapp.com/advisory/ntap-20240621-0006"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43138",
+              "name": "https://nvd.nist.gov/vuln/detail/CVE-2021-43138"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/advisories/GHSA-fwr7-v2mv-hh25",
+              "name": "https://github.com/advisories/GHSA-fwr7-v2mv-hh25"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/master/lib/internal/iterator.js",
+              "name": "https://github.com/caolan/async/blob/master/lib/internal/iterator.js"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/pull/1828",
+              "name": "https://github.com/caolan/async/pull/1828"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:\\>\\=2.0.0\\<2.6.4:*:*:*:*:*:*:*"
+              }
+            }
+          ]
+        },
+        {
+          "source": "OSSINDEX",
+          "name": "CVE-2024-39249",
+          "severity": "MEDIUM",
+          "cvssv2": {
+            "score": 6.300000190734863,
+            "accessVector": "NETWORK",
+            "accessComplexity": "LOW",
+            "authenticationr": "$enc.json($vuln.cvssV2.cvssData.authentication)",
+            "confidentialityImpact": "$enc.json($vuln.cvssV2.cvssData.confidentialityImpact)",
+            "integrityImpact": "$enc.json($vuln.cvssV2.cvssData.integrityImpact)",
+            "availabilityImpact": "$enc.json($vuln.cvssV2.cvssData.availabilityImpact)",
+            "severity": "MEDIUM",
+            "version": "2.0"
+          },
+          "cwes": ["CWE-1333"],
+          "description": "Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function. NOTE: this is disputed by the supplier because there is no realistic threat model: regular expressions are not used with untrusted input.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2024-39249 for details",
+          "notes": "",
+          "references": [
+            {
+              "source": "OSSIndex",
+              "url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-39249",
+              "name": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-39249"
+            },
+            {
+              "source": "OSSINDEX",
+              "url": "https://ossindex.sonatype.org/vulnerability/CVE-2024-39249?component-type=npm&component-name=async&utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2",
+              "name": "[CVE-2024-39249] CWE-1333"
+            },
+            {
+              "source": "OSSIndex",
+              "url": "https://github.com/caolan/async/issues/1975",
+              "name": "https://github.com/caolan/async/issues/1975"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:2.6.3:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/ElectronBackend/opossum-file/convertToOpossum.ts
+++ b/src/ElectronBackend/opossum-file/convertToOpossum.ts
@@ -31,3 +31,22 @@ export async function convertScancodeToOpossum(
     throw new Error('Conversion of ScanCode file to .opossum file failed');
   }
 }
+
+export async function convertOwaspToOpossum(
+  pathToOwasp: string,
+  pathToOpossum: string,
+): Promise<void> {
+  try {
+    await execFile(OPOSSUM_FILE_EXECUTABLE, [
+      'generate',
+      '-o',
+      pathToOpossum,
+      '--owasp-json',
+      pathToOwasp,
+    ]);
+  } catch (error) {
+    throw new Error(
+      'Conversion of OWASP Dependency-check file to .opossum file failed',
+    );
+  }
+}

--- a/src/e2e-tests/__tests__/import-dialog.test.ts
+++ b/src/e2e-tests/__tests__/import-dialog.test.ts
@@ -89,6 +89,32 @@ test('imports scancode file', async ({
   await resourcesTree.assert.resourceIsVisible('src');
 });
 
+test('imports OWASP file', async ({
+  menuBar,
+  importDialog,
+  resourcesTree,
+  window,
+}) => {
+  await stubDialog(window.app, 'showOpenDialogSync', [
+    importDialog.owaspFilePath,
+  ]);
+  await stubDialog(
+    window.app,
+    'showSaveDialogSync',
+    getDotOpossumFilePath(importDialog.owaspFilePath, ['json']),
+  );
+
+  await menuBar.openImportOwaspDependencyScanFile();
+  await importDialog.assert.titleIsVisible();
+
+  await importDialog.inputFileSelection.click();
+  await importDialog.opossumFileSelection.click();
+  await importDialog.importButton.click();
+
+  await importDialog.assert.titleIsHidden();
+  await resourcesTree.assert.resourceIsVisible('contrib');
+});
+
 test('shows error when no file path is set', async ({
   menuBar,
   importDialog,

--- a/src/e2e-tests/owasp-dependency-check-report.json
+++ b/src/e2e-tests/owasp-dependency-check-report.json
@@ -1,0 +1,301 @@
+{
+  "reportSchema": "1.1",
+  "scanInfo": {
+    "engineVersion": "6.2.2",
+    "dataSource": [
+      {
+        "name": "NVD CVE Checked",
+        "timestamp": "2021-09-20T12:10:45"
+      },
+      {
+        "name": "NVD CVE Modified",
+        "timestamp": "2021-09-20T12:00:01"
+      },
+      {
+        "name": "VersionCheckOn",
+        "timestamp": "2021-09-19T13:55:55"
+      }
+    ]
+  },
+  "projectInfo": {
+    "name": "",
+    "reportDate": "2021-09-20T12:10:51.304633Z",
+    "credits": {
+      "NVD": "This report contains data retrieved from the National Vulnerability Database: http://nvd.nist.gov",
+      "NPM": "This report may contain data retrieved from the NPM Public Advisories: https://www.npmjs.com/advisories",
+      "RETIREJS": "This report may contain data retrieved from the RetireJS community: https://retirejs.github.io/retire.js/",
+      "OSSINDEX": "This report may contain data retrieved from the Sonatype OSS Index: https://ossindex.sonatype.org"
+    }
+  },
+  "dependencies": [
+    {
+      "isVirtual": false,
+      "fileName": "DotZLib.csproj",
+      "filePath": "contrib/dotzlib/DotZLib/DotZLib.csproj",
+      "md5": "1549ce82a2662e77a22625f68c0a5d36",
+      "sha1": "99238c2ad633a641687d722e8c80aaa0a8c8bdd2",
+      "sha256": "21606db31dfef6410dd438b73f1db68856eacabcce6c0f0411fc4f17e17001f3",
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "DotZLib"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGH",
+            "source": "file",
+            "name": "name",
+            "value": "DotZLib"
+          }
+        ],
+        "versionEvidence": []
+      }
+    },
+    {
+      "isVirtual": true,
+      "fileName": "async:2.6.3",
+      "filePath": "/home/hellgartner/workspace/meta_oss/code/old-opossumUI/yarn.lock?async",
+      "projectReferences": ["yarn.lock: transitive"],
+      "evidenceCollected": {
+        "vendorEvidence": [
+          {
+            "type": "vendor",
+            "confidence": "HIGH",
+            "source": "package.json",
+            "name": "name",
+            "value": "async"
+          }
+        ],
+        "productEvidence": [
+          {
+            "type": "product",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "name",
+            "value": "async"
+          }
+        ],
+        "versionEvidence": [
+          {
+            "type": "version",
+            "confidence": "HIGHEST",
+            "source": "package.json",
+            "name": "version",
+            "value": "2.6.3"
+          }
+        ]
+      },
+      "packages": [
+        {
+          "id": "pkg:npm/async@2.6.3",
+          "confidence": "HIGHEST",
+          "url": "https://ossindex.sonatype.org/component/pkg:npm/async@2.6.3?utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2"
+        }
+      ],
+      "vulnerabilities": [
+        {
+          "source": "OSSINDEX",
+          "name": "CVE-2021-43138",
+          "severity": "HIGH",
+          "cvssv3": {
+            "baseScore": 7.800000190734863,
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseSeverity": "HIGH",
+            "version": "3.1"
+          },
+          "cwes": ["CWE-1321"],
+          "description": "In Async before 2.6.4 and 3.x before 3.2.2, a malicious user can obtain privileges via the mapValues() method, aka lib/internal/iterator.js createObjectIterator prototype pollution.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2021-43138 for details",
+          "notes": "",
+          "references": [
+            {
+              "source": "OSSIndex",
+              "url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43138",
+              "name": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43138"
+            },
+            {
+              "source": "OSSINDEX",
+              "url": "https://ossindex.sonatype.org/vulnerability/CVE-2021-43138?component-type=npm&component-name=async&utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2",
+              "name": "[CVE-2021-43138] CWE-1321"
+            },
+            {
+              "source": "OSSIndex",
+              "url": "https://github.com/caolan/async/pull/1828",
+              "name": "https://github.com/caolan/async/pull/1828"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:2.6.3:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true"
+              }
+            }
+          ]
+        },
+        {
+          "source": "NPM",
+          "name": "GHSA-fwr7-v2mv-hh25",
+          "unscored": "true",
+          "severity": "high",
+          "cvssv3": {
+            "baseScore": 7.800000190734863,
+            "attackVector": "LOCAL",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseSeverity": "HIGH",
+            "version": "3.1"
+          },
+          "cwes": ["CWE-1321"],
+          "description": "A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the `mapValues()` method.",
+          "notes": "",
+          "references": [
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md#v264",
+              "name": "https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md#v264"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://jsfiddle.net/oz5twjd9",
+              "name": "https://jsfiddle.net/oz5twjd9"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UM6XJ73Q3NAM5KSGCOKJ2ZIA6GUWUJLK"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/commit/e1ecdbf79264f9ab488c7799f4c76996d5dca66d",
+              "name": "https://github.com/caolan/async/commit/e1ecdbf79264f9ab488c7799f4c76996d5dca66d"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/master/lib/mapValuesLimit.js",
+              "name": "https://github.com/caolan/async/blob/master/lib/mapValuesLimit.js"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/compare/v2.6.3...v2.6.4",
+              "name": "https://github.com/caolan/async/compare/v2.6.3...v2.6.4"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/commit/8f7f90342a6571ba1c197d747ebed30c368096d2",
+              "name": "https://github.com/caolan/async/commit/8f7f90342a6571ba1c197d747ebed30c368096d2"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://security.netapp.com/advisory/ntap-20240621-0006",
+              "name": "https://security.netapp.com/advisory/ntap-20240621-0006"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-43138",
+              "name": "https://nvd.nist.gov/vuln/detail/CVE-2021-43138"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/advisories/GHSA-fwr7-v2mv-hh25",
+              "name": "https://github.com/advisories/GHSA-fwr7-v2mv-hh25"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3",
+              "name": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/MTEUUTNIEBHGKUKKLNUZSV7IEP6IP3Q3"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/blob/master/lib/internal/iterator.js",
+              "name": "https://github.com/caolan/async/blob/master/lib/internal/iterator.js"
+            },
+            {
+              "source": "NPM Advisory reference: ",
+              "url": "https://github.com/caolan/async/pull/1828",
+              "name": "https://github.com/caolan/async/pull/1828"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:\\>\\=2.0.0\\<2.6.4:*:*:*:*:*:*:*"
+              }
+            }
+          ]
+        },
+        {
+          "source": "OSSINDEX",
+          "name": "CVE-2024-39249",
+          "severity": "MEDIUM",
+          "cvssv2": {
+            "score": 6.300000190734863,
+            "accessVector": "NETWORK",
+            "accessComplexity": "LOW",
+            "authenticationr": "$enc.json($vuln.cvssV2.cvssData.authentication)",
+            "confidentialityImpact": "$enc.json($vuln.cvssV2.cvssData.confidentialityImpact)",
+            "integrityImpact": "$enc.json($vuln.cvssV2.cvssData.integrityImpact)",
+            "availabilityImpact": "$enc.json($vuln.cvssV2.cvssData.availabilityImpact)",
+            "severity": "MEDIUM",
+            "version": "2.0"
+          },
+          "cwes": ["CWE-1333"],
+          "description": "Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function. NOTE: this is disputed by the supplier because there is no realistic threat model: regular expressions are not used with untrusted input.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2024-39249 for details",
+          "notes": "",
+          "references": [
+            {
+              "source": "OSSIndex",
+              "url": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-39249",
+              "name": "http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2024-39249"
+            },
+            {
+              "source": "OSSINDEX",
+              "url": "https://ossindex.sonatype.org/vulnerability/CVE-2024-39249?component-type=npm&component-name=async&utm_source=dependency-check&utm_medium=integration&utm_content=12.0.2",
+              "name": "[CVE-2024-39249] CWE-1333"
+            },
+            {
+              "source": "OSSIndex",
+              "url": "https://github.com/caolan/async/issues/1975",
+              "name": "https://github.com/caolan/async/issues/1975"
+            }
+          ],
+          "vulnerableSoftware": [
+            {
+              "software": {
+                "id": "cpe:2.3:a:*:async:2.6.3:*:*:*:*:*:*:*",
+                "vulnerabilityIdMatched": "true"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/e2e-tests/page-objects/ImportDialog.ts
+++ b/src/e2e-tests/page-objects/ImportDialog.ts
@@ -16,6 +16,7 @@ export class ImportDialog {
 
   readonly legacyFilePath: string;
   readonly scancodeFilePath: string;
+  readonly owaspFilePath: string;
 
   constructor(
     window: Page,
@@ -36,6 +37,11 @@ export class ImportDialog {
 
     this.legacyFilePath = info.outputPath(`${legacyFilename}.json`);
     this.scancodeFilePath = path.resolve(__dirname, '..', 'scancode.json');
+    this.owaspFilePath = path.resolve(
+      __dirname,
+      '..',
+      'owasp-dependency-check-report.json',
+    );
   }
 
   public assert = {

--- a/src/e2e-tests/page-objects/MenuBar.ts
+++ b/src/e2e-tests/page-objects/MenuBar.ts
@@ -38,6 +38,14 @@ export class MenuBar {
     await clickMenuItem(this.window.app, 'label', 'ScanCode File (.json)');
   }
 
+  async openImportOwaspDependencyScanFile(): Promise<void> {
+    await clickMenuItem(
+      this.window.app,
+      'label',
+      'OWASP Dependency-Check (.json)',
+    );
+  }
+
   async toggleQaMode(): Promise<void> {
     await clickMenuItem(this.window.app, 'label', 'QA Mode');
   }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -232,6 +232,7 @@ export interface ExternalAttributionSources {
 export enum FileType {
   LEGACY_OPOSSUM,
   SCANCODE_JSON,
+  OWASP_JSON,
 }
 
 export interface FileFormatInfo {


### PR DESCRIPTION
### Summary of changes

Splitting up the menu.ts  file

### Context and reason for change

Reason: It got too large over time

### How can the changes be tested

Double check the menu
This PR should not NOT introduce any functional changes

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
