### PR TITLE
Change menu structure on MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "opossum-ui",
+  "productName": "OpossumUI",
   "description": "The OpossumUI enables the editing of attribution information that is assigned to a resource tree.",
   "license": "Apache-2.0",
   "version": "0.1.0",

--- a/src/ElectronBackend/main/menu.ts
+++ b/src/ElectronBackend/main/menu.ts
@@ -3,7 +3,8 @@
 // SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { BrowserWindow, Menu } from 'electron';
+import { BrowserWindow, Menu, MenuItem } from 'electron';
+import os from 'os';
 
 import { getAboutMenu } from './menu/aboutMenu';
 import { getEditMenu } from './menu/editMenu';
@@ -15,6 +16,7 @@ export async function createMenu(mainWindow: BrowserWindow): Promise<Menu> {
   const webContents = mainWindow.webContents;
 
   return Menu.buildFromTemplate([
+    ...(os.platform() === 'darwin' ? [{ role: 'appMenu' } as MenuItem] : []),
     getFileMenu(mainWindow),
     getEditMenu(webContents),
     await getViewMenu(),

--- a/src/ElectronBackend/main/menu/fileMenu.ts
+++ b/src/ElectronBackend/main/menu/fileMenu.ts
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { app, BrowserWindow } from 'electron';
+import os from 'os';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import {
@@ -278,7 +279,7 @@ export function getFileMenu(mainWindow: BrowserWindow) {
       getProjectMetadata(webContents),
       getProjectStatistics(webContents),
       getSetBaseUrl(mainWindow),
-      getQuit(),
+      ...(os.platform() === 'darwin' ? [] : [getQuit()]),
     ],
   };
 }


### PR DESCRIPTION
### Summary of changes

Add standard app menu on MacOS. This also has the effect that the "File" menu is actually seen with the name "File" and is no longer sort of hidden behind the app name.

### Context and reason for change

This kind of menu structure follows the standard for MacOS apps.

### How can the changes be tested

Open OpossumUI on a MacOS device and check the menu structure. Also check that the menu structure is not affected when opening OpossumUI on non-MacOS devices.
