### PR TITLE
Add classification to internal data model

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -66,6 +66,12 @@ const inputFileContent: ParsedOpossumInputFile = {
     a: 1,
     folder: {},
   },
+  config: {
+    classifications: {
+      0: 'UNKNOWN',
+      1: 'CRITICAL',
+    },
+  },
   externalAttributions: {
     [externalAttributionUuid]: {
       source,
@@ -107,6 +113,12 @@ const expectedFileContent: ParsedFileContent = {
     projectTitle: 'Test Title',
   },
   resources: { a: 1, folder: {} },
+  config: {
+    classifications: {
+      0: 'UNKNOWN',
+      1: 'CRITICAL',
+    },
+  },
   manualAttributions: {
     attributions: {},
     resourcesToAttributions: {},
@@ -362,6 +374,12 @@ describe('Test of loading function', () => {
           resources: {
             a: 1,
           },
+          config: {
+            classifications: {
+              0: 'UNKNOWN',
+              1: 'CRITICAL',
+            },
+          },
           externalAttributions: {
             [externalAttributionUuid]: {
               source,
@@ -418,6 +436,12 @@ describe('Test of loading function', () => {
       const expectedLoadedFile: ParsedFileContent = {
         metadata: EMPTY_PROJECT_METADATA,
         resources: { a: 1 },
+        config: {
+          classifications: {
+            0: 'UNKNOWN',
+            1: 'CRITICAL',
+          },
+        },
         manualAttributions: {
           attributions: {
             [manualAttributionUuid]: {

--- a/src/ElectronBackend/input/__tests__/parseFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/parseFile.test.ts
@@ -25,6 +25,12 @@ const correctInput: ParsedOpossumInputFile = {
     projectId: '2a58a469-738e-4508-98d3-a27bce6e71f7',
     fileCreationDate: '2020-07-23 11:47:13.764544',
   },
+  config: {
+    classifications: {
+      0: 'UNKNOWN',
+      1: 'CRITICAL',
+    },
+  },
   externalAttributions: {
     [testUuid]: {
       source: {

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -167,6 +167,7 @@ export async function loadInputAndOutputFromFilePath(
   mainWindow.webContents.send(AllowedFrontendChannels.FileLoaded, {
     metadata: parsedInputData.metadata,
     resources: parsedInputData.resources,
+    config: parsedInputData.config,
     manualAttributions: {
       attributions: manualAttributions,
       resourcesToAttributions: parsedOutputData.resourcesToAttributions,

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -5,6 +5,7 @@
 import {
   BaseUrlsForSources,
   ExternalAttributionSources,
+  ProjectConfig,
   ProjectMetadata,
   RawAttributions,
   Resources,
@@ -45,6 +46,7 @@ export interface RawFrequentLicense {
 export interface ParsedOpossumInputFile {
   metadata: ProjectMetadata;
   resources: Resources;
+  config: ProjectConfig;
   externalAttributions: RawAttributions;
   resourcesToAttributions: ResourcesToAttributions;
   frequentLicenses?: Array<RawFrequentLicense>;

--- a/src/Frontend/shared-constants.ts
+++ b/src/Frontend/shared-constants.ts
@@ -6,6 +6,7 @@ import {
   AttributionData,
   FrequentLicenses,
   PackageInfo,
+  ProjectConfig,
   ProjectMetadata,
 } from '../shared/shared-types';
 import { text } from '../shared/text';
@@ -31,6 +32,10 @@ export const EMPTY_FREQUENT_LICENSES: FrequentLicenses = {
 export const EMPTY_PROJECT_METADATA: ProjectMetadata = {
   projectId: '',
   fileCreationDate: '',
+};
+
+export const EMPTY_PROJECT_CONFIG: ProjectConfig = {
+  classifications: {},
 };
 
 export const EMPTY_DISPLAY_PACKAGE_INFO: PackageInfo = {

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -223,7 +223,9 @@ describe('loadFromFile', () => {
 
     testStore.dispatch(loadFromFile(testParsedFileContent));
     expect(getResources(testStore.getState())).toEqual(expectedResources);
-    expect(getClassifications(testStore.getState())).toEqual(expectedConfig);
+    expect(getClassifications(testStore.getState())).toEqual(
+      expectedConfig.classifications,
+    );
     expect(getManualData(testStore.getState())).toEqual(expectedManualData);
     expect(getExternalData(testStore.getState())).toEqual(expectedExternalData);
     expect(getFrequentLicensesNameOrder(testStore.getState())).toEqual(

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -11,6 +11,7 @@ import {
   FrequentLicenses,
   PackageInfo,
   ParsedFileContent,
+  ProjectConfig,
   Resources,
   ResourcesToAttributions,
 } from '../../../../../shared/shared-types';
@@ -20,6 +21,7 @@ import { initialResourceState } from '../../../reducers/resource-reducer';
 import {
   getAttributionBreakpoints,
   getBaseUrlsForSources,
+  getClassifications,
   getExternalAttributionSources,
   getExternalData,
   getFilesWithChildren,
@@ -42,6 +44,13 @@ const testResources: Resources = {
       'something.js': 1,
     },
     'readme.md': 1,
+  },
+};
+
+const testConfig: ProjectConfig = {
+  classifications: {
+    0: 'UNKNOWN',
+    1: 'CRITICAL',
   },
 };
 
@@ -129,6 +138,7 @@ describe('loadFromFile', () => {
     const testParsedFileContent: ParsedFileContent = {
       metadata: EMPTY_PROJECT_METADATA,
       resources: testResources,
+      config: testConfig,
       manualAttributions: {
         attributions: testManualAttributions,
         resourcesToAttributions: testResourcesToManualAttributions,
@@ -149,6 +159,7 @@ describe('loadFromFile', () => {
       },
     };
     const expectedResources: Resources = testResources;
+    const expectedConfig: ProjectConfig = testConfig;
     const expectedManualData: AttributionData = {
       attributions: testManualAttributions,
       resourcesToAttributions: testResourcesToManualAttributions,
@@ -212,6 +223,7 @@ describe('loadFromFile', () => {
 
     testStore.dispatch(loadFromFile(testParsedFileContent));
     expect(getResources(testStore.getState())).toEqual(expectedResources);
+    expect(getClassifications(testStore.getState())).toEqual(expectedConfig);
     expect(getManualData(testStore.getState())).toEqual(expectedManualData);
     expect(getExternalData(testStore.getState())).toEqual(expectedExternalData);
     expect(getFrequentLicensesNameOrder(testStore.getState())).toEqual(
@@ -248,6 +260,7 @@ describe('loadFromFile', () => {
     const testParsedFileContent: ParsedFileContent = {
       metadata: EMPTY_PROJECT_METADATA,
       resources: testResources,
+      config: testConfig,
       manualAttributions: {
         attributions: testManualAttributions,
         resourcesToAttributions: testResourcesToManualAttributions,

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -9,6 +9,7 @@ import {
   ExternalAttributionSources,
   FrequentLicenses,
   PackageInfo,
+  ProjectConfig,
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
@@ -24,6 +25,7 @@ import {
   ACTION_SET_FILES_WITH_CHILDREN,
   ACTION_SET_FREQUENT_LICENSES,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
+  ACTION_SET_PROJECT_CONFIG,
   ACTION_SET_PROJECT_METADATA,
   ACTION_SET_RESOURCES,
   ACTION_SET_TEMPORARY_PACKAGE_INFO,
@@ -36,6 +38,7 @@ import {
   SetFrequentLicensesAction,
   SetIsPreferenceFeatureEnabled,
   SetManualDataAction,
+  SetProjectConfigAction,
   SetProjectMetadata,
   SetResourcesAction,
   SetTemporaryDisplayPackageInfoAction,
@@ -47,6 +50,10 @@ export function resetResourceState(): ResetResourceStateAction {
 
 export function setResources(resources: Resources | null): SetResourcesAction {
   return { type: ACTION_SET_RESOURCES, payload: resources };
+}
+
+export function setConfig(config: ProjectConfig): SetProjectConfigAction {
+  return { type: ACTION_SET_PROJECT_CONFIG, payload: config };
 }
 
 export function setManualData(

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -7,6 +7,7 @@ import { AppThunkAction } from '../../types';
 import {
   setAttributionBreakpoints,
   setBaseUrlsForSources,
+  setConfig,
   setExternalAttributionSources,
   setExternalData,
   setFilesWithChildren,
@@ -23,6 +24,8 @@ export function loadFromFile(
 ): AppThunkAction {
   return (dispatch) => {
     dispatch(setResources(parsedFileContent.resources));
+
+    dispatch(setConfig(parsedFileContent.config));
 
     dispatch(
       setManualData(

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -9,6 +9,7 @@ import {
   ExternalAttributionSources,
   FrequentLicenses,
   PackageInfo,
+  ProjectConfig,
   ProjectMetadata,
   Resources,
   ResourcesToAttributions,
@@ -18,6 +19,7 @@ export const ACTION_SET_SELECTED_ATTRIBUTION_ID =
   'ACTION_SET_SELECTED_ATTRIBUTION_ID';
 export const ACTION_RESET_RESOURCE_STATE = 'ACTION_RESET_RESOURCE_STATE';
 export const ACTION_SET_RESOURCES = 'ACTION_SET_RESOURCES';
+export const ACTION_SET_PROJECT_CONFIG = 'ACTION_SET_PROJECT_CONFIG';
 export const ACTION_SET_MANUAL_ATTRIBUTION_DATA =
   'ACTION_SET_MANUAL_ATTRIBUTION_DATA';
 export const ACTION_SET_EXTERNAL_ATTRIBUTION_DATA =
@@ -63,6 +65,7 @@ export const ACTION_SET_ENABLE_PREFERENCE_FEATURE =
 export type ResourceAction =
   | ResetResourceStateAction
   | SetResourcesAction
+  | SetProjectConfigAction
   | SetManualDataAction
   | SetExternalDataAction
   | SetFrequentLicensesAction
@@ -95,6 +98,11 @@ export interface ResetResourceStateAction {
 export interface SetResourcesAction {
   type: typeof ACTION_SET_RESOURCES;
   payload: Resources | null;
+}
+
+export interface SetProjectConfigAction {
+  type: typeof ACTION_SET_PROJECT_CONFIG;
+  payload: ProjectConfig;
 }
 
 export interface SetManualDataAction {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -8,6 +8,7 @@ import {
   ExternalAttributionSources,
   FrequentLicenses,
   PackageInfo,
+  ProjectConfig,
   ProjectMetadata,
   Resources,
 } from '../../../shared/shared-types';
@@ -15,6 +16,7 @@ import {
   EMPTY_ATTRIBUTION_DATA,
   EMPTY_DISPLAY_PACKAGE_INFO,
   EMPTY_FREQUENT_LICENSES,
+  EMPTY_PROJECT_CONFIG,
   EMPTY_PROJECT_METADATA,
   ROOT_PATH,
 } from '../../shared-constants';
@@ -71,6 +73,7 @@ export const initialResourceState: ResourceState = {
   isPreferenceFeatureEnabled: false,
   manualData: EMPTY_ATTRIBUTION_DATA,
   metadata: EMPTY_PROJECT_METADATA,
+  config: EMPTY_PROJECT_CONFIG,
   resolvedExternalAttributions: new Set(),
   resources: null,
   resourceIds: null,
@@ -92,6 +95,7 @@ export type ResourceState = {
   isPreferenceFeatureEnabled: boolean;
   manualData: AttributionData;
   metadata: ProjectMetadata;
+  config: ProjectConfig;
   resolvedExternalAttributions: Set<string>;
   resources: Resources | null;
   resourceIds: Array<string> | null;

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -38,6 +38,7 @@ import {
   ACTION_SET_FILES_WITH_CHILDREN,
   ACTION_SET_FREQUENT_LICENSES,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
+  ACTION_SET_PROJECT_CONFIG,
   ACTION_SET_PROJECT_METADATA,
   ACTION_SET_RESOLVED_EXTERNAL_ATTRIBUTIONS,
   ACTION_SET_RESOURCES,
@@ -120,6 +121,11 @@ export const resourceState = (
         resourceIds: action.payload
           ? getResourceIdsFromResources(action.payload)
           : null,
+      };
+    case ACTION_SET_PROJECT_CONFIG:
+      return {
+        ...state,
+        config: action.payload,
       };
     case ACTION_SET_MANUAL_ATTRIBUTION_DATA:
       return {

--- a/src/Frontend/state/selectors/resource-selectors.ts
+++ b/src/Frontend/state/selectors/resource-selectors.ts
@@ -9,6 +9,7 @@ import {
   Attributions,
   AttributionsToResources,
   BaseUrlsForSources,
+  Classifications,
   ExternalAttributionSources,
   FrequentLicenseName,
   LicenseTexts,
@@ -139,6 +140,10 @@ export function getFilesWithChildren(state: State): Set<string> {
 
 export function getProjectMetadata(state: State): ProjectMetadata {
   return state.resourceState.metadata;
+}
+
+export function getClassifications(state: State): Classifications {
+  return state.resourceState.config.classifications;
 }
 
 export function getPackageInfoOfSelectedAttribution(

--- a/src/Frontend/test-helpers/general-test-helpers.ts
+++ b/src/Frontend/test-helpers/general-test-helpers.ts
@@ -15,6 +15,7 @@ import {
 } from '../../shared/shared-types';
 import {
   EMPTY_FREQUENT_LICENSES,
+  EMPTY_PROJECT_CONFIG,
   EMPTY_PROJECT_METADATA,
 } from '../shared-constants';
 import { canResourceHaveChildren } from '../util/can-resource-have-children';
@@ -22,6 +23,7 @@ import { canResourceHaveChildren } from '../util/can-resource-have-children';
 const EMPTY_PARSED_FILE_CONTENT: ParsedFileContent = {
   metadata: EMPTY_PROJECT_METADATA,
   resources: {},
+  config: EMPTY_PROJECT_CONFIG,
   manualAttributions: {
     attributions: {},
     resourcesToAttributions: {},

--- a/src/Frontend/util/get-stripped-package-info.ts
+++ b/src/Frontend/util/get-stripped-package-info.ts
@@ -26,6 +26,7 @@ const strippedPackageInfoTemplate: {
 } = {
   attributionConfidence: true,
   comment: true,
+  classification: false,
   copyright: true,
   count: false,
   criticality: false,

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -52,6 +52,7 @@ interface EphemeralPackageInfoProps {
 
 export interface PackageInfo extends EphemeralPackageInfoProps {
   attributionConfidence?: number;
+  classification?: number;
   comment?: string;
   copyright?: string;
   count?: number;
@@ -139,9 +140,18 @@ export interface ProjectMetadata {
   [otherMetadata: string]: unknown;
 }
 
+export interface Classifications {
+  [classification: number]: string;
+}
+
+export interface ProjectConfig {
+  classifications: Classifications;
+}
+
 export interface ParsedFileContent {
   metadata: ProjectMetadata;
   resources: Resources;
+  config: ProjectConfig;
   manualAttributions: InputFileAttributionData;
   externalAttributions: InputFileAttributionData;
   frequentLicenses: FrequentLicenses;

--- a/src/testing/Faker.ts
+++ b/src/testing/Faker.ts
@@ -263,6 +263,7 @@ class OpossumModule {
     return {
       metadata: OpossumModule.metadata(),
       resources: {},
+      config: { classifications: {} },
       externalAttributions: {},
       resourcesToAttributions: {},
       ...props,


### PR DESCRIPTION
### Summary of changes

Added classification to internal data model:
* Add field for classification config in resource state
* Add classification field on attributions

### Context and reason for change

Upcoming tickets will need access to classification data included in .opossum files.

### How can the changes be tested

* Check that files can be parsed and opened without error
* (Optional) log parts of internal state to console after load has finished, check that classification data in internal state is correct
