### PR TITLE
Fix criticality icons

### DIFF
--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsList/AttributionsList.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsList/AttributionsList.tsx
@@ -5,7 +5,6 @@
 import MuiDivider from '@mui/material/Divider';
 import { without } from 'lodash';
 
-import { Criticality } from '../../../../../shared/shared-types';
 import { TRANSITION } from '../../../../shared-styles';
 import { changeSelectedAttributionOrOpenUnsavedPopup } from '../../../../state/actions/popup-actions/popup-actions';
 import { useAppDispatch } from '../../../../state/hooks';
@@ -64,7 +63,6 @@ export const AttributionsList: React.FC<PackagesPanelChildrenProps> = ({
             focused,
             resolved: attributionIdsForReplacement.includes(attributionId),
             incomplete: isPackageInfoIncomplete(attribution),
-            criticality: Criticality.None,
           }}
           packageInfo={attribution}
           checkbox={{

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/SignalsList/SignalsList.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/SignalsList/SignalsList.tsx
@@ -6,7 +6,6 @@ import MuiDivider from '@mui/material/Divider';
 import { groupBy as _groupBy, orderBy as _orderBy, without } from 'lodash';
 import { useMemo } from 'react';
 
-import { Criticality } from '../../../../../shared/shared-types';
 import { TRANSITION } from '../../../../shared-styles';
 import { changeSelectedAttributionOrOpenUnsavedPopup } from '../../../../state/actions/popup-actions/popup-actions';
 import { useAppDispatch, useAppSelector } from '../../../../state/hooks';
@@ -108,7 +107,6 @@ export const SignalsList: React.FC<PackagesPanelChildrenProps> = ({
             selected,
             focused,
             resolved: resolvedExternalAttributionIds.has(attributionId),
-            criticality: Criticality.None,
           }}
           packageInfo={attribution}
           checkbox={{

--- a/src/Frontend/Components/PackageCard/PackageCard.tsx
+++ b/src/Frontend/Components/PackageCard/PackageCard.tsx
@@ -107,7 +107,7 @@ export interface PackageCardConfig {
 
 export interface PackageCardProps {
   packageInfo: PackageInfo;
-  cardConfig?: PackageCardConfig;
+  cardConfig?: Partial<PackageCardConfig>;
   onClick?(): void;
   checkbox?: {
     checked: boolean;


### PR DESCRIPTION
### Summary of changes

Fix bug where criticality icons where not showing in the attribution and signal lists.

### Context and reason for change

Bug fix

### How can the changes be tested

Check that the criticality icons are again displayed correctly in the attribution and signal lists.
