### PR TITLE
Introduce sorting for signals per source table

### DIFF
--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -103,10 +103,11 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
 
   const handleRequestSort = (columnId: string) => {
     if (ordering.orderedColumn === columnId) {
-      setOrdering({
-        ...ordering,
-        orderDirection: ordering.orderDirection === 'asc' ? 'desc' : 'asc',
-      });
+      setOrdering((currentOrdering) => ({
+        ...currentOrdering,
+        orderDirection:
+          currentOrdering.orderDirection === 'asc' ? 'desc' : 'asc',
+      }));
     } else {
       setOrdering({
         orderDirection: 'asc',

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -5,7 +5,11 @@
 import MuiBox from '@mui/material/Box';
 import MuiTable from '@mui/material/Table';
 import MuiTableBody from '@mui/material/TableBody';
+import MuiTableCell from '@mui/material/TableCell';
 import MuiTableContainer from '@mui/material/TableContainer';
+import MuiTableFooter from '@mui/material/TableFooter';
+import MuiTableHead from '@mui/material/TableHead';
+import MuiTableRow from '@mui/material/TableRow';
 import MuiTypography from '@mui/material/Typography';
 
 import {
@@ -16,6 +20,7 @@ import {
 import { AttributionCountPerSourcePerLicenseTableFooter } from './AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter';
 import { AttributionCountPerSourcePerLicenseTableHead } from './AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead';
 import { AttributionCountPerSourcePerLicenseTableRow } from './AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow';
+import { tableClasses } from '../../shared-styles';
 
 const classes = {
   container: {
@@ -38,46 +43,117 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
     props.licenseCounts.totalAttributionsPerSource,
   );
 
+  const totalNumberOfAttributionsPerSource = sourceNames.map((sourceName) =>
+    props.licenseCounts.totalAttributionsPerSource[sourceName].toString(),
+  );
+  const totalNumberOfAttributions = Object.values(
+    props.licenseCounts.totalAttributionsPerSource,
+  )
+    .reduce((partialSum, num) => partialSum + num, 0)
+    .toString();
+
+  const footerRow = [FOOTER_TITLE]
+    .concat(totalNumberOfAttributionsPerSource)
+    .concat(totalNumberOfAttributions);
+  const headerRow = [LICENSE_COLUMN_NAME_IN_TABLE]
+    .concat(sourceNames)
+    .concat(TOTAL_SOURCES_TITLE)
+    .map(
+      (sourceName) => sourceName.charAt(0).toUpperCase() + sourceName.slice(1),
+    );
+
+  Object.entries(
+    props.licenseCounts.attributionCountPerSourcePerLicense,
+  ).forEach(
+    ([licenseName, value]) =>
+      (value[TOTAL_SOURCES_TITLE] =
+        props.licenseCounts.totalAttributionsPerLicense[licenseName]),
+  );
+
+  const tableHead = (
+    <MuiTableHead>
+      <MuiTableRow>
+        {headerRow.map((columnHeader, columnIndex) => (
+          <MuiTableCell
+            sx={tableClasses.head}
+            key={columnIndex}
+            align={columnIndex === 0 ? 'left' : 'center'}
+          >
+            {columnHeader}
+          </MuiTableCell>
+        ))}
+      </MuiTableRow>
+    </MuiTableHead>
+  );
+
+  const buildTableRow = (licenseName: string, rowIndex: number) => {
+    const licenseNameCell = (
+      <MuiTableCell
+        sx={{
+          ...tableClasses.body,
+        }}
+        key={0}
+        align={'left'}
+      >
+        <span>{licenseName}</span>
+      </MuiTableCell>
+    );
+
+    const countBySourceCells = sourceNames
+      .concat(TOTAL_SOURCES_TITLE)
+      .map((sourceName, sourceIdx) => {
+        const columnIndex = 1 + sourceIdx;
+
+        return (
+          <MuiTableCell
+            sx={{
+              ...tableClasses.body,
+            }}
+            key={columnIndex}
+            align={'center'}
+          >
+            {props.licenseCounts.attributionCountPerSourcePerLicense[
+              licenseName
+            ][sourceName] || '-'}
+          </MuiTableCell>
+        );
+      });
+
+    return (
+      <MuiTableRow key={rowIndex}>
+        {[licenseNameCell, ...countBySourceCells]}
+      </MuiTableRow>
+    );
+  };
+
+  const tableFooter = (
+    <MuiTableFooter>
+      <MuiTableRow>
+        {footerRow.map((total, columnIndex) => (
+          <MuiTableCell
+            sx={tableClasses.footer}
+            key={columnIndex}
+            align={columnIndex === 0 ? 'left' : 'center'}
+          >
+            {total}
+          </MuiTableCell>
+        ))}
+      </MuiTableRow>
+    </MuiTableFooter>
+  );
+
   return (
     <MuiBox>
       <MuiTypography variant="subtitle1">{props.title}</MuiTypography>
       <MuiTableContainer sx={classes.container}>
         <MuiTable size="small" stickyHeader>
-          <AttributionCountPerSourcePerLicenseTableHead
-            sourceNames={sourceNames}
-          />
+          {tableHead}
           <MuiTableBody>
             {Object.keys(props.licenseNamesWithCriticality)
               .toSorted()
-              .map((licenseName, rowIndex) => (
-                <AttributionCountPerSourcePerLicenseTableRow
-                  sourceNames={sourceNames}
-                  signalCountsPerSource={
-                    props.licenseCounts.attributionCountPerSourcePerLicense[
-                      licenseName
-                    ]
-                  }
-                  licenseName={licenseName}
-                  licenseCriticality={
-                    props.licenseNamesWithCriticality[licenseName]
-                  }
-                  licenseClassification={
-                    props.licenseNamesWithClassification[licenseName]
-                  }
-                  totalSignalCount={
-                    props.licenseCounts.totalAttributionsPerLicense[licenseName]
-                  }
-                  key={rowIndex}
-                  rowIndex={rowIndex}
-                />
-              ))}
+              .map(buildTableRow)}
           </MuiTableBody>
-          <AttributionCountPerSourcePerLicenseTableFooter
-            sourceNames={sourceNames}
-            totalAttributionsPerSource={
-              props.licenseCounts.totalAttributionsPerSource
-            }
-          />
+          {tableFooter}
         </MuiTable>
       </MuiTableContainer>
     </MuiBox>

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -7,7 +7,7 @@ import MuiTable from '@mui/material/Table';
 import MuiTableBody from '@mui/material/TableBody';
 import MuiTableContainer from '@mui/material/TableContainer';
 import MuiTypography from '@mui/material/Typography';
-import { upperFirst } from 'lodash';
+import { orderBy, upperFirst } from 'lodash';
 import { useMemo, useState } from 'react';
 
 import { text } from '../../../shared/text';
@@ -115,23 +115,33 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
     }
   };
 
-  const orderedLicenseNames = useMemo(
-    () =>
-      orderLicenseNames(
-        props.licenseNamesWithCriticality,
-        props.licenseNamesWithClassification,
-        props.licenseCounts,
-        columnConfig,
-        ordering,
-      ),
-    [
+  const orderedLicenseNames = useMemo(() => {
+    const orderedColumnType = columnConfig.getColumnById(
+      ordering.orderedColumn,
+    )?.columnType;
+
+    if (orderedColumnType === undefined) {
+      return orderBy(
+        Object.keys(props.licenseNamesWithCriticality),
+        (licenseName) => licenseName.toLowerCase(),
+        ordering.orderDirection,
+      );
+    }
+
+    return orderLicenseNames(
       props.licenseNamesWithCriticality,
       props.licenseNamesWithClassification,
       props.licenseCounts,
-      columnConfig,
-      ordering,
-    ],
-  );
+      ordering.orderDirection,
+      orderedColumnType,
+    );
+  }, [
+    props.licenseNamesWithCriticality,
+    props.licenseNamesWithClassification,
+    props.licenseCounts,
+    columnConfig,
+    ordering,
+  ]);
 
   return (
     <MuiBox>

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { orderBy } from 'lodash';
+
+import { Criticality } from '../../../shared/shared-types';
+import {
+  LicenseCounts,
+  LicenseNamesWithClassification,
+  LicenseNamesWithCriticality,
+} from '../../types/types';
+import { TableOrdering } from './AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead';
+
+export function orderLicenseNames(
+  licenseNamesWithCriticality: LicenseNamesWithCriticality,
+  licenseNamesWithClassification: LicenseNamesWithClassification,
+  licenseCounts: LicenseCounts,
+  ordering: TableOrdering,
+  sourceNames: Array<string>,
+): Array<string> {
+  return orderBy(
+    Object.keys(licenseNamesWithCriticality),
+    [
+      (licenseName) => {
+        const numStartingColumns = 3;
+
+        if (ordering.orderedColumn === 0) {
+          return licenseName.toLowerCase();
+        } else if (ordering.orderedColumn === 1) {
+          switch (licenseNamesWithCriticality[licenseName]) {
+            case Criticality.High:
+              return 2;
+            case Criticality.Medium:
+              return 1;
+            default:
+              return 0;
+          }
+        } else if (ordering.orderedColumn === 2) {
+          return licenseNamesWithClassification[licenseName];
+        } else if (
+          ordering.orderedColumn <
+          numStartingColumns + sourceNames.length
+        ) {
+          return (
+            licenseCounts.attributionCountPerSourcePerLicense[licenseName][
+              sourceNames[ordering.orderedColumn - numStartingColumns]
+            ] ?? 0
+          );
+        }
+
+        return licenseCounts.totalAttributionsPerLicense[licenseName];
+      },
+      (licenseName) => licenseName.toLowerCase(),
+    ],
+    [ordering.orderDirection, 'asc'],
+  );
+}

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import { TableCellProps } from '@mui/material';
 import { orderBy } from 'lodash';
 
 import { Criticality } from '../../../shared/shared-types';
@@ -10,24 +11,76 @@ import {
   LicenseNamesWithClassification,
   LicenseNamesWithCriticality,
 } from '../../types/types';
-import { TableOrdering } from './AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead';
+import { Order } from '../TableCellWithSorting/TableCellWithSorting';
+
+export enum SingleColumn {
+  NAME = 'NAME',
+  CRITICALITY = 'CRITICALITY',
+  CLASSIFICATION = 'CLASSIFICATION',
+  TOTAL = 'TOTAL',
+}
+
+export type CountPerSourceColumn = {
+  sourceName: string;
+};
+
+export type ColumnType = SingleColumn | CountPerSourceColumn;
+
+export type Column = {
+  columnName: string;
+  columnType: ColumnType;
+  columnId: string;
+  align: TableCellProps['align'];
+};
+
+export type ColumnGroup = {
+  groupName: string;
+  columns: Array<Column>;
+};
+
+export class ColumnConfig {
+  readonly groups: Array<ColumnGroup>;
+
+  constructor(groups: Array<ColumnGroup>) {
+    this.groups = groups;
+  }
+
+  getColumns(): Array<Column> {
+    return this.groups.flatMap((columnGroup) => columnGroup.columns);
+  }
+
+  getColumnById(id: string): Column | undefined {
+    return this.getColumns().find((column) => column.columnId === id);
+  }
+}
+
+export type TableOrdering = {
+  orderDirection: Order;
+  orderedColumn: string;
+};
 
 export function orderLicenseNames(
   licenseNamesWithCriticality: LicenseNamesWithCriticality,
   licenseNamesWithClassification: LicenseNamesWithClassification,
   licenseCounts: LicenseCounts,
+  columnConfig: ColumnConfig,
   ordering: TableOrdering,
-  sourceNames: Array<string>,
 ): Array<string> {
+  const orderedColumnType = columnConfig.getColumnById(
+    ordering.orderedColumn,
+  )?.columnType;
+
+  if (orderedColumnType === undefined) {
+    return [];
+  }
+
   return orderBy(
     Object.keys(licenseNamesWithCriticality),
     [
       (licenseName) => {
-        const numStartingColumns = 3;
-
-        if (ordering.orderedColumn === 0) {
+        if (orderedColumnType === SingleColumn.NAME) {
           return licenseName.toLowerCase();
-        } else if (ordering.orderedColumn === 1) {
+        } else if (orderedColumnType === SingleColumn.CRITICALITY) {
           switch (licenseNamesWithCriticality[licenseName]) {
             case Criticality.High:
               return 2;
@@ -36,20 +89,17 @@ export function orderLicenseNames(
             default:
               return 0;
           }
-        } else if (ordering.orderedColumn === 2) {
+        } else if (orderedColumnType === SingleColumn.CLASSIFICATION) {
           return licenseNamesWithClassification[licenseName];
-        } else if (
-          ordering.orderedColumn <
-          numStartingColumns + sourceNames.length
-        ) {
-          return (
-            licenseCounts.attributionCountPerSourcePerLicense[licenseName][
-              sourceNames[ordering.orderedColumn - numStartingColumns]
-            ] ?? 0
-          );
+        } else if (orderedColumnType === SingleColumn.TOTAL) {
+          return licenseCounts.totalAttributionsPerLicense[licenseName];
         }
 
-        return licenseCounts.totalAttributionsPerLicense[licenseName];
+        return (
+          licenseCounts.attributionCountPerSourcePerLicense[licenseName][
+            orderedColumnType.sourceName
+          ] ?? 0
+        );
       },
       (licenseName) => licenseName.toLowerCase(),
     ],

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.util.ts
@@ -63,17 +63,9 @@ export function orderLicenseNames(
   licenseNamesWithCriticality: LicenseNamesWithCriticality,
   licenseNamesWithClassification: LicenseNamesWithClassification,
   licenseCounts: LicenseCounts,
-  columnConfig: ColumnConfig,
-  ordering: TableOrdering,
+  orderDirection: Order,
+  orderedColumnType: ColumnType,
 ): Array<string> {
-  const orderedColumnType = columnConfig.getColumnById(
-    ordering.orderedColumn,
-  )?.columnType;
-
-  if (orderedColumnType === undefined) {
-    return [];
-  }
-
   return orderBy(
     Object.keys(licenseNamesWithCriticality),
     [
@@ -103,6 +95,6 @@ export function orderLicenseNames(
       },
       (licenseName) => licenseName.toLowerCase(),
     ],
-    [ordering.orderDirection, 'asc'],
+    [orderDirection, 'asc'],
   );
 }

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableFooter/AttributionCountPerSourcePerLicenseTableFooter.tsx
@@ -9,9 +9,14 @@ import { sum } from 'lodash';
 
 import { text } from '../../../../shared/text';
 import { tableClasses } from '../../../shared-styles';
+import {
+  Column,
+  ColumnConfig,
+  SingleColumn,
+} from '../AttributionCountPerSourcePerLicenseTable.util';
 
 interface AttributionCountPerSourcePerLicenseTableFooterProps {
-  sourceNames: Array<string>;
+  columnConfig: ColumnConfig;
   totalAttributionsPerSource: { [sourceName: string]: number };
 }
 
@@ -21,24 +26,41 @@ export const AttributionCountPerSourcePerLicenseTableFooter: React.FC<
   return (
     <MuiTableFooter>
       <MuiTableRow>
-        <MuiTableCell sx={tableClasses.footer} align={'left'}>
-          {text.attributionCountPerSourcePerLicenseTable.footerTitle}
-        </MuiTableCell>
-        <MuiTableCell sx={tableClasses.footer} />
-        <MuiTableCell sx={tableClasses.footer} />
-        {props.sourceNames.map((sourceName, sourceIdx) => (
-          <MuiTableCell
-            sx={tableClasses.footer}
-            key={sourceIdx}
-            align={'center'}
-          >
-            {props.totalAttributionsPerSource[sourceName]}
-          </MuiTableCell>
-        ))}
-        <MuiTableCell sx={tableClasses.footer} align={'center'}>
-          {sum(Object.values(props.totalAttributionsPerSource))}
-        </MuiTableCell>
+        {props.columnConfig.getColumns().map((column, columnIdx) => {
+          return (
+            <MuiTableCell
+              sx={tableClasses.footer}
+              key={columnIdx}
+              align={column.align}
+            >
+              <FooterCellContent
+                column={column}
+                totalAttributionsPerSource={props.totalAttributionsPerSource}
+              />
+            </MuiTableCell>
+          );
+        })}
       </MuiTableRow>
     </MuiTableFooter>
   );
+};
+
+interface FooterCellContentProps {
+  column: Column;
+  totalAttributionsPerSource: { [sourceName: string]: number };
+}
+
+const FooterCellContent: React.FC<FooterCellContentProps> = (props) => {
+  if (props.column.columnType === SingleColumn.NAME) {
+    return text.attributionCountPerSourcePerLicenseTable.footerTitle;
+  } else if (
+    props.column.columnType === SingleColumn.CRITICALITY ||
+    props.column.columnType === SingleColumn.CLASSIFICATION
+  ) {
+    return null;
+  } else if (props.column.columnType === SingleColumn.TOTAL) {
+    return sum(Object.values(props.totalAttributionsPerSource));
+  }
+
+  return props.totalAttributionsPerSource[props.column.columnType.sourceName];
 };

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -6,14 +6,13 @@ import MuiTableCell from '@mui/material/TableCell';
 import MuiTableHead from '@mui/material/TableHead';
 import MuiTableRow from '@mui/material/TableRow';
 import { SxProps } from '@mui/system';
-import { upperFirst } from 'lodash';
 
-import { text } from '../../../../shared/text';
 import { tableClasses } from '../../../shared-styles';
+import { TableCellWithSorting } from '../../TableCellWithSorting/TableCellWithSorting';
 import {
-  Order,
-  TableCellWithSorting,
-} from '../../TableCellWithSorting/TableCellWithSorting';
+  ColumnConfig,
+  TableOrdering,
+} from '../AttributionCountPerSourcePerLicenseTable.util';
 
 const classes = {
   headerCellWithVerticalSeparator: {
@@ -24,73 +23,62 @@ const classes = {
   },
 } satisfies SxProps;
 
-export type TableOrdering = {
-  orderDirection: Order;
-  orderedColumn: number;
-};
-
 interface AttributionCountPerSourcePerLicenseTableHeadProps {
-  sourceNames: Array<string>;
+  columnConfig: ColumnConfig;
   tableOrdering: TableOrdering;
-  onRequestSort: (columnIndex: number) => void;
+  onRequestSort: (columnId: string) => void;
 }
 
 export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
   AttributionCountPerSourcePerLicenseTableHeadProps
 > = (props) => {
-  const componentText = text.attributionCountPerSourcePerLicenseTable;
-
-  const headerRow = [
-    componentText.columns.licenseName,
-    componentText.columns.criticality.title,
-    componentText.columns.classification,
-    ...props.sourceNames.map(upperFirst),
-    componentText.columns.totalSources,
-  ];
-
   return (
     <MuiTableHead sx={{ position: 'sticky', top: 0 }}>
       <MuiTableRow>
-        <MuiTableCell
-          sx={{
-            ...tableClasses.head,
-            ...classes.headerCellWithVerticalSeparator,
-            ...classes.headerCellWithHorizontalSeparator,
-          }}
-          align={'center'}
-          colSpan={3}
-        >
-          {componentText.columns.licenseInfo}
-        </MuiTableCell>
-        <MuiTableCell
-          sx={{
-            ...tableClasses.head,
-            ...classes.headerCellWithHorizontalSeparator,
-          }}
-          align={'center'}
-          colSpan={props.sourceNames.length + 1}
-        >
-          {componentText.columns.signalCountPerSource}
-        </MuiTableCell>
+        {props.columnConfig.groups.map((columnGroup, idx) => {
+          return (
+            <MuiTableCell
+              sx={{
+                ...tableClasses.head,
+                ...(idx !== props.columnConfig.groups.length - 1
+                  ? classes.headerCellWithVerticalSeparator
+                  : {}),
+                ...classes.headerCellWithHorizontalSeparator,
+              }}
+              align={'center'}
+              colSpan={columnGroup.columns.length}
+              key={idx}
+            >
+              {columnGroup.groupName}
+            </MuiTableCell>
+          );
+        })}
       </MuiTableRow>
       <MuiTableRow>
-        {headerRow.map((columnHeader, columnIndex) => (
-          <TableCellWithSorting
-            sx={{
-              ...tableClasses.head,
-              ...(columnIndex === 2
-                ? classes.headerCellWithVerticalSeparator
-                : {}),
-            }}
-            key={columnIndex}
-            align={columnIndex === 0 ? 'left' : 'center'}
-            order={props.tableOrdering.orderDirection}
-            isSortedColumn={props.tableOrdering.orderedColumn === columnIndex}
-            onRequestSort={() => props.onRequestSort(columnIndex)}
-          >
-            {columnHeader}
-          </TableCellWithSorting>
-        ))}
+        {props.columnConfig.groups.flatMap((columnGroup, groupIdx) =>
+          columnGroup.columns.map((column, columnIdx) => {
+            return (
+              <TableCellWithSorting
+                sx={{
+                  ...tableClasses.head,
+                  ...(columnIdx === columnGroup.columns.length - 1 &&
+                  groupIdx !== props.columnConfig.groups.length - 1
+                    ? classes.headerCellWithVerticalSeparator
+                    : {}),
+                }}
+                key={column.columnName}
+                align={column.align}
+                order={props.tableOrdering.orderDirection}
+                isSortedColumn={
+                  props.tableOrdering.orderedColumn === column.columnId
+                }
+                onRequestSort={() => props.onRequestSort(column.columnId)}
+              >
+                {column.columnName}
+              </TableCellWithSorting>
+            );
+          }),
+        )}
       </MuiTableRow>
     </MuiTableHead>
   );

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -67,7 +67,9 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
                     : {}),
                 }}
                 key={column.columnName}
-                align={column.align}
+                tableCellProps={{
+                  align: column.align,
+                }}
                 order={props.tableOrdering.orderDirection}
                 isSortedColumn={
                   props.tableOrdering.orderedColumn === column.columnId

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -24,10 +24,14 @@ const classes = {
   },
 } satisfies SxProps;
 
+export type TableOrdering = {
+  orderDirection: Order;
+  orderedColumn: number;
+};
+
 interface AttributionCountPerSourcePerLicenseTableHeadProps {
   sourceNames: Array<string>;
-  order: Order;
-  orderBy: number;
+  tableOrdering: TableOrdering;
   onRequestSort: (columnIndex: number) => void;
 }
 
@@ -80,8 +84,8 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
             }}
             key={columnIndex}
             align={columnIndex === 0 ? 'left' : 'center'}
-            order={props.order}
-            isSortedColumn={props.orderBy === columnIndex}
+            order={props.tableOrdering.orderDirection}
+            isSortedColumn={props.tableOrdering.orderedColumn === columnIndex}
             onRequestSort={() => props.onRequestSort(columnIndex)}
           >
             {columnHeader}

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -10,6 +10,10 @@ import { upperFirst } from 'lodash';
 
 import { text } from '../../../../shared/text';
 import { tableClasses } from '../../../shared-styles';
+import {
+  Order,
+  TableCellWithSorting,
+} from '../../TableCellWithSorting/TableCellWithSorting';
 
 const classes = {
   headerCellWithVerticalSeparator: {
@@ -22,6 +26,9 @@ const classes = {
 
 interface AttributionCountPerSourcePerLicenseTableHeadProps {
   sourceNames: Array<string>;
+  order: Order;
+  orderBy: number;
+  onRequestSort: (columnIndex: number) => void;
 }
 
 export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
@@ -64,7 +71,7 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
       </MuiTableRow>
       <MuiTableRow>
         {headerRow.map((columnHeader, columnIndex) => (
-          <MuiTableCell
+          <TableCellWithSorting
             sx={{
               ...tableClasses.head,
               ...(columnIndex === 2
@@ -73,9 +80,12 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
             }}
             key={columnIndex}
             align={columnIndex === 0 ? 'left' : 'center'}
+            order={props.order}
+            isSortedColumn={props.orderBy === columnIndex}
+            onRequestSort={() => props.onRequestSort(columnIndex)}
           >
             {columnHeader}
-          </MuiTableCell>
+          </TableCellWithSorting>
         ))}
       </MuiTableRow>
     </MuiTableHead>

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -11,9 +11,14 @@ import { OpossumColors, tableClasses } from '../../../shared-styles';
 import { useAppSelector } from '../../../state/hooks';
 import { getClassifications } from '../../../state/selectors/resource-selectors';
 import { CriticalityIcon } from '../../Icons/Icons';
+import {
+  Column,
+  ColumnConfig,
+  SingleColumn,
+} from '../AttributionCountPerSourcePerLicenseTable.util';
 
 interface AttributionCountPerSourcePerLicenseTableRowProps {
-  sourceNames: Array<string>;
+  columnConfig: ColumnConfig;
   signalCountsPerSource: { [sourceName: string]: number };
   licenseName: string;
   licenseCriticality: Criticality | undefined;
@@ -33,61 +38,69 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
         : OpossumColors.almostWhiteBlue,
   };
 
+  return (
+    <MuiTableRow>
+      {props.columnConfig.getColumns().map((column, columnIdx) => {
+        return (
+          <MuiTableCell
+            sx={bodyClassWithBackgroundColor}
+            key={columnIdx}
+            align={column.align}
+          >
+            <RowCellContent
+              signalCountsPerSource={props.signalCountsPerSource}
+              licenseName={props.licenseName}
+              licenseCriticality={props.licenseCriticality}
+              licenseClassification={props.licenseClassification}
+              totalSignalCount={props.totalSignalCount}
+              column={column}
+            />
+          </MuiTableCell>
+        );
+      })}
+    </MuiTableRow>
+  );
+};
+
+interface RowCellContentProps {
+  signalCountsPerSource: { [sourceName: string]: number };
+  licenseName: string;
+  licenseCriticality: Criticality | undefined;
+  licenseClassification: number | undefined;
+  totalSignalCount: number;
+  column: Column;
+}
+
+const RowCellContent: React.FC<RowCellContentProps> = (props) => {
   const componentText = text.attributionCountPerSourcePerLicenseTable;
 
   const classifications = useAppSelector(getClassifications);
 
+  if (props.column.columnType === SingleColumn.NAME) {
+    return props.licenseName;
+  } else if (props.column.columnType === SingleColumn.CRITICALITY) {
+    return props.licenseCriticality === undefined ? (
+      componentText.none
+    ) : (
+      <CriticalityIcon
+        criticality={props.licenseCriticality}
+        tooltip={
+          props.licenseCriticality === Criticality.High
+            ? componentText.columns.criticality.high
+            : componentText.columns.criticality.medium
+        }
+      />
+    );
+  } else if (props.column.columnType === SingleColumn.CLASSIFICATION) {
+    return props.licenseClassification
+      ? (classifications[props.licenseClassification] ?? componentText.none)
+      : componentText.none;
+  } else if (props.column.columnType === SingleColumn.TOTAL) {
+    return props.totalSignalCount;
+  }
+
   return (
-    <MuiTableRow>
-      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'left'}>
-        {props.licenseName}
-      </MuiTableCell>
-      {renderCriticalityCell()}
-      {renderClassificationCell()}
-      {props.sourceNames.map((sourceName, sourceIdx) => (
-        <MuiTableCell
-          sx={bodyClassWithBackgroundColor}
-          align={'center'}
-          key={sourceIdx}
-        >
-          {props.signalCountsPerSource[sourceName] || componentText.none}
-        </MuiTableCell>
-      ))}
-      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
-        {props.totalSignalCount}
-      </MuiTableCell>
-    </MuiTableRow>
+    props.signalCountsPerSource[props.column.columnType.sourceName] ||
+    componentText.none
   );
-
-  function renderCriticalityCell() {
-    return (
-      <MuiTableCell sx={bodyClassWithBackgroundColor} align={'center'}>
-        {props.licenseCriticality === undefined ? (
-          componentText.none
-        ) : (
-          <CriticalityIcon
-            criticality={props.licenseCriticality}
-            tooltip={
-              props.licenseCriticality === Criticality.High
-                ? componentText.columns.criticality.high
-                : componentText.columns.criticality.medium
-            }
-          />
-        )}
-      </MuiTableCell>
-    );
-  }
-
-  function renderClassificationCell() {
-    return (
-      <MuiTableCell sx={bodyClassWithBackgroundColor} key={1} align={'center'}>
-        <span>
-          {props.licenseClassification
-            ? (classifications[props.licenseClassification] ??
-              componentText.none)
-            : componentText.none}
-        </span>
-      </MuiTableCell>
-    );
-  }
 };

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -45,6 +45,7 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
           <MuiTableCell
             sx={bodyClassWithBackgroundColor}
             key={columnIdx}
+            data-testid={`signalsPerSourceBodyCell${columnIdx}`}
             align={column.align}
           >
             <RowCellContent

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableRow/AttributionCountPerSourcePerLicenseTableRow.tsx
@@ -5,7 +5,7 @@
 import MuiTableCell from '@mui/material/TableCell';
 import MuiTableRow from '@mui/material/TableRow';
 
-import { Criticality } from '../../../../shared/shared-types';
+import { Classification, Criticality } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { OpossumColors, tableClasses } from '../../../shared-styles';
 import { useAppSelector } from '../../../state/hooks';
@@ -21,8 +21,8 @@ interface AttributionCountPerSourcePerLicenseTableRowProps {
   columnConfig: ColumnConfig;
   signalCountsPerSource: { [sourceName: string]: number };
   licenseName: string;
-  licenseCriticality: Criticality | undefined;
-  licenseClassification: number | undefined;
+  licenseCriticality: Criticality;
+  licenseClassification: Classification | undefined;
   totalSignalCount: number;
   rowIndex: number;
 }
@@ -66,8 +66,8 @@ export const AttributionCountPerSourcePerLicenseTableRow: React.FC<
 interface RowCellContentProps {
   signalCountsPerSource: { [sourceName: string]: number };
   licenseName: string;
-  licenseCriticality: Criticality | undefined;
-  licenseClassification: number | undefined;
+  licenseCriticality: Criticality;
+  licenseClassification: Classification | undefined;
   totalSignalCount: number;
   column: Column;
 }
@@ -80,7 +80,7 @@ const RowCellContent: React.FC<RowCellContentProps> = (props) => {
   if (props.column.columnType === SingleColumn.NAME) {
     return props.licenseName;
   } else if (props.column.columnType === SingleColumn.CRITICALITY) {
-    return props.licenseCriticality === undefined ? (
+    return props.licenseCriticality === Criticality.None ? (
       componentText.none
     ) : (
       <CriticalityIcon

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.util.test.ts
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.util.test.ts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { Criticality } from '../../../../shared/shared-types';
+import { LicenseCounts } from '../../../types/types';
+import {
+  orderLicenseNames,
+  SingleColumn,
+} from '../AttributionCountPerSourcePerLicenseTable.util';
+
+describe('orderLicenseNames', () => {
+  const licenseNamesWithCriticality = {
+    a: Criticality.High,
+    b: Criticality.High,
+    c: Criticality.Medium,
+    d: Criticality.Medium,
+    e: undefined,
+    f: undefined,
+  };
+
+  const licenseNamesWithClassifications = {
+    a: 0,
+    b: 3,
+    c: 1,
+    d: 1,
+    e: 2,
+    f: 0,
+  };
+
+  const licenseCounts: LicenseCounts = {
+    attributionCountPerSourcePerLicense: {
+      a: { source1: 3, source2: 7 },
+      b: { source1: 5, source2: 8 },
+      c: { source1: 0, source2: 5 },
+      d: { source1: 1, source2: 1 },
+      e: { source1: 5, source2: 5 },
+      f: { source1: 4, source2: 6 },
+    },
+    totalAttributionsPerLicense: {
+      a: 10,
+      b: 13,
+      c: 5,
+      d: 2,
+      e: 10,
+      f: 10,
+    },
+    totalAttributionsPerSource: {},
+  };
+
+  it('orders by license name', () => {
+    const expectedOrder = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+    const actualOrder = orderLicenseNames(
+      licenseNamesWithCriticality,
+      licenseNamesWithClassifications,
+      licenseCounts,
+      'asc',
+      SingleColumn.NAME,
+    );
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('orders by criticality', () => {
+    const expectedOrder = ['e', 'f', 'c', 'd', 'a', 'b'];
+
+    const actualOrder = orderLicenseNames(
+      licenseNamesWithCriticality,
+      licenseNamesWithClassifications,
+      licenseCounts,
+      'asc',
+      SingleColumn.CRITICALITY,
+    );
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('orders by classification', () => {
+    const expectedOrder = ['a', 'f', 'c', 'd', 'e', 'b'];
+
+    const actualOrder = orderLicenseNames(
+      licenseNamesWithCriticality,
+      licenseNamesWithClassifications,
+      licenseCounts,
+      'asc',
+      SingleColumn.CLASSIFICATION,
+    );
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('orders by total count', () => {
+    const expectedOrder = ['d', 'c', 'a', 'e', 'f', 'b'];
+
+    const actualOrder = orderLicenseNames(
+      licenseNamesWithCriticality,
+      licenseNamesWithClassifications,
+      licenseCounts,
+      'asc',
+      SingleColumn.TOTAL,
+    );
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('orders by count for selected source', () => {
+    const expectedOrder = ['c', 'd', 'a', 'f', 'b', 'e'];
+
+    const actualOrder = orderLicenseNames(
+      licenseNamesWithCriticality,
+      licenseNamesWithClassifications,
+      licenseCounts,
+      'asc',
+      { sourceName: 'source1' },
+    );
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+});

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.util.test.ts
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.util.test.ts
@@ -15,8 +15,8 @@ describe('orderLicenseNames', () => {
     b: Criticality.High,
     c: Criticality.Medium,
     d: Criticality.Medium,
-    e: undefined,
-    f: undefined,
+    e: Criticality.None,
+    f: Criticality.None,
   };
 
   const licenseNamesWithClassifications = {

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -138,7 +138,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
                 data={signalCountByClassification}
                 title={
                   text.projectStatisticsPopup.charts
-                    .signalCountByClassificationPieChart
+                    .signalCountByClassificationPieChart.title
                 }
               />
               <AccordionWithPieChart

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -142,6 +142,12 @@ export const ProjectStatisticsPopup: React.FC = () => {
                 }
               />
               <AccordionWithPieChart
+                data={signalCountByClassification}
+                title={
+                  ProjectStatisticsPopupTitle.SignalCountByClassificationPieChart
+                }
+              />
+              <AccordionWithPieChart
                 data={incompleteAttributionsData}
                 title={
                   text.projectStatisticsPopup.charts

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -138,13 +138,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
                 data={signalCountByClassification}
                 title={
                   text.projectStatisticsPopup.charts
-                    .signalCountByClassificationPieChart.title
-                }
-              />
-              <AccordionWithPieChart
-                data={signalCountByClassification}
-                title={
-                  ProjectStatisticsPopupTitle.SignalCountByClassificationPieChart
+                    .signalCountByClassificationPieChart
                 }
               />
               <AccordionWithPieChart

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -235,6 +235,63 @@ describe('The ProjectStatisticsPopup', () => {
     expect(screen.getByText('First party')).toBeInTheDocument();
   });
 
+  it('supports sorting the signals per sources table', async () => {
+    const testExternalAttributions: Attributions = {
+      uuid_1: {
+        source: {
+          name: 'scancode',
+          documentConfidence: 10,
+        },
+        licenseName: 'Apache License Version 2.0',
+        id: 'uuid_1',
+      },
+      uuid_2: {
+        source: {
+          name: 'reuser',
+          documentConfidence: 90,
+        },
+        licenseName: 'The MIT License (MIT)',
+        id: 'uuid_2',
+      },
+    };
+    renderComponent(<ProjectStatisticsPopup />, {
+      actions: [
+        loadFromFile(
+          getParsedInputFileEnrichedWithTestData({
+            externalAttributions: testExternalAttributions,
+          }),
+        ),
+      ],
+    });
+
+    const getLicenseNames = () =>
+      screen
+        .getAllByTestId('signalsPerSourceBodyCell0')
+        .map((element) => element.textContent);
+
+    // sorted by license name ASC
+    expect(getLicenseNames()).toStrictEqual([
+      'Apache License Version 2.0',
+      'The MIT License (MIT)',
+    ]);
+
+    await userEvent.click(screen.getByText('Scancode'));
+
+    // sorted by count on scancode source ASC
+    expect(getLicenseNames()).toStrictEqual([
+      'The MIT License (MIT)',
+      'Apache License Version 2.0',
+    ]);
+
+    await userEvent.click(screen.getByText('Scancode'));
+
+    // sorted by count on scancode source DESC
+    expect(getLicenseNames()).toStrictEqual([
+      'Apache License Version 2.0',
+      'The MIT License (MIT)',
+    ]);
+  });
+
   it('allows toggling of show-on-startup checkbox', async () => {
     renderComponent(<ProjectStatisticsPopup />);
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -243,6 +243,7 @@ describe('The ProjectStatisticsPopup', () => {
           documentConfidence: 10,
         },
         licenseName: 'Apache License Version 2.0',
+        criticality: Criticality.None,
         id: 'uuid_1',
       },
       uuid_2: {
@@ -251,6 +252,7 @@ describe('The ProjectStatisticsPopup', () => {
           documentConfidence: 90,
         },
         licenseName: 'The MIT License (MIT)',
+        criticality: Criticality.None,
         id: 'uuid_2',
       },
     };

--- a/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
+++ b/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
@@ -22,7 +22,7 @@ export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
     <MuiTableCell
       {...props}
       sx={{
-        '.Mui-active': { color: 'white' },
+        '.Mui-active': { color: 'white !important' },
         '& :hover': { color: 'white !important' },
         ...props.sx,
       }}

--- a/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
+++ b/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { TableCellProps, TableSortLabel } from '@mui/material';
+import MuiBox from '@mui/material/Box';
+import MuiTableCell from '@mui/material/TableCell';
+import { visuallyHidden } from '@mui/utils';
+
+export type Order = 'asc' | 'desc';
+
+interface TableCellWithSortingProps extends TableCellProps {
+  order: Order;
+  isSortedColumn: boolean;
+  onRequestSort: () => void;
+}
+
+export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
+  props,
+) => {
+  return (
+    <MuiTableCell
+      {...props}
+      sx={{
+        '.Mui-active': { color: 'white' },
+        '& :hover': { color: 'white !important' },
+        ...props.sx,
+      }}
+      sortDirection={props.isSortedColumn ? props.order : false}
+    >
+      <TableSortLabel
+        sx={{
+          '& .MuiTableSortLabel-icon': { color: 'white !important' },
+        }}
+        active={props.isSortedColumn}
+        direction={props.isSortedColumn ? props.order : 'asc'}
+        onClick={props.onRequestSort}
+      >
+        {props.children}
+        {props.isSortedColumn ? (
+          <MuiBox component="span" sx={visuallyHidden}>
+            {`sorted ${props.order}ending`}
+          </MuiBox>
+        ) : null}
+      </TableSortLabel>
+    </MuiTableCell>
+  );
+};

--- a/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
+++ b/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
@@ -5,14 +5,18 @@
 import { TableCellProps, TableSortLabel } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiTableCell from '@mui/material/TableCell';
+import { SxProps } from '@mui/system';
 import { visuallyHidden } from '@mui/utils';
+import { PropsWithChildren } from 'react';
 
 export type Order = 'asc' | 'desc';
 
-interface TableCellWithSortingProps extends TableCellProps {
+interface TableCellWithSortingProps extends PropsWithChildren {
   order: Order;
   isSortedColumn: boolean;
   onRequestSort: () => void;
+  tableCellProps?: TableCellProps;
+  sx?: SxProps;
 }
 
 export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
@@ -20,7 +24,7 @@ export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
 ) => {
   return (
     <MuiTableCell
-      {...props}
+      {...props.tableCellProps}
       sx={{
         '.Mui-active': { color: 'white !important' },
         '& :hover': { color: 'white !important' },


### PR DESCRIPTION
### Summary of changes

Make the signals per source table sortable by each column.

### Context and reason for change

For larger .opossum files, being able to sort the table by e.g. criticality can help reviewers get a better overview of the signals need to look at.

### How can the changes be tested

Check that sorting works correctly for the signals per source table.
