### PR TITLE
feat: respect settings for showing also in overview table

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,13 +9,19 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
+const openDevTools = (mainWindow: BrowserWindow) => {
+  const devtools = new BrowserWindow();
+  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
+  mainWindow.webContents.openDevTools({ mode: 'detach' });
+};
+
 export async function loadWebApp(
   mainWindow: Electron.CrossProcessExports.BrowserWindow,
 ) {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    mainWindow.webContents.openDevTools();
+    openDevTools(mainWindow);
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,19 +9,13 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
-const openDevTools = (mainWindow: BrowserWindow) => {
-  const devtools = new BrowserWindow();
-  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
-  mainWindow.webContents.openDevTools({ mode: 'detach' });
-};
-
 export async function loadWebApp(
   mainWindow: Electron.CrossProcessExports.BrowserWindow,
 ) {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    openDevTools(mainWindow);
+    mainWindow.webContents.openDevTools();
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -136,9 +136,21 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
   );
 
   const [ordering, setOrdering] = useState<TableOrdering>(defaultOrdering);
+  const effectiveOrdering = columnConfig.getColumnById(ordering.orderedColumn)
+    ? ordering
+    : defaultOrdering;
 
   const handleRequestSort = (columnId: string, defaultOrder: Order) => {
-    if (ordering.orderedColumn === columnId) {
+    if (
+      effectiveOrdering !== ordering &&
+      effectiveOrdering.orderedColumn === columnId
+    ) {
+      setOrdering({
+        ...effectiveOrdering,
+        orderDirection:
+          effectiveOrdering.orderDirection === 'asc' ? 'desc' : 'asc',
+      });
+    } else if (ordering.orderedColumn === columnId) {
       setOrdering((currentOrdering) => ({
         ...currentOrdering,
         orderDirection:
@@ -151,10 +163,6 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
       });
     }
   };
-
-  const effectiveOrdering = columnConfig.getColumnById(ordering.orderedColumn)
-    ? ordering
-    : defaultOrdering;
 
   const orderedLicenseNames = useMemo(() => {
     const orderedColumnType = columnConfig.getColumnById(

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -7,9 +7,11 @@ import MuiTable from '@mui/material/Table';
 import MuiTableBody from '@mui/material/TableBody';
 import MuiTableContainer from '@mui/material/TableContainer';
 import { orderBy, upperFirst } from 'lodash';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { text } from '../../../shared/text';
+import { useShowClassifications } from '../../state/variables/use-show-classifications';
+import { useShowCriticality } from '../../state/variables/use-show-criticality';
 import {
   LicenseCounts,
   LicenseNamesWithClassification,
@@ -17,6 +19,7 @@ import {
 } from '../../types/types';
 import { Order } from '../TableCellWithSorting/TableCellWithSorting';
 import {
+  Column,
   ColumnConfig,
   orderLicenseNames,
   SingleColumn,
@@ -32,7 +35,7 @@ const classes = {
   },
 };
 
-interface AttributionCountPerSourcePerLicenseTableProps {
+export interface AttributionCountPerSourcePerLicenseTableProps {
   licenseCounts: LicenseCounts;
   licenseNamesWithCriticality: LicenseNamesWithCriticality;
   licenseNamesWithClassification: LicenseNamesWithClassification;
@@ -47,6 +50,39 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
     props.licenseCounts.totalAttributionsPerSource,
   );
 
+  const showCriticality = useShowCriticality();
+  const showClassifications = useShowClassifications();
+
+  const getCriticalityColumn = useCallback((): Array<Column> => {
+    if (showCriticality) {
+      return [
+        {
+          columnName: componentText.columns.criticality.title,
+          columnType: SingleColumn.CRITICALITY,
+          columnId: SingleColumn.CRITICALITY,
+          align: 'center',
+          defaultOrder: 'desc',
+        },
+      ];
+    }
+    return [];
+  }, [componentText.columns.criticality.title, showCriticality]);
+
+  const getClassificationColumn = useCallback((): Array<Column> => {
+    if (showClassifications) {
+      return [
+        {
+          columnName: componentText.columns.classification,
+          columnType: SingleColumn.CLASSIFICATION,
+          columnId: SingleColumn.CLASSIFICATION,
+          align: 'center',
+          defaultOrder: 'desc',
+        },
+      ];
+    }
+    return [];
+  }, [componentText.columns.classification, showClassifications]);
+
   const columnConfig: ColumnConfig = useMemo(
     () =>
       new ColumnConfig([
@@ -60,20 +96,8 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
               align: 'left',
               defaultOrder: 'asc',
             },
-            {
-              columnName: componentText.columns.criticality.title,
-              columnType: SingleColumn.CRITICALITY,
-              columnId: SingleColumn.CRITICALITY,
-              align: 'center',
-              defaultOrder: 'desc',
-            },
-            {
-              columnName: componentText.columns.classification,
-              columnType: SingleColumn.CLASSIFICATION,
-              columnId: SingleColumn.CLASSIFICATION,
-              align: 'center',
-              defaultOrder: 'desc',
-            },
+            ...getCriticalityColumn(),
+            ...getClassificationColumn(),
           ],
         },
         {
@@ -96,7 +120,15 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
           ],
         },
       ]),
-    [sourceNames, componentText],
+    [
+      componentText.columns.licenseInfo,
+      componentText.columns.licenseName,
+      componentText.columns.classification,
+      componentText.columns.signalCountPerSource,
+      componentText.columns.totalSources,
+      getCriticalityColumn,
+      sourceNames,
+    ],
   );
 
   const [ordering, setOrdering] = useState<TableOrdering>({

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTable.tsx
@@ -41,6 +41,10 @@ export interface AttributionCountPerSourcePerLicenseTableProps {
   licenseNamesWithClassification: LicenseNamesWithClassification;
 }
 
+const defaultOrdering: TableOrdering = {
+  orderDirection: 'asc',
+  orderedColumn: SingleColumn.NAME,
+};
 export const AttributionCountPerSourcePerLicenseTable: React.FC<
   AttributionCountPerSourcePerLicenseTableProps
 > = (props) => {
@@ -123,18 +127,15 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
     [
       componentText.columns.licenseInfo,
       componentText.columns.licenseName,
-      componentText.columns.classification,
       componentText.columns.signalCountPerSource,
       componentText.columns.totalSources,
       getCriticalityColumn,
+      getClassificationColumn,
       sourceNames,
     ],
   );
 
-  const [ordering, setOrdering] = useState<TableOrdering>({
-    orderDirection: 'asc',
-    orderedColumn: SingleColumn.NAME,
-  });
+  const [ordering, setOrdering] = useState<TableOrdering>(defaultOrdering);
 
   const handleRequestSort = (columnId: string, defaultOrder: Order) => {
     if (ordering.orderedColumn === columnId) {
@@ -151,16 +152,20 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
     }
   };
 
+  const effectiveOrdering = columnConfig.getColumnById(ordering.orderedColumn)
+    ? ordering
+    : defaultOrdering;
+
   const orderedLicenseNames = useMemo(() => {
     const orderedColumnType = columnConfig.getColumnById(
-      ordering.orderedColumn,
+      effectiveOrdering.orderedColumn,
     )?.columnType;
 
     if (orderedColumnType === undefined) {
       return orderBy(
         Object.keys(props.licenseNamesWithCriticality),
         (licenseName) => licenseName.toLowerCase(),
-        ordering.orderDirection,
+        effectiveOrdering.orderDirection,
       );
     }
 
@@ -168,15 +173,16 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
       props.licenseNamesWithCriticality,
       props.licenseNamesWithClassification,
       props.licenseCounts,
-      ordering.orderDirection,
+      effectiveOrdering.orderDirection,
       orderedColumnType,
     );
   }, [
+    columnConfig,
+    effectiveOrdering.orderedColumn,
+    effectiveOrdering.orderDirection,
     props.licenseNamesWithCriticality,
     props.licenseNamesWithClassification,
     props.licenseCounts,
-    columnConfig,
-    ordering,
   ]);
 
   return (
@@ -185,7 +191,7 @@ export const AttributionCountPerSourcePerLicenseTable: React.FC<
         <MuiTable size="small" stickyHeader>
           <AttributionCountPerSourcePerLicenseTableHead
             columnConfig={columnConfig}
-            tableOrdering={ordering}
+            tableOrdering={effectiveOrdering}
             onRequestSort={handleRequestSort}
           />
           <MuiTableBody>

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/AttributionCountPerSourcePerLicenseTableHead/AttributionCountPerSourcePerLicenseTableHead.tsx
@@ -36,7 +36,10 @@ export const AttributionCountPerSourcePerLicenseTableHead: React.FC<
   AttributionCountPerSourcePerLicenseTableHeadProps
 > = (props) => {
   return (
-    <MuiTableHead sx={{ position: 'sticky', top: 0 }}>
+    <MuiTableHead
+      sx={{ position: 'sticky', top: 0 }}
+      data-testid={'license-table-header'}
+    >
       <MuiTableRow>
         {props.columnConfig.groups.map((columnGroup, idx) => {
           return (

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
@@ -133,5 +133,15 @@ describe('Attribution count per source per license table', () => {
       'SourceB',
       'Total',
     ]);
+
+    fireEvent.click(screen.getByText('Name'));
+
+    expectHeaderTextsToEqual(screen, [
+      'Namesorted descending', //correct, the sorted, descending is for a11y
+      'Classification',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
   });
 });

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
@@ -50,7 +50,7 @@ function expectHeaderTextsToEqual(
   expectedHeaderTexts: Array<string>,
 ) {
   const headerTexts = screen
-    .getAllByTestId('classification-table-row-header')
+    .getAllByTestId('table-cell-with-sorting')
     .map((node) => node.textContent);
 
   expect(headerTexts).toEqual(expectedHeaderTexts);
@@ -60,11 +60,7 @@ describe('Attribution count per source per license table', () => {
   it('shows by default criticality and classification columns', () => {
     renderComponent(<AttributionCountPerSourcePerLicenseTable {...props} />);
 
-    const headerTexts = screen
-      .getAllByTestId('classification-table-row-header')
-      .map((node) => node.textContent);
-
-    expect(headerTexts).toEqual([
+    expectHeaderTextsToEqual(screen, [
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
       'Classification',
@@ -79,11 +75,7 @@ describe('Attribution count per source per license table', () => {
       actions: [setUserSetting({ showCriticality: false })],
     });
 
-    const headerTexts = screen
-      .getAllByTestId('classification-table-row-header')
-      .map((node) => node.textContent);
-
-    expect(headerTexts).toEqual([
+    expectHeaderTextsToEqual(screen, [
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Classification',
       'SourceA',
@@ -97,11 +89,7 @@ describe('Attribution count per source per license table', () => {
       actions: [setUserSetting({ showClassifications: false })],
     });
 
-    const headerTexts = screen
-      .getAllByTestId('classification-table-row-header')
-      .map((node) => node.textContent);
-
-    expect(headerTexts).toEqual([
+    expectHeaderTextsToEqual(screen, [
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
       'SourceA',
@@ -126,8 +114,8 @@ describe('Attribution count per source per license table', () => {
     fireEvent.click(screen.getByText('Criticality'));
 
     expectHeaderTextsToEqual(screen, [
-      'Name', //correct, the sorted, ascending is for a11y
-      'Criticalitysorted descending',
+      'Name',
+      'Criticalitysorted descending', //correct, the sorted, descending is for a11y
       'Classification',
       'SourceA',
       'SourceB',

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { screen } from '@testing-library/react';
+import { Screen } from '@testing-library/dom/types/screen';
+import { act, fireEvent, screen } from '@testing-library/react';
 
 import { Criticality } from '../../../../shared/shared-types';
 import { setUserSetting } from '../../../state/actions/user-settings-actions/user-settings-actions';
@@ -43,6 +44,17 @@ const props: AttributionCountPerSourcePerLicenseTableProps = {
     licenseB: 3,
   },
 };
+
+function expectHeaderTextsToEqual(
+  screen: Screen,
+  expectedHeaderTexts: Array<string>,
+) {
+  const headerTexts = screen
+    .getAllByTestId('classification-table-row-header')
+    .map((node) => node.textContent);
+
+  expect(headerTexts).toEqual(expectedHeaderTexts);
+}
 
 describe('Attribution count per source per license table', () => {
   it('shows by default criticality and classification columns', () => {
@@ -92,6 +104,43 @@ describe('Attribution count per source per license table', () => {
     expect(headerTexts).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+  });
+
+  it('switches back to default sorting if the sorted by column is dropped', () => {
+    const { store } = renderComponent(
+      <AttributionCountPerSourcePerLicenseTable {...props} />,
+    );
+    expectHeaderTextsToEqual(screen, [
+      'Namesorted ascending', //correct, the sorted, ascending is for a11y
+      'Criticality',
+      'Classification',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+
+    fireEvent.click(screen.getByText('Criticality'));
+
+    expectHeaderTextsToEqual(screen, [
+      'Name', //correct, the sorted, ascending is for a11y
+      'Criticalitysorted descending',
+      'Classification',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+
+    act(() => {
+      store.dispatch(setUserSetting({ showCriticality: false }));
+    });
+
+    expectHeaderTextsToEqual(screen, [
+      'Namesorted ascending', //correct, the sorted, ascending is for a11y
+      'Classification',
       'SourceA',
       'SourceB',
       'Total',

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
@@ -45,22 +45,23 @@ const props: AttributionCountPerSourcePerLicenseTableProps = {
   },
 };
 
-function expectHeaderTextsToEqual(
-  screen: Screen,
-  expectedHeaderTexts: Array<string>,
-) {
-  const headerTexts = screen
+function getHeaderTexts(screen: Screen): Array<string> {
+  const isHtmlElement = (
+    node: HTMLElement | undefined,
+  ): node is HTMLElement => {
+    return !!node;
+  };
+  return screen
     .getAllByTestId('table-cell-with-sorting')
-    .map((node) => node.textContent);
-
-  expect(headerTexts).toEqual(expectedHeaderTexts);
+    .filter(isHtmlElement)
+    .map((node) => node.textContent || '');
 }
 
 describe('Attribution count per source per license table', () => {
   it('shows by default criticality and classification columns', () => {
     renderComponent(<AttributionCountPerSourcePerLicenseTable {...props} />);
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
       'Classification',
@@ -75,7 +76,7 @@ describe('Attribution count per source per license table', () => {
       actions: [setUserSetting({ showCriticality: false })],
     });
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Classification',
       'SourceA',
@@ -89,7 +90,7 @@ describe('Attribution count per source per license table', () => {
       actions: [setUserSetting({ showClassifications: false })],
     });
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
       'SourceA',
@@ -102,7 +103,7 @@ describe('Attribution count per source per license table', () => {
     const { store } = renderComponent(
       <AttributionCountPerSourcePerLicenseTable {...props} />,
     );
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Criticality',
       'Classification',
@@ -113,7 +114,7 @@ describe('Attribution count per source per license table', () => {
 
     fireEvent.click(screen.getByText('Criticality'));
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Name',
       'Criticalitysorted descending', //correct, the sorted, descending is for a11y
       'Classification',
@@ -126,7 +127,7 @@ describe('Attribution count per source per license table', () => {
       store.dispatch(setUserSetting({ showCriticality: false }));
     });
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted ascending', //correct, the sorted, ascending is for a11y
       'Classification',
       'SourceA',
@@ -136,7 +137,7 @@ describe('Attribution count per source per license table', () => {
 
     fireEvent.click(screen.getByText('Name'));
 
-    expectHeaderTextsToEqual(screen, [
+    expect(getHeaderTexts(screen)).toEqual([
       'Namesorted descending', //correct, the sorted, descending is for a11y
       'Classification',
       'SourceA',

--- a/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
+++ b/src/Frontend/Components/AttributionCountPerSourcePerLicenseTable/__tests__/AttributionCountPerSourcePerLicenseTable.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { screen } from '@testing-library/react';
+
+import { Criticality } from '../../../../shared/shared-types';
+import { setUserSetting } from '../../../state/actions/user-settings-actions/user-settings-actions';
+import { renderComponent } from '../../../test-helpers/render';
+import { LicenseCounts } from '../../../types/types';
+import {
+  AttributionCountPerSourcePerLicenseTable,
+  AttributionCountPerSourcePerLicenseTableProps,
+} from '../AttributionCountPerSourcePerLicenseTable';
+
+const licenseCounts: LicenseCounts = {
+  attributionCountPerSourcePerLicense: {
+    licenseA: {
+      sourceA: 1,
+      sourceB: 3,
+    },
+    licenseB: {
+      sourceB: 2,
+    },
+  },
+  totalAttributionsPerLicense: {
+    licenseA: 4,
+    licenseB: 2,
+  },
+  totalAttributionsPerSource: {
+    sourceA: 1,
+    sourceB: 5,
+  },
+};
+const props: AttributionCountPerSourcePerLicenseTableProps = {
+  licenseCounts,
+  licenseNamesWithCriticality: {
+    licenseA: Criticality.High,
+    licenseB: Criticality.Medium,
+  },
+  licenseNamesWithClassification: {
+    licenseA: 2,
+    licenseB: 3,
+  },
+};
+
+describe('Attribution count per source per license table', () => {
+  it('shows by default criticality and classification columns', () => {
+    renderComponent(<AttributionCountPerSourcePerLicenseTable {...props} />);
+
+    const headerTexts = screen
+      .getAllByTestId('classification-table-row-header')
+      .map((node) => node.textContent);
+
+    expect(headerTexts).toEqual([
+      'Namesorted ascending', //correct, the sorted, ascending is for a11y
+      'Criticality',
+      'Classification',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+  });
+
+  it('does not show criticality if disabled', () => {
+    renderComponent(<AttributionCountPerSourcePerLicenseTable {...props} />, {
+      actions: [setUserSetting({ showCriticality: false })],
+    });
+
+    const headerTexts = screen
+      .getAllByTestId('classification-table-row-header')
+      .map((node) => node.textContent);
+
+    expect(headerTexts).toEqual([
+      'Namesorted ascending', //correct, the sorted, ascending is for a11y
+      'Classification',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+  });
+
+  it('does not show classification if disabled', () => {
+    renderComponent(<AttributionCountPerSourcePerLicenseTable {...props} />, {
+      actions: [setUserSetting({ showClassifications: false })],
+    });
+
+    const headerTexts = screen
+      .getAllByTestId('classification-table-row-header')
+      .map((node) => node.textContent);
+
+    expect(headerTexts).toEqual([
+      'Namesorted ascending', //correct, the sorted, ascending is for a11y
+      'Criticality',
+      'SourceA',
+      'SourceB',
+      'Total',
+    ]);
+  });
+});

--- a/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
+++ b/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
@@ -32,6 +32,7 @@ export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
         ...props.sx,
       }}
       sortDirection={props.isSortedColumn ? props.order : false}
+      data-testid="classification-table-row-header"
     >
       <TableSortLabel
         sx={{

--- a/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
+++ b/src/Frontend/Components/TableCellWithSorting/TableCellWithSorting.tsx
@@ -32,7 +32,7 @@ export const TableCellWithSorting: React.FC<TableCellWithSortingProps> = (
         ...props.sx,
       }}
       sortDirection={props.isSortedColumn ? props.order : false}
-      data-testid="classification-table-row-header"
+      data-testid="table-cell-with-sorting"
     >
       <TableSortLabel
         sx={{


### PR DESCRIPTION
### Summary of changes

Also adapt the statistics table based on the configuration for showing classifications and criticality

### Context and reason for change

See https://github.com/opossum-tool/OpossumUI/issues/2849

### How can the changes be tested

Open the statistics popup and toggle the classifications/criticality on and off

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
