### PR TITLE
fix: remove warn messages from recharts library

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,12 +9,6 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
-const openDevTools = (mainWindow: BrowserWindow) => {
-  const devtools = new BrowserWindow();
-  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
-  mainWindow.webContents.openDevTools({ mode: 'detach' });
-};
-
 export async function createWindow(): Promise<BrowserWindow> {
   const mainWindow = new BrowserWindow({
     width: 1920,
@@ -33,7 +27,7 @@ export async function createWindow(): Promise<BrowserWindow> {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    openDevTools(mainWindow);
+    mainWindow.webContents.openDevTools();
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,6 +9,12 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
+const openDevTools = (mainWindow: BrowserWindow) => {
+  const devtools = new BrowserWindow();
+  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
+  mainWindow.webContents.openDevTools({ mode: 'detach' });
+};
+
 export async function createWindow(): Promise<BrowserWindow> {
   const mainWindow = new BrowserWindow({
     width: 1920,
@@ -27,7 +33,7 @@ export async function createWindow(): Promise<BrowserWindow> {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    mainWindow.webContents.openDevTools();
+    openDevTools(mainWindow);
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -111,7 +111,11 @@ export const ProjectStatisticsPopup: React.FC = () => {
             <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
             <MuiTab label={text.projectStatisticsPopup.tabs.details} />
           </MuiTabs>
-          <TabPanel tabIndex={0} selectedTab={selectedTab}>
+          <TabPanel
+            tabIndex={0}
+            selectedTab={selectedTab}
+            drawNotSelectedTab={false}
+          >
             <ChartGrid>
               <ChartGridItem testId={'attributionBarChart'}>
                 <MuiTypography variant="subtitle1">
@@ -178,7 +182,11 @@ export const ProjectStatisticsPopup: React.FC = () => {
               </ChartGridItem>
             </ChartGrid>
           </TabPanel>
-          <TabPanel tabIndex={1} selectedTab={selectedTab}>
+          <TabPanel
+            tabIndex={1}
+            selectedTab={selectedTab}
+            drawNotSelectedTab={true}
+          >
             <AttributionCountPerSourcePerLicenseTable
               licenseCounts={licenseCounts}
               licenseNamesWithCriticality={licenseNamesWithCriticality}
@@ -213,13 +221,20 @@ export const ProjectStatisticsPopup: React.FC = () => {
 interface TabPanelProps extends React.PropsWithChildren {
   tabIndex: number;
   selectedTab: number;
+  drawNotSelectedTab: boolean;
 }
 
 const TabPanel: React.FC<TabPanelProps> = (props) => {
+  const isSelected = props.selectedTab === props.tabIndex;
+  const hideViaCss = !isSelected && props.drawNotSelectedTab;
+  const doNotDrawAtAll = !isSelected && !props.drawNotSelectedTab;
+  if (doNotDrawAtAll) {
+    return null;
+  }
   return (
     <MuiBox
       sx={{
-        ...(props.selectedTab !== props.tabIndex ? { display: 'none' } : {}),
+        ...(hideViaCss ? { display: 'none' } : {}),
         flexGrow: 1,
         overflowY: 'auto',
       }}

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -111,11 +111,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
             <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
             <MuiTab label={text.projectStatisticsPopup.tabs.details} />
           </MuiTabs>
-          <TabPanel
-            tabIndex={0}
-            selectedTab={selectedTab}
-            renderWhenInactive={false}
-          >
+          <TabPanel tabIndex={0} selectedTab={selectedTab}>
             <ChartGrid>
               <ChartGridItem testId={'attributionBarChart'}>
                 <MuiTypography variant="subtitle1">
@@ -182,11 +178,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
               </ChartGridItem>
             </ChartGrid>
           </TabPanel>
-          <TabPanel
-            tabIndex={1}
-            selectedTab={selectedTab}
-            renderWhenInactive={true}
-          >
+          <TabPanel tabIndex={1} selectedTab={selectedTab}>
             <AttributionCountPerSourcePerLicenseTable
               licenseCounts={licenseCounts}
               licenseNamesWithCriticality={licenseNamesWithCriticality}
@@ -221,20 +213,16 @@ export const ProjectStatisticsPopup: React.FC = () => {
 interface TabPanelProps extends React.PropsWithChildren {
   tabIndex: number;
   selectedTab: number;
-  renderWhenInactive: boolean;
 }
 
 const TabPanel: React.FC<TabPanelProps> = (props) => {
   const isSelected = props.selectedTab === props.tabIndex;
-  const hideViaCss = !isSelected && props.renderWhenInactive;
-  const doNotDrawAtAll = !isSelected && !props.renderWhenInactive;
-  if (doNotDrawAtAll) {
+  if (!isSelected) {
     return null;
   }
   return (
     <MuiBox
       sx={{
-        ...(hideViaCss ? { display: 'none' } : {}),
         flexGrow: 1,
         overflowY: 'auto',
       }}

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -114,7 +114,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
           <TabPanel
             tabIndex={0}
             selectedTab={selectedTab}
-            drawNotSelectedTab={false}
+            renderWhenInactive={false}
           >
             <ChartGrid>
               <ChartGridItem testId={'attributionBarChart'}>
@@ -185,7 +185,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
           <TabPanel
             tabIndex={1}
             selectedTab={selectedTab}
-            drawNotSelectedTab={true}
+            renderWhenInactive={true}
           >
             <AttributionCountPerSourcePerLicenseTable
               licenseCounts={licenseCounts}
@@ -221,13 +221,13 @@ export const ProjectStatisticsPopup: React.FC = () => {
 interface TabPanelProps extends React.PropsWithChildren {
   tabIndex: number;
   selectedTab: number;
-  drawNotSelectedTab: boolean;
+  renderWhenInactive: boolean;
 }
 
 const TabPanel: React.FC<TabPanelProps> = (props) => {
   const isSelected = props.selectedTab === props.tabIndex;
-  const hideViaCss = !isSelected && props.drawNotSelectedTab;
-  const doNotDrawAtAll = !isSelected && !props.drawNotSelectedTab;
+  const hideViaCss = !isSelected && props.renderWhenInactive;
+  const doNotDrawAtAll = !isSelected && !props.renderWhenInactive;
   if (doNotDrawAtAll) {
     return null;
   }

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -13,7 +13,7 @@ import { renderComponent } from '../../../test-helpers/render';
 import { ProjectStatisticsPopup } from '../ProjectStatisticsPopup';
 
 describe('The ProjectStatisticsPopup', () => {
-  it('displays license names and source names', () => {
+  it('displays license names and source names', async () => {
     const testExternalAttributions: Attributions = {
       uuid_1: {
         source: {
@@ -44,10 +44,13 @@ describe('The ProjectStatisticsPopup', () => {
         ),
       ],
     });
-    expect(screen.getByText('Apache License Version 2.0')).toBeInTheDocument();
-    expect(screen.getByText('The MIT License (MIT)')).toBeInTheDocument();
-    expect(screen.getByText('Scancode')).toBeInTheDocument();
-    expect(screen.getByText('Reuser')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Licenses'));
+
+    expect(screen.getByText('Apache License Version 2.0')).toBeVisible();
+    expect(screen.getByText('The MIT License (MIT)')).toBeVisible();
+    expect(screen.getByText('Scancode')).toBeVisible();
+    expect(screen.getByText('Reuser')).toBeVisible();
   });
 
   it('renders all pie charts when there are signals and attributions', () => {
@@ -108,23 +111,23 @@ describe('The ProjectStatisticsPopup', () => {
       screen.getByText(
         text.projectStatisticsPopup.charts.mostFrequentLicenseCountPieChart,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.criticalSignalsCountPieChart.title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.signalCountByClassificationPieChart
           .title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.incompleteAttributionsPieChart.title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
   });
 
   it('does not render pie charts when there are no signals and no attributions', () => {
@@ -199,18 +202,18 @@ describe('The ProjectStatisticsPopup', () => {
       screen.getByText(
         text.projectStatisticsPopup.charts.mostFrequentLicenseCountPieChart,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.criticalSignalsCountPieChart.title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.signalCountByClassificationPieChart
           .title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
   });
 
   it('renders attribution bar chart and signals per sources table even when there are no attributions and no signals', async () => {
@@ -229,7 +232,7 @@ describe('The ProjectStatisticsPopup', () => {
       screen.getByText(
         text.projectStatisticsPopup.charts.attributionProperties.title,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
 
     await userEvent.click(
       screen.getByText(text.projectStatisticsPopup.tabs.details),
@@ -239,7 +242,7 @@ describe('The ProjectStatisticsPopup', () => {
       screen.getByText(
         text.attributionCountPerSourcePerLicenseTable.columns.licenseInfo,
       ),
-    ).toBeInTheDocument();
+    ).toBeVisible();
   });
 
   it('supports sorting the signals per sources table', async () => {
@@ -272,6 +275,8 @@ describe('The ProjectStatisticsPopup', () => {
         ),
       ],
     });
+
+    await userEvent.click(screen.getByText('Licenses'));
 
     const getLicenseNames = () =>
       screen


### PR DESCRIPTION
### Summary of changes

If not shown, do not even render recharts to avoid showing warning in the logs

### Context and reason for change

When on the statistics table tab, recharts shows warnings in the logs
![image](https://github.com/user-attachments/assets/100d99df-0ee9-415d-8d87-5cb16f7b97f6)

### How can the changes be tested

* Open the statistics tab
* Switch to the details table
* check js logs to ensure no entries are there

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
