### PR TITLE
fix: config is optional

### DIFF
--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import { cloneDeep } from 'lodash';
 import { v4 as uuid4 } from 'uuid';
 
+import { EMPTY_PROJECT_CONFIG } from '../../Frontend/shared-constants';
 import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   Attributions,
@@ -167,7 +168,7 @@ export async function loadInputAndOutputFromFilePath(
   mainWindow.webContents.send(AllowedFrontendChannels.FileLoaded, {
     metadata: parsedInputData.metadata,
     resources: parsedInputData.resources,
-    config: parsedInputData.config,
+    config: parsedInputData.config ?? EMPTY_PROJECT_CONFIG,
     manualAttributions: {
       attributions: manualAttributions,
       resourcesToAttributions: parsedOutputData.resourcesToAttributions,

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -46,7 +46,7 @@ export interface RawFrequentLicense {
 export interface ParsedOpossumInputFile {
   metadata: ProjectMetadata;
   resources: Resources;
-  config: ProjectConfig;
+  config?: ProjectConfig;
   externalAttributions: RawAttributions;
   resourcesToAttributions: ResourcesToAttributions;
   frequentLicenses?: Array<RawFrequentLicense>;


### PR DESCRIPTION
### Summary of changes

When loading an input file without `config` field, we replace the resulting `undefined` with an object that represents an empty config properly.

### Context and reason for change

Since config is optional, we need to handle the case when it is not present in the opossum file

### How can the changes be tested

Not directly since nothing uses `getClassifications` right now. However my next PR cause errors on opossum files without `config` section.