### PR TITLE
Add classification column to "Signals per Sources" table in project statistics popup

### DIFF
--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -8,7 +8,11 @@ import MuiTableBody from '@mui/material/TableBody';
 import MuiTableContainer from '@mui/material/TableContainer';
 import MuiTypography from '@mui/material/Typography';
 
-import { LicenseCounts, LicenseNamesWithCriticality } from '../../types/types';
+import {
+  LicenseCounts,
+  LicenseNamesWithClassification,
+  LicenseNamesWithCriticality,
+} from '../../types/types';
 import { AttributionCountPerSourcePerLicenseTableFooter } from './AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter';
 import { AttributionCountPerSourcePerLicenseTableHead } from './AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead';
 import { AttributionCountPerSourcePerLicenseTableRow } from './AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow';
@@ -23,6 +27,7 @@ const classes = {
 interface AttributionCountPerSourcePerLicenseTableProps {
   licenseCounts: LicenseCounts;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
+  licenseNamesWithClassification: LicenseNamesWithClassification;
   title: string;
 }
 

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -61,10 +61,14 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
                   licenseCriticality={
                     props.licenseNamesWithCriticality[licenseName]
                   }
+                  licenseClassification={
+                    props.licenseNamesWithClassification[licenseName]
+                  }
                   totalSignalCount={
                     props.licenseCounts.totalAttributionsPerLicense[licenseName]
                   }
                   key={rowIndex}
+                  rowIndex={rowIndex}
                 />
               ))}
           </MuiTableBody>

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter.tsx
@@ -25,6 +25,7 @@ export const AttributionCountPerSourcePerLicenseTableFooter: React.FC<
           {text.attributionCountPerSourcePerLicenseTable.footerTitle}
         </MuiTableCell>
         <MuiTableCell sx={tableClasses.footer} />
