### PR TITLE
Tabs in project statistics

### DIFF
--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -3,7 +3,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import MuiBox from '@mui/material/Box';
+import MuiTab from '@mui/material/Tab';
+import MuiTabs from '@mui/material/Tabs';
 import MuiTypography from '@mui/material/Typography';
+import { useState } from 'react';
 
 import { Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
@@ -96,66 +99,80 @@ export const ProjectStatisticsPopup: React.FC = () => {
   const [showProjectStatistics, setShowProjectStatistics, hydrated] =
     useUserSetting({ defaultValue: true, key: 'showProjectStatistics' });
 
+  const [selectedTab, setSelectedTab] = useState(0);
+
   return (
     <NotificationPopup
       content={
         <>
-          <MuiBox style={classes.panels}>
-            <MuiBox style={classes.leftPanel}>
-              <AttributionPropertyCountTable
-                attributionPropertyCountsEntries={Object.entries(
-                  manualAttributionPropertyCounts,
-                )}
-                title={
-                  text.projectStatisticsPopup.charts
-                    .attributionPropertyCountTable
-                }
-              />
+          <MuiTabs
+            value={selectedTab}
+            onChange={(_, tab) => setSelectedTab(tab)}
+            sx={{ marginBottom: '10px' }}
+          >
+            <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
+            <MuiTab label={text.projectStatisticsPopup.tabs.details} />
+          </MuiTabs>
+          <TabPanel tabIndex={0} selectedTab={selectedTab}>
+            <MuiBox style={classes.panels}>
+              <MuiBox style={classes.leftPanel}>
+                <AttributionPropertyCountTable
+                  attributionPropertyCountsEntries={Object.entries(
+                    manualAttributionPropertyCounts,
+                  )}
+                  title={
+                    text.projectStatisticsPopup.charts
+                      .attributionPropertyCountTable
+                  }
+                />
+              </MuiBox>
+              <MuiBox style={classes.rightPanel}>
+                <MuiTypography variant="subtitle1">
+                  {isThereAnyPieChartData
+                    ? text.projectStatisticsPopup.charts.pieChartsSectionHeader
+                    : null}
+                </MuiTypography>
+                <AccordionWithPieChart
+                  data={mostFrequentLicenseCountData}
+                  title={
+                    text.projectStatisticsPopup.charts
+                      .mostFrequentLicenseCountPieChart
+                  }
+                  defaultExpanded={true}
+                />
+                <AccordionWithPieChart
+                  data={criticalSignalsCount}
+                  title={
+                    text.projectStatisticsPopup.charts
+                      .criticalSignalsCountPieChart.title
+                  }
+                  pieChartColorMap={CRITICALITY_COLORS}
+                />
+                <AccordionWithPieChart
+                  data={signalCountByClassification}
+                  title={
+                    text.projectStatisticsPopup.charts
+                      .signalCountByClassificationPieChart.title
+                  }
+                />
+                <AccordionWithPieChart
+                  data={incompleteAttributionsData}
+                  title={
+                    text.projectStatisticsPopup.charts
+                      .incompleteAttributionsPieChart
+                  }
+                />
+              </MuiBox>
             </MuiBox>
-            <MuiBox style={classes.rightPanel}>
-              <MuiTypography variant="subtitle1">
-                {isThereAnyPieChartData
-                  ? text.projectStatisticsPopup.charts.pieChartsSectionHeader
-                  : null}
-              </MuiTypography>
-              <AccordionWithPieChart
-                data={mostFrequentLicenseCountData}
-                title={
-                  text.projectStatisticsPopup.charts
-                    .mostFrequentLicenseCountPieChart
-                }
-                defaultExpanded={true}
-              />
-              <AccordionWithPieChart
-                data={criticalSignalsCount}
-                title={
-                  text.projectStatisticsPopup.charts
-                    .criticalSignalsCountPieChart.title
-                }
-                pieChartColorMap={CRITICALITY_COLORS}
-              />
-              <AccordionWithPieChart
-                data={signalCountByClassification}
-                title={
-                  text.projectStatisticsPopup.charts
-                    .signalCountByClassificationPieChart.title
-                }
-              />
-              <AccordionWithPieChart
-                data={incompleteAttributionsData}
-                title={
-                  text.projectStatisticsPopup.charts
-                    .incompleteAttributionsPieChart
-                }
-              />
-            </MuiBox>
-          </MuiBox>
-          <AttributionCountPerSourcePerLicenseTable
-            licenseCounts={licenseCounts}
-            licenseNamesWithCriticality={licenseNamesWithCriticality}
-            licenseNamesWithClassification={licenseNamesWithClassification}
-            title={text.projectStatisticsPopup.charts.licenseCountsTable}
-          />
+          </TabPanel>
+          <TabPanel tabIndex={1} selectedTab={selectedTab}>
+            <AttributionCountPerSourcePerLicenseTable
+              licenseCounts={licenseCounts}
+              licenseNamesWithCriticality={licenseNamesWithCriticality}
+              licenseNamesWithClassification={licenseNamesWithClassification}
+              title={text.projectStatisticsPopup.charts.licenseCountsTable}
+            />
+          </TabPanel>
         </>
       }
       header={text.projectStatisticsPopup.title}
@@ -177,5 +194,20 @@ export const ProjectStatisticsPopup: React.FC = () => {
         />
       }
     />
+  );
+};
+
+interface TabPanelProps extends React.PropsWithChildren {
+  tabIndex: number;
+  selectedTab: number;
+}
+
+const TabPanel: React.FC<TabPanelProps> = (props) => {
+  return (
+    <div
+      style={props.selectedTab !== props.tabIndex ? { display: 'none' } : {}}
+    >
+      {props.children}
+    </div>
   );
 };

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -108,7 +108,11 @@ export const ProjectStatisticsPopup: React.FC = () => {
           <MuiTabs
             value={selectedTab}
             onChange={(_, tab) => setSelectedTab(tab)}
-            sx={{ marginBottom: '10px' }}
+            sx={{
+              marginBottom: '12px',
+              borderBottom: 1,
+              borderColor: 'divider',
+            }}
           >
             <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
             <MuiTab label={text.projectStatisticsPopup.tabs.details} />

--- a/src/e2e-tests/__tests__/project-statistics.test.ts
+++ b/src/e2e-tests/__tests__/project-statistics.test.ts
@@ -53,6 +53,7 @@ test('hidden signals are ignored for project statistics', async ({
 }) => {
   await menuBar.openProjectStatistics();
   await projectStatisticsPopup.assert.titleIsVisible();
+  await projectStatisticsPopup.detailsTab.click();
 
   await projectStatisticsPopup.assert.totalSignalCount(2);
 
@@ -67,5 +68,7 @@ test('hidden signals are ignored for project statistics', async ({
   await signalsPanel.packageCard.assert.isHidden(packageInfo3);
 
   await menuBar.openProjectStatistics();
+  await projectStatisticsPopup.detailsTab.click();
+
   await projectStatisticsPopup.assert.totalSignalCount(1);
 });

--- a/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
+++ b/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
@@ -10,12 +10,14 @@ export class ProjectStatisticsPopup {
   private readonly node: Locator;
   readonly title: Locator;
   readonly closeButton: Locator;
+  readonly detailsTab: Locator;
   readonly totalSignalCount: Locator;
 
   constructor(window: Page) {
     this.node = window.getByLabel('project statistics');
     this.title = this.node.getByRole('heading').getByText('Project Statistics');
     this.closeButton = this.node.getByRole('button', { name: 'Close' });
+    this.detailsTab = this.node.getByRole('tab', { name: 'Details' });
     this.totalSignalCount = this.node
       .getByRole('table')
       .filter({

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -165,6 +165,10 @@ export const text = {
   },
   projectStatisticsPopup: {
     title: 'Project Statistics',
+    tabs: {
+      overview: 'Overview',
+      details: 'Details',
+    },
     toggleStartupCheckbox: 'Show project statistics on startup',
     criticalLicensesSignalCountColumnName: 'Signals Count',
     charts: {


### PR DESCRIPTION
### Summary of changes

Divide project statistics popup into two tabs, one for a general overview with charts and one for the signals per sources table with more detailed information.

### Context and reason for change

The project statistics popup was quite cluttered with a lot of elements being displayed at once. Additionally, moving the table to a separate tab allows for the pie charts to be always displayed, without the need for accordions.

### How can the changes be tested

Look at the new tabs in the project statistics popup. Note: Layout of the first tab in the project statistics popup will be fixed in a future stacked PR.