### PR TITLE
Simplify listener error handling

### DIFF
--- a/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
+++ b/src/ElectronBackend/errorHandling/__tests__/errorHandling.test.ts
@@ -9,7 +9,6 @@ import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { SendErrorInformationArgs } from '../../../shared/shared-types';
 import { loadInputAndOutputFromFilePath } from '../../input/importFromFile';
 import {
-  createVoidListenerCallbackWithErrorHandling,
   getMessageBoxContentForErrorsWrapper,
   getMessageBoxForErrors,
 } from '../errorHandling';
@@ -34,52 +33,6 @@ jest.mock('../../main/listeners', () => ({
 }));
 
 describe('error handling', () => {
-  describe('createListenerCallbackWithErrorHandling', () => {
-    it('returns a wrapper that calls the input function with the same parameters', async () => {
-      const mainWindow = {
-        webContents: { send: jest.fn() },
-      } as unknown as BrowserWindow;
-
-      const testFunction = jest.fn();
-      const testArgs = {
-        arg1: '1',
-        arg2: true,
-      };
-
-      await createVoidListenerCallbackWithErrorHandling(
-        mainWindow,
-        testFunction,
-      )(testArgs);
-      expect(testFunction).toHaveBeenCalledTimes(1);
-      expect(testFunction).toHaveBeenCalledWith(
-        expect.objectContaining(testArgs),
-      );
-    });
-
-    it('shows errors from the input function in a messageBox', async () => {
-      const mainWindow = {
-        webContents: { send: jest.fn() },
-      } as unknown as BrowserWindow;
-
-      function testFunction(): void {
-        throw new Error('TEST_ERROR');
-      }
-
-      await createVoidListenerCallbackWithErrorHandling(
-        mainWindow,
-        testFunction,
-      )();
-
-      expect(dialog.showMessageBox).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error',
-          message: 'Error in app backend: TEST_ERROR',
-          buttons: ['Reload File', 'Quit'],
-        }),
-      );
-    });
-  });
-
   describe('getMessageBoxContentForErrors', () => {
     it('for backend errors', () => {
       const testError = new Error('TEST_ERROR');

--- a/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
+++ b/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
@@ -9,7 +9,7 @@ import * as MockDate from 'mockdate';
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { writeFile } from '../../../shared/write-file';
 import { setGlobalBackendState } from '../globalBackendState';
-import { getSaveFileListener } from '../listeners';
+import { saveFileListener } from '../listeners';
 
 jest.mock('electron', () => ({
   dialog: {
@@ -42,7 +42,7 @@ describe('getSaveFileListener', () => {
     } as unknown as BrowserWindow;
     setGlobalBackendState({});
 
-    await getSaveFileListener(mainWindow)(
+    await saveFileListener(mainWindow)(
       AllowedFrontendChannels.SaveFileRequest,
       {
         manualAttributions: {},
@@ -72,7 +72,7 @@ describe('getSaveFileListener', () => {
       projectId: 'uuid_1',
     });
 
-    await getSaveFileListener(mainWindow)(
+    await saveFileListener(mainWindow)(
       AllowedFrontendChannels.SaveFileRequest,
       {
         manualAttributions: {},
@@ -102,7 +102,7 @@ describe('getSaveFileListener', () => {
       } as unknown as BrowserWindow;
       setGlobalBackendState({});
 
-      const listener = getSaveFileListener(mainWindow);
+      const listener = saveFileListener(mainWindow);
 
       setGlobalBackendState({
         resourceFilePath: '/resourceFile.json',

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -27,9 +27,8 @@ import {
 import { writeFile, writeOpossumFile } from '../../shared/write-file';
 import { LoadedFileFormat } from '../enums/enums';
 import {
-  createListenerCallbackWithErrorHandling,
-  createVoidListenerCallbackWithErrorHandling,
-  ListenerErrorReporting,
+  sendListenerErrorToFrontend,
+  showListenerErrorInMessageBox,
 } from '../errorHandling/errorHandling';
 import { loadInputAndOutputFromFilePath } from '../input/importFromFile';
 import { serializeAttributions } from '../input/parseInputData';
@@ -51,12 +50,10 @@ import {
 } from './globalBackendState';
 import logger from './logger';
 
-export function getSaveFileListener(
-  mainWindow: BrowserWindow,
-): (_: unknown, args: SaveFileArgs) => Promise<void> {
-  return createVoidListenerCallbackWithErrorHandling(
-    mainWindow,
-    (_: unknown, args: SaveFileArgs) => {
+export const saveFileListener =
+  (mainWindow: BrowserWindow) =>
+  async (_: unknown, args: SaveFileArgs): Promise<void> => {
+    try {
       const globalBackendState = getGlobalBackendState();
 
       if (!globalBackendState.projectId) {
@@ -77,9 +74,10 @@ export function getSaveFileListener(
       };
 
       return writeOutputJsonToFile(outputFileContent);
-    },
-  );
-}
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
+    }
+  };
 
 async function writeOutputJsonToFile(
   outputFileContent: OpossumOutputFile,
@@ -100,20 +98,21 @@ async function writeOutputJsonToFile(
   }
 }
 
-export function getOpenFileListener(
-  mainWindow: BrowserWindow,
-  onOpen: () => void,
-): () => Promise<void> {
-  return createVoidListenerCallbackWithErrorHandling(mainWindow, async () => {
-    const filePaths = openOpossumFileDialog();
-    if (!filePaths || filePaths.length < 1) {
-      return;
-    }
-    const filePath = filePaths[0];
+export const openFileListener =
+  (mainWindow: BrowserWindow, onOpen: () => void) =>
+  async (): Promise<void> => {
+    try {
+      const filePaths = openOpossumFileDialog();
+      if (!filePaths || filePaths.length < 1) {
+        return;
+      }
+      const filePath = filePaths[0];
 
-    await handleOpeningFile(mainWindow, filePath, onOpen);
-  });
-}
+      await handleOpeningFile(mainWindow, filePath, onOpen);
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
+    }
+  };
 
 export async function handleOpeningFile(
   mainWindow: BrowserWindow,
@@ -126,28 +125,21 @@ export async function handleOpeningFile(
   await openFile(mainWindow, filePath, onOpen);
 }
 
-export function getImportFileListener(
-  mainWindow: BrowserWindow,
-  fileFormat: FileFormatInfo,
-): () => Promise<void> {
-  return createVoidListenerCallbackWithErrorHandling(mainWindow, () => {
+export const importFileListener =
+  (mainWindow: BrowserWindow, fileFormat: FileFormatInfo) => (): void => {
     mainWindow.webContents.send(
       AllowedFrontendChannels.ImportFileShowDialog,
       fileFormat,
     );
-  });
-}
+  };
 
-export function getImportFileSelectInputListener(
-  mainWindow: BrowserWindow,
-): (
-  _: Electron.IpcMainInvokeEvent,
-  fileFormat: FileFormatInfo,
-) => Promise<string> {
-  return createListenerCallbackWithErrorHandling(
-    mainWindow,
-    '',
-    (_: Electron.IpcMainInvokeEvent, fileFormat: FileFormatInfo) => {
+export const importFileSelectInputListener =
+  (mainWindow: BrowserWindow) =>
+  async (
+    _: Electron.IpcMainInvokeEvent,
+    fileFormat: FileFormatInfo,
+  ): Promise<string> => {
+    try {
       const filePaths = openNonOpossumFileDialog(fileFormat);
 
       // NOTE: explicitly checking filePaths.length creates issues in e2e tests
@@ -155,41 +147,35 @@ export function getImportFileSelectInputListener(
       // and object with number indices for some reason, so filePaths.length is
       // undefined in e2e tests
       return filePaths?.[0] || '';
-    },
-  );
-}
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
+      return '';
+    }
+  };
 
-export function getImportFileSelectSaveLocationListener(
-  mainWindow: BrowserWindow,
-): (_: Electron.IpcMainInvokeEvent, defaultPath: string) => Promise<string> {
-  return createListenerCallbackWithErrorHandling(
-    mainWindow,
-    '',
-    (_: Electron.IpcMainInvokeEvent, defaultPath: string) => {
-      const filePath = saveFileDialog(defaultPath);
-      return filePath ?? '';
-    },
-  );
-}
+export const importFileSelectSaveLocationListener =
+  (mainWindow: BrowserWindow) =>
+  async (
+    _: Electron.IpcMainInvokeEvent,
+    defaultPath: string,
+  ): Promise<string> => {
+    try {
+      return saveFileDialog(defaultPath) ?? '';
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
+      return '';
+    }
+  };
 
-export function getImportFileConvertAndLoadListener(
-  mainWindow: BrowserWindow,
-  onOpen: () => void,
-): (
-  _: Electron.IpcMainInvokeEvent,
-  resourceFilePath: string,
-  fileType: FileType,
-  opossumFilePath: string,
-) => Promise<boolean> {
-  return createListenerCallbackWithErrorHandling(
-    mainWindow,
-    false,
-    async (
-      _: Electron.IpcMainInvokeEvent,
-      resourceFilePath: string,
-      fileType: FileType,
-      opossumFilePath: string,
-    ) => {
+export const importFileConvertAndLoadListener =
+  (mainWindow: BrowserWindow, onOpen: () => void) =>
+  async (
+    _: Electron.IpcMainInvokeEvent,
+    resourceFilePath: string,
+    fileType: FileType,
+    opossumFilePath: string,
+  ): Promise<boolean> => {
+    try {
       if (!resourceFilePath.trim() || !fs.existsSync(resourceFilePath)) {
         throw new Error('Input file does not exist');
       }
@@ -215,10 +201,11 @@ export function getImportFileConvertAndLoadListener(
       await openFile(mainWindow, opossumFilePath, onOpen, true);
 
       return true;
-    },
-    ListenerErrorReporting.SendToFrontend,
-  );
-}
+    } catch (error) {
+      sendListenerErrorToFrontend(mainWindow, error);
+      return false;
+    }
+  };
 
 function initializeGlobalBackendState(
   filePath: string,
@@ -247,44 +234,46 @@ function initializeGlobalBackendState(
   setGlobalBackendState(newGlobalBackendState);
 }
 
-export function getDeleteAndCreateNewAttributionFileListener(
-  mainWindow: BrowserWindow,
-  onOpen: () => void,
-): () => Promise<void> {
-  return createVoidListenerCallbackWithErrorHandling(mainWindow, async () => {
-    const globalBackendState = getGlobalBackendState();
-    const resourceFilePath = globalBackendState.resourceFilePath as string;
+export const deleteAndCreateNewAttributionFileListener =
+  (mainWindow: BrowserWindow, onOpen: () => void) =>
+  async (): Promise<void> => {
+    try {
+      const globalBackendState = getGlobalBackendState();
+      const resourceFilePath = globalBackendState.resourceFilePath as string;
 
-    logger.info(
-      `Deleting attribution file and opening input file ${resourceFilePath}`,
-    );
-    if (globalBackendState.attributionFilePath) {
-      fs.unlinkSync(globalBackendState.attributionFilePath);
-    } else {
-      throw new Error(
-        `Failed to delete output file. Attribution file path is incorrect: ${globalBackendState.attributionFilePath}`,
+      logger.info(
+        `Deleting attribution file and opening input file ${resourceFilePath}`,
       );
+      if (globalBackendState.attributionFilePath) {
+        fs.unlinkSync(globalBackendState.attributionFilePath);
+      } else {
+        throw new Error(
+          `Failed to delete output file. Attribution file path is incorrect: ${globalBackendState.attributionFilePath}`,
+        );
+      }
+      await openFile(mainWindow, resourceFilePath, onOpen);
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
     }
-    await openFile(mainWindow, resourceFilePath, onOpen);
-  });
-}
+  };
 
-export function getSelectBaseURLListener(
-  mainWindow: BrowserWindow,
-): () => void {
-  return createVoidListenerCallbackWithErrorHandling(mainWindow, () => {
-    const baseURLs = selectBaseURLDialog();
-    if (!baseURLs || baseURLs.length < 1) {
-      return;
+export const selectBaseURLListener =
+  (mainWindow: BrowserWindow) => async (): Promise<void> => {
+    try {
+      const baseURLs = selectBaseURLDialog();
+      if (!baseURLs || baseURLs.length < 1) {
+        return;
+      }
+      const baseURL = baseURLs[0];
+      const formattedBaseURL = formatBaseURL(baseURL);
+
+      mainWindow.webContents.send(AllowedFrontendChannels.SetBaseURLForRoot, {
+        baseURLForRoot: formattedBaseURL,
+      });
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
     }
-    const baseURL = baseURLs[0];
-    const formattedBaseURL = formatBaseURL(baseURL);
-
-    mainWindow.webContents.send(AllowedFrontendChannels.SetBaseURLForRoot, {
-      baseURLForRoot: formattedBaseURL,
-    });
-  });
-}
+  };
 
 function formatBaseURL(baseURL: string): string {
   return `file://${baseURL}/{path}`;
@@ -327,28 +316,26 @@ export function linkHasHttpSchema(link: string): boolean {
   return url.protocol === 'https:' || url.protocol === 'http:';
 }
 
-export function getOpenLinkListener(): (
+export async function openLinkListener(
   _: unknown,
   args: OpenLinkArgs,
-) => Promise<Error | void> {
-  return async (_, args: OpenLinkArgs): Promise<Error | void> => {
-    try {
-      if (!linkHasHttpSchema(args.link)) {
-        // noinspection ExceptionCaughtLocallyJS
-        throw new Error(`Invalid URL ${args.link}`);
-      }
-      // Does not throw on Linux if link cannot be opened.
-      // see https://github.com/electron/electron/issues/28183
-      return await shell.openExternal(args.link);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        logger.info(`Cannot open link ${args.link}: ${error.message}`);
-        return error;
-      }
-      logger.info(`Cannot open link ${args.link}`);
-      return new Error('Cannot open link');
+): Promise<Error | void> {
+  try {
+    if (!linkHasHttpSchema(args.link)) {
+      // noinspection ExceptionCaughtLocallyJS
+      throw new Error(`Invalid URL ${args.link}`);
     }
-  };
+    // Does not throw on Linux if link cannot be opened.
+    // see https://github.com/electron/electron/issues/28183
+    return await shell.openExternal(args.link);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      logger.info(`Cannot open link ${args.link}: ${error.message}`);
+      return error;
+    }
+    logger.info(`Cannot open link ${args.link}`);
+    return new Error('Cannot open link');
+  }
 }
 
 interface FileExporterAndExportedFilePath<T> {
@@ -404,8 +391,9 @@ export function getExportedFilePathAndFileExporter(
   }
 }
 
-export function exportFile(mainWindow: BrowserWindow) {
-  return async (_: unknown, exportArgs: ExportArgsType): Promise<void> => {
+export const exportFileListener =
+  (mainWindow: BrowserWindow) =>
+  async (_: unknown, exportArgs: ExportArgsType): Promise<void> => {
     const { exportedFilePath, fileExporter } =
       getExportedFilePathAndFileExporter(exportArgs.type);
 
@@ -417,6 +405,8 @@ export function exportFile(mainWindow: BrowserWindow) {
         logger.error('Failed to create export');
         throw new Error('Failed to create export');
       }
+    } catch (error) {
+      await showListenerErrorInMessageBox(mainWindow, error);
     } finally {
       setLoadingState(mainWindow.webContents, false);
 
@@ -425,16 +415,6 @@ export function exportFile(mainWindow: BrowserWindow) {
       }
     }
   };
-}
-
-export function getExportFileListener(
-  mainWindow: BrowserWindow,
-): (_: unknown, args: ExportArgsType) => Promise<void> {
-  return createVoidListenerCallbackWithErrorHandling(
-    mainWindow,
-    exportFile(mainWindow),
-  );
-}
 
 async function createFollowUp(
   followUpFilePath: string,

--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -9,14 +9,14 @@ import { IpcChannel } from '../../shared/ipc-channels';
 import { getMessageBoxContentForErrorsWrapper } from '../errorHandling/errorHandling';
 import { createWindow } from './createWindow';
 import {
-  getDeleteAndCreateNewAttributionFileListener,
-  getExportFileListener,
-  getImportFileConvertAndLoadListener,
-  getImportFileSelectInputListener,
-  getImportFileSelectSaveLocationListener,
-  getOpenFileListener,
-  getOpenLinkListener,
-  getSaveFileListener,
+  deleteAndCreateNewAttributionFileListener,
+  exportFileListener,
+  importFileConvertAndLoadListener,
+  importFileSelectInputListener,
+  importFileSelectSaveLocationListener,
+  openFileListener,
+  openLinkListener,
+  saveFileListener,
 } from './listeners';
 import { createMenu } from './menu';
 import { activateMenuItems } from './menu/initiallyDisabledMenuItems';
@@ -66,30 +66,27 @@ export async function main(): Promise<void> {
     });
     ipcMain.handle(
       IpcChannel.OpenFile,
-      getOpenFileListener(mainWindow, activateMenuItems),
+      openFileListener(mainWindow, activateMenuItems),
     );
     ipcMain.handle(
       IpcChannel.ImportFileSelectInput,
-      getImportFileSelectInputListener(mainWindow),
+      importFileSelectInputListener(mainWindow),
     );
     ipcMain.handle(
       IpcChannel.ImportFileSelectSaveLocation,
-      getImportFileSelectSaveLocationListener(mainWindow),
+      importFileSelectSaveLocationListener(mainWindow),
     );
     ipcMain.handle(
       IpcChannel.ImportFileConvertAndLoad,
-      getImportFileConvertAndLoadListener(mainWindow, activateMenuItems),
+      importFileConvertAndLoadListener(mainWindow, activateMenuItems),
     );
-    ipcMain.handle(IpcChannel.SaveFile, getSaveFileListener(mainWindow));
+    ipcMain.handle(IpcChannel.SaveFile, saveFileListener(mainWindow));
     ipcMain.handle(
       IpcChannel.DeleteFile,
-      getDeleteAndCreateNewAttributionFileListener(
-        mainWindow,
-        activateMenuItems,
-      ),
+      deleteAndCreateNewAttributionFileListener(mainWindow, activateMenuItems),
     );
-    ipcMain.handle(IpcChannel.ExportFile, getExportFileListener(mainWindow));
-    ipcMain.handle(IpcChannel.OpenLink, getOpenLinkListener());
+    ipcMain.handle(IpcChannel.ExportFile, exportFileListener(mainWindow));
+    ipcMain.handle(IpcChannel.OpenLink, openLinkListener);
     ipcMain.handle(IpcChannel.GetUserSettings, (_, key) =>
       UserSettings.get(key),
     );

--- a/src/ElectronBackend/main/menu/fileMenu.ts
+++ b/src/ElectronBackend/main/menu/fileMenu.ts
@@ -14,7 +14,7 @@ import {
 import { isFileLoaded } from '../../utils/getLoadedFile';
 import { getGlobalBackendState } from '../globalBackendState';
 import { getIconBasedOnTheme } from '../iconHelpers';
-import { getImportFileListener, getSelectBaseURLListener } from '../listeners';
+import { importFileListener, selectBaseURLListener } from '../listeners';
 import { INITIALLY_DISABLED_ITEMS_INFO } from './initiallyDisabledMenuItems';
 
 export const importFileFormats: Array<FileFormatInfo> = [
@@ -56,7 +56,7 @@ function getImportFile(mainWindow: Electron.CrossProcessExports.BrowserWindow) {
     label: 'Import File',
     submenu: importFileFormats.map((fileFormat) => ({
       label: `${fileFormat.name} (${fileFormat.extensions.map((ext) => `.${ext}`).join('/')})`,
-      click: getImportFileListener(mainWindow, fileFormat),
+      click: importFileListener(mainWindow, fileFormat),
     })),
   };
 }
@@ -118,9 +118,7 @@ function getSetBaseUrl(mainWindow: Electron.CrossProcessExports.BrowserWindow) {
       'icons/restore-black.png',
     ),
     label: 'Set Path to Sources',
-    click: () => {
-      getSelectBaseURLListener(mainWindow)();
-    },
+    click: selectBaseURLListener(mainWindow),
   };
 }
 


### PR DESCRIPTION
* dedicated error handling methods were getting too restrictive and complex
* simply using try/catch blocks directly is just as good
* also change listener functions into curried lambda functions to reduce function signature boilerplate

### Summary of changes

* Replaced dedicated error handling functions with simply using try/catch blocks
* Changed listener functions into curried lambda functions

### Context and reason for change

* Dedicated error handling functions had quite complex definitions and were getting a bit restrictive, e.g. to use a finally block for error handling the functions would have required yet another parameter. Also, they were basically just wrappers around try/catch with very little additional functionality
* Listener functions had quite some boilerplate as typescript doesn't support currying for normal functions. This can be done in a more concise manner when using lambda functions instead

### How can the changes be tested

* Check that listener errors are still reported as before