+        <MuiTableCell sx={tableClasses.footer} />
         {props.sourceNames.map((sourceName, sourceIdx) => (
           <MuiTableCell
             sx={tableClasses.footer}

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -5,6 +5,7 @@
 import MuiTableCell from '@mui/material/TableCell';
 import MuiTableHead from '@mui/material/TableHead';
 import MuiTableRow from '@mui/material/TableRow';
+import { SxProps } from '@mui/system';
 import { upperFirst } from 'lodash';
 
 import { text } from '../../../../shared/text';
@@ -17,7 +18,7 @@ const classes = {
   headerCellWithHorizontalSeparator: {
     borderBottom: '1.5px solid lightgray',
   },
-};
+} satisfies SxProps;
 
 interface AttributionCountPerSourcePerLicenseTableHeadProps {
   sourceNames: Array<string>;

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -10,6 +10,15 @@ import { upperFirst } from 'lodash';
 import { text } from '../../../../shared/text';
 import { tableClasses } from '../../../shared-styles';
 
+const classes = {
+  headerCellWithVerticalSeparator: {
+    borderRight: '2px solid lightgray',
+  },
+  headerCellWithHorizontalSeparator: {
+    borderBottom: '1.5px solid lightgray',
+  },
+};
+
 interface AttributionCountPerSourcePerLicenseTableHeadProps {
   sourceNames: Array<string>;
 }
@@ -20,18 +29,47 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
   const componentText = text.attributionCountPerSourcePerLicenseTable;
 
   const headerRow = [
-    componentText.columnNames.licenseName,
-    componentText.columnNames.criticality.title,
+    componentText.columns.licenseName,
+    componentText.columns.criticality.title,
+    componentText.columns.classification,
     ...props.sourceNames.map(upperFirst),
-    componentText.columnNames.totalSources,
+    componentText.columns.totalSources,
   ];
 
   return (
-    <MuiTableHead>
+    <MuiTableHead sx={{ position: 'sticky', top: 0 }}>
+      <MuiTableRow>
+        <MuiTableCell
+          sx={{
+            ...tableClasses.head,
+            ...classes.headerCellWithVerticalSeparator,
+            ...classes.headerCellWithHorizontalSeparator,
+          }}
+          align={'center'}
+          colSpan={3}
+        >
+          {componentText.columns.licenseInfo}
+        </MuiTableCell>
+        <MuiTableCell
+          sx={{
+            ...tableClasses.head,
+            ...classes.headerCellWithHorizontalSeparator,
+          }}
+          align={'center'}
+          colSpan={props.sourceNames.length + 1}
+        >
+          {componentText.columns.signalCountPerSource}
+        </MuiTableCell>
+      </MuiTableRow>
       <MuiTableRow>
         {headerRow.map((columnHeader, columnIndex) => (
           <MuiTableCell
-            sx={tableClasses.head}
+            sx={{
+              ...tableClasses.head,
+              ...(columnIndex === 2
+                ? classes.headerCellWithVerticalSeparator
+                : {}),
+            }}
             key={columnIndex}
             align={columnIndex === 0 ? 'left' : 'center'}
           >

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -7,7 +7,9 @@ import MuiTableRow from '@mui/material/TableRow';
 
 import { Criticality } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
-import { tableClasses } from '../../../shared-styles';
+import { OpossumColors, tableClasses } from '../../../shared-styles';
+import { useAppSelector } from '../../../state/hooks';
+import { getClassifications } from '../../../state/selectors/resource-selectors';
 import { CriticalityIcon } from '../../Icons/Icons';
 
 interface AttributionCountPerSourcePerLicenseTableRowProps {
@@ -15,24 +17,43 @@ interface AttributionCountPerSourcePerLicenseTableRowProps {
   signalCountsPerSource: { [sourceName: string]: number };
   licenseName: string;
   licenseCriticality: Criticality | undefined;
+  licenseClassification: number | undefined;
   totalSignalCount: number;
+  rowIndex: number;
 }
 
 export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
   AttributionCountPerSourcePerLicenseTableRowProps
 > = (props) => {
+  const bodyClassWithBackgroundColor = {
+    ...tableClasses.body,
+    backgroundColor:
+      props.rowIndex % 2 === 0
+        ? OpossumColors.lightestBlue
+        : OpossumColors.almostWhiteBlue,
+  };
+
+  const componentText = text.attributionCountPerSourcePerLicenseTable;
+
+  const classifications = useAppSelector(getClassifications);
+
   return (
     <MuiTableRow>
-      <MuiTableCell sx={tableClasses.body} align={'left'}>
+      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'left'}>
         {props.licenseName}
       </MuiTableCell>
       {renderCriticalityCell()}
+      {renderClassificationCell()}
       {props.sourceNames.map((sourceName, sourceIdx) => (
-        <MuiTableCell sx={tableClasses.body} align={'center'} key={sourceIdx}>
+        <MuiTableCell
+          sx={bodyClassWithBackgroundColor}
+          align={'center'}
+          key={sourceIdx}
+        >
           {props.signalCountsPerSource[sourceName] || '-'}
         </MuiTableCell>
       ))}
-      <MuiTableCell sx={tableClasses.body} align={'center'}>
+      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
         {props.totalSignalCount}
       </MuiTableCell>
     </MuiTableRow>
@@ -40,7 +61,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
 
   function renderCriticalityCell() {
     return (
-      <MuiTableCell sx={tableClasses.body} align={'center'}>
+      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
         {props.licenseCriticality === undefined ? (
           '-'
         ) : (
@@ -48,13 +69,24 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
             criticality={props.licenseCriticality}
             tooltip={
               props.licenseCriticality === Criticality.High
-                ? text.attributionCountPerSourcePerLicenseTable.columnNames
-                    .criticality.high
-                : text.attributionCountPerSourcePerLicenseTable.columnNames
-                    .criticality.medium
+                ? componentText.columns.criticality.high
+                : componentText.columns.criticality.medium
             }
           />
         )}
+      </MuiTableCell>
+    );
+  }
+
+  function renderClassificationCell() {
+    return (
+      <MuiTableCell sx={bodyClassWithBackgroundColor} key={1} align={'center'}>
+        <span>
+          {props.licenseClassification
+            ? (classifications[props.licenseClassification] ??
+              componentText.absent)
+            : componentText.absent}
+        </span>
       </MuiTableCell>
     );
   }

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -50,7 +50,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
           align={'center'}
           key={sourceIdx}
         >
-          {props.signalCountsPerSource[sourceName] || '-'}
+          {props.signalCountsPerSource[sourceName] || componentText.absent}
         </MuiTableCell>
       ))}
       <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
@@ -63,7 +63,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
     return (
       <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
         {props.licenseCriticality === undefined ? (
-          '-'
+          componentText.absent
         ) : (
           <CriticalityIcon
             criticality={props.licenseCriticality}

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -50,7 +50,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
           align={'center'}
           key={sourceIdx}
         >
-          {props.signalCountsPerSource[sourceName] || componentText.absent}
+          {props.signalCountsPerSource[sourceName] || componentText.none}
         </MuiTableCell>
       ))}
       <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
@@ -63,7 +63,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
     return (
       <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
         {props.licenseCriticality === undefined ? (
-          componentText.absent
+          componentText.none
         ) : (
           <CriticalityIcon
             criticality={props.licenseCriticality}
@@ -84,8 +84,8 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
         <span>
           {props.licenseClassification
             ? (classifications[props.licenseClassification] ??
-              componentText.absent)
-            : componentText.absent}
+              componentText.none)
+            : componentText.none}
         </span>
       </MuiTableCell>
     );

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -29,7 +29,6 @@ import {
   getIncompleteAttributionsCount,
   getMostFrequentLicenses,
   getSignalCountByClassification,
-  getUniqueLicenseNameToAttribution,
 } from './ProjectStatisticsPopup.util';
 
 const classes = {
@@ -49,17 +48,12 @@ export const ProjectStatisticsPopup: React.FC = () => {
     getUnresolvedExternalAttributions,
   );
 
-  const strippedLicenseNameToAttribution = getUniqueLicenseNameToAttribution(
-    unresolvedExternalAttribution,
-  );
-
   const {
     licenseCounts,
     licenseNamesWithCriticality,
     licenseNamesWithClassification,
   } = aggregateLicensesAndSourcesFromAttributions(
     unresolvedExternalAttribution,
-    strippedLicenseNameToAttribution,
     attributionSources,
   );
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -179,6 +179,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
           <AttributionCountPerSourcePerLicenseTable
             licenseCounts={licenseCounts}
             licenseNamesWithCriticality={licenseNamesWithCriticality}
+            licenseNamesWithClassification={licenseNamesWithClassification}
             title={text.projectStatisticsPopup.charts.licenseCountsTable}
           />
         </>

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
@@ -36,13 +36,14 @@ export const ATTRIBUTION_TOTAL = 'Total Attributions';
 
 export function aggregateLicensesAndSourcesFromAttributions(
   attributions: Attributions,
-  strippedLicenseNameToAttribution: UniqueLicenseNameToAttributions,
   attributionSources: ExternalAttributionSources,
 ): {
   licenseCounts: LicenseCounts;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
   licenseNamesWithClassification: LicenseNamesWithClassification;
 } {
+  const strippedLicenseNameToAttribution =
+    getUniqueLicenseNameToAttribution(attributions);
   const {
     attributionCountPerSourcePerLicense,
     totalAttributionsPerLicense,
@@ -209,7 +210,7 @@ export function getLicenseCriticality(licenseCriticalityCounts: {
       : undefined;
 }
 
-export function getUniqueLicenseNameToAttribution(
+function getUniqueLicenseNameToAttribution(
   attributions: Attributions,
 ): UniqueLicenseNameToAttributions {
   const uniqueLicenseNameToAttributions: UniqueLicenseNameToAttributions = {};

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
@@ -226,28 +226,6 @@ export function getUniqueLicenseNameToAttribution(
   return uniqueLicenseNameToAttributions;
 }
 
-export function getLicenseNameVariants(
-  licenseName: string,
-  attributions: Attributions,
-): Set<string> {
-  const strippedLicenseName = getStrippedLicenseName(licenseName);
-  const licenseNames: Set<string> = new Set<string>();
-
-  for (const attributionId of Object.keys(attributions)) {
-    const attributionLicenseName =
-      attributions[attributionId].licenseName || '';
-    const attributionStrippedLicenseName = getStrippedLicenseName(
-      attributions[attributionId].licenseName || '',
-    );
-
-    if (attributionStrippedLicenseName === strippedLicenseName) {
-      licenseNames.add(attributionLicenseName);
-    }
-  }
-
-  return licenseNames;
-}
-
 export function getStrippedLicenseName(licenseName: string): string {
   return licenseName.replace(/[\s-]/g, '').toLowerCase();
 }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -221,7 +221,7 @@ describe('The ProjectStatisticsPopup', () => {
         ),
       ],
     });
-    expect(screen.getAllByText('License Name')).toHaveLength(1);
+    expect(screen.getAllByText('License Info')).toHaveLength(1);
     expect(screen.getAllByText('Total')).toHaveLength(2);
     expect(screen.getByText('Follow up')).toBeInTheDocument();
     expect(screen.getByText('First party')).toBeInTheDocument();

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
@@ -21,7 +21,6 @@ import {
   getLicenseCriticality,
   getMostFrequentLicenses,
   getStrippedLicenseName,
-  getUniqueLicenseNameToAttribution,
 } from '../ProjectStatisticsPopup.util';
 
 const testAttributions_1: Attributions = {
@@ -154,12 +153,9 @@ describe('aggregateLicensesAndSourcesFromAttributions', () => {
       'The MIT License (MIT)': undefined,
     };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
     const { licenseCounts, licenseNamesWithCriticality } =
       aggregateLicensesAndSourcesFromAttributions(
         testAttributions_1,
-        strippedLicenseNameToAttribution,
         attributionSources,
       );
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
@@ -19,7 +19,6 @@ import {
   getCriticalSignalsCount,
   getIncompleteAttributionsCount,
   getLicenseCriticality,
-  getLicenseNameVariants,
   getMostFrequentLicenses,
   getStrippedLicenseName,
   getUniqueLicenseNameToAttribution,
@@ -207,23 +206,6 @@ describe('getLicenseCriticality', () => {
     const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
 
     expect(licenseCriticality).toEqual(expectedLicenseCriticality);
-  });
-});
-
-describe('getLicenseNameVariants', () => {
-  it('gets equivalent license names from attributions', () => {
-    const gpl2 = 'GPL-2.0';
-    const gpl2variant1 = 'gpl 2.0';
-    const testAttributions: Attributions = {
-      uuid1: { licenseName: gpl2, id: 'uuid1' },
-      uuid2: { licenseName: gpl2variant1, id: 'uuid2' },
-      uuid3: { licenseName: 'something else', id: 'uuid3' },
-    };
-    const expectedLicenseNameVariants = new Set([gpl2, gpl2variant1]);
-
-    const licenseNameVariants = getLicenseNameVariants(gpl2, testAttributions);
-
-    expect(licenseNameVariants).toEqual(expectedLicenseNameVariants);
   });
 });
 

--- a/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
+++ b/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
@@ -20,7 +20,7 @@ export class ProjectStatisticsPopup {
       .getByRole('table')
       .filter({
         hasText:
-          text.attributionCountPerSourcePerLicenseTable.columnNames.licenseName,
+          text.attributionCountPerSourcePerLicenseTable.columns.licenseName,
       })
       .getByRole('row')
       .last()

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -199,7 +199,7 @@ export const text = {
       classification: 'Classification',
       totalSources: 'Total',
     },
-    absent: '-',
+    none: '-',
   },
   unsavedChangesPopup: {
     title: 'Unsaved Changes',

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -194,6 +194,7 @@ export const text = {
         medium: 'Medium Criticality',
         high: 'High Criticality',
       },
+      classification: 'Classification',
       totalSources: 'Total',
     },
   },

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -187,8 +187,10 @@ export const text = {
   },
   attributionCountPerSourcePerLicenseTable: {
     footerTitle: 'Total',
-    columnNames: {
-      licenseName: 'License Name',
+    columns: {
+      licenseInfo: 'License Info',
+      signalCountPerSource: 'Signal Count per Source',
+      licenseName: 'Name',
       criticality: {
         title: 'Criticality',
         medium: 'Medium Criticality',
@@ -197,6 +199,7 @@ export const text = {
       classification: 'Classification',
       totalSources: 'Total',
     },
+    absent: '-',
   },
   unsavedChangesPopup: {
     title: 'Unsaved Changes',


### PR DESCRIPTION
### Summary of changes

Added a new column to the "Signals per Sources" table in the project statistics popup for displaying the classification of each license.

### Context and reason for change

see #2804 

### How can the changes be tested

Check that classification information is shown correctly in the project statistics popup.

closes #2804