### PR TITLE
Refactor/extract switchable progress bar

### DIFF
--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -29,12 +29,10 @@ export const SwitchableProcessBar: React.FC = () => {
   const [showCriticalSignals, setShowCriticalSignals] = useState(false);
   const [progressData] = useProgressData();
 
-  function toggleShowCriticalSignals() {
-    return () =>
-      setShowCriticalSignals(
-        (currentShowCriticalSignals: boolean) => !currentShowCriticalSignals,
-      );
-  }
+  const toggleShowCriticalSignals = () =>
+    setShowCriticalSignals(
+      (currentShowCriticalSignals) => !currentShowCriticalSignals,
+    );
 
   if (!progressData) {
     return <MuiBox flex={1} />;
@@ -54,7 +52,7 @@ export const SwitchableProcessBar: React.FC = () => {
             : text.defaultProgressBar.switcherTooltip
         }
         isChecked={showCriticalSignals}
-        handleSwitchClick={toggleShowCriticalSignals()}
+        handleSwitchClick={toggleShowCriticalSignals}
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -11,13 +11,18 @@ import { useProgressData } from '../../state/variables/use-progress-data';
 import { ProgressBar } from '../ProgressBar/ProgressBar';
 import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
 
-const progressBarContainerStyling: SxProps = {
-  flex: 1,
-  display: 'flex',
-  marginLeft: '12px',
-  marginRight: '12px',
-  gap: '12px',
-};
+const classes = {
+  container: {
+    flex: 1,
+    display: 'flex',
+    marginLeft: '12px',
+    marginRight: '12px',
+    gap: '12px',
+  },
+  tooltip: {
+    margin: 'auto',
+  },
+} satisfies SxProps;
 
 export const SwitchableProcessBar: React.FC = () => {
   const text = fullText.topBar.switchableProgressBar;
@@ -35,14 +40,14 @@ export const SwitchableProcessBar: React.FC = () => {
     return <MuiBox flex={1} />;
   }
   return (
-    <MuiBox sx={progressBarContainerStyling}>
+    <MuiBox sx={classes.container}>
       <ProgressBar
         sx={{ flex: 1 }}
         progressBarData={progressData}
         showCriticalSignals={showCriticalSignals}
       />
       <SwitchWithTooltip
-        sx={{ margin: 'auto' }}
+        sx={classes.tooltip}
         switchToolTipText={
           showCriticalSignals
             ? text.criticalSignalsBar.switcherTooltip

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
+import { SxProps } from '@mui/system';
 import { useState } from 'react';
 
 import { text as fullText } from '../../../shared/text';
@@ -10,16 +11,12 @@ import { useProgressData } from '../../state/variables/use-progress-data';
 import { ProgressBar } from '../ProgressBar/ProgressBar';
 import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
 
-const classes = {
-  progressBarContainer: {
-    flex: 1,
-    display: 'flex',
-    marginLeft: '12px',
-    marginRight: '12px',
-  },
-  switch: {
-    margin: 'auto',
-  },
+const progressBarContainerStyling: SxProps = {
+  flex: 1,
+  display: 'flex',
+  marginLeft: '12px',
+  marginRight: '12px',
+  gap: '12px',
 };
 
 export const SwitchableProcessBar: React.FC = () => {
@@ -38,14 +35,14 @@ export const SwitchableProcessBar: React.FC = () => {
     return <MuiBox flex={1} />;
   }
   return (
-    <MuiBox sx={classes.progressBarContainer}>
+    <MuiBox sx={progressBarContainerStyling}>
       <ProgressBar
-        sx={classes.progressBarContainer}
+        sx={{ flex: 1 }}
         progressBarData={progressData}
         showCriticalSignals={showCriticalSignals}
       />
       <SwitchWithTooltip
-        sx={classes.switch}
+        sx={{ margin: 'auto' }}
         switchToolTipText={
           showCriticalSignals
             ? text.criticalSignalsBar.switcherTooltip

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -5,6 +5,7 @@
 import MuiBox from '@mui/material/Box';
 import { useState } from 'react';
 
+import { text as fullText } from '../../../shared/text';
 import { useProgressData } from '../../state/variables/use-progress-data';
 import { ProgressBar } from '../ProgressBar/ProgressBar';
 import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
@@ -22,6 +23,7 @@ const classes = {
 };
 
 export const SwitchableProcessBar: React.FC = () => {
+  const text = fullText.topBar.switchableProgressBar;
   const [showCriticalSignals, setShowCriticalSignals] = useState(false);
   const [progressData] = useProgressData();
 
@@ -46,8 +48,8 @@ export const SwitchableProcessBar: React.FC = () => {
         sx={classes.switch}
         switchToolTipText={
           showCriticalSignals
-            ? 'Critical signals progress bar selected'
-            : 'Progress bar selected'
+            ? text.criticalSignalsBar.switcherTooltip
+            : text.defaultProgressBar.switcherTooltip
         }
         isChecked={showCriticalSignals}
         handleSwitchClick={toggleShowCriticalSignals()}

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import MuiBox from '@mui/material/Box';
+import { useState } from 'react';
+
+import { useProgressData } from '../../state/variables/use-progress-data';
+import { ProgressBar } from '../ProgressBar/ProgressBar';
+import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
+
+const classes = {
+  progressBarContainer: {
+    flex: 1,
+    display: 'flex',
+    marginLeft: '12px',
+    marginRight: '12px',
+  },
+  switch: {
+    margin: 'auto',
+  },
+};
+
+export const SwitchableProcessBar: React.FC = () => {
+  const [showCriticalSignals, setShowCriticalSignals] = useState(false);
+  const [progressData] = useProgressData();
+
+  if (!progressData) {
+    return <MuiBox flex={1} />;
+  }
+  return (
+    <MuiBox sx={classes.progressBarContainer}>
+      <ProgressBar
+        sx={classes.progressBarContainer}
+        progressBarData={progressData}
+        showCriticalSignals={showCriticalSignals}
+      />
+      <SwitchWithTooltip
+        sx={classes.switch}
+        switchToolTipText={
+          showCriticalSignals
+            ? 'Critical signals progress bar selected'
+            : 'Progress bar selected'
+        }
+        isChecked={showCriticalSignals}
+        handleSwitchClick={() => setShowCriticalSignals(!showCriticalSignals)}
+      />
+    </MuiBox>
+  );
+};

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -25,6 +25,13 @@ export const SwitchableProcessBar: React.FC = () => {
   const [showCriticalSignals, setShowCriticalSignals] = useState(false);
   const [progressData] = useProgressData();
 
+  function toggleShowCriticalSignals() {
+    return () =>
+      setShowCriticalSignals(
+        (currentShowCriticalSignals: boolean) => !currentShowCriticalSignals,
+      );
+  }
+
   if (!progressData) {
     return <MuiBox flex={1} />;
   }
@@ -43,7 +50,7 @@ export const SwitchableProcessBar: React.FC = () => {
             : 'Progress bar selected'
         }
         isChecked={showCriticalSignals}
-        handleSwitchClick={() => setShowCriticalSignals(!showCriticalSignals)}
+        handleSwitchClick={toggleShowCriticalSignals()}
       />
     </MuiBox>
   );

--- a/src/Frontend/Components/SwitchableProcessBar/__tests__/SwitchableProcessBar.test.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/__tests__/SwitchableProcessBar.test.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { screen } from '@testing-library/react';
+
+import { setVariable } from '../../../state/actions/variables-actions/variables-actions';
+import { PROGRESS_DATA } from '../../../state/variables/use-progress-data';
+import { renderComponent } from '../../../test-helpers/render';
+import { ProgressBarData } from '../../../types/types';
+import { SwitchableProcessBar } from '../SwitchableProcessBar';
+
+describe('SwitchableProcessBar', () => {
+  it('does not display the progress bar when no progress data available', () => {
+    renderComponent(<SwitchableProcessBar />);
+    expect(screen.queryByLabelText('ProgressBar')).not.toBeInTheDocument();
+  });
+
+  it('displays the progress bar when progress data available', () => {
+    renderComponent(<SwitchableProcessBar />, {
+      actions: [
+        setVariable<ProgressBarData>(PROGRESS_DATA, {
+          fileCount: 6,
+          filesWithHighlyCriticalExternalAttributionsCount: 1,
+          filesWithMediumCriticalExternalAttributionsCount: 1,
+          filesWithManualAttributionCount: 3,
+          filesWithOnlyExternalAttributionCount: 1,
+          filesWithOnlyPreSelectedAttributionCount: 1,
+          resourcesWithMediumCriticalExternalAttributions: [],
+          resourcesWithNonInheritedExternalAttributionOnly: [],
+          resourcesWithHighlyCriticalExternalAttributions: [],
+        }),
+      ],
+    });
+    expect(screen.getByLabelText('ProgressBar')).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -8,7 +8,6 @@ import MuiBox from '@mui/material/Box';
 import MuiToggleButton from '@mui/material/ToggleButton';
 import MuiToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import MuiTypography from '@mui/material/Typography';
-import { useState } from 'react';
 
 import commitInfo from '../../../commitInfo.json';
 import { View } from '../../enums/enums';
@@ -19,26 +18,15 @@ import {
 } from '../../state/actions/popup-actions/popup-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getSelectedView } from '../../state/selectors/view-selector';
-import { useProgressData } from '../../state/variables/use-progress-data';
 import { BackendCommunication } from '../BackendCommunication/BackendCommunication';
 import { IconButton } from '../IconButton/IconButton';
-import { ProgressBar } from '../ProgressBar/ProgressBar';
-import { SwitchWithTooltip } from '../SwitchWithTooltip/SwitchWithTooltip';
+import { SwitchableProcessBar } from '../SwitchableProcessBar/SwitchableProcessBar';
 
 const classes = {
   root: {
     height: '36px',
     background: OpossumColors.darkBlue,
     display: 'flex',
-  },
-  progressBarContainer: {
-    flex: 1,
-    display: 'flex',
-    marginLeft: '12px',
-    marginRight: '12px',
-  },
-  switch: {
-    margin: 'auto',
   },
   openFileIcon: {
     margin: '8px',
@@ -80,9 +68,6 @@ export const TopBar: React.FC = () => {
   const selectedView = useAppSelector(getSelectedView);
   const dispatch = useAppDispatch();
 
-  const [showCriticalSignals, setShowCriticalSignals] = useState(false);
-  const [progressData] = useProgressData();
-
   function handleClick(
     _: React.MouseEvent<HTMLElement>,
     selectedView: View,
@@ -110,7 +95,7 @@ export const TopBar: React.FC = () => {
           />
         }
       />
-      {renderProgressBar()}
+      <SwitchableProcessBar />
       <MuiToggleButtonGroup
         size="small"
         value={selectedView}
@@ -139,30 +124,4 @@ export const TopBar: React.FC = () => {
       </MuiBox>
     </MuiBox>
   );
-
-  function renderProgressBar() {
-    if (!progressData) {
-      return <MuiBox flex={1} />;
-    }
-
-    return (
-      <MuiBox sx={classes.progressBarContainer}>
-        <ProgressBar
-          sx={classes.progressBarContainer}
-          progressBarData={progressData}
-          showCriticalSignals={showCriticalSignals}
-        />
-        <SwitchWithTooltip
-          sx={classes.switch}
-          switchToolTipText={
-            showCriticalSignals
-              ? 'Critical signals progress bar selected'
-              : 'Progress bar selected'
-          }
-          isChecked={showCriticalSignals}
-          handleSwitchClick={() => setShowCriticalSignals(!showCriticalSignals)}
-        />
-      </MuiBox>
-    );
-  }
 };

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -10,6 +10,7 @@ import MuiToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import MuiTypography from '@mui/material/Typography';
 
 import commitInfo from '../../../commitInfo.json';
+import { text } from '../../../shared/text';
 import { View } from '../../enums/enums';
 import { OpossumColors } from '../../shared-styles';
 import {
@@ -83,7 +84,7 @@ export const TopBar: React.FC = () => {
     <MuiBox aria-label={'top bar'} sx={classes.root}>
       <BackendCommunication />
       <IconButton
-        tooltipTitle="open file"
+        tooltipTitle={text.topBar.openFile.toolTipTitle}
         tooltipPlacement="right"
         onClick={(): void => {
           handleOpenFileClick();
@@ -91,7 +92,7 @@ export const TopBar: React.FC = () => {
         icon={
           <FolderOpenIcon
             sx={classes.openFileIcon}
-            aria-label={'open file icon'}
+            aria-label={text.topBar.openFile.ariaLabel}
           />
         }
       />
@@ -107,14 +108,14 @@ export const TopBar: React.FC = () => {
           sx={classes.viewButtons}
           disabled={selectedView === View.Audit}
         >
-          {'Audit'}
+          {text.topBar.audit}
         </MuiToggleButton>
         <MuiToggleButton
           value={View.Report}
           sx={classes.viewButtons}
           disabled={selectedView === View.Report}
         >
-          {'Report'}
+          {text.topBar.report}
         </MuiToggleButton>
       </MuiToggleButtonGroup>
       <MuiBox sx={classes.versionInfo}>

--- a/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
+++ b/src/Frontend/Components/TopBar/__tests__/TopBar.test.tsx
@@ -6,15 +6,12 @@
 import { fireEvent, screen } from '@testing-library/react';
 
 import { View } from '../../../enums/enums';
-import { setVariable } from '../../../state/actions/variables-actions/variables-actions';
 import { initialResourceState } from '../../../state/reducers/resource-reducer';
 import {
   isAuditViewSelected,
   isReportViewSelected,
 } from '../../../state/selectors/view-selector';
-import { PROGRESS_DATA } from '../../../state/variables/use-progress-data';
 import { renderComponent } from '../../../test-helpers/render';
-import { ProgressBarData } from '../../../types/types';
 import { TopBar } from '../TopBar';
 
 describe('TopBar', () => {
@@ -37,29 +34,5 @@ describe('TopBar', () => {
     fireEvent.click(screen.getByText(View.Report));
     expect(isAuditViewSelected(store.getState())).toBe(false);
     expect(isReportViewSelected(store.getState())).toBe(true);
-  });
-
-  it('does not display the progress bar when no progress data available', () => {
-    renderComponent(<TopBar />);
-    expect(screen.queryByLabelText('ProgressBar')).not.toBeInTheDocument();
-  });
-
-  it('displays the progress bar when progress data available', () => {
-    renderComponent(<TopBar />, {
-      actions: [
-        setVariable<ProgressBarData>(PROGRESS_DATA, {
-          fileCount: 6,
-          filesWithHighlyCriticalExternalAttributionsCount: 1,
-          filesWithMediumCriticalExternalAttributionsCount: 1,
-          filesWithManualAttributionCount: 3,
-          filesWithOnlyExternalAttributionCount: 1,
-          filesWithOnlyPreSelectedAttributionCount: 1,
-          resourcesWithMediumCriticalExternalAttributions: [],
-          resourcesWithNonInheritedExternalAttributionOnly: [],
-          resourcesWithHighlyCriticalExternalAttributions: [],
-        }),
-      ],
-    });
-    expect(screen.getByLabelText('ProgressBar')).toBeInTheDocument();
   });
 });

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -349,4 +349,20 @@ export const text = {
     noOpenFileToMergeInto: 'No open file to merge into',
     cantCreateBackup: 'Unable to create backup of currently open Opossum file',
   },
+  topBar: {
+    openFile: {
+      ariaLabel: 'open file icon',
+      toolTipTitle: 'open file',
+    },
+    audit: 'Audit',
+    report: 'Report',
+    switchableProgressBar: {
+      criticalSignalsBar: {
+        switcherTooltip: 'Critical signals progress bar selected',
+      },
+      defaultProgressBar: {
+        switcherTooltip: 'Progress bar selected',
+      },
+    },
+  },
 } as const;


### PR DESCRIPTION
### Summary of changes

Make the TopBar component smaller by extracting everything which belongs to the progressBar into its own component

### Context and reason for change

This isolates the component which should ease the upcoming changes

### How can the changes be tested

Open any opossumUi file and check the ProgressBar works as expected

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
