### PR TITLE
feat: update input file schema to include configurable classifications for signals

### DIFF
--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -11,6 +11,18 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "config": {
+      "type": "object",
+      "description": "Additional configuration for OpossumUI.",
+      "additionalProperties": true,
+      "properties": {
+        "classifications": {
+          "type": "object",
+          "description": "Mapping of classification values to human-readable labels. See \"classification\" field of \"externalAttribution\".",
+          "additionalProperties": true
+        }
+      }
+    },
     "resources": {
       "id": "#ResourcesSchema",
       "type": "object",
@@ -120,6 +132,11 @@
           "criticality": {
             "type": "string",
             "description": "Indication on how critical a signal is. Possible values are \"high\" and \"medium\"."
+          },
+          "classification": {
+            "type": "number",
+            "description": "Signal classification by usage, usually based on the license. Zero corresponds to unrestricted usage ehile higher levels mean more and more restrictions. Exact values and labels need to be configured in the config section.",
+            "minimum": 0
           },
           "copyright": {
             "type": "string",

--- a/src/ElectronBackend/input/OpossumInputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumInputFileSchema.json
@@ -13,13 +13,17 @@
   "properties": {
     "config": {
       "type": "object",
-      "description": "Additional configuration for OpossumUI.",
-      "additionalProperties": true,
+      "description": "Configuration for OpossumUI.",
       "properties": {
         "classifications": {
           "type": "object",
           "description": "Mapping of classification values to human-readable labels. See \"classification\" field of \"externalAttribution\".",
-          "additionalProperties": true
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[0-9]+$": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -135,7 +139,7 @@
           },
           "classification": {
             "type": "number",
-            "description": "Signal classification by usage, usually based on the license. Zero corresponds to unrestricted usage ehile higher levels mean more and more restrictions. Exact values and labels need to be configured in the config section.",
+            "description": "Signal classification by usage, usually based on the license. Zero corresponds to unrestricted usage while higher levels mean more and more restrictions. Exact values and labels need to be configured in the config section.",
             "minimum": 0
           },
           "copyright": {


### PR DESCRIPTION
### Summary of changes

Introduces a new field on `externalAttributions` called `classification`. It is a positive integer and its meaning (i.e. text label) can be configured via a new mapping `classifications`. In anticipation of further configurable items in the future, a new top-level key `config` is introduced with `classification` being its only subkey currently.

### Context and reason for change

We want to replace criticality by something more universally usable. Thus we introduce its successor in this PR and will build on this is in following work.

No further changes are required at this point. Opening files with OpossumUI and saving them preserves the `classification` information out-of-the-box since the input file is never changed.

#### Compatibility
This change is backwards compatible: new versions of OpossumUI can open old opossum files. However, new opossum files (with config and/or classification) cannot be opened by old OpossumUI releases.

### How can the changes be tested

There should be no functional changes because we just added optional fields. Everything that worked before still works.