### PR TITLE
Add attribution form chip for classification 

### DIFF
--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -28,7 +28,7 @@ import {
 import { useUserSetting } from '../../../state/variables/use-user-setting';
 import { prettifySource } from '../../../util/prettify-source';
 import {
-  CriticalClassificationIcon,
+  ClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -218,12 +218,12 @@ export function useAuditingOptions({
         id: 'classification',
         label: packageInfo.classification,
         icon: (
-          <CriticalClassificationIcon
+          <ClassificationIcon
             noTooltip
             classification={packageInfo.classification}
           />
         ),
-        selected: !!packageInfo.classification,
+        selected: packageInfo.classification !== undefined,
         interactive: false,
       },
       {

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -21,6 +21,7 @@ import {
   useAppStore,
 } from '../../../state/hooks';
 import {
+  getClassifications,
   getExternalAttributionSources,
   getIsPreferenceFeatureEnabled,
   getTemporaryDisplayPackageInfo,
@@ -60,6 +61,8 @@ export function useAuditingOptions({
   const isPreferenceFeatureEnabled = useAppSelector(
     getIsPreferenceFeatureEnabled,
   );
+  const classifications = useAppSelector(getClassifications);
+
   const source = useMemo(() => {
     const sourceName =
       packageInfo.source?.additionalName || packageInfo.source?.name;
@@ -216,7 +219,9 @@ export function useAuditingOptions({
       },
       {
         id: 'classification',
-        label: packageInfo.classification,
+        label:
+          classifications[packageInfo.classification ?? 0] ||
+          `${packageInfo.classification} - not configured`,
         icon: (
           <ClassificationIcon
             noTooltip
@@ -270,6 +275,7 @@ export function useAuditingOptions({
     ],
     [
       attributionSources,
+      classifications,
       dispatch,
       isEditable,
       isPreferenceFeatureEnabled,

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -28,6 +28,7 @@ import {
 import { useUserSetting } from '../../../state/variables/use-user-setting';
 import { prettifySource } from '../../../util/prettify-source';
 import {
+  ClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -214,6 +215,18 @@ export function useAuditingOptions({
         interactive: false,
       },
       {
+        id: 'classification',
+        label: packageInfo.classification,
+        icon: (
+          <ClassificationIcon
+            noTooltip
+            classification={packageInfo.classification}
+          />
+        ),
+        selected: !!packageInfo.classification,
+        interactive: false,
+      },
+      {
         id: 'confidence',
         label: text.auditingOptions.confidence,
         icon: (
@@ -261,6 +274,7 @@ export function useAuditingOptions({
       isEditable,
       isPreferenceFeatureEnabled,
       packageInfo.attributionConfidence,
+      packageInfo.classification,
       packageInfo.criticality,
       packageInfo.excludeFromNotice,
       packageInfo.followUp,

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -29,7 +29,7 @@ import {
 import { useUserSetting } from '../../../state/variables/use-user-setting';
 import { prettifySource } from '../../../util/prettify-source';
 import {
-  CriticalClassificationIcon,
+  ClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -223,7 +223,7 @@ export function useAuditingOptions({
           classifications[packageInfo.classification ?? 0] ||
           `${packageInfo.classification} - not configured`,
         icon: (
-          <CriticalClassificationIcon
+          <ClassificationIcon
             noTooltip
             classification={packageInfo.classification}
           />

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -29,7 +29,7 @@ import {
 import { useUserSetting } from '../../../state/variables/use-user-setting';
 import { prettifySource } from '../../../util/prettify-source';
 import {
-  ClassificationIcon,
+  CriticalClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -223,12 +223,12 @@ export function useAuditingOptions({
           classifications[packageInfo.classification ?? 0] ||
           `${packageInfo.classification} - not configured`,
         icon: (
-          <ClassificationIcon
+          <CriticalClassificationIcon
             noTooltip
             classification={packageInfo.classification}
           />
         ),
-        selected: packageInfo.classification !== undefined,
+        selected: !!packageInfo.classification,
         interactive: false,
       },
       {

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -28,7 +28,7 @@ import {
 import { useUserSetting } from '../../../state/variables/use-user-setting';
 import { prettifySource } from '../../../util/prettify-source';
 import {
-  ClassificationIcon,
+  CriticalClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FollowUpIcon,
@@ -218,7 +218,7 @@ export function useAuditingOptions({
         id: 'classification',
         label: packageInfo.classification,
         icon: (
-          <ClassificationIcon
+          <CriticalClassificationIcon
             noTooltip
             classification={packageInfo.classification}
           />

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -6,7 +6,11 @@
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { Criticality, PackageInfo } from '../../../../shared/shared-types';
+import {
+  Criticality,
+  PackageInfo,
+  RawCriticality,
+} from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { faker } from '../../../../testing/Faker';
 import { setFrequentLicenses } from '../../../state/actions/resource-actions/all-views-simple-actions';
@@ -165,6 +169,26 @@ describe('AttributionForm', () => {
       expect(
         screen.getByText(text.auditingOptions.modifiedPreferred),
       ).toBeInTheDocument();
+    });
+
+    [Criticality.Medium, Criticality.High].forEach((criticality) => {
+      it(`renders a chip for ${RawCriticality[criticality]} criticality`, () => {
+        const packageInfo = faker.opossum.packageInfo({
+          criticality,
+        });
+
+        renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+        const criticalityChip = screen.queryByTestId(
+          'auditing-option-criticality',
+        );
+        expect(criticalityChip).toBeInTheDocument();
+        expect(criticalityChip).toHaveTextContent(
+          text.auditingOptions[
+            criticality !== Criticality.None ? criticality : Criticality.Medium
+          ] as string,
+        );
+      });
     });
   });
 

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -16,271 +16,283 @@ import { generatePurl } from '../../../util/handle-purl';
 import { AttributionForm } from '../AttributionForm';
 
 describe('AttributionForm', () => {
-  it('copies PURL to clipboard', async () => {
-    const writeText = jest.fn();
-    (navigator.clipboard as unknown) = { writeText };
-    const packageInfo = faker.opossum.packageInfo();
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+  describe('PURL handling', () => {
+    it('copies PURL to clipboard', async () => {
+      const writeText = jest.fn();
+      (navigator.clipboard as unknown) = { writeText };
+      const packageInfo = faker.opossum.packageInfo();
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-    await userEvent.click(
-      screen.getByLabelText(text.attributionColumn.copyToClipboard),
-    );
+      await userEvent.click(
+        screen.getByLabelText(text.attributionColumn.copyToClipboard),
+      );
 
-    expect(writeText).toHaveBeenCalledTimes(1);
-    expect(writeText).toHaveBeenCalledWith(generatePurl(packageInfo));
-  });
-
-  it('pastes PURL from clipboard', async () => {
-    const packageInfo = faker.opossum.packageInfo();
-    const purl = generatePurl(packageInfo);
-    const readText = jest.fn().mockReturnValue(purl.toString());
-    (navigator.clipboard as unknown) = { readText };
-    renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-    );
-
-    await userEvent.click(
-      screen.getByLabelText(text.attributionColumn.pasteFromClipboard),
-    );
-
-    expect(readText).toHaveBeenCalledTimes(1);
-    expect(
-      screen.getByDisplayValue(packageInfo.packageName!),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByDisplayValue(packageInfo.packageVersion!),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByDisplayValue(packageInfo.packageType!),
-    ).toBeInTheDocument();
-  });
-
-  it('renders a source name, if it is defined', () => {
-    const packageInfo: PackageInfo = {
-      source: faker.opossum.source(),
-      criticality: Criticality.None,
-      id: faker.string.uuid(),
-    };
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
-
-    expect(screen.getByText(packageInfo.source!.name)).toBeInTheDocument();
-  });
-
-  it('renders the name of the original source for external attributions', () => {
-    const source = faker.opossum.source({
-      additionalName: faker.company.name(),
-    });
-    const packageInfo = faker.opossum.packageInfo({
-      source,
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith(generatePurl(packageInfo));
     });
 
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+    it('pastes PURL from clipboard', async () => {
+      const packageInfo = faker.opossum.packageInfo();
+      const purl = generatePurl(packageInfo);
+      const readText = jest.fn().mockReturnValue(purl.toString());
+      (navigator.clipboard as unknown) = { readText };
+      renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+      );
 
-    expect(screen.getByText(source.additionalName!)).toBeInTheDocument();
+      await userEvent.click(
+        screen.getByLabelText(text.attributionColumn.pasteFromClipboard),
+      );
+
+      expect(readText).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByDisplayValue(packageInfo.packageName!),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue(packageInfo.packageVersion!),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue(packageInfo.packageType!),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('renders original signal source for manual attributions', () => {
-    const source = faker.opossum.source();
-    const packageInfo = faker.opossum.packageInfo({
-      originalAttributionSource: source,
+  describe('chips at the top of the attribution form', () => {
+    it('renders a source name, if it is defined', () => {
+      const packageInfo: PackageInfo = {
+        source: faker.opossum.source(),
+        criticality: Criticality.None,
+        id: faker.string.uuid(),
+      };
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(screen.getByText(packageInfo.source!.name)).toBeInTheDocument();
     });
 
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+    it('renders the name of the original source for external attributions', () => {
+      const source = faker.opossum.source({
+        additionalName: faker.company.name(),
+      });
+      const packageInfo = faker.opossum.packageInfo({
+        source,
+      });
 
-    expect(
-      screen.getByText(text.attributionColumn.originallyFrom + source.name),
-    ).toBeInTheDocument();
-  });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-  it('renders a chip for follow-up', async () => {
-    const packageInfo = faker.opossum.packageInfo();
-    const { store } = renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-    );
-
-    expect(
-      getTemporaryDisplayPackageInfo(store.getState()).followUp,
-    ).toBeUndefined();
-
-    await userEvent.click(screen.getByText(text.auditingOptions.add));
-    await userEvent.click(screen.getByText(text.auditingOptions.followUp));
-    await userEvent.keyboard('{Escape}');
-
-    expect(getTemporaryDisplayPackageInfo(store.getState()).followUp).toBe(
-      true,
-    );
-  });
-
-  it('renders a chip for exclude from notice', async () => {
-    const packageInfo = faker.opossum.packageInfo();
-    const { store } = renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-    );
-
-    expect(
-      getTemporaryDisplayPackageInfo(store.getState()).excludeFromNotice,
-    ).toBeUndefined();
-
-    await userEvent.click(screen.getByText(text.auditingOptions.add));
-    await userEvent.click(
-      screen.getByText(text.auditingOptions.excludedFromNotice),
-    );
-    await userEvent.keyboard('{Escape}');
-    expect(
-      getTemporaryDisplayPackageInfo(store.getState()).excludeFromNotice,
-    ).toBe(true);
-  });
-
-  it('renders a chip for needs review', async () => {
-    const packageInfo = faker.opossum.packageInfo();
-    const { store } = renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-    );
-
-    expect(
-      getTemporaryDisplayPackageInfo(store.getState()).needsReview,
-    ).toBeUndefined();
-
-    await userEvent.click(screen.getByText(text.auditingOptions.add));
-    await userEvent.click(screen.getByText(text.auditingOptions.needsReview));
-    await userEvent.keyboard('{Escape}');
-
-    expect(getTemporaryDisplayPackageInfo(store.getState()).needsReview).toBe(
-      true,
-    );
-  });
-
-  it('renders a chip for modified preferred', () => {
-    const packageInfo = faker.opossum.packageInfo({
-      packageName: faker.lorem.word(),
-      originalAttributionWasPreferred: true,
-      wasPreferred: false,
+      expect(screen.getByText(source.additionalName!)).toBeInTheDocument();
     });
 
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+    it('renders original signal source for manual attributions', () => {
+      const source = faker.opossum.source();
+      const packageInfo = faker.opossum.packageInfo({
+        originalAttributionSource: source,
+      });
 
-    expect(
-      screen.getByText(text.auditingOptions.modifiedPreferred),
-    ).toBeInTheDocument();
-  });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-  it('renders a URL icon and opens a link in browser', () => {
-    const packageInfo: PackageInfo = {
-      url: 'https://www.testurl.com/',
-      criticality: Criticality.None,
-      id: faker.string.uuid(),
-    };
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
-
-    expect(screen.getByLabelText('Url icon')).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText('Url icon'));
-    expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
-      packageInfo.url,
-    );
-  });
-
-  it('opens a link without protocol', () => {
-    const packageInfo: PackageInfo = {
-      url: 'www.testurl.com',
-      criticality: Criticality.None,
-      id: faker.string.uuid(),
-    };
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
-
-    fireEvent.click(screen.getByLabelText('Url icon'));
-    expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
-      `https://${packageInfo.url}`,
-    );
-  });
-
-  it('hides url icon if empty url', () => {
-    const packageInfo: PackageInfo = {
-      url: '',
-      criticality: Criticality.None,
-      id: faker.string.uuid(),
-    };
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
-
-    expect(screen.queryByLabelText('Url icon')).not.toBeInTheDocument();
-  });
-
-  it('shows default license text placeholder when frequent license name selected and no custom license text entered', async () => {
-    const defaultLicenseText = faker.lorem.paragraphs();
-    const packageInfo = faker.opossum.packageInfo();
-    renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-      {
-        actions: [
-          setFrequentLicenses({
-            nameOrder: [],
-            texts: { [packageInfo.licenseName!]: defaultLicenseText },
-          }),
-        ],
-      },
-    );
-
-    await userEvent.click(screen.getByLabelText('license-text-toggle-button'));
-
-    expect(
-      screen.getByRole('textbox', {
-        name: text.attributionColumn.licenseTextDefault,
-      }),
-    ).toHaveAttribute('placeholder', defaultLicenseText);
-    expect(
-      screen.getByLabelText(text.attributionColumn.licenseTextDefault),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText(text.attributionColumn.licenseText),
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show default license text placeholder when custom license text entered', async () => {
-    const defaultLicenseText = faker.lorem.paragraphs();
-    const packageInfo = faker.opossum.packageInfo({
-      licenseText: faker.lorem.paragraphs(),
+      expect(
+        screen.getByText(text.attributionColumn.originallyFrom + source.name),
+      ).toBeInTheDocument();
     });
-    renderComponent(
-      <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
-      {
-        actions: [
-          setFrequentLicenses({
-            nameOrder: [],
-            texts: { [packageInfo.licenseName!]: defaultLicenseText },
-          }),
-        ],
-      },
-    );
 
-    await userEvent.click(screen.getByLabelText('license-text-toggle-button'));
+    it('renders a chip for follow-up', async () => {
+      const packageInfo = faker.opossum.packageInfo();
+      const { store } = renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+      );
 
-    expect(
-      screen.getByRole('textbox', {
-        name: text.attributionColumn.licenseText,
-      }),
-    ).not.toHaveAttribute('placeholder', defaultLicenseText);
-    expect(
-      screen.queryByLabelText(text.attributionColumn.licenseTextDefault),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByLabelText(text.attributionColumn.licenseText),
-    ).toBeInTheDocument();
+      expect(
+        getTemporaryDisplayPackageInfo(store.getState()).followUp,
+      ).toBeUndefined();
+
+      await userEvent.click(screen.getByText(text.auditingOptions.add));
+      await userEvent.click(screen.getByText(text.auditingOptions.followUp));
+      await userEvent.keyboard('{Escape}');
+
+      expect(getTemporaryDisplayPackageInfo(store.getState()).followUp).toBe(
+        true,
+      );
+    });
+
+    it('renders a chip for exclude from notice', async () => {
+      const packageInfo = faker.opossum.packageInfo();
+      const { store } = renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+      );
+
+      expect(
+        getTemporaryDisplayPackageInfo(store.getState()).excludeFromNotice,
+      ).toBeUndefined();
+
+      await userEvent.click(screen.getByText(text.auditingOptions.add));
+      await userEvent.click(
+        screen.getByText(text.auditingOptions.excludedFromNotice),
+      );
+      await userEvent.keyboard('{Escape}');
+      expect(
+        getTemporaryDisplayPackageInfo(store.getState()).excludeFromNotice,
+      ).toBe(true);
+    });
+
+    it('renders a chip for needs review', async () => {
+      const packageInfo = faker.opossum.packageInfo();
+      const { store } = renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+      );
+
+      expect(
+        getTemporaryDisplayPackageInfo(store.getState()).needsReview,
+      ).toBeUndefined();
+
+      await userEvent.click(screen.getByText(text.auditingOptions.add));
+      await userEvent.click(screen.getByText(text.auditingOptions.needsReview));
+      await userEvent.keyboard('{Escape}');
+
+      expect(getTemporaryDisplayPackageInfo(store.getState()).needsReview).toBe(
+        true,
+      );
+    });
+
+    it('renders a chip for modified preferred', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        packageName: faker.lorem.word(),
+        originalAttributionWasPreferred: true,
+        wasPreferred: false,
+      });
+
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(
+        screen.getByText(text.auditingOptions.modifiedPreferred),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('does not show copyright or license name fields when attribution is first party', () => {
-    const packageInfo = faker.opossum.packageInfo({ firstParty: true });
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+  describe('url handling', () => {
+    it('renders a URL icon and opens a link in browser', () => {
+      const packageInfo: PackageInfo = {
+        url: 'https://www.testurl.com/',
+        criticality: Criticality.None,
+        id: faker.string.uuid(),
+      };
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-    expect(screen.queryByLabelText('Copyright')).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText('License Expression'),
-    ).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Url icon')).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText('Url icon'));
+      expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
+        packageInfo.url,
+      );
+    });
+
+    it('opens a link without protocol', () => {
+      const packageInfo: PackageInfo = {
+        url: 'www.testurl.com',
+        criticality: Criticality.None,
+        id: faker.string.uuid(),
+      };
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      fireEvent.click(screen.getByLabelText('Url icon'));
+      expect(global.window.electronAPI.openLink).toHaveBeenCalledWith(
+        `https://${packageInfo.url}`,
+      );
+    });
+
+    it('hides url icon if empty url', () => {
+      const packageInfo: PackageInfo = {
+        url: '',
+        criticality: Criticality.None,
+        id: faker.string.uuid(),
+      };
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(screen.queryByLabelText('Url icon')).not.toBeInTheDocument();
+    });
   });
 
-  it('does show copyright or license name fields when attribution is third party', () => {
-    const packageInfo = faker.opossum.packageInfo({ firstParty: false });
-    renderComponent(<AttributionForm packageInfo={packageInfo} />);
+  describe('license handling', () => {
+    it('shows default license text placeholder when frequent license name selected and no custom license text entered', async () => {
+      const defaultLicenseText = faker.lorem.paragraphs();
+      const packageInfo = faker.opossum.packageInfo();
+      renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+        {
+          actions: [
+            setFrequentLicenses({
+              nameOrder: [],
+              texts: { [packageInfo.licenseName!]: defaultLicenseText },
+            }),
+          ],
+        },
+      );
 
-    expect(screen.getByLabelText('Copyright')).toBeInTheDocument();
-    expect(screen.getByLabelText('License Expression')).toBeInTheDocument();
+      await userEvent.click(
+        screen.getByLabelText('license-text-toggle-button'),
+      );
+
+      expect(
+        screen.getByRole('textbox', {
+          name: text.attributionColumn.licenseTextDefault,
+        }),
+      ).toHaveAttribute('placeholder', defaultLicenseText);
+      expect(
+        screen.getByLabelText(text.attributionColumn.licenseTextDefault),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(text.attributionColumn.licenseText),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show default license text placeholder when custom license text entered', async () => {
+      const defaultLicenseText = faker.lorem.paragraphs();
+      const packageInfo = faker.opossum.packageInfo({
+        licenseText: faker.lorem.paragraphs(),
+      });
+      renderComponent(
+        <AttributionForm packageInfo={packageInfo} onEdit={jest.fn()} />,
+        {
+          actions: [
+            setFrequentLicenses({
+              nameOrder: [],
+              texts: { [packageInfo.licenseName!]: defaultLicenseText },
+            }),
+          ],
+        },
+      );
+
+      await userEvent.click(
+        screen.getByLabelText('license-text-toggle-button'),
+      );
+
+      expect(
+        screen.getByRole('textbox', {
+          name: text.attributionColumn.licenseText,
+        }),
+      ).not.toHaveAttribute('placeholder', defaultLicenseText);
+      expect(
+        screen.queryByLabelText(text.attributionColumn.licenseTextDefault),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByLabelText(text.attributionColumn.licenseText),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show copyright or license name fields when attribution is first party', () => {
+      const packageInfo = faker.opossum.packageInfo({ firstParty: true });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(screen.queryByLabelText('Copyright')).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText('License Expression'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does show copyright or license name fields when attribution is third party', () => {
+      const packageInfo = faker.opossum.packageInfo({ firstParty: false });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(screen.getByLabelText('Copyright')).toBeInTheDocument();
+      expect(screen.getByLabelText('License Expression')).toBeInTheDocument();
+    });
   });
 });

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -244,22 +244,22 @@ describe('AttributionForm', () => {
         expect(classificationChip).toBeInTheDocument();
       });
 
-      it('renders a chip for items with classification 0', () => {
+      it('Does not render a chip for items with classification 0', () => {
         const packageInfo = faker.opossum.packageInfo({
           classification: 0,
         });
 
         renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-        const classificationChip = screen.getByTestId(
+        const classificationChip = screen.queryByTestId(
           'auditing-option-classification',
         );
-        expect(classificationChip).toBeInTheDocument();
+        expect(classificationChip).not.toBeInTheDocument();
       });
 
       it('shows the correct text if configured', () => {
         const packageInfo = faker.opossum.packageInfo({
-          classification: 0,
+          classification: 1,
         });
         const classificationText = faker.word.words();
 
@@ -267,7 +267,7 @@ describe('AttributionForm', () => {
           actions: [
             setConfig({
               classifications: {
-                0: classificationText,
+                1: classificationText,
               },
             }),
           ],
@@ -282,7 +282,7 @@ describe('AttributionForm', () => {
 
       it('shows the backup text if no configuration', () => {
         const packageInfo = faker.opossum.packageInfo({
-          classification: 0,
+          classification: 1,
         });
         renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
@@ -290,7 +290,7 @@ describe('AttributionForm', () => {
           'auditing-option-classification',
         );
         expect(classificationChip).toBeInTheDocument();
-        expect(classificationChip).toHaveTextContent('0 - not configured');
+        expect(classificationChip).toHaveTextContent('1 - not configured');
       });
     });
   });

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -13,7 +13,10 @@ import {
 } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
 import { faker } from '../../../../testing/Faker';
-import { setFrequentLicenses } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  setConfig,
+  setFrequentLicenses,
+} from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { getTemporaryDisplayPackageInfo } from '../../../state/selectors/resource-selectors';
 import { renderComponent } from '../../../test-helpers/render';
 import { generatePurl } from '../../../util/handle-purl';
@@ -227,30 +230,68 @@ describe('AttributionForm', () => {
       });
     });
 
-    it('renders a chip for items with classification', () => {
-      const packageInfo = faker.opossum.packageInfo({
-        classification: 1,
+    describe('classification chip', () => {
+      it('renders a chip for items with classification', () => {
+        const packageInfo = faker.opossum.packageInfo({
+          classification: 1,
+        });
+
+        renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+        const classificationChip = screen.queryByTestId(
+          'auditing-option-classification',
+        );
+        expect(classificationChip).toBeInTheDocument();
       });
 
-      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+      it('renders a chip for items with classification 0', () => {
+        const packageInfo = faker.opossum.packageInfo({
+          classification: 0,
+        });
 
-      const classificationChip = screen.queryByTestId(
-        'auditing-option-classification',
-      );
-      expect(classificationChip).toBeInTheDocument();
-    });
+        renderComponent(<AttributionForm packageInfo={packageInfo} />);
 
-    it('renders a chip for items with classification 0', () => {
-      const packageInfo = faker.opossum.packageInfo({
-        classification: 0,
+        const classificationChip = screen.getByTestId(
+          'auditing-option-classification',
+        );
+        expect(classificationChip).toBeInTheDocument();
       });
 
-      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+      it('shows the correct text if configured', () => {
+        const packageInfo = faker.opossum.packageInfo({
+          classification: 0,
+        });
+        const classificationText = faker.word.words();
 
-      const classificationChip = screen.queryByTestId(
-        'auditing-option-classification',
-      );
-      expect(classificationChip).toBeInTheDocument();
+        renderComponent(<AttributionForm packageInfo={packageInfo} />, {
+          actions: [
+            setConfig({
+              classifications: {
+                0: classificationText,
+              },
+            }),
+          ],
+        });
+
+        const classificationChip = screen.getByTestId(
+          'auditing-option-classification',
+        );
+        expect(classificationChip).toBeInTheDocument();
+        expect(classificationChip).toHaveTextContent(classificationText);
+      });
+
+      it('shows the backup text if no configuration', () => {
+        const packageInfo = faker.opossum.packageInfo({
+          classification: 0,
+        });
+        renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+        const classificationChip = screen.getByTestId(
+          'auditing-option-classification',
+        );
+        expect(classificationChip).toBeInTheDocument();
+        expect(classificationChip).toHaveTextContent('0 - not configured');
+      });
     });
   });
 

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -226,6 +226,19 @@ describe('AttributionForm', () => {
         );
       });
     });
+
+    it('renders a chip for items with classification', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        classification: 1,
+      });
+
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      const classificationChip = screen.queryByTestId(
+        'auditing-option-classification',
+      );
+      expect(classificationChip).toBeInTheDocument();
+    });
   });
 
   describe('url handling', () => {

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -239,6 +239,19 @@ describe('AttributionForm', () => {
       );
       expect(classificationChip).toBeInTheDocument();
     });
+
+    it('renders a chip for items with classification 0', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        classification: 0,
+      });
+
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      const classificationChip = screen.queryByTestId(
+        'auditing-option-classification',
+      );
+      expect(classificationChip).toBeInTheDocument();
+    });
   });
 
   describe('url handling', () => {

--- a/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
+++ b/src/Frontend/Components/AttributionForm/__tests__/AttributionForm.test.tsx
@@ -157,6 +157,42 @@ describe('AttributionForm', () => {
       );
     });
 
+    it('renders a chip for preferred', () => {
+      const packageInfo = faker.opossum.packageInfo({ preferred: true });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(
+        screen.getByTestId('auditing-option-preferred'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a chip for was-preferred', () => {
+      const packageInfo = faker.opossum.packageInfo({ wasPreferred: true });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(
+        screen.getByTestId('auditing-option-was-preferred'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a chip for pre-selected signals', () => {
+      const packageInfo = faker.opossum.packageInfo({ preSelected: true });
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(
+        screen.getByTestId('auditing-option-pre-selected'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a chip showing the confidence', () => {
+      const packageInfo = faker.opossum.packageInfo({});
+      renderComponent(<AttributionForm packageInfo={packageInfo} />);
+
+      expect(
+        screen.getByTestId('auditing-option-confidence'),
+      ).toBeInTheDocument();
+    });
+
     it('renders a chip for modified preferred', () => {
       const packageInfo = faker.opossum.packageInfo({
         packageName: faker.lorem.word(),

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -19,7 +19,6 @@ import WhatshotIcon from '@mui/icons-material/Whatshot';
 import WidgetsIcon from '@mui/icons-material/Widgets';
 import { Icon, SxProps } from '@mui/material';
 import MuiTooltip from '@mui/material/Tooltip';
-import { ReactNode } from 'react';
 
 import { Classifications, Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
@@ -208,28 +207,22 @@ export function CriticalityIcon({
   );
 }
 
-export function ClassificationIcon({
-  className,
-  classification,
-  classification_mapping,
-  noTooltip,
-  sx,
-  tooltipPlacement,
-}: IconProps & {
-  classification?: number;
-  classification_mapping?: Classifications;
-}): ReactNode {
-  if (classification === undefined) {
+export function ClassificationIcon(
+  props: IconProps & {
+    classification?: number;
+    classification_mapping?: Classifications;
+  },
+) {
+  if (!props.classification) {
     return null;
   }
-  const tooltip =
-    classification_mapping?.[classification] ||
-    `${classification} - not configured`;
+
+  const tooltip = props.classification_mapping?.[props.classification];
 
   return (
     <MuiTooltip
-      title={noTooltip ? undefined : tooltip}
-      placement={tooltipPlacement}
+      title={props.noTooltip ? undefined : tooltip}
+      placement={props.tooltipPlacement}
       disableInteractive
       data-testid={'classification-tooltip'}
     >
@@ -241,26 +234,14 @@ export function ClassificationIcon({
           fontFamily: 'sans-serif',
           fontWeight: 'bold',
           fontSize: 'medium !important',
-          ...sx,
+          ...props.sx,
         }}
-        className={className}
+        className={props.className}
       >
         C
       </Icon>
     </MuiTooltip>
   );
-}
-
-export function CriticalClassificationIcon(
-  props: IconProps & {
-    classification?: number;
-    classification_mapping?: Classifications;
-  },
-) {
-  if (!props.classification || props.classification === 0) {
-    return null;
-  }
-  return <ClassificationIcon {...props} />;
 }
 
 export function SignalIcon({

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -19,6 +19,7 @@ import WhatshotIcon from '@mui/icons-material/Whatshot';
 import WidgetsIcon from '@mui/icons-material/Widgets';
 import { Icon, SxProps } from '@mui/material';
 import MuiTooltip from '@mui/material/Tooltip';
+import { ReactNode } from 'react';
 
 import { Classifications, Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
@@ -207,7 +208,7 @@ export function CriticalityIcon({
   );
 }
 
-export function CriticalClassificationIcon({
+export function ClassificationIcon({
   className,
   classification,
   classification_mapping,
@@ -217,13 +218,16 @@ export function CriticalClassificationIcon({
 }: IconProps & {
   classification?: number;
   classification_mapping?: Classifications;
-}) {
-  if (!classification || classification === 0) {
+}): ReactNode {
+  if (classification === undefined) {
     return null;
   }
   const tooltip =
     classification_mapping?.[classification] ||
     `${classification} - not configured`;
+
+  const color =
+    classification === 0 ? OpossumColors.darkBlue : OpossumColors.red;
 
   return (
     <MuiTooltip
@@ -236,11 +240,11 @@ export function CriticalClassificationIcon({
         aria-label={'Classification icon'}
         sx={{
           ...baseIcon,
-          color: `${OpossumColors.red} !important`,
-          ...sx,
+          color: `${color} !important`,
           fontFamily: 'sans-serif',
           fontWeight: 'bold',
           fontSize: 'medium !important',
+          ...sx,
         }}
         className={className}
       >
@@ -248,6 +252,18 @@ export function CriticalClassificationIcon({
       </Icon>
     </MuiTooltip>
   );
+}
+
+export function CriticalClassificationIcon(
+  props: IconProps & {
+    classification?: number;
+    classification_mapping?: Classifications;
+  },
+) {
+  if (!props.classification || props.classification === 0) {
+    return null;
+  }
+  return <ClassificationIcon {...props} />;
 }
 
 export function SignalIcon({

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -226,9 +226,6 @@ export function ClassificationIcon({
     classification_mapping?.[classification] ||
     `${classification} - not configured`;
 
-  const color =
-    classification === 0 ? OpossumColors.darkBlue : OpossumColors.red;
-
   return (
     <MuiTooltip
       title={noTooltip ? undefined : tooltip}
@@ -240,7 +237,7 @@ export function ClassificationIcon({
         aria-label={'Classification icon'}
         sx={{
           ...baseIcon,
-          color: `${color} !important`,
+          color: `${OpossumColors.red} !important`,
           fontFamily: 'sans-serif',
           fontWeight: 'bold',
           fontSize: 'medium !important',

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -207,7 +207,7 @@ export function CriticalityIcon({
   );
 }
 
-export function ClassificationIcon({
+export function CriticalClassificationIcon({
   className,
   classification,
   classification_mapping,

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -25,10 +25,6 @@ import { text } from '../../../shared/text';
 import { baseIcon, criticalityColor, OpossumColors } from '../../shared-styles';
 
 const classes = {
-  nonClickableIcon: {
-    ...baseIcon,
-    color: OpossumColors.darkBlue,
-  },
   resourceIcon: {
     width: '18px',
     height: '18px',

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -211,6 +211,7 @@ export function ClassificationIcon({
   className,
   classification,
   classification_mapping,
+  noTooltip,
   sx,
   tooltipPlacement,
 }: IconProps & {
@@ -220,13 +221,17 @@ export function ClassificationIcon({
   if (!classification || classification === 0) {
     return null;
   }
-  const tooltip = classification_mapping?.[classification];
-  if (!tooltip) {
-    return null;
-  }
+  const tooltip =
+    classification_mapping?.[classification] ||
+    `${classification} - not configured`;
 
   return (
-    <MuiTooltip title={tooltip} placement={tooltipPlacement} disableInteractive>
+    <MuiTooltip
+      title={noTooltip ? undefined : tooltip}
+      placement={tooltipPlacement}
+      disableInteractive
+      data-testid={'classification-tooltip'}
+    >
       <Icon
         aria-label={'Classification icon'}
         sx={{

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { Criticality } from '../../../../shared/shared-types';
 import {
   BreakpointIcon,
+  ClassificationIcon,
   CriticalClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
@@ -78,7 +79,7 @@ describe('The Icons', () => {
     expect(screen.getByLabelText('Criticality icon')).toBeInTheDocument();
   });
   describe('classification icon', () => {
-    it('does not render ClassificationIcon for classification 0', () => {
+    it('does not render CriticalClassificationIcon for classification 0', () => {
       render(<CriticalClassificationIcon classification={0} />);
 
       expect(
@@ -86,7 +87,7 @@ describe('The Icons', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('renders ClassificationIcon', async () => {
+    it('renders CriticalClassificationIcon for larger classifications', async () => {
       render(
         <CriticalClassificationIcon
           classification={1}
@@ -103,7 +104,7 @@ describe('The Icons', () => {
     });
 
     it('renders ClassificationIcon for un-configured classifications', async () => {
-      render(<CriticalClassificationIcon classification={1} />);
+      render(<ClassificationIcon classification={1} />);
 
       expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
 
@@ -111,6 +112,23 @@ describe('The Icons', () => {
 
       const tooltip = await screen.findByRole('tooltip');
       expect(tooltip).toHaveTextContent('1 - not configured');
+    });
+
+    it('renders ClassificationIcon for classification 0', () => {
+      render(<ClassificationIcon classification={0} />);
+
+      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
+    });
+
+    it('does not show tooltip if deactivated', async () => {
+      render(<ClassificationIcon classification={0} noTooltip />);
+
+      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
+
+      await hoverOverIcon('classification-tooltip');
+
+      const tooltip = screen.queryByRole('tooltip');
+      expect(tooltip).not.toBeInTheDocument();
     });
   });
 

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -9,7 +9,6 @@ import { Criticality } from '../../../../shared/shared-types';
 import {
   BreakpointIcon,
   ClassificationIcon,
-  CriticalClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   ExcludeFromNoticeIcon,
@@ -80,7 +79,7 @@ describe('The Icons', () => {
   });
   describe('classification icon', () => {
     it('does not render CriticalClassificationIcon for classification 0', () => {
-      render(<CriticalClassificationIcon classification={0} />);
+      render(<ClassificationIcon classification={0} />);
 
       expect(
         screen.queryByLabelText('Classification icon'),
@@ -89,7 +88,7 @@ describe('The Icons', () => {
 
     it('renders CriticalClassificationIcon for larger classifications', async () => {
       render(
-        <CriticalClassificationIcon
+        <ClassificationIcon
           classification={1}
           classification_mapping={{ 1: 'Test' }}
         />,
@@ -103,25 +102,8 @@ describe('The Icons', () => {
       expect(tooltip).toHaveTextContent('Test');
     });
 
-    it('renders ClassificationIcon for un-configured classifications', async () => {
-      render(<ClassificationIcon classification={1} />);
-
-      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
-
-      await hoverOverIcon('classification-tooltip');
-
-      const tooltip = await screen.findByRole('tooltip');
-      expect(tooltip).toHaveTextContent('1 - not configured');
-    });
-
-    it('renders ClassificationIcon for classification 0', () => {
-      render(<ClassificationIcon classification={0} />);
-
-      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
-    });
-
     it('does not show tooltip if deactivated', async () => {
-      render(<ClassificationIcon classification={0} noTooltip />);
+      render(<ClassificationIcon classification={1} noTooltip />);
 
       expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
 

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { Criticality } from '../../../../shared/shared-types';
 import {
   BreakpointIcon,
-  ClassificationIcon,
+  CriticalClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   ExcludeFromNoticeIcon,
@@ -79,7 +79,7 @@ describe('The Icons', () => {
   });
   describe('classification icon', () => {
     it('does not render ClassificationIcon for classification 0', () => {
-      render(<ClassificationIcon classification={0} />);
+      render(<CriticalClassificationIcon classification={0} />);
 
       expect(
         screen.queryByLabelText('Classification icon'),
@@ -88,7 +88,7 @@ describe('The Icons', () => {
 
     it('renders ClassificationIcon', async () => {
       render(
-        <ClassificationIcon
+        <CriticalClassificationIcon
           classification={1}
           classification_mapping={{ 1: 'Test' }}
         />,
@@ -103,7 +103,7 @@ describe('The Icons', () => {
     });
 
     it('renders ClassificationIcon for un-configured classifications', async () => {
-      render(<ClassificationIcon classification={1} />);
+      render(<CriticalClassificationIcon classification={1} />);
 
       expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
 

--- a/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
+++ b/src/Frontend/Components/Icons/__tests__/Icons.test.tsx
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Criticality } from '../../../../shared/shared-types';
 import {
@@ -18,7 +19,21 @@ import {
   PreSelectedIcon,
 } from '../Icons';
 
+async function hoverOverIcon(testid: string) {
+  await userEvent.hover(screen.getByTestId(testid), {
+    advanceTimers: jest.runOnlyPendingTimersAsync,
+  });
+}
+
 describe('The Icons', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
   it('renders ExcludeFromNoticeIcon', () => {
     render(<ExcludeFromNoticeIcon />);
 
@@ -62,24 +77,41 @@ describe('The Icons', () => {
 
     expect(screen.getByLabelText('Criticality icon')).toBeInTheDocument();
   });
+  describe('classification icon', () => {
+    it('does not render ClassificationIcon for classification 0', () => {
+      render(<ClassificationIcon classification={0} />);
 
-  it('does not render ClassificationIcon for classification 0', () => {
-    render(<ClassificationIcon classification={0} />);
+      expect(
+        screen.queryByLabelText('Classification icon'),
+      ).not.toBeInTheDocument();
+    });
 
-    expect(
-      screen.queryByLabelText('Classification icon'),
-    ).not.toBeInTheDocument();
-  });
+    it('renders ClassificationIcon', async () => {
+      render(
+        <ClassificationIcon
+          classification={1}
+          classification_mapping={{ 1: 'Test' }}
+        />,
+      );
 
-  it('renders ClassificationIcon', () => {
-    render(
-      <ClassificationIcon
-        classification={1}
-        classification_mapping={{ 1: 'Test' }}
-      />,
-    );
+      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
 
-    expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
+      await hoverOverIcon('classification-tooltip');
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Test');
+    });
+
+    it('renders ClassificationIcon for un-configured classifications', async () => {
+      render(<ClassificationIcon classification={1} />);
+
+      expect(screen.getByLabelText('Classification icon')).toBeInTheDocument();
+
+      await hoverOverIcon('classification-tooltip');
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent('1 - not configured');
+    });
   });
 
   it('renders BreakpointIcon', () => {

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -5,7 +5,7 @@
 import { Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import {
-  ClassificationIcon,
+  CriticalClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
@@ -43,7 +43,7 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
     cardConfig.classification_mapping?.[cardConfig.classification]
   ) {
     rightIcons.push(
-      <ClassificationIcon
+      <CriticalClassificationIcon
         key={'classification-icon'}
         classification={cardConfig.classification}
         classification_mapping={cardConfig.classification_mapping}

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -5,7 +5,7 @@
 import { Criticality } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import {
-  CriticalClassificationIcon,
+  ClassificationIcon,
   CriticalityIcon,
   ExcludeFromNoticeIcon,
   FirstPartyIcon,
@@ -40,7 +40,7 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
   }
   if (cardConfig.classification && cardConfig.classification_mapping) {
     rightIcons.push(
-      <CriticalClassificationIcon
+      <ClassificationIcon
         key={'classification-icon'}
         classification={cardConfig.classification}
         classification_mapping={cardConfig.classification_mapping}

--- a/src/Frontend/Components/PackageCard/PackageCard.util.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.util.tsx
@@ -38,10 +38,7 @@ export function getRightIcons(cardConfig: PackageCardConfig) {
       />,
     );
   }
-  if (
-    cardConfig.classification &&
-    cardConfig.classification_mapping?.[cardConfig.classification]
-  ) {
+  if (cardConfig.classification && cardConfig.classification_mapping) {
     rightIcons.push(
       <CriticalClassificationIcon
         key={'classification-icon'}

--- a/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
+++ b/src/Frontend/Components/PackageCard/__tests__/PackageCard.test.tsx
@@ -5,6 +5,7 @@
 import { screen } from '@testing-library/react';
 
 import { faker } from '../../../../testing/Faker';
+import { setConfig } from '../../../state/actions/resource-actions/all-views-simple-actions';
 import { renderComponent } from '../../../test-helpers/render';
 import { PackageCard } from '../PackageCard';
 
@@ -69,5 +70,70 @@ describe('The PackageCard', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(packageInfo.licenseName!)).toBeInTheDocument();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  describe('classification icon', () => {
+    it('renders the classification icon for classification > 0', () => {
+      const packageInfo = faker.opossum.packageInfo({ classification: 1 });
+      const classificationText = faker.word.words();
+
+      renderComponent(
+        <PackageCard packageInfo={packageInfo} onClick={jest.fn()} />,
+        {
+          actions: [
+            setConfig({
+              classifications: {
+                1: classificationText,
+              },
+            }),
+          ],
+        },
+      );
+
+      const classificationIcon = screen.getByTestId('classification-tooltip');
+      expect(classificationIcon).toBeVisible();
+    });
+
+    it('does not render the classification icon for classification 0', () => {
+      const packageInfo = faker.opossum.packageInfo({ classification: 0 });
+      const classificationText = faker.word.words();
+
+      renderComponent(
+        <PackageCard packageInfo={packageInfo} onClick={jest.fn()} />,
+        {
+          actions: [
+            setConfig({
+              classifications: {
+                1: classificationText,
+              },
+            }),
+          ],
+        },
+      );
+
+      const classificationIcon = screen.queryByTestId('classification-tooltip');
+      expect(classificationIcon).not.toBeInTheDocument();
+    });
+
+    it('does render the classification icon for un-configured classifications', () => {
+      const packageInfo = faker.opossum.packageInfo({ classification: 3 });
+      const classificationText = faker.word.words();
+
+      renderComponent(
+        <PackageCard packageInfo={packageInfo} onClick={jest.fn()} />,
+        {
+          actions: [
+            setConfig({
+              classifications: {
+                1: classificationText,
+              },
+            }),
+          ],
+        },
+      );
+
+      const classificationIcon = screen.queryByTestId('classification-tooltip');
+      expect(classificationIcon).toBeVisible();
+    });
   });
 });

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
@@ -14,7 +14,7 @@ import { text } from '../../../../../../shared/text';
 import { treeItemClasses } from '../../../../../shared-styles';
 import {
   BreakpointIcon,
-  ClassificationIcon,
+  CriticalClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   FileIcon,
@@ -113,7 +113,7 @@ export const ResourcesTreeNodeLabel: React.FC<Props> = (props) => {
           <SignalIcon />
         ))}
       {props.hasUnresolvedExternalAttribution && (
-        <ClassificationIcon
+        <CriticalClassificationIcon
           classification={props.classification}
           classification_mapping={props.classification_mapping}
           tooltipPlacement={'right'}

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTreeNode/ResourcesTreeNodeLabel/ResourcesTreeNodeLabel.tsx
@@ -14,7 +14,7 @@ import { text } from '../../../../../../shared/text';
 import { treeItemClasses } from '../../../../../shared-styles';
 import {
   BreakpointIcon,
-  CriticalClassificationIcon,
+  ClassificationIcon,
   CriticalityIcon,
   DirectoryIcon,
   FileIcon,
@@ -113,7 +113,7 @@ export const ResourcesTreeNodeLabel: React.FC<Props> = (props) => {
           <SignalIcon />
         ))}
       {props.hasUnresolvedExternalAttribution && (
-        <CriticalClassificationIcon
+        <ClassificationIcon
           classification={props.classification}
           classification_mapping={props.classification_mapping}
           tooltipPlacement={'right'}


### PR DESCRIPTION
### Summary of changes

Add a chip in the attribution form showing the classification of the signal

### Context and reason for change

We are currently introducing classifications into opossum-ui

### How can the changes be tested

* ci,
* Load a file with classifications and select a few of the signals (should show the new chip) 
* Promote a signal to an attribution and observe the chip vanishing

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
