### PR TITLE
Refactor ProjectStatisticsPopup.util.ts

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -30,7 +30,6 @@ import {
   getIncompleteAttributionsCount,
   getMostFrequentLicenses,
   getSignalCountByClassification,
-  getUniqueLicenseNameToAttribution,
 } from './ProjectStatisticsPopup.util';
 
 const classes = {
@@ -50,17 +49,12 @@ export const ProjectStatisticsPopup: React.FC = () => {
     getUnresolvedExternalAttributions,
   );
 
-  const strippedLicenseNameToAttribution = getUniqueLicenseNameToAttribution(
-    unresolvedExternalAttribution,
-  );
-
   const {
     licenseCounts,
     licenseNamesWithCriticality,
     licenseNamesWithClassification,
   } = aggregateLicensesAndSourcesFromAttributions(
     unresolvedExternalAttribution,
-    strippedLicenseNameToAttribution,
     attributionSources,
   );
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
@@ -35,13 +35,14 @@ export const ATTRIBUTION_TOTAL = 'Total Attributions';
 
 export function aggregateLicensesAndSourcesFromAttributions(
   attributions: Attributions,
-  strippedLicenseNameToAttribution: UniqueLicenseNameToAttributions,
   attributionSources: ExternalAttributionSources,
 ): {
   licenseCounts: LicenseCounts;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
   licenseNamesWithClassification: LicenseNamesWithClassification;
 } {
+  const strippedLicenseNameToAttribution =
+    getUniqueLicenseNameToAttribution(attributions);
   const {
     attributionCountPerSourcePerLicense,
     totalAttributionsPerLicense,
@@ -208,7 +209,7 @@ export function getLicenseCriticality(licenseCriticalityCounts: {
       : undefined;
 }
 
-export function getUniqueLicenseNameToAttribution(
+function getUniqueLicenseNameToAttribution(
   attributions: Attributions,
 ): UniqueLicenseNameToAttributions {
   const uniqueLicenseNameToAttributions: UniqueLicenseNameToAttributions = {};

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
@@ -225,28 +225,6 @@ export function getUniqueLicenseNameToAttribution(
   return uniqueLicenseNameToAttributions;
 }
 
-export function getLicenseNameVariants(
-  licenseName: string,
-  attributions: Attributions,
-): Set<string> {
-  const strippedLicenseName = getStrippedLicenseName(licenseName);
-  const licenseNames: Set<string> = new Set<string>();
-
-  for (const attributionId of Object.keys(attributions)) {
-    const attributionLicenseName =
-      attributions[attributionId].licenseName || '';
-    const attributionStrippedLicenseName = getStrippedLicenseName(
-      attributions[attributionId].licenseName || '',
-    );
-
-    if (attributionStrippedLicenseName === strippedLicenseName) {
-      licenseNames.add(attributionLicenseName);
-    }
-  }
-
-  return licenseNames;
-}
-
 export function getStrippedLicenseName(licenseName: string): string {
   return licenseName.replace(/[\s-]/g, '').toLowerCase();
 }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
@@ -21,7 +21,6 @@ import {
   getLicenseCriticality,
   getMostFrequentLicenses,
   getStrippedLicenseName,
-  getUniqueLicenseNameToAttribution,
 } from '../ProjectStatisticsPopup.util';
 
 const testAttributions_1: Attributions = {
@@ -154,12 +153,9 @@ describe('aggregateLicensesAndSourcesFromAttributions', () => {
       'The MIT License (MIT)': undefined,
     };
 
-    const strippedLicenseNameToAttribution =
-      getUniqueLicenseNameToAttribution(testAttributions_1);
     const { licenseCounts, licenseNamesWithCriticality } =
       aggregateLicensesAndSourcesFromAttributions(
         testAttributions_1,
-        strippedLicenseNameToAttribution,
         attributionSources,
       );
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.util.test.tsx
@@ -19,7 +19,6 @@ import {
   getCriticalSignalsCount,
   getIncompleteAttributionsCount,
   getLicenseCriticality,
-  getLicenseNameVariants,
   getMostFrequentLicenses,
   getStrippedLicenseName,
   getUniqueLicenseNameToAttribution,
@@ -207,23 +206,6 @@ describe('getLicenseCriticality', () => {
     const licenseCriticality = getLicenseCriticality(licenseCriticalityCounts);
 
     expect(licenseCriticality).toEqual(expectedLicenseCriticality);
-  });
-});
-
-describe('getLicenseNameVariants', () => {
-  it('gets equivalent license names from attributions', () => {
-    const gpl2 = 'GPL-2.0';
-    const gpl2variant1 = 'gpl 2.0';
-    const testAttributions: Attributions = {
-      uuid1: { licenseName: gpl2, id: 'uuid1' },
-      uuid2: { licenseName: gpl2variant1, id: 'uuid2' },
-      uuid3: { licenseName: 'something else', id: 'uuid3' },
-    };
-    const expectedLicenseNameVariants = new Set([gpl2, gpl2variant1]);
-
-    const licenseNameVariants = getLicenseNameVariants(gpl2, testAttributions);
-
-    expect(licenseNameVariants).toEqual(expectedLicenseNameVariants);
   });
 });
 


### PR DESCRIPTION
### Summary of changes

Small cleanups around PrjectStatisticsPopup.util.ts
* delete unused function `getLicenseNameVariants`
* move getUniqueLicenseNameToAttribution inside of PrjectStatisticsPopup.util.ts to make using the methods a bit easier

### Context and reason for change

Boy Scout rule
