### PR TITLE
feat: improve progress bar legends

### DIFF
--- a/src/Frontend/Components/ProgressBar/ProgressBar.util.tsx
+++ b/src/Frontend/Components/ProgressBar/ProgressBar.util.tsx
@@ -2,15 +2,10 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import MuiBox from '@mui/material/Box';
 import { sum } from 'lodash';
 
 import { Criticality } from '../../../shared/shared-types';
-import {
-  classificationUnknownColor,
-  criticalityColor,
-  OpossumColors,
-} from '../../shared-styles';
+import { criticalityColor, OpossumColors } from '../../shared-styles';
 import { navigateToSelectedPathOrOpenUnsavedPopup } from '../../state/actions/popup-actions/popup-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
@@ -19,6 +14,8 @@ import {
 } from '../../state/selectors/resource-selectors';
 import { ProgressBarData } from '../../types/types';
 import { moveElementsToEnd } from '../../util/lodash-extension-utils';
+
+export const classificationUnknownColor = OpossumColors.lightestBlue;
 
 export function useOnProgressBarClick(resourceIds: Array<string>) {
   const dispatch = useAppDispatch();
@@ -42,93 +39,7 @@ export function useOnProgressBarClick(resourceIds: Array<string>) {
   };
 }
 
-export function getProgressBarTooltipText(
-  progressBarData: ProgressBarData,
-): React.ReactNode {
-  return (
-    <MuiBox>
-      Number of resources…
-      <br />
-      …with attributions:{' '}
-      {new Intl.NumberFormat().format(
-        progressBarData.filesWithManualAttributionCount,
-      )}
-      <br />
-      …with only pre-selected attributions:{' '}
-      {new Intl.NumberFormat().format(
-        progressBarData.filesWithOnlyPreSelectedAttributionCount,
-      )}
-      <br />
-      …with only signals:{' '}
-      {new Intl.NumberFormat().format(
-        progressBarData.filesWithOnlyExternalAttributionCount,
-      )}
-    </MuiBox>
-  );
-}
-
-export function getCriticalityBarTooltipText(
-  progressBarData: ProgressBarData,
-): React.ReactNode {
-  const filesWithNonCriticalExternalAttributions =
-    progressBarData.filesWithOnlyExternalAttributionCount -
-    progressBarData.filesWithHighlyCriticalExternalAttributionsCount -
-    progressBarData.filesWithMediumCriticalExternalAttributionsCount;
-  return (
-    <MuiBox>
-      Number of resources with signals and no attributions…
-      <br />
-      …containing highly critical signals:{' '}
-      {new Intl.NumberFormat().format(
-        progressBarData.filesWithHighlyCriticalExternalAttributionsCount,
-      )}{' '}
-      <br />
-      …containing medium critical signals:{' '}
-      {new Intl.NumberFormat().format(
-        progressBarData.filesWithMediumCriticalExternalAttributionsCount,
-      )}{' '}
-      <br />
-      …containing only non-critical signals:{' '}
-      {new Intl.NumberFormat().format(filesWithNonCriticalExternalAttributions)}
-    </MuiBox>
-  );
-}
-
-export function getClassificationBarTooltipText(
-  progressBarData: ProgressBarData,
-): React.ReactNode {
-  const numberOfResourcesWithSignalsAndNoAttributionAndClassification = sum(
-    Object.values(progressBarData.classificationStatistics).map(
-      (entry) => entry.correspondingFiles.length,
-    ),
-  );
-
-  const numberOfResourcesWithSignalsAndNoAttributionAndNoClassification =
-    progressBarData.filesWithOnlyExternalAttributionCount -
-    numberOfResourcesWithSignalsAndNoAttributionAndClassification;
-  return (
-    <MuiBox>
-      Number of resources with signals and no attributions…
-      {Object.values(progressBarData.classificationStatistics)
-        .toReversed()
-        .map((classificationStatisticsEntry) => (
-          <div key={classificationStatisticsEntry.description}>
-            ...containing classification{' '}
-            {classificationStatisticsEntry.description}:{' '}
-            {classificationStatisticsEntry.correspondingFiles.length}
-          </div>
-        ))}
-      {numberOfResourcesWithSignalsAndNoAttributionAndNoClassification && (
-        <div>
-          ...without classification:{' '}
-          {numberOfResourcesWithSignalsAndNoAttributionAndNoClassification}
-        </div>
-      )}
-    </MuiBox>
-  );
-}
-
-export function getProgressBarBackground(
+export function getAttributionBarBackground(
   progressBarData: ProgressBarData,
 ): string {
   let filesWithManualAttributions: number =

--- a/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
+++ b/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.test.tsx
@@ -15,7 +15,7 @@ import { ProgressBar } from '../ProgressBar';
 async function clickOnAttributionProgressBar() {
   await userEvent.click(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.attributionProgressBar.ariaLabel,
+      text.topBar.switchableProgressBar.attributionBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -26,7 +26,7 @@ async function clickOnAttributionProgressBar() {
 async function hoverOverAttributionProgressBar() {
   await userEvent.hover(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.attributionProgressBar.ariaLabel,
+      text.topBar.switchableProgressBar.attributionBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -37,7 +37,7 @@ async function hoverOverAttributionProgressBar() {
 async function hoverOverCriticalityProgressBar() {
   await userEvent.hover(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.criticalSignalsBar.ariaLabel,
+      text.topBar.switchableProgressBar.criticalityBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -48,7 +48,7 @@ async function hoverOverCriticalityProgressBar() {
 async function hoverOverClassificationProgressBar() {
   await userEvent.hover(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.classificationProgressBar.ariaLabel,
+      text.topBar.switchableProgressBar.classificationBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -59,7 +59,7 @@ async function hoverOverClassificationProgressBar() {
 async function clickOnCriticalityProgressBar() {
   await userEvent.click(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.criticalSignalsBar.ariaLabel,
+      text.topBar.switchableProgressBar.criticalityBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -70,7 +70,7 @@ async function clickOnCriticalityProgressBar() {
 async function clickOnClassificationProgressBar() {
   await userEvent.click(
     screen.getByLabelText(
-      text.topBar.switchableProgressBar.classificationProgressBar.ariaLabel,
+      text.topBar.switchableProgressBar.classificationBar.ariaLabel,
     ),
     {
       advanceTimers: jest.runOnlyPendingTimersAsync,
@@ -262,13 +262,13 @@ describe('ProgressBar', () => {
       screen.getByText(/Number of resources with signals and no attributions/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/containing classification first: 4/),
+      screen.getByText(/containing classification "first": 4/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/containing classification second: 3/),
+      screen.getByText(/containing classification "second": 3/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/containing classification third: 2/),
+      screen.getByText(/containing classification "third": 2/),
     ).toBeInTheDocument();
     expect(screen.getByText(/without classification: 11/)).toBeInTheDocument();
   });

--- a/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.util.test.ts
+++ b/src/Frontend/Components/ProgressBar/__tests__/ProgressBar.util.test.ts
@@ -4,19 +4,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Criticality } from '../../../../shared/shared-types';
 import { faker } from '../../../../testing/Faker';
-import {
-  classificationUnknownColor,
-  criticalityColor,
-  OpossumColors,
-} from '../../../shared-styles';
+import { criticalityColor, OpossumColors } from '../../../shared-styles';
 import {
   ClassificationStatistics,
   ProgressBarData,
 } from '../../../types/types';
 import {
+  classificationUnknownColor,
+  getAttributionBarBackground,
   getClassificationBarBackground,
   getCriticalityBarBackground,
-  getProgressBarBackground,
   roundToAtLeastOnePercentAndNormalize,
 } from '../ProgressBar.util';
 
@@ -46,7 +43,7 @@ describe('ProgressBar helpers', () => {
       ` ${OpossumColors.pastelRed} 66% 99%,` +
       ` ${OpossumColors.lightestBlue} 99%)`;
     const actualProgressBarBackground =
-      getProgressBarBackground(testProgressBarData);
+      getAttributionBarBackground(testProgressBarData);
     expect(actualProgressBarBackground).toEqual(expectedProgressBarBackground);
   });
 

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.util.ts
@@ -13,7 +13,6 @@ import {
   PackageInfo,
 } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
-import { classificationUnknownColor } from '../../shared-styles';
 import {
   AttributionCountPerSourcePerLicense,
   ChartDataItem,
@@ -342,14 +341,15 @@ export function getSignalCountByClassification(
   licenseNamesWithClassification: LicenseNamesWithClassification,
   classifications: ClassificationsConfig,
 ): [Array<ChartDataItem>, { [segmentName: string]: string }] {
-  const NO_CLASSIFICATION = -1;
   const classificationCounts: Record<Classification, number> = {};
 
   for (const [license, attributionCount] of Object.entries(
     licenseCounts.totalAttributionsPerLicense,
   )) {
-    const classification =
-      licenseNamesWithClassification[license] ?? NO_CLASSIFICATION;
+    const classification = licenseNamesWithClassification[license];
+    if (classification === undefined) {
+      continue;
+    }
     classificationCounts[classification] =
       (classificationCounts[classification] ?? 0) + attributionCount;
   }
@@ -369,15 +369,6 @@ export function getSignalCountByClassification(
       };
     })
     .filter(({ count }) => count > 0);
-
-  if (classificationCounts[NO_CLASSIFICATION]) {
-    pieChartData.push({
-      name: text.projectStatisticsPopup.charts
-        .signalCountByClassificationPieChart.noClassification,
-      count: classificationCounts[NO_CLASSIFICATION],
-      color: classificationUnknownColor,
-    });
-  }
 
   const colorMap = Object.fromEntries(
     pieChartData.map((colorChartEntry) => [

--- a/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/__tests__/ProjectStatisticsPopup.test.tsx
@@ -101,7 +101,7 @@ describe('The ProjectStatisticsPopup', () => {
     expect(screen.getByText('Reuser')).toBeVisible();
   });
 
-  it('renders all pie charts when there are signals and attributions', () => {
+  it('renders expected pie charts when there are signals and attributions', () => {
     renderComponent(<ProjectStatisticsPopup />, {
       actions: [
         loadFromFile(getParsedInputFileEnrichedWithTestData(fileSetup)),
@@ -119,11 +119,11 @@ describe('The ProjectStatisticsPopup', () => {
       ),
     ).toBeVisible();
     expect(
-      screen.getByText(
+      screen.queryByText(
         text.projectStatisticsPopup.charts.signalCountByClassificationPieChart
           .title,
       ),
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(
         text.projectStatisticsPopup.charts.incompleteAttributionsPieChart.title,
@@ -166,7 +166,7 @@ describe('The ProjectStatisticsPopup', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders pie charts related to signals even if there are no attributions', () => {
+  it('renders expected pie charts related to signals even if there are no attributions', () => {
     const testManualAttributions: Attributions = {};
     const testExternalAttributions: Attributions = {
       uuid_1: {
@@ -210,11 +210,11 @@ describe('The ProjectStatisticsPopup', () => {
       ),
     ).toBeVisible();
     expect(
-      screen.getByText(
+      screen.queryByText(
         text.projectStatisticsPopup.charts.signalCountByClassificationPieChart
           .title,
       ),
-    ).toBeVisible();
+    ).not.toBeInTheDocument();
   });
 
   it('renders attribution bar chart and signals per sources table even when there are no attributions and no signals', async () => {

--- a/src/Frontend/Components/SwitchableProgressBar/SwitchableProgressBar.tsx
+++ b/src/Frontend/Components/SwitchableProgressBar/SwitchableProgressBar.tsx
@@ -51,15 +51,15 @@ export const SwitchableProgressBar: React.FC = () => {
     ProgressBarSwitchConfiguration
   > = {
     attribution: {
-      label: text.attributionProgressBar.selectLabel,
+      label: text.attributionBar.selectLabel,
       active: true,
     },
     criticality: {
-      label: text.criticalSignalsBar.selectLabel,
+      label: text.criticalityBar.selectLabel,
       active: showCriticality,
     },
     classification: {
-      label: text.classificationProgressBar.selectLabel,
+      label: text.classificationBar.selectLabel,
       active: showClassifications,
     },
   };

--- a/src/Frontend/Components/SwitchableProgressBar/SwitchableProgressBar.tsx
+++ b/src/Frontend/Components/SwitchableProgressBar/SwitchableProgressBar.tsx
@@ -41,7 +41,7 @@ interface ProgressBarSwitchConfiguration {
   active: boolean;
 }
 
-export const SwitchableProcessBar: React.FC = () => {
+export const SwitchableProgressBar: React.FC = () => {
   const [userSettings] = useUserSettings();
   const showClassifications = userSettings.showClassifications;
   const showCriticality = userSettings.showCriticality;
@@ -64,21 +64,20 @@ export const SwitchableProcessBar: React.FC = () => {
     },
   };
 
-  const [currentProgressBar, setcurrentProgressBar] =
+  const [currentProgressBar, setCurrentProgressBar] =
     useState<SelectedProgressBar>('attribution');
   const [progressData] = useProgressData();
 
   const handleProgressBarChange = (
     event: SelectChangeEvent<SelectedProgressBar>,
   ): void => {
-    setcurrentProgressBar(event.target.value as SelectedProgressBar);
+    setCurrentProgressBar(event.target.value as SelectedProgressBar);
   };
 
-  const effectiveCurrentProgressBar = switchableProgressBarConfiguration[
-    currentProgressBar
-  ].active
-    ? currentProgressBar
-    : 'attribution';
+  const effectiveCurrentProgressBar: SelectedProgressBar =
+    switchableProgressBarConfiguration[currentProgressBar].active
+      ? currentProgressBar
+      : 'attribution';
 
   const activeProgressBarConfigurations = Object.fromEntries(
     Object.entries(switchableProgressBarConfiguration).filter(
@@ -93,6 +92,7 @@ export const SwitchableProcessBar: React.FC = () => {
   if (!progressData) {
     return <MuiBox flex={1} />;
   }
+
   return (
     <MuiBox sx={classes.container}>
       <ProgressBar
@@ -109,13 +109,11 @@ export const SwitchableProcessBar: React.FC = () => {
           aria-label={text.selectAriaLabel}
         >
           {Object.entries(activeProgressBarConfigurations).map(
-            ([key, progressBarSwitchConfiguration]) => {
-              return (
-                <MenuItem key={key} value={key}>
-                  {progressBarSwitchConfiguration.label}
-                </MenuItem>
-              );
-            },
+            ([key, progressBarSwitchConfiguration]) => (
+              <MenuItem key={key} value={key}>
+                {progressBarSwitchConfiguration.label}
+              </MenuItem>
+            ),
           )}
         </Select>
       )}

--- a/src/Frontend/Components/SwitchableProgressBar/__tests__/SwitchableProcessBar.test.tsx
+++ b/src/Frontend/Components/SwitchableProgressBar/__tests__/SwitchableProcessBar.test.tsx
@@ -28,7 +28,7 @@ const PROGRESS_BAR_DATA: ProgressBarData = {
 
 const switchableProgressBarText = text.topBar.switchableProgressBar;
 const attributionProgressBarLabel =
-  switchableProgressBarText.attributionProgressBar.ariaLabel;
+  switchableProgressBarText.attributionBar.ariaLabel;
 
 function openSelect() {
   fireEvent.mouseDown(screen.getByRole('combobox'), {
@@ -38,12 +38,9 @@ function openSelect() {
 
 function expectSelectToBeOpen() {
   expect(
-    screen.getByText(
-      switchableProgressBarText.attributionProgressBar.selectLabel,
-      {
-        selector: 'li',
-      },
-    ),
+    screen.getByText(switchableProgressBarText.attributionBar.selectLabel, {
+      selector: 'li',
+    }),
   ).toBeInTheDocument();
 }
 
@@ -55,13 +52,13 @@ async function selectEntry(selectLabel: string) {
 
 function getCriticalSignalsProgressBar() {
   return screen.getByLabelText(
-    switchableProgressBarText.criticalSignalsBar.ariaLabel,
+    switchableProgressBarText.criticalityBar.ariaLabel,
   );
 }
 
 function getAttributionProgressBar() {
   return screen.getByLabelText(
-    switchableProgressBarText.attributionProgressBar.ariaLabel,
+    switchableProgressBarText.attributionBar.ariaLabel,
   );
 }
 
@@ -97,15 +94,13 @@ describe('SwitchableProcessBar', () => {
 
     openSelect();
     expectSelectToBeOpen();
-    await selectEntry(switchableProgressBarText.criticalSignalsBar.selectLabel);
+    await selectEntry(switchableProgressBarText.criticalityBar.selectLabel);
 
     expect(getCriticalSignalsProgressBar()).toBeInTheDocument();
 
     openSelect();
     expectSelectToBeOpen();
-    await selectEntry(
-      switchableProgressBarText.attributionProgressBar.selectLabel,
-    );
+    await selectEntry(switchableProgressBarText.attributionBar.selectLabel);
 
     expect(getAttributionProgressBar()).toBeInTheDocument();
   });

--- a/src/Frontend/Components/SwitchableProgressBar/__tests__/SwitchableProcessBar.test.tsx
+++ b/src/Frontend/Components/SwitchableProgressBar/__tests__/SwitchableProcessBar.test.tsx
@@ -11,7 +11,7 @@ import { setVariable } from '../../../state/actions/variables-actions/variables-
 import { PROGRESS_DATA } from '../../../state/variables/use-progress-data';
 import { renderComponent } from '../../../test-helpers/render';
 import { ProgressBarData } from '../../../types/types';
-import { SwitchableProcessBar } from '../SwitchableProcessBar';
+import { SwitchableProgressBar } from '../SwitchableProgressBar';
 
 const PROGRESS_BAR_DATA: ProgressBarData = {
   fileCount: 6,
@@ -76,12 +76,12 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('does not display the progress bar when no progress data available', () => {
-    renderComponent(<SwitchableProcessBar />);
+    renderComponent(<SwitchableProgressBar />);
     expect(screen.queryByLabelText(/Progress bar .*/)).not.toBeInTheDocument();
   });
 
   it('displays the progress bar when progress data available', () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA)],
     });
 
@@ -91,7 +91,7 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('switches the progress bar via the select', async () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA)],
     });
 
@@ -111,7 +111,7 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('offers all three possible progress bars by default', async () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA)],
     });
 
@@ -130,7 +130,7 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('does not offer classifications if disabled', async () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [
         setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA),
         setUserSetting({ showClassifications: false }),
@@ -148,7 +148,7 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('does not offer criticality if disabled', async () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [
         setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA),
         setUserSetting({ showCriticality: false }),
@@ -166,7 +166,7 @@ describe('SwitchableProcessBar', () => {
   });
 
   it('does not show select if only one option to select', () => {
-    renderComponent(<SwitchableProcessBar />, {
+    renderComponent(<SwitchableProgressBar />, {
       actions: [
         setVariable<ProgressBarData>(PROGRESS_DATA, PROGRESS_BAR_DATA),
         setUserSetting({ showCriticality: false, showClassifications: false }),

--- a/src/Frontend/Components/TopBar/TopBar.tsx
+++ b/src/Frontend/Components/TopBar/TopBar.tsx
@@ -21,7 +21,7 @@ import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import { getSelectedView } from '../../state/selectors/view-selector';
 import { BackendCommunication } from '../BackendCommunication/BackendCommunication';
 import { IconButton } from '../IconButton/IconButton';
-import { SwitchableProcessBar } from '../SwitchableProcessBar/SwitchableProcessBar';
+import { SwitchableProgressBar } from '../SwitchableProgressBar/SwitchableProgressBar';
 
 const classes = {
   root: {
@@ -96,7 +96,7 @@ export const TopBar: React.FC = () => {
           />
         }
       />
-      <SwitchableProcessBar />
+      <SwitchableProgressBar />
       <MuiToggleButtonGroup
         size="small"
         value={selectedView}

--- a/src/Frontend/shared-styles.ts
+++ b/src/Frontend/shared-styles.ts
@@ -40,8 +40,6 @@ export const OpossumColors = {
   brown: 'hsl(33, 55%, 44%)',
 };
 
-export const classificationUnknownColor = OpossumColors.lightOrange;
-
 export const criticalityColor = {
   [Criticality.High]: OpossumColors.orange,
   [Criticality.Medium]: OpossumColors.mediumOrange,

--- a/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
+++ b/src/e2e-tests/page-objects/ProjectStatisticsPopup.ts
@@ -83,10 +83,7 @@ export class ProjectStatisticsPopup {
     },
 
     signalsByClassificationIsVisible: async (): Promise<void> => {
-      await expect(this.signalsByClassificationChart).toContainText(
-        text.projectStatisticsPopup.charts.signalCountByClassificationPieChart
-          .noClassification,
-      );
+      await expect(this.signalsByClassificationChart).toBeVisible();
     },
     signalsByClassificationIsShown: async (): Promise<void> => {
       await expect(this.signalsByClassificationChart).toBeVisible();

--- a/src/e2e-tests/page-objects/TopBar.ts
+++ b/src/e2e-tests/page-objects/TopBar.ts
@@ -60,21 +60,24 @@ export class TopBar {
       await retry(async () => {
         await this.progressBar.hover();
         await Promise.all([
-          expect(
-            this.tooltip.getByText(
-              `with attributions: ${filesWithAttributions}`,
-            ),
-          ).toBeVisible(),
-          expect(
-            this.tooltip.getByText(
-              `with only pre-selected attributions: ${filesWithOnlyPreSelectedAttributions}`,
-            ),
-          ).toBeVisible(),
-          expect(
-            this.tooltip.getByText(
-              `with only signals: ${filesWithOnlySignals}`,
-            ),
-          ).toBeVisible(),
+          filesWithAttributions &&
+            (await expect(
+              this.tooltip.getByText(
+                `with attributions: ${filesWithAttributions}`,
+              ),
+            ).toBeVisible()),
+          filesWithOnlyPreSelectedAttributions &&
+            (await expect(
+              this.tooltip.getByText(
+                `with only pre-selected attributions: ${filesWithOnlyPreSelectedAttributions}`,
+              ),
+            ).toBeVisible()),
+          filesWithOnlySignals &&
+            (await expect(
+              this.tooltip.getByText(
+                `with only signals: ${filesWithOnlySignals}`,
+              ),
+            ).toBeVisible()),
         ]);
       });
     },

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -195,7 +195,6 @@ export const text = {
       },
       signalCountByClassificationPieChart: {
         title: 'Signals by Classification',
-        noClassification: 'No classification',
       },
       incompleteAttributionsPieChart: {
         title: 'Incomplete Attributions',
@@ -411,17 +410,31 @@ export const text = {
     report: 'Report',
     switchableProgressBar: {
       selectAriaLabel: 'ProgressBar Switcher',
-      criticalSignalsBar: {
-        selectLabel: 'Criticalities',
-        ariaLabel: 'Progress bar for to be handled critical signals',
-      },
-      attributionProgressBar: {
+      attributionBar: {
+        intro: 'Number of resources',
         selectLabel: 'Attributions',
         ariaLabel: 'Progress bar for attribution progress',
+        filesWithManualAttribution: 'with attributions',
+        filesWithOnlyPreSelectedAttribution:
+          'with only pre-selected attributions',
+        filesWithOnlyExternalAttribution: 'with only signals',
+        filesWithNeitherAttributionsOrSignals:
+          'with neither attributions or signals',
       },
-      classificationProgressBar: {
+      criticalityBar: {
+        intro: 'Number of resources with signals and no attributions',
+        selectLabel: 'Criticalities',
+        ariaLabel: 'Progress bar for to be handled critical signals',
+        filesWithHighlyCriticalSignals: 'containing highly critical signals',
+        filesWithMediumCriticalSignals: 'containing medium critical signals',
+        filesWithOnlyNonCriticalSignals: 'containing only non-critical signals',
+      },
+      classificationBar: {
+        intro: 'Number of resources with signals and no attributions',
         selectLabel: 'Classifications',
         ariaLabel: 'Progress bar for to be handled classifications',
+        containingClassification: 'containing classification',
+        withoutClassification: 'without classification',
       },
     },
   },

--- a/src/testing/Faker.ts
+++ b/src/testing/Faker.ts
@@ -128,6 +128,7 @@ class OpossumModule {
       packageType: faker.commerce.productMaterial().toLowerCase(),
       packageVersion: faker.system.semver(),
       source: OpossumModule.source(),
+      classification: 0,
       url: faker.internet.url(),
       ...props,
     };
@@ -268,7 +269,11 @@ class OpossumModule {
     return {
       metadata: OpossumModule.metadata(),
       resources: {},
-      config: { classifications: {} },
+      config: {
+        classifications: {
+          0: 'the good stuff',
+        },
+      },
       externalAttributions: {},
       resourcesToAttributions: {},
       ...props,


### PR DESCRIPTION
### Summary of changes

- rename progress bar component for consistency
- remove any tooltip rows that have zero items (0-width slices are not visible)
- make items without classification information lightest blue (similar handling as in other progress bars)
- renaming for consistency

### How can the changes be tested

Inspect the tooltips for the three progress bars when some of them contain zero-width categories.