### PR TITLE
fix: adjust casing for Progress Bar Select

### DIFF
--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -367,8 +367,8 @@ export const text = {
         ariaLabel: 'Progress bar attribution progress',
       },
       classificationProgressBar: {
-        selectLabel: 'Signals by classification',
-        ariaLabel: 'Progress bar classification',
+        selectLabel: 'Signals by Classification',
+        ariaLabel: 'Progress bar Classification',
       },
     },
   },

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -359,16 +359,16 @@ export const text = {
     switchableProgressBar: {
       selectAriaLabel: 'ProgressBar Switcher',
       criticalSignalsBar: {
-        selectLabel: 'Critical Signals',
+        selectLabel: 'Criticalities',
         ariaLabel: 'Progress bar for to be handled critical signals',
       },
       attributionProgressBar: {
-        selectLabel: 'Attribution Progress',
-        ariaLabel: 'Progress bar attribution progress',
+        selectLabel: 'Attributions',
+        ariaLabel: 'Progress bar for attribution progress',
       },
       classificationProgressBar: {
-        selectLabel: 'Signals by Classification',
-        ariaLabel: 'Progress bar Classification',
+        selectLabel: 'Classifications',
+        ariaLabel: 'Progress bar for to be handled classifications',
       },
     },
   },


### PR DESCRIPTION
### Summary of changes

Adjust casing of Classification Bar in Dropdown

### Context and reason for change

To make sure it is consistent

### How can the changes be tested

Open the select next to the toolbar

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
