### PR TITLE
Refactor/use enum value in progress bar

### DIFF
--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -8,7 +8,7 @@ import MuiTooltip from '@mui/material/Tooltip';
 
 import { text } from '../../../shared/text';
 import { OpossumColors } from '../../shared-styles';
-import { ProgressBarData } from '../../types/types';
+import { ProgressBarData, SelectedProgressBar } from '../../types/types';
 import {
   getCriticalityBarBackground,
   getCriticalityBarTooltipText,
@@ -33,7 +33,7 @@ const classes = {
 interface ProgressBarProps {
   sx?: SxProps;
   progressBarData: ProgressBarData;
-  showCriticalSignals: boolean;
+  selectedProgressBar: SelectedProgressBar;
 }
 
 export const ProgressBar: React.FC<ProgressBarProps> = (props) => {
@@ -53,7 +53,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = (props) => {
     <MuiBox sx={props.sx}>
       <MuiTooltip
         title={
-          props.showCriticalSignals
+          props.selectedProgressBar === 'criticality'
             ? getCriticalityBarTooltipText(props.progressBarData)
             : getProgressBarTooltipText(props.progressBarData)
         }
@@ -61,19 +61,20 @@ export const ProgressBar: React.FC<ProgressBarProps> = (props) => {
       >
         <MuiBox
           aria-label={
-            props.showCriticalSignals
+            props.selectedProgressBar === 'criticality'
               ? text.topBar.switchableProgressBar.criticalSignalsBar.ariaLabel
               : text.topBar.switchableProgressBar.attributionProgressBar
                   .ariaLabel
           }
           sx={{
             ...classes.bar,
-            background: props.showCriticalSignals
-              ? getCriticalityBarBackground(props.progressBarData)
-              : getProgressBarBackground(props.progressBarData),
+            background:
+              props.selectedProgressBar === 'criticality'
+                ? getCriticalityBarBackground(props.progressBarData)
+                : getProgressBarBackground(props.progressBarData),
           }}
           onClick={
-            props.showCriticalSignals
+            props.selectedProgressBar === 'criticality'
               ? onCriticalityBarClick
               : onProgressBarClick
           }

--- a/src/Frontend/Components/ProgressBar/ProgressBar.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.tsx
@@ -30,6 +30,13 @@ const classes = {
   },
 };
 
+interface ProgressBarInternals {
+  tooltipText: React.ReactNode;
+  ariaLabel: string;
+  background: string;
+  onClickHandler: () => void;
+}
+
 interface ProgressBarProps {
   sx?: SxProps;
   progressBarData: ProgressBarData;
@@ -49,35 +56,42 @@ export const ProgressBar: React.FC<ProgressBarProps> = (props) => {
       ? resourcesWithCriticalExternalAttributions
       : props.progressBarData.resourcesWithNonInheritedExternalAttributionOnly,
   );
+
+  const progressBarConfiguration: Record<
+    SelectedProgressBar,
+    ProgressBarInternals
+  > = {
+    attribution: {
+      tooltipText: getProgressBarTooltipText(props.progressBarData),
+      ariaLabel:
+        text.topBar.switchableProgressBar.attributionProgressBar.ariaLabel,
+      background: getProgressBarBackground(props.progressBarData),
+      onClickHandler: onProgressBarClick,
+    },
+    criticality: {
+      tooltipText: getCriticalityBarTooltipText(props.progressBarData),
+      ariaLabel: text.topBar.switchableProgressBar.criticalSignalsBar.ariaLabel,
+      background: getCriticalityBarBackground(props.progressBarData),
+      onClickHandler: onCriticalityBarClick,
+    },
+  };
+
+  const currentProgressBarConfiguration =
+    progressBarConfiguration[props.selectedProgressBar];
+
   return (
     <MuiBox sx={props.sx}>
       <MuiTooltip
-        title={
-          props.selectedProgressBar === 'criticality'
-            ? getCriticalityBarTooltipText(props.progressBarData)
-            : getProgressBarTooltipText(props.progressBarData)
-        }
+        title={currentProgressBarConfiguration.tooltipText}
         followCursor
       >
         <MuiBox
-          aria-label={
-            props.selectedProgressBar === 'criticality'
-              ? text.topBar.switchableProgressBar.criticalSignalsBar.ariaLabel
-              : text.topBar.switchableProgressBar.attributionProgressBar
-                  .ariaLabel
-          }
+          aria-label={currentProgressBarConfiguration.ariaLabel}
           sx={{
             ...classes.bar,
-            background:
-              props.selectedProgressBar === 'criticality'
-                ? getCriticalityBarBackground(props.progressBarData)
-                : getProgressBarBackground(props.progressBarData),
+            background: currentProgressBarConfiguration.background,
           }}
-          onClick={
-            props.selectedProgressBar === 'criticality'
-              ? onCriticalityBarClick
-              : onProgressBarClick
-          }
+          onClick={currentProgressBarConfiguration.onClickHandler}
         />
       </MuiTooltip>
     </MuiBox>

--- a/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
@@ -73,7 +73,7 @@ describe('ProgressBar', () => {
     const resourceId2 = faker.opossum.filePath(resourceName2);
     const { store } = renderComponent(
       <ProgressBar
-        showCriticalSignals={false}
+        selectedProgressBar={'attribution'}
         progressBarData={{
           fileCount: 6,
           filesWithHighlyCriticalExternalAttributionsCount: 1,
@@ -107,7 +107,7 @@ describe('ProgressBar', () => {
   it('renders regular progress bar', async () => {
     renderComponent(
       <ProgressBar
-        showCriticalSignals={false}
+        selectedProgressBar={'attribution'}
         progressBarData={{
           fileCount: 6,
           filesWithHighlyCriticalExternalAttributionsCount: 1,
@@ -134,7 +134,7 @@ describe('ProgressBar', () => {
   it('renders criticality progress bar', async () => {
     renderComponent(
       <ProgressBar
-        showCriticalSignals
+        selectedProgressBar={'criticality'}
         progressBarData={{
           fileCount: 6,
           filesWithHighlyCriticalExternalAttributionsCount: 1,
@@ -171,7 +171,7 @@ describe('ProgressBar', () => {
     const resourceId2 = faker.opossum.filePath(resourceName2);
     const { store } = renderComponent(
       <ProgressBar
-        showCriticalSignals
+        selectedProgressBar={'criticality'}
         progressBarData={{
           fileCount: 6,
           filesWithHighlyCriticalExternalAttributionsCount: 1,

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -10,9 +10,8 @@ import React, { useState } from 'react';
 import { text as fullText } from '../../../shared/text';
 import { OpossumColors } from '../../shared-styles';
 import { useProgressData } from '../../state/variables/use-progress-data';
+import { SelectedProgressBar } from '../../types/types';
 import { ProgressBar } from '../ProgressBar/ProgressBar';
-
-type SelectedProgressBar = 'attribution' | 'criticality';
 
 const classes = {
   container: {
@@ -56,14 +55,14 @@ const progressBarConfigurations: Record<
 };
 
 export const SwitchableProcessBar: React.FC = () => {
-  const [currentProgressBar, setCurrentProgressBar] =
+  const [currentProgressBar, setcurrentProgressBar] =
     useState<SelectedProgressBar>('attribution');
   const [progressData] = useProgressData();
 
   const handleProgressBarChange = (
     event: SelectChangeEvent<SelectedProgressBar>,
   ): void => {
-    setCurrentProgressBar(event.target.value as SelectedProgressBar);
+    setcurrentProgressBar(event.target.value as SelectedProgressBar);
   };
 
   if (!progressData) {
@@ -74,9 +73,7 @@ export const SwitchableProcessBar: React.FC = () => {
       <ProgressBar
         sx={classes.progressBar}
         progressBarData={progressData}
-        showCriticalSignals={
-          progressBarConfigurations[currentProgressBar].showCriticalSignals
-        }
+        selectedProgressBar={currentProgressBar}
       />
       <Select<SelectedProgressBar>
         size={'small'}

--- a/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
+++ b/src/Frontend/Components/SwitchableProcessBar/SwitchableProcessBar.tsx
@@ -37,7 +37,6 @@ const text = fullText.topBar.switchableProgressBar;
 
 interface ProgressBarConfiguration {
   selectLabel: string;
-  showCriticalSignals: boolean;
 }
 
 const progressBarConfigurations: Record<
@@ -46,11 +45,9 @@ const progressBarConfigurations: Record<
 > = {
   attribution: {
     selectLabel: text.attributionProgressBar.selectLabel,
-    showCriticalSignals: false,
   },
   criticality: {
     selectLabel: text.criticalSignalsBar.selectLabel,
-    showCriticalSignals: true,
   },
 };
 

--- a/src/Frontend/types/types.ts
+++ b/src/Frontend/types/types.ts
@@ -15,6 +15,8 @@ export type State = {
   variablesState: VariablesState;
 };
 
+export type SelectedProgressBar = 'attribution' | 'criticality';
+
 export interface ProgressBarData {
   fileCount: number;
   filesWithManualAttributionCount: number;


### PR DESCRIPTION
### Summary of changes

In the progress bar, no longer use a boolean to switch between the two types but the enum value

### Context and reason for change

Next step is to add a third option, at this point the boolean will no longer work

### How can the changes be tested
CI or checking the progress bar manually

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
