### PR TITLE
Rollback logging progress messages to dialogs from frontend

### DIFF
--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -26,7 +26,6 @@ import { loadFromFile } from '../../state/actions/resource-actions/load-actions'
 import {
   openPopup,
   setLoading,
-  writeLogMessage,
 } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getBaseUrlsForSources } from '../../state/selectors/resource-selectors';
@@ -121,7 +120,6 @@ export const BackendCommunication: React.FC = () => {
     (_, log) => {
       const { date, level, message } = log;
       console[level](`${dayjs(date).format('HH:mm:ss.SSS')} ${message}`);
-      dispatch(writeLogMessage(log));
     },
     [dispatch],
   );

--- a/src/Frontend/Components/ImportDialog/ImportDialog.tsx
+++ b/src/Frontend/Components/ImportDialog/ImportDialog.tsx
@@ -6,12 +6,13 @@ import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 import { useState } from 'react';
 
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { FileFormatInfo, Log } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { getDotOpossumFilePath } from '../../../shared/write-file';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
-import { useAppDispatch, useStateEffect } from '../../state/hooks';
-import { getLogMessage } from '../../state/selectors/view-selector';
+import { useAppDispatch } from '../../state/hooks';
+import { LoggingListener, useIpcRenderer } from '../../util/use-ipc-renderer';
 import { FilePathInput } from '../FilePathInput/FilePathInput';
 import { LogDisplay } from '../LogDisplay/LogDisplay';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
@@ -30,9 +31,9 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
 
   const [logToDisplay, setLogToDisplay] = useState<Log | null>(null);
 
