### PR TITLE
Unify handling of loading state

### DIFF
--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { BrowserWindow, dialog, shell, WebContents } from 'electron';
-import fs from 'fs';
 
 import {
   AllowedFrontendChannels,
@@ -16,10 +15,8 @@ import {
   ExportSpdxDocumentYamlArgs,
   ExportType,
 } from '../../../shared/shared-types';
-import { writeFile } from '../../../shared/write-file';
 import { faker } from '../../../testing/Faker';
 import * as errorHandling from '../../errorHandling/errorHandling';
-import { loadInputAndOutputFromFilePath } from '../../input/importFromFile';
 import { writeCsvToFile } from '../../output/writeCsvToFile';
 import { writeSpdxFile } from '../../output/writeSpdxFile';
 import { createWindow } from '../createWindow';
@@ -30,7 +27,6 @@ import {
 } from '../dialogs';
 import { setGlobalBackendState } from '../globalBackendState';
 import {
-  deleteAndCreateNewAttributionFileListener,
   exportFileListener,
   importFileListener,
   importFileSelectInputListener,
@@ -107,37 +103,6 @@ jest.mock('../dialogs', () => ({
   saveFileDialog: jest.fn(),
   selectBaseURLDialog: jest.fn(),
 }));
-
-describe('getDeleteAndCreateNewAttributionFileListener', () => {
-  it('deletes attribution file and calls loadInputAndOutputFromFilePath', async () => {
-    const mainWindow = {
-      webContents: {
-        send: jest.fn(),
-      },
-      setTitle: jest.fn(),
-    } as unknown as BrowserWindow;
-
-    const fileName = faker.string.uuid();
-    const resourceFilePath = `${fileName}.json`;
-    const jsonPath = await writeFile({
-      content: faker.string.sample(),
-      path: faker.outputPath(`${fileName}_attribution.json`),
-    });
-
-    setGlobalBackendState({
-      resourceFilePath,
-      attributionFilePath: jsonPath,
-    });
-
-    await deleteAndCreateNewAttributionFileListener(mainWindow, () => {})();
-
-    expect(fs.existsSync(jsonPath)).toBeFalsy();
-    expect(loadInputAndOutputFromFilePath).toHaveBeenCalledWith(
-      expect.anything(),
-      resourceFilePath,
-    );
-  });
-});
 
 describe('getSelectBaseURLListener', () => {
   it('opens base url dialog and sends selected path to frontend', async () => {

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -119,10 +119,14 @@ export async function handleOpeningFile(
   filePath: string,
   onOpen: () => void,
 ): Promise<void> {
+  setLoadingState(mainWindow.webContents, true);
+
   logger.info('Initializing global backend state');
   initializeGlobalBackendState(filePath, true);
 
   await openFile(mainWindow, filePath, onOpen);
+
+  setLoadingState(mainWindow.webContents, false);
 }
 
 export const importFileListener =
@@ -192,18 +196,22 @@ export const importFileConvertAndLoadListener =
         throw new Error('Output directory does not exist');
       }
 
+      setLoadingState(mainWindow.webContents, true);
+
       logger.info('Converting input file to .opossum format');
       await convertToOpossum(resourceFilePath, opossumFilePath, fileType);
 
       logger.info('Updating global backend state');
       initializeGlobalBackendState(opossumFilePath, true);
 
-      await openFile(mainWindow, opossumFilePath, onOpen, true);
+      await openFile(mainWindow, opossumFilePath, onOpen);
 
       return true;
     } catch (error) {
       sendListenerErrorToFrontend(mainWindow, error);
       return false;
+    } finally {
+      setLoadingState(mainWindow.webContents, false);
     }
   };
 
@@ -234,29 +242,6 @@ function initializeGlobalBackendState(
   setGlobalBackendState(newGlobalBackendState);
 }
 
-export const deleteAndCreateNewAttributionFileListener =
-  (mainWindow: BrowserWindow, onOpen: () => void) =>
-  async (): Promise<void> => {
-    try {
-      const globalBackendState = getGlobalBackendState();
-      const resourceFilePath = globalBackendState.resourceFilePath as string;
-
-      logger.info(
-        `Deleting attribution file and opening input file ${resourceFilePath}`,
-      );
-      if (globalBackendState.attributionFilePath) {
-        fs.unlinkSync(globalBackendState.attributionFilePath);
-      } else {
-        throw new Error(
-          `Failed to delete output file. Attribution file path is incorrect: ${globalBackendState.attributionFilePath}`,
-        );
-      }
-      await openFile(mainWindow, resourceFilePath, onOpen);
-    } catch (error) {
-      await showListenerErrorInMessageBox(mainWindow, error);
-    }
-  };
-
 export const selectBaseURLListener =
   (mainWindow: BrowserWindow) => async (): Promise<void> => {
     try {
@@ -283,21 +268,10 @@ export async function openFile(
   mainWindow: BrowserWindow,
   filePath: string,
   onOpen: () => void,
-  isImport?: boolean,
 ): Promise<void> {
-  if (!isImport) {
-    setLoadingState(mainWindow.webContents, true);
-  }
-
-  try {
-    await loadInputAndOutputFromFilePath(mainWindow, filePath);
-    setTitle(mainWindow, filePath);
-    onOpen();
-  } finally {
-    if (!isImport) {
-      setLoadingState(mainWindow.webContents, false);
-    }
-  }
+  await loadInputAndOutputFromFilePath(mainWindow, filePath);
+  setTitle(mainWindow, filePath);
+  onOpen();
 }
 
 function setTitle(mainWindow: BrowserWindow, filePath: string): void {

--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -5,11 +5,10 @@
 import { dialog, ipcMain, Menu, systemPreferences } from 'electron';
 import os from 'os';
 
-import { IpcChannel } from '../../shared/ipc-channels';
+import { AllowedFrontendChannels, IpcChannel } from '../../shared/ipc-channels';
 import { getMessageBoxContentForErrorsWrapper } from '../errorHandling/errorHandling';
 import { createWindow } from './createWindow';
 import {
-  deleteAndCreateNewAttributionFileListener,
   exportFileListener,
   importFileConvertAndLoadListener,
   importFileSelectInputListener,
@@ -81,11 +80,12 @@ export async function main(): Promise<void> {
       importFileConvertAndLoadListener(mainWindow, activateMenuItems),
     );
     ipcMain.handle(IpcChannel.SaveFile, saveFileListener(mainWindow));
-    ipcMain.handle(
-      IpcChannel.DeleteFile,
-      deleteAndCreateNewAttributionFileListener(mainWindow, activateMenuItems),
-    );
     ipcMain.handle(IpcChannel.ExportFile, exportFileListener(mainWindow));
+    ipcMain.handle(IpcChannel.StopLoading, () =>
+      mainWindow.webContents.send(AllowedFrontendChannels.FileLoading, {
+        isLoading: false,
+      }),
+    );
     ipcMain.handle(IpcChannel.OpenLink, openLinkListener);
     ipcMain.handle(IpcChannel.GetUserSettings, (_, key) =>
       UserSettings.get(key),

--- a/src/ElectronBackend/main/menu/fileMenu.ts
+++ b/src/ElectronBackend/main/menu/fileMenu.ts
@@ -14,7 +14,12 @@ import {
 import { isFileLoaded } from '../../utils/getLoadedFile';
 import { getGlobalBackendState } from '../globalBackendState';
 import { getIconBasedOnTheme } from '../iconHelpers';
-import { importFileListener, selectBaseURLListener } from '../listeners';
+import {
+  importFileListener,
+  selectBaseURLListener,
+  setLoadingState,
+} from '../listeners';
+import logger from '../logger';
 import { INITIALLY_DISABLED_ITEMS_INFO } from './initiallyDisabledMenuItems';
 
 export const importFileFormats: Array<FileFormatInfo> = [
@@ -141,6 +146,8 @@ function getExportFollowUp(webContents: Electron.WebContents) {
       'icons/follow-up-black.png',
     ),
     click: () => {
+      setLoadingState(webContents, true);
+      logger.info('Preparing data for follow-up export');
       webContents.send(
         AllowedFrontendChannels.ExportFileRequest,
         ExportType.FollowUp,
@@ -159,6 +166,8 @@ function getExportCompactBom(webContents: Electron.WebContents) {
     ),
     label: INITIALLY_DISABLED_ITEMS_INFO.compactComponentList.label,
     click: () => {
+      setLoadingState(webContents, true);
+      logger.info('Preparing data for compact component list export');
       webContents.send(
         AllowedFrontendChannels.ExportFileRequest,
         ExportType.CompactBom,
@@ -177,6 +186,8 @@ function getExportDetailedBom(webContents: Electron.WebContents) {
     ),
     label: INITIALLY_DISABLED_ITEMS_INFO.detailedComponentList.label,
     click: () => {
+      setLoadingState(webContents, true);
+      logger.info('Preparing data for detailed component list export');
       webContents.send(
         AllowedFrontendChannels.ExportFileRequest,
         ExportType.DetailedBom,
@@ -192,6 +203,8 @@ function getExportSpdxYaml(webContents: Electron.WebContents) {
     icon: getIconBasedOnTheme('icons/yaml-white.png', 'icons/yaml-black.png'),
     label: INITIALLY_DISABLED_ITEMS_INFO.spdxYAML.label,
     click: () => {
+      setLoadingState(webContents, true);
+      logger.info('Preparing data for SPDX (yaml) export');
       webContents.send(
         AllowedFrontendChannels.ExportFileRequest,
         ExportType.SpdxDocumentYaml,
@@ -202,11 +215,13 @@ function getExportSpdxYaml(webContents: Electron.WebContents) {
   };
 }
 
-function getExportSpdsJson(webContents: Electron.WebContents) {
+function getExportSpdxJson(webContents: Electron.WebContents) {
   return {
     icon: getIconBasedOnTheme('icons/json-white.png', 'icons/json-black.png'),
     label: INITIALLY_DISABLED_ITEMS_INFO.spdxJSON.label,
     click: () => {
+      setLoadingState(webContents, true);
+      logger.info('Preparing data for SPDX (json) export');
       webContents.send(
         AllowedFrontendChannels.ExportFileRequest,
         ExportType.SpdxDocumentJson,
@@ -229,7 +244,7 @@ function getExportSubMenu(webContents: Electron.WebContents) {
       getExportCompactBom(webContents),
       getExportDetailedBom(webContents),
       getExportSpdxYaml(webContents),
-      getExportSpdsJson(webContents),
+      getExportSpdxJson(webContents),
     ],
   };
 }

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -27,6 +27,7 @@ const electronAPI: ElectronAPI = {
   exportFile: (args) => ipcRenderer.invoke(IpcChannel.ExportFile, args),
   saveFile: (saveFileArgs) =>
     ipcRenderer.invoke(IpcChannel.SaveFile, saveFileArgs),
+  stopLoading: () => ipcRenderer.invoke(IpcChannel.StopLoading),
   on: (channel, listener) => {
     ipcRenderer.on(channel, listener);
     return () => ipcRenderer.removeListener(channel, listener);

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -23,15 +23,11 @@ import {
   setBaseUrlsForSources,
 } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { loadFromFile } from '../../state/actions/resource-actions/load-actions';
-import {
-  openPopup,
-  setLoading,
-} from '../../state/actions/view-actions/view-actions';
+import { openPopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getBaseUrlsForSources } from '../../state/selectors/resource-selectors';
 import {
   ExportFileRequestListener,
-  IsLoadingListener,
   LoggingListener,
   ShowImportDialogListener,
   useIpcRenderer,
@@ -99,14 +95,6 @@ export const BackendCommunication: React.FC = () => {
       );
     }
   }
-
-  useIpcRenderer<IsLoadingListener>(
-    AllowedFrontendChannels.FileLoading,
-    (_, { isLoading }) => {
-      dispatch(setLoading(isLoading));
-    },
-    [dispatch],
-  );
   useIpcRenderer(AllowedFrontendChannels.FileLoaded, fileLoadedListener, [
     dispatch,
   ]);

--- a/src/Frontend/Components/ImportDialog/ImportDialog.tsx
+++ b/src/Frontend/Components/ImportDialog/ImportDialog.tsx
@@ -12,7 +12,11 @@ import { text } from '../../../shared/text';
 import { getDotOpossumFilePath } from '../../../shared/write-file';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch } from '../../state/hooks';
-import { LoggingListener, useIpcRenderer } from '../../util/use-ipc-renderer';
+import {
+  IsLoadingListener,
+  LoggingListener,
+  useIpcRenderer,
+} from '../../util/use-ipc-renderer';
 import { FilePathInput } from '../FilePathInput/FilePathInput';
 import { LogDisplay } from '../LogDisplay/LogDisplay';
 import { NotificationPopup } from '../NotificationPopup/NotificationPopup';
@@ -27,7 +31,13 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
   const [inputFilePath, setInputFilePath] = useState<string>('');
   const [opossumFilePath, setOpossumFilePath] = useState<string>('');
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useIpcRenderer<IsLoadingListener>(
+    AllowedFrontendChannels.FileLoading,
+    (_, { isLoading }) => setIsLoading(isLoading),
+    [],
+  );
 
   const [logToDisplay, setLogToDisplay] = useState<Log | null>(null);
 
@@ -82,8 +92,6 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
   }
 
   async function onConfirm(): Promise<void> {
-    setIsLoading(true);
-
     const success = await window.electronAPI.importFileConvertAndLoad(
       inputFilePath,
       fileFormat.fileType,
@@ -93,8 +101,6 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
     if (success) {
       dispatch(closePopup());
     }
-
-    setIsLoading(false);
   }
 
   return (

--- a/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
+++ b/src/Frontend/Components/ProcessPopup/__tests__/ProcessPopup.test.tsx
@@ -10,7 +10,6 @@ import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
 import { ElectronAPI, Log } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { faker } from '../../../../testing/Faker';
-import { setLoading } from '../../../state/actions/view-actions/view-actions';
 import { renderComponent } from '../../../test-helpers/render';
 import { ProcessPopup } from '../ProcessPopup';
 
@@ -43,20 +42,28 @@ describe('ProcessPopup', () => {
     expect(screen.queryByText(text.processPopup.title)).not.toBeInTheDocument();
   });
 
-  it('renders dialog when loading is true', async () => {
-    const { store } = renderComponent(<ProcessPopup />);
+  it('renders dialog when loading is true', () => {
+    renderComponent(<ProcessPopup />);
 
-    await act(() => store.dispatch(setLoading(true)));
+    act(() =>
+      electronAPI.send(AllowedFrontendChannels.FileLoading, {
+        isLoading: true,
+      }),
+    );
 
     expect(screen.getByText(text.processPopup.title)).toBeInTheDocument();
   });
 
-  it('clears previous log messages when loading begins another time', async () => {
+  it('clears previous log messages when loading begins another time', () => {
     const date = faker.date.recent();
     const message = faker.lorem.sentence();
-    const { store } = renderComponent(<ProcessPopup />);
+    renderComponent(<ProcessPopup />);
 
-    await act(() => store.dispatch(setLoading(true)));
+    act(() =>
+      electronAPI.send(AllowedFrontendChannels.FileLoading, {
+        isLoading: true,
+      }),
+    );
     act(
       () =>
         void electronAPI.send(AllowedFrontendChannels.Logging, {
@@ -65,8 +72,11 @@ describe('ProcessPopup', () => {
           level: 'info',
         } satisfies Log),
     );
-    await act(() => store.dispatch(setLoading(false)));
-    await act(() => store.dispatch(setLoading(true)));
+    act(() =>
+      electronAPI.send(AllowedFrontendChannels.FileLoading, {
+        isLoading: true,
+      }),
+    );
 
     expect(screen.queryByText(message)).not.toBeInTheDocument();
   });

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -185,5 +185,6 @@ export function closePopupAndUnsetTargets(): AppThunkAction {
     dispatch(setOpenFileRequest(false));
     dispatch(setImportFileRequest(null));
     dispatch(setExportFileRequest(null));
+    window.electronAPI.stopLoading();
   };
 }

--- a/src/Frontend/state/actions/resource-actions/export-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/export-actions.ts
@@ -25,12 +25,9 @@ import {
   getResources,
 } from '../../selectors/resource-selectors';
 import { AppThunkAction } from '../../types';
-import { setLoading } from '../view-actions/view-actions';
 
 export function exportFile(exportType: ExportType): AppThunkAction {
-  return (dispatch, getState) => {
-    dispatch(setLoading(true));
-
+  return (_, getState) => {
     switch (exportType) {
       case ExportType.SpdxDocumentJson:
         exportSpdxDocument(getState(), ExportType.SpdxDocumentJson);

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -14,7 +14,6 @@ export const ACTION_RESET_VIEW_STATE = 'ACTION_RESET_VIEW_STATE';
 export const ACTION_SET_OPEN_FILE_REQUEST = 'ACTION_SET_OPEN_FILE_REQUEST';
 export const ACTION_SET_IMPORT_FILE_REQUEST = 'ACTION_SET_IMPORT_FILE_REQUEST';
 export const ACTION_SET_EXPORT_FILE_REQUEST = 'ACTION_SET_EXPORT_FILE_REQUEST';
-export const ACTION_SET_LOADING = 'ACTION_SET_LOADING';
 
 export type ViewAction =
   | SetView
@@ -24,8 +23,7 @@ export type ViewAction =
   | OpenPopupAction
   | SetOpenFileRequestAction
   | SetImportFileRequestAction
-  | SetExportFileRequestAction
-  | SetLoadingAction;
+  | SetExportFileRequestAction;
 
 export interface ResetViewStateAction {
   type: typeof ACTION_RESET_VIEW_STATE;
@@ -63,9 +61,4 @@ export interface SetImportFileRequestAction {
 export interface SetExportFileRequestAction {
   type: typeof ACTION_SET_EXPORT_FILE_REQUEST;
   payload: ExportType | null;
-}
-
-export interface SetLoadingAction {
-  type: typeof ACTION_SET_LOADING;
-  payload: boolean;
 }

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -16,7 +16,6 @@ import {
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_EXPORT_FILE_REQUEST,
   ACTION_SET_IMPORT_FILE_REQUEST,
-  ACTION_SET_LOADING,
   ACTION_SET_OPEN_FILE_REQUEST,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -25,7 +24,6 @@ import {
   ResetViewStateAction,
   SetExportFileRequestAction,
   SetImportFileRequestAction,
-  SetLoadingAction,
   SetOpenFileRequestAction,
   SetTargetView,
   SetView,
@@ -102,8 +100,4 @@ export function setExportFileRequest(
   exportFileRequest: ExportType | null,
 ): SetExportFileRequestAction {
   return { type: ACTION_SET_EXPORT_FILE_REQUEST, payload: exportFileRequest };
-}
-
-export function setLoading(loading: boolean): SetLoadingAction {
-  return { type: ACTION_SET_LOADING, payload: loading };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -12,7 +12,6 @@ import {
   ACTION_RESET_VIEW_STATE,
   ACTION_SET_EXPORT_FILE_REQUEST,
   ACTION_SET_IMPORT_FILE_REQUEST,
-  ACTION_SET_LOADING,
   ACTION_SET_OPEN_FILE_REQUEST,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
@@ -26,7 +25,6 @@ export interface ViewState {
   openFileRequest: boolean;
   importFileRequest: FileFormatInfo | null;
   exportFileRequest: ExportType | null;
-  loading: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -36,7 +34,6 @@ export const initialViewState: ViewState = {
   openFileRequest: false,
   importFileRequest: null,
   exportFileRequest: null,
-  loading: false,
 };
 
 export function viewState(
@@ -84,11 +81,6 @@ export function viewState(
       return {
         ...state,
         exportFileRequest: action.payload,
-      };
-    case ACTION_SET_LOADING:
-      return {
-        ...state,
-        loading: action.payload,
       };
     default:
       return state;

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -46,7 +46,3 @@ export function getImportFileRequest(state: State): FileFormatInfo | null {
 export function getExportFileRequest(state: State): ExportType | null {
   return state.viewState.exportFileRequest;
 }
-
-export function isLoading(state: State): boolean {
-  return state.viewState.loading;
-}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export enum IpcChannel {
-  DeleteFile = 'delete-file',
   ExportFile = 'export-file',
   OpenFile = 'open-file',
   ImportFileSelectInput = 'import-file-select-input',
@@ -13,6 +12,7 @@ export enum IpcChannel {
   ImportFileConvertAndLoad = 'import-file-convert-and-load',
   OpenLink = 'open-link',
   SaveFile = 'save-file',
+  StopLoading = 'stop-loading',
   GetUserSettings = 'get-user-settings',
   SetUserSettings = 'set-user-settings',
   Quit = 'quit',

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -268,6 +268,7 @@ export interface ElectronAPI {
   ) => Promise<boolean>;
   exportFile: (args: ExportArgsType) => void;
   saveFile: (saveFileArgs: SaveFileArgs) => void;
+  stopLoading: () => void;
   on: (channel: AllowedFrontendChannels, listener: Listener) => () => void;
   getUserSetting: <T extends keyof UserSettings>(
     key: T,

--- a/src/testing/setup-tests.ts
+++ b/src/testing/setup-tests.ts
@@ -41,6 +41,7 @@ global.window.electronAPI = {
   importFileConvertAndLoad: jest.fn(),
   exportFile: jest.fn(),
   saveFile: jest.fn(),
+  stopLoading: jest.fn(),
   on: jest.fn().mockReturnValue(jest.fn()),
   getUserSetting: jest.fn().mockReturnValue(undefined),
   setUserSetting: jest.fn(),


### PR DESCRIPTION
### Summary of changes

* the loading state is set/unset from the backend only
* frontend components directly listen on the FileLoading ipc channel again, no more loading state in redux
* add StopLoading ipc channel as a temporary solution for handling loading state on export (see #2812)

### Context and reason for change

* Heavy operations requiring the use of loading state should all run in the backend to guarantee that the UI stays responsive, thus the loading state should also be controlled from the backend
* Inconsistent handling of loading state in different components is confusing and can lead to bugs

### How can the changes be tested

Check that the ProcessPopup is shown for open/export and that the import dialog properly displays logs during loading.
