### PR TITLE
Feat icon for classification

### DIFF
--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import AnnouncementIcon from '@mui/icons-material/Announcement';
+import ContentPasteSharpIcon from '@mui/icons-material/ContentPasteSharp';
 import DescriptionIcon from '@mui/icons-material/Description';
 import ExploreIcon from '@mui/icons-material/Explore';
 import Filter1Icon from '@mui/icons-material/Filter1';
@@ -203,6 +204,40 @@ export function CriticalityIcon({
         sx={{
           ...baseIcon,
           color: `${criticalityColor[criticality]} !important`,
+          ...sx,
+        }}
+        className={className}
+      />
+    </MuiTooltip>
+  );
+}
+
+export function ClassificationIcon({
+  className,
+  classification,
+  noTooltip,
+  tooltip,
+  sx,
+  tooltipPlacement,
+}: IconProps & {
+  classification?: number;
+  tooltip?: string;
+}) {
+  if (!classification || classification === 0) {
+    return null;
+  }
+
+  return (
+    <MuiTooltip
+      title={noTooltip ? undefined : tooltip}
+      placement={tooltipPlacement}
+      disableInteractive
+    >
+      <ContentPasteSharpIcon
+        aria-label={'Classification icon'}
+        sx={{
+          ...baseIcon,
+          color: `${OpossumColors.mediumOrange} !important`,
           ...sx,
         }}
         className={className}

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -237,7 +237,7 @@ export function ClassificationIcon({
         aria-label={'Classification icon'}
         sx={{
           ...baseIcon,
-          color: `${OpossumColors.mediumOrange} !important`,
+          color: `${OpossumColors.red} !important`,
           ...sx,
         }}
         className={className}

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import AnnouncementIcon from '@mui/icons-material/Announcement';
-import ContentPasteSharpIcon from '@mui/icons-material/ContentPasteSharp';
 import DescriptionIcon from '@mui/icons-material/Description';
 import ExploreIcon from '@mui/icons-material/Explore';
 import Filter1Icon from '@mui/icons-material/Filter1';
@@ -18,7 +17,7 @@ import StarIcon from '@mui/icons-material/Star';
 import StarHalfIcon from '@mui/icons-material/StarHalf';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
 import WidgetsIcon from '@mui/icons-material/Widgets';
-import { SxProps } from '@mui/material';
+import { Icon, SxProps } from '@mui/material';
 import MuiTooltip from '@mui/material/Tooltip';
 
 import { Criticality } from '../../../shared/shared-types';
@@ -233,15 +232,20 @@ export function ClassificationIcon({
       placement={tooltipPlacement}
       disableInteractive
     >
-      <ContentPasteSharpIcon
+      <Icon
         aria-label={'Classification icon'}
         sx={{
           ...baseIcon,
           color: `${OpossumColors.red} !important`,
           ...sx,
+          fontFamily: 'sans-serif',
+          fontWeight: 'bold',
+          fontSize: 'medium !important',
         }}
         className={className}
-      />
+      >
+        C
+      </Icon>
     </MuiTooltip>
   );
 }

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -20,7 +20,7 @@ import WidgetsIcon from '@mui/icons-material/Widgets';
 import { Icon, SxProps } from '@mui/material';
 import MuiTooltip from '@mui/material/Tooltip';
 
-import { Criticality } from '../../../shared/shared-types';
+import { Classifications, Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { baseIcon, criticalityColor, OpossumColors } from '../../shared-styles';
 
@@ -214,24 +214,23 @@ export function CriticalityIcon({
 export function ClassificationIcon({
   className,
   classification,
-  noTooltip,
-  tooltip,
+  classification_mapping,
   sx,
   tooltipPlacement,
 }: IconProps & {
   classification?: number;
-  tooltip?: string;
+  classification_mapping?: Classifications;
 }) {
   if (!classification || classification === 0) {
     return null;
   }
+  const tooltip = classification_mapping?.[classification];
+  if (!tooltip) {
+    return null;
+  }
 
   return (
-    <MuiTooltip
-      title={noTooltip ? undefined : tooltip}
-      placement={tooltipPlacement}
-      disableInteractive
-    >
+    <MuiTooltip title={tooltip} placement={tooltipPlacement} disableInteractive>
       <Icon
         aria-label={'Classification icon'}
         sx={{

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -7,6 +7,7 @@ import { render, screen } from '@testing-library/react';
 import { Criticality } from '../../../../shared/shared-types';
 import {
   BreakpointIcon,
+  ClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   ExcludeFromNoticeIcon,
@@ -60,6 +61,20 @@ describe('The Icons', () => {
     render(<CriticalityIcon criticality={Criticality.High} />);
 
     expect(screen.getByLabelText('Criticality icon')).toBeInTheDocument();
+  });
+
+  it('does not render ClassificationIcon for classification 0', () => {
+    render(<ClassificationIcon classification={0} />);
+
+    expect(
+      screen.queryByLabelText('Classification icon'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders ClassificationIcon', () => {
+    render(<ClassificationIcon classification={1} />);
+
+    expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
   });
 
   it('renders BreakpointIcon', () => {

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -72,7 +72,12 @@ describe('The Icons', () => {
   });
 
   it('renders ClassificationIcon', () => {
-    render(<ClassificationIcon classification={1} />);
+    render(
+      <ClassificationIcon
+        classification={1}
+        classification_mapping={{ 1: 'Test' }}
+      />,
+    );
 
     expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
   });

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -90,6 +90,7 @@ const classes = {
 export interface PackageCardConfig {
   criticality: Criticality;
   classification?: number;
+  classification_mapping?: Classifications;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
   focused?: boolean;
@@ -102,7 +103,6 @@ export interface PackageCardConfig {
   resolved?: boolean;
   selected?: boolean;
   wasPreferred?: boolean;
-  classification_mapping?: Classifications;
 }
 
 export interface PackageCardProps {

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -9,9 +9,15 @@ import MuiTypography from '@mui/material/Typography';
 import { SxProps } from '@mui/system';
 import { memo, useEffect, useMemo, useRef } from 'react';
 
-import { Criticality, PackageInfo } from '../../../shared/shared-types';
+import {
+  Classifications,
+  Criticality,
+  PackageInfo,
+} from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { OpossumColors } from '../../shared-styles';
+import { useAppSelector } from '../../state/hooks';
+import { getClassifications } from '../../state/selectors/resource-selectors';
 import { getCardLabels } from '../../util/get-card-labels';
 import { maybePluralize } from '../../util/maybe-pluralize';
 import { Checkbox } from '../Checkbox/Checkbox';
@@ -83,6 +89,7 @@ const classes = {
 
 export interface PackageCardConfig {
   criticality: Criticality;
+  classification?: number;
   excludeFromNotice?: boolean;
   firstParty?: boolean;
   focused?: boolean;
@@ -95,6 +102,7 @@ export interface PackageCardConfig {
   resolved?: boolean;
   selected?: boolean;
   wasPreferred?: boolean;
+  classification_mapping?: Classifications;
 }
 
 export interface PackageCardProps {
@@ -115,9 +123,11 @@ export const PackageCard = memo(
       () => getCardLabels(packageInfo),
       [packageInfo],
     );
+    const classification_mapping = useAppSelector(getClassifications);
     const effectiveCardConfig = useMemo<PackageCardConfig>(
       () => ({
         criticality: packageInfo.criticality,
+        classification: packageInfo.classification,
         excludeFromNotice: packageInfo.excludeFromNotice,
         firstParty: packageInfo.firstParty,
         followUp: packageInfo.followUp,
@@ -126,9 +136,10 @@ export const PackageCard = memo(
         needsReview: packageInfo.needsReview,
         originalWasPreferred: packageInfo.originalAttributionWasPreferred,
         wasPreferred: packageInfo.wasPreferred,
+        classification_mapping,
         ...cardConfig,
       }),
-      [cardConfig, packageInfo],
+      [cardConfig, packageInfo, classification_mapping],
     );
     const rightIcons = useMemo(
       () => getRightIcons(effectiveCardConfig),

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -5,6 +5,7 @@
 import { Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import {
+  ClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
@@ -34,6 +35,18 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
         key={'criticality-icon'}
         criticality={cardConfig.criticality}
         tooltip={text.auditingOptions[cardConfig.criticality]}
+      />,
+    );
+  }
+  if (cardConfig.classification) {
+    const text = cardConfig.classification_mapping
+      ? cardConfig.classification_mapping[cardConfig.classification]
+      : 'Unknown classification';
+    rightIcons.push(
+      <ClassificationIcon
+        key={'classification-icon'}
+        classification={cardConfig.classification}
+        tooltip={text}
       />,
     );
   }

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -39,14 +39,14 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
     );
   }
   if (cardConfig.classification) {
-    const text = cardConfig.classification_mapping
-      ? cardConfig.classification_mapping[cardConfig.classification]
-      : 'Unknown classification';
     rightIcons.push(
       <ClassificationIcon
         key={'classification-icon'}
         classification={cardConfig.classification}
-        tooltip={text}
+        tooltip={
+          cardConfig.classification_mapping?.[cardConfig.classification] ??
+          text.auditingOptions.unknownClassification
+        }
       />,
     );
   }

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -38,15 +38,15 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
       />,
     );
   }
-  if (cardConfig.classification) {
+  if (
+    cardConfig.classification &&
+    cardConfig.classification_mapping?.[cardConfig.classification]
+  ) {
     rightIcons.push(
       <ClassificationIcon
         key={'classification-icon'}
         classification={cardConfig.classification}
-        tooltip={
-          cardConfig.classification_mapping?.[cardConfig.classification] ??
-          text.auditingOptions.unknownClassification
-        }
+        classification_mapping={cardConfig.classification_mapping}
       />,
     );
   }

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.tsx
@@ -5,6 +5,7 @@
 import { useAppSelector } from '../../../../state/hooks';
 import {
   getAttributionBreakpoints,
+  getClassifications,
   getExternalAttributions,
   getFilesWithChildren,
   getManualAttributions,
@@ -19,6 +20,7 @@ import {
   containsExternalAttribution,
   containsManualAttribution,
   containsResourcesWithOnlyExternalAttribution,
+  getClassification,
   getCriticality,
   getDisplayName,
   hasExternalAttribution,
@@ -50,6 +52,7 @@ export function ResourcesTreeNode({ node, nodeId, nodeName }: TreeNode) {
   const filesWithChildren = useAppSelector(getFilesWithChildren);
 
   const canHaveChildren = node !== 1;
+  const classification_mapping = useAppSelector(getClassifications);
 
   return (
     <ResourcesTreeNodeLabel
@@ -88,6 +91,13 @@ export function ResourcesTreeNode({ node, nodeId, nodeName }: TreeNode) {
         externalAttributions,
         resolvedExternalAttributions,
       )}
+      classification={getClassification(
+        nodeId,
+        resourcesToExternalAttributions,
+        externalAttributions,
+        resolvedExternalAttributions,
+      )}
+      classification_mapping={classification_mapping}
       isAttributionBreakpoint={attributionBreakpoints.has(nodeId)}
       showFolderIcon={canHaveChildren && !filesWithChildren.has(nodeId)}
       containsResourcesWithOnlyExternalAttribution={

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
@@ -47,6 +47,31 @@ export function getCriticality(
   return Criticality.None;
 }
 
+export function getClassification(
+  nodeId: string,
+  resourcesToExternalAttributions: ResourcesToAttributions,
+  externalAttributions: Attributions,
+  resolvedExternalAttributions: Set<string>,
+): number | undefined {
+  if (
+    hasUnresolvedExternalAttribution(
+      nodeId,
+      resourcesToExternalAttributions,
+      resolvedExternalAttributions,
+    )
+  ) {
+    return Math.max(
+      ...resourcesToExternalAttributions[nodeId]
+        .map(
+          (attributionId) =>
+            externalAttributions[attributionId]?.classification,
+        )
+        .filter((classification) => classification !== undefined),
+    );
+  }
+  return undefined;
+}
+
 function isRootResource(resourceName: string): boolean {
   return resourceName === '';
 }

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNode.util.ts
@@ -60,7 +60,7 @@ export function getClassification(
       resolvedExternalAttributions,
     )
   ) {
-    return Math.max(
+    const largestClassification = Math.max(
       ...resourcesToExternalAttributions[nodeId]
         .map(
           (attributionId) =>
@@ -68,6 +68,7 @@ export function getClassification(
         )
         .filter((classification) => classification !== undefined),
     );
+    return largestClassification < 0 ? undefined : largestClassification;
   }
   return undefined;
 }

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
@@ -112,19 +112,13 @@ export const ResourcesTreeNodeLabel: React.FC<Props> = (props) => {
         ) : (
           <SignalIcon />
         ))}
-      {props.hasUnresolvedExternalAttribution &&
-        (props.classification && props.classification > 0 ? (
-          <ClassificationIcon
-            classification={props.classification}
-            tooltip={
-              props.classification_mapping?.[props.classification] ??
-              text.resourceBrowser.unknownClassification
-            }
-            tooltipPlacement={'right'}
-          />
-        ) : (
-          <SignalIcon />
-        ))}
+      {props.hasUnresolvedExternalAttribution && (
+        <ClassificationIcon
+          classification={props.classification}
+          classification_mapping={props.classification_mapping}
+          tooltipPlacement={'right'}
+        />
+      )}
     </MuiBox>
   );
 };

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
@@ -6,11 +6,15 @@ import { SxProps } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiTypography from '@mui/material/Typography';
 
-import { Criticality } from '../../../../../../shared/shared-types';
+import {
+  Classifications,
+  Criticality,
+} from '../../../../../../shared/shared-types';
 import { text } from '../../../../../../shared/text';
 import { treeItemClasses } from '../../../../../shared-styles';
 import {
   BreakpointIcon,
+  ClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   FileIcon,
@@ -30,6 +34,8 @@ interface Props {
   showFolderIcon: boolean;
   containsResourcesWithOnlyExternalAttribution: boolean;
   criticality?: Criticality;
+  classification?: number;
+  classification_mapping?: Classifications;
 }
 
 export const ResourcesTreeNodeLabel: React.FC<Props> = (props) => {
@@ -100,6 +106,19 @@ export const ResourcesTreeNodeLabel: React.FC<Props> = (props) => {
               props.criticality === Criticality.High
                 ? text.resourceBrowser.hasHighlyCriticalSignals
                 : text.resourceBrowser.hasMediumCriticalSignals
+            }
+            tooltipPlacement={'right'}
+          />
+        ) : (
+          <SignalIcon />
+        ))}
+      {props.hasUnresolvedExternalAttribution &&
+        (props.classification && props.classification > 0 ? (
+          <ClassificationIcon
+            classification={props.classification}
+            tooltip={
+              props.classification_mapping?.[props.classification] ??
+              text.resourceBrowser.unknownClassification
             }
             tooltipPlacement={'right'}
           />

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
@@ -55,7 +55,7 @@ describe('ResourcesTreeNodeLabel', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a folder with signal and icon', () => {
+  it('renders a folder with signal and criticality icon', () => {
     render(
       <ResourcesTreeNodeLabel
         labelText={'Test label'}
@@ -99,6 +99,59 @@ describe('ResourcesTreeNodeLabel', () => {
     );
 
     expect(screen.getByText('Test label')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Criticality icon')).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Directory icon without information'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a folder with signal and classification icon', () => {
+    render(
+      <ResourcesTreeNodeLabel
+        labelText={'Test label'}
+        hasManualAttribution={false}
+        hasExternalAttribution={true}
+        hasUnresolvedExternalAttribution={true}
+        containsExternalAttribution={false}
+        containsManualAttribution={false}
+        hasParentWithManualAttribution={false}
+        canHaveChildren={true}
+        isAttributionBreakpoint={false}
+        showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
+        classification={1}
+      />,
+    );
+
+    expect(screen.getByText('Test label')).toBeInTheDocument();
+    expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Directory icon with signal'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a folder with resolved signal but without classification icon', () => {
+    render(
+      <ResourcesTreeNodeLabel
+        labelText={'Test label'}
+        hasManualAttribution={false}
+        hasExternalAttribution={true}
+        hasUnresolvedExternalAttribution={false}
+        containsExternalAttribution={false}
+        containsManualAttribution={false}
+        hasParentWithManualAttribution={false}
+        canHaveChildren={true}
+        isAttributionBreakpoint={false}
+        showFolderIcon={true}
+        containsResourcesWithOnlyExternalAttribution={true}
+        classification={1}
+      />,
+    );
+
+    expect(screen.getByText('Test label')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Classification icon'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByLabelText('Directory icon without information'),
     ).toBeInTheDocument();

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/__tests__/ResourcesTreeNodeLabel.test.tsx
@@ -120,6 +120,7 @@ describe('ResourcesTreeNodeLabel', () => {
         showFolderIcon={true}
         containsResourcesWithOnlyExternalAttribution={true}
         classification={1}
+        classification_mapping={{ 1: 'Test' }}
       />,
     );
 

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../shared/shared-types';
 import {
   containsManualAttribution,
+  getClassification,
   getCriticality,
 } from '../ResourcesTreeNode.util';
 
@@ -41,6 +42,36 @@ describe('ResourcesTreeNode', () => {
         new Set(),
       );
       expect(criticality).toEqual(expectedCriticalities[nodeId]);
+    }
+  });
+
+  it('getClassification', () => {
+    const resourcesToExternalAttributions: ResourcesToAttributions = {
+      '/test_file1.ts': ['attr1', 'attr2'],
+      '/test_file2.ts': ['attr3'],
+      '/test_file3.ts': ['attr2', 'attr3'],
+    };
+    const externalAttributions: Attributions = {
+      attr1: { classification: 2, id: 'attr1' },
+      attr2: { classification: 0, id: 'attr2' },
+      attr3: { id: 'attr3' },
+    };
+    const expectedClassifications: {
+      [resource: string]: number | undefined;
+    } = {
+      '/test_file1.ts': 2,
+      '/test_file2.ts': undefined,
+      '/test_file3.ts': 0,
+    };
+
+    for (const nodeId of Object.keys(resourcesToExternalAttributions)) {
+      const classification = getClassification(
+        nodeId,
+        resourcesToExternalAttributions,
+        externalAttributions,
+        new Set(),
+      );
+      expect(classification).toEqual(expectedClassifications[nodeId]);
     }
   });
 

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
@@ -31,7 +31,7 @@ describe('getting criticality from ResourcesTreeNode', () => {
       externalAttributions,
       new Set(),
     );
-    expect(criticality).toEqual(Criticality.None)
+    expect(criticality).toEqual(Criticality.None);
   });
   it('is medium if at least one attribute has medium criticality and there is no highly critical one', () => {
     const criticality = getCriticality(
@@ -60,9 +60,17 @@ describe('getting classification from ResourcesTreeNode', () => {
     '/test_file_0_2.ts': ['classification_0', 'classification_2'],
   };
   const externalAttributions: Attributions = {
-    classification_missing: { id: 'attr3', criticality: Criticality.None},
-    classification_0: { classification: 0, id: 'attr2', criticality: Criticality.None},
-    classification_2: { classification: 2, id: 'attr1', criticality: Criticality.None },
+    classification_missing: { id: 'attr3', criticality: Criticality.None },
+    classification_0: {
+      classification: 0,
+      id: 'attr2',
+      criticality: Criticality.None,
+    },
+    classification_2: {
+      classification: 2,
+      id: 'attr1',
+      criticality: Criticality.None,
+    },
   };
 
   it('is undefined if there is no information', () => {

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/__tests__/ResourcesTreeNode.util.test.ts
@@ -6,96 +6,90 @@ import {
   Attributions,
   Criticality,
   ResourcesToAttributions,
-  ResourcesWithAttributedChildren,
 } from '../../../../../../shared/shared-types';
-import {
-  containsManualAttribution,
-  getClassification,
-  getCriticality,
-} from '../ResourcesTreeNode.util';
+import { getClassification, getCriticality } from '../ResourcesTreeNode.util';
 
-describe('ResourcesTreeNode', () => {
-  it('getCriticality', () => {
-    const resourcesToExternalAttributions: ResourcesToAttributions = {
-      '/test_file1.ts': ['attr1', 'attr2'],
-      '/test_file2.ts': ['attr3'],
-      '/test_file3.ts': ['attr2', 'attr3'],
-    };
-    const externalAttributions: Attributions = {
-      attr1: { criticality: Criticality.High, id: 'attr1' },
-      attr2: { criticality: Criticality.Medium, id: 'attr2' },
-      attr3: { criticality: Criticality.None, id: 'attr3' },
-    };
-    const expectedCriticalities: {
-      [resource: string]: Criticality;
-    } = {
-      '/test_file1.ts': Criticality.High,
-      '/test_file2.ts': Criticality.None,
-      '/test_file3.ts': Criticality.Medium,
-    };
+describe('getting criticality from ResourcesTreeNode', () => {
+  const resourcesToExternalAttributions: ResourcesToAttributions = {
+    '/test_file_missing.ts': ['criticality_missing'],
+    '/test_file_missing_medium.ts': [
+      'criticality_missing',
+      'criticality_medium',
+    ],
+    '/test_file_medium_high.ts': ['criticality_medium', 'criticality_high'],
+  };
+  const externalAttributions: Attributions = {
+    criticality_missing: { criticality: Criticality.None, id: 'attr3' },
+    criticality_medium: { criticality: Criticality.Medium, id: 'attr2' },
+    criticality_high: { criticality: Criticality.High, id: 'attr1' },
+  };
 
-    for (const nodeId of Object.keys(resourcesToExternalAttributions)) {
-      const criticality = getCriticality(
-        nodeId,
-        resourcesToExternalAttributions,
-        externalAttributions,
-        new Set(),
-      );
-      expect(criticality).toEqual(expectedCriticalities[nodeId]);
-    }
+  it('is none if there is no higher criticality', () => {
+    const criticality = getCriticality(
+      '/test_file_missing.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(criticality).toEqual(Criticality.None)
   });
-
-  it('getClassification', () => {
-    const resourcesToExternalAttributions: ResourcesToAttributions = {
-      '/test_file1.ts': ['attr1', 'attr2'],
-      '/test_file2.ts': ['attr3'],
-      '/test_file3.ts': ['attr2', 'attr3'],
-    };
-    const externalAttributions: Attributions = {
-      attr1: { classification: 2, id: 'attr1' },
-      attr2: { classification: 0, id: 'attr2' },
-      attr3: { id: 'attr3' },
-    };
-    const expectedClassifications: {
-      [resource: string]: number | undefined;
-    } = {
-      '/test_file1.ts': 2,
-      '/test_file2.ts': undefined,
-      '/test_file3.ts': 0,
-    };
-
-    for (const nodeId of Object.keys(resourcesToExternalAttributions)) {
-      const classification = getClassification(
-        nodeId,
-        resourcesToExternalAttributions,
-        externalAttributions,
-        new Set(),
-      );
-      expect(classification).toEqual(expectedClassifications[nodeId]);
-    }
+  it('is medium if at least one attribute has medium criticality and there is no highly critical one', () => {
+    const criticality = getCriticality(
+      '/test_file_missing_medium.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(criticality).toEqual(Criticality.Medium);
   });
+  it('is high if any attribute is highly critical', () => {
+    const criticality = getCriticality(
+      '/test_file_medium_high.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(criticality).toEqual(Criticality.High);
+  });
+});
 
-  it.each`
-    nodeId     | expectedReturn
-    ${'path1'} | ${true}
-    ${'path2'} | ${true}
-    ${'path3'} | ${false}
-    ${'path4'} | ${false}
-  `(
-    'checks if $nodeId containsManualAttribution: $expectedReturn',
-    ({ nodeId, expectedReturn }) => {
-      const resourcesWithManualAttributedChildren: ResourcesWithAttributedChildren =
-        {
-          paths: ['path1', 'path2'],
-          pathsToIndices: { path1: 1, path3: 3 },
-          attributedChildren: { 1: new Set([]) },
-        };
-      expect(
-        containsManualAttribution(
-          nodeId,
-          resourcesWithManualAttributedChildren,
-        ),
-      ).toEqual(expectedReturn);
-    },
-  );
+describe('getting classification from ResourcesTreeNode', () => {
+  const resourcesToExternalAttributions: ResourcesToAttributions = {
+    '/test_file_missing.ts': ['classification_missing'],
+    '/test_file_missing_0.ts': ['classification_missing', 'classification_0'],
+    '/test_file_0_2.ts': ['classification_0', 'classification_2'],
+  };
+  const externalAttributions: Attributions = {
+    classification_missing: { id: 'attr3', criticality: Criticality.None},
+    classification_0: { classification: 0, id: 'attr2', criticality: Criticality.None},
+    classification_2: { classification: 2, id: 'attr1', criticality: Criticality.None },
+  };
+
+  it('is undefined if there is no information', () => {
+    const classification = getClassification(
+      '/test_file_missing.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(classification).toBeUndefined();
+  });
+  it('gives classification if some info is missing', () => {
+    const classification = getClassification(
+      '/test_file_missing_0.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(classification).toBe(0);
+  });
+  it('is equal to the highest classification', () => {
+    const classification = getClassification(
+      '/test_file_0_2.ts',
+      resourcesToExternalAttributions,
+      externalAttributions,
+      new Set(),
+    );
+    expect(classification).toBe(2);
+  });
 });

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -181,7 +181,6 @@ export const text = {
     hasHighlyCriticalSignals: 'Has highly critical signals',
     hasMediumCriticalSignals: 'Has medium critical signals',
     hasSignals: 'Has signals',
-    unknownClassification: 'Unknown classification',
   },
   auditingOptions: {
     add: 'Add Auditing Option',
@@ -195,7 +194,6 @@ export const text = {
     needsReview: 'Needs Review by QA',
     preselected: 'Pre-selected',
     previouslyPreferred: 'Previously Preferred',
-    unknownClassification: 'Unknown Classification',
   },
   generic: {
     unknown: 'unknown',

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -181,6 +181,7 @@ export const text = {
     hasHighlyCriticalSignals: 'Has highly critical signals',
     hasMediumCriticalSignals: 'Has medium critical signals',
     hasSignals: 'Has signals',
+    unknownClassification: 'Unknown classification',
   },
   auditingOptions: {
     add: 'Add Auditing Option',
@@ -194,6 +195,7 @@ export const text = {
     needsReview: 'Needs Review by QA',
     preselected: 'Pre-selected',
     previouslyPreferred: 'Previously Preferred',
+    unknownClassification: 'Unknown Classification',
   },
   generic: {
     unknown: 'unknown',


### PR DESCRIPTION
### Summary of changes
Add icons for classifications. These are only shown, when the classification value is not 0. These icons are shown in
* next to the attribution/signal titles in the middle pane
* next to file name in the file tree on the left

![image](https://github.com/user-attachments/assets/e4bdd034-0edf-4ecf-89ec-1824d46de384)


### Context and reason for change
We want to show license classifications in prominent places.

### How can the changes be tested

open an opossum file with license classifications and verify that the icons are present. This is the test file I used (renamed to .zip because GitHub can't stomach opossums):
[test_classifications.zip](https://github.com/user-attachments/files/18960103/test_classifications.zip)