-  useStateEffect(
-    getLogMessage,
-    (log) => {
+  useIpcRenderer<LoggingListener>(
+    AllowedFrontendChannels.Logging,
+    (_, log) => {
       if (isLoading) {
         setLogToDisplay(log);
       }

--- a/src/Frontend/Components/ProcessPopup/ProcessPopup.tsx
+++ b/src/Frontend/Components/ProcessPopup/ProcessPopup.tsx
@@ -6,10 +6,12 @@ import MuiDialog from '@mui/material/Dialog';
 import MuiDialogTitle from '@mui/material/DialogTitle';
 import { useEffect, useState } from 'react';
 
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { Log } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
-import { useAppSelector, useStateEffect } from '../../state/hooks';
-import { getLogMessage, isLoading } from '../../state/selectors/view-selector';
+import { useAppSelector } from '../../state/hooks';
+import { isLoading } from '../../state/selectors/view-selector';
+import { LoggingListener, useIpcRenderer } from '../../util/use-ipc-renderer';
 import { LogDisplay } from '../LogDisplay/LogDisplay';
 import { DialogContent } from './ProcessPopup.style';
 
@@ -23,9 +25,9 @@ export function ProcessPopup() {
     }
   }, [loading]);
 
-  useStateEffect(
-    getLogMessage,
-    (log) => {
+  useIpcRenderer<LoggingListener>(
+    AllowedFrontendChannels.Logging,
+    (_, log) => {
       if (log) {
         setLogs((prev) => [...prev, log]);
       }

--- a/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
+++ b/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
@@ -3,17 +3,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { act, screen } from '@testing-library/react';
+import { IpcRendererEvent } from 'electron';
+import { noop } from 'lodash';
 
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
+import { ElectronAPI, Log } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { faker } from '../../../../testing/Faker';
-import {
-  setLoading,
-  writeLogMessage,
-} from '../../../state/actions/view-actions/view-actions';
 import { renderComponent } from '../../../test-helpers/render';
 import { ProcessPopup } from '../ProcessPopup';
 
+type Listener = (event: IpcRendererEvent, ...args: Array<unknown>) => void;
+
+const electronAPI: {
+  events: Partial<Record<AllowedFrontendChannels, Listener>>;
+  on: (channel: AllowedFrontendChannels, listener: Listener) => () => void;
+  send: (channel: AllowedFrontendChannels, ...args: Array<unknown>) => void;
+} = {
+  events: {},
+  on(channel: AllowedFrontendChannels, listener: Listener): () => void {
+    this.events[channel] = listener;
+    return noop;
+  },
+  send(channel: AllowedFrontendChannels, ...args: Array<unknown>): void {
+    this.events[channel]?.({} as IpcRendererEvent, ...args);
+  },
+};
+
 describe('ProcessPopup', () => {
+  beforeEach(() => {
+    electronAPI.events = {};
+    global.window.electronAPI = electronAPI as unknown as ElectronAPI;
+  });
+
   it('renders no dialog when loading is false', () => {
     renderComponent(<ProcessPopup />);
 
@@ -21,7 +43,14 @@ describe('ProcessPopup', () => {
   });
 
   it('renders dialog when loading is true', () => {
-    renderComponent(<ProcessPopup />, { actions: [setLoading(true)] });
+    renderComponent(<ProcessPopup />);
+
+    act(
+      () =>
+        void electronAPI.send(AllowedFrontendChannels.FileLoading, {
+          isLoading: true,
+        }),
+    );
 
     expect(screen.getByText(text.processPopup.title)).toBeInTheDocument();
   });
@@ -29,22 +58,28 @@ describe('ProcessPopup', () => {
   it('clears previous log messages when loading begins another time', () => {
     const date = faker.date.recent();
     const message = faker.lorem.sentence();
+    renderComponent(<ProcessPopup />);
 
-    const popup = <ProcessPopup />;
-
-    const { store } = renderComponent(popup, {
-      actions: [
-        setLoading(true),
-        writeLogMessage({
+    act(
+      () =>
+        void electronAPI.send(AllowedFrontendChannels.FileLoading, {
+          isLoading: true,
+        }),
+    );
+    act(
+      () =>
+        void electronAPI.send(AllowedFrontendChannels.Logging, {
           date,
           message,
           level: 'info',
+        } satisfies Log),
+    );
+    act(
+      () =>
+        void electronAPI.send(AllowedFrontendChannels.FileLoading, {
+          isLoading: true,
         }),
-      ],
-    });
-
-    act(() => void store.dispatch(setLoading(false)));
-    act(() => void store.dispatch(setLoading(true)));
+    );
 
     expect(screen.queryByText(message)).not.toBeInTheDocument();
   });

--- a/src/Frontend/state/actions/resource-actions/export-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/export-actions.ts
@@ -25,7 +25,7 @@ import {
   getResources,
 } from '../../selectors/resource-selectors';
 import { AppThunkAction } from '../../types';
-import { setLoading, writeInfoLogMessage } from '../view-actions/view-actions';
+import { setLoading } from '../view-actions/view-actions';
 
 export function exportFile(exportType: ExportType): AppThunkAction {
   return (dispatch, getState) => {
@@ -33,35 +33,22 @@ export function exportFile(exportType: ExportType): AppThunkAction {
 
     switch (exportType) {
       case ExportType.SpdxDocumentJson:
-        dispatch(writeInfoLogMessage('Preparing data for SPDX (json) export'));
         exportSpdxDocument(getState(), ExportType.SpdxDocumentJson);
         break;
 
       case ExportType.SpdxDocumentYaml:
-        dispatch(writeInfoLogMessage('Preparing data for SPDX (yaml) export'));
         exportSpdxDocument(getState(), ExportType.SpdxDocumentYaml);
         break;
 
       case ExportType.FollowUp:
-        dispatch(writeInfoLogMessage('Preparing data for follow-up export'));
         exportFollowUp(getState());
         break;
 
       case ExportType.CompactBom:
-        dispatch(
-          writeInfoLogMessage(
-            'Preparing data for compact component list export',
-          ),
-        );
         exportCompactBom(getState());
         break;
 
       case ExportType.DetailedBom:
-        dispatch(
-          writeInfoLogMessage(
-            'Preparing data for detailed component list export',
-          ),
-        );
         exportDetailedBom(getState());
         break;
     }

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -2,11 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  ExportType,
-  FileFormatInfo,
-  Log,
-} from '../../../../shared/shared-types';
+import { ExportType, FileFormatInfo } from '../../../../shared/shared-types';
 import { View } from '../../../enums/enums';
 import { PopupInfo } from '../../../types/types';
 
@@ -19,7 +15,6 @@ export const ACTION_SET_OPEN_FILE_REQUEST = 'ACTION_SET_OPEN_FILE_REQUEST';
 export const ACTION_SET_IMPORT_FILE_REQUEST = 'ACTION_SET_IMPORT_FILE_REQUEST';
 export const ACTION_SET_EXPORT_FILE_REQUEST = 'ACTION_SET_EXPORT_FILE_REQUEST';
 export const ACTION_SET_LOADING = 'ACTION_SET_LOADING';
-export const ACTION_SET_LOG_MESSAGE = 'ACTION_SET_LOG_MESSAGE';
 
 export type ViewAction =
   | SetView
@@ -30,8 +25,7 @@ export type ViewAction =
   | SetOpenFileRequestAction
   | SetImportFileRequestAction
   | SetExportFileRequestAction
-  | SetLoadingAction
-  | SetLogMessageAction;
+  | SetLoadingAction;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -74,9 +68,4 @@ export interface SetExportFileRequestAction {
 export interface SetLoadingAction {
   type: typeof ACTION_SET_LOADING;
   payload: boolean;
-}
-
-export interface SetLogMessageAction {
-  type: typeof ACTION_SET_LOG_MESSAGE;
-  payload: Log;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -2,11 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import {
-  ExportType,
-  FileFormatInfo,
-  Log,
-} from '../../../../shared/shared-types';
+import { ExportType, FileFormatInfo } from '../../../../shared/shared-types';
 import { PopupType, View } from '../../../enums/enums';
 import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../../shared-constants';
 import { State } from '../../../types/types';
@@ -21,7 +17,6 @@ import {
   ACTION_SET_EXPORT_FILE_REQUEST,
   ACTION_SET_IMPORT_FILE_REQUEST,
   ACTION_SET_LOADING,
-  ACTION_SET_LOG_MESSAGE,
   ACTION_SET_OPEN_FILE_REQUEST,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -31,7 +26,6 @@ import {
   SetExportFileRequestAction,
   SetImportFileRequestAction,
   SetLoadingAction,
-  SetLogMessageAction,
   SetOpenFileRequestAction,
   SetTargetView,
   SetView,
@@ -112,16 +106,4 @@ export function setExportFileRequest(
 
 export function setLoading(loading: boolean): SetLoadingAction {
   return { type: ACTION_SET_LOADING, payload: loading };
-}
-
-export function writeLogMessage(log: Log): SetLogMessageAction {
-  return { type: ACTION_SET_LOG_MESSAGE, payload: log };
-}
-
-export function writeInfoLogMessage(message: string): SetLogMessageAction {
-  return writeLogMessage({
-    date: new Date(),
-    message,
-    level: 'info',
-  });
 }

--- a/src/Frontend/state/hooks.ts
+++ b/src/Frontend/state/hooks.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { memoize } from 'proxy-memoize';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 
 import { State } from '../types/types';
@@ -19,19 +19,3 @@ export const useAppSelector = <T>(
   useSelector<State, T>(useCallback(memoize(fn), deps));
 
 export const useAppStore = useStore<State>;
-
-type WithParameter<F, A> = F extends () => infer R ? (v: A) => R : never;
-
-export const useStateEffect = <T>(
-  selector: (state: State) => T,
-  effect: WithParameter<React.EffectCallback, T>,
-  effectDeps: Array<unknown>,
-  selectorDeps: Array<unknown> = [],
-): void => {
-  const selectedState = useAppSelector(selector, selectorDeps);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const effectCallback = useCallback(effect, effectDeps);
-  useEffect(() => {
-    return effectCallback(selectedState);
-  }, [selectedState, effectCallback]);
-};

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ExportType, FileFormatInfo, Log } from '../../../shared/shared-types';
+import { ExportType, FileFormatInfo } from '../../../shared/shared-types';
 import { View } from '../../enums/enums';
 import { PopupInfo } from '../../types/types';
 import {
@@ -13,7 +13,6 @@ import {
   ACTION_SET_EXPORT_FILE_REQUEST,
   ACTION_SET_IMPORT_FILE_REQUEST,
   ACTION_SET_LOADING,
-  ACTION_SET_LOG_MESSAGE,
   ACTION_SET_OPEN_FILE_REQUEST,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -28,7 +27,6 @@ export interface ViewState {
   importFileRequest: FileFormatInfo | null;
   exportFileRequest: ExportType | null;
   loading: boolean;
-  logMessage: Log | null;
 }
 
 export const initialViewState: ViewState = {
@@ -39,7 +37,6 @@ export const initialViewState: ViewState = {
   importFileRequest: null,
   exportFileRequest: null,
   loading: false,
-  logMessage: null,
 };
 
 export function viewState(
@@ -92,11 +89,6 @@ export function viewState(
       return {
         ...state,
         loading: action.payload,
-      };
-    case ACTION_SET_LOG_MESSAGE:
-      return {
-        ...state,
-        logMessage: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ExportType, FileFormatInfo, Log } from '../../../shared/shared-types';
+import { ExportType, FileFormatInfo } from '../../../shared/shared-types';
 import { View } from '../../enums/enums';
 import { PopupInfo, State } from '../../types/types';
 
@@ -49,8 +49,4 @@ export function getExportFileRequest(state: State): ExportType | null {
 
 export function isLoading(state: State): boolean {
   return state.viewState.loading;
-}
-
-export function getLogMessage(state: State): Log | null {
-  return state.viewState.logMessage;
 }


### PR DESCRIPTION
### Summary of changes

Remove functionality for writing log messages (displayed as progress messages in popups/dialogs) from frontend. Now, such log messages are once again only being sent from the backend.

### Context and reason for change

Displaying log messages from both backend and frontend led to a lot of complexity for a non-critical use case.

### How can the changes be tested

Check that other log messages are still displayed normally.
