### PR TITLE
fix: disable path selection during file processing

### DIFF
--- a/src/Frontend/Components/FilePathInput/FilePathInput.tsx
+++ b/src/Frontend/Components/FilePathInput/FilePathInput.tsx
@@ -25,6 +25,7 @@ interface FilePathInputProps {
   text: string;
   onClick: () => void;
   tooltipProps?: Partial<TooltipProps>;
+  disabled: boolean;
 }
 
 export const FilePathInput: React.FC<FilePathInputProps> = (props) => {
@@ -41,6 +42,7 @@ export const FilePathInput: React.FC<FilePathInputProps> = (props) => {
       // behavior (e.g. horizontal text scrolling) that we don't want here
       inputComponent={CustomInput}
       sx={{ marginTop: '20px' }}
+      disabled={props.disabled}
     />
   );
 };

--- a/src/Frontend/Components/ImportDialog/ImportDialog.tsx
+++ b/src/Frontend/Components/ImportDialog/ImportDialog.tsx
@@ -24,6 +24,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
 
   const [inputFilePath, setInputFilePath] = useState<string>('');
   const [opossumFilePath, setOpossumFilePath] = useState<string>('');
+  const [importInProgress, setImportInProgress] = useState<boolean>(false);
 
   const {
     processingStatusUpdatedEvents,
@@ -32,6 +33,10 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
   } = useProcessingStatusUpdated();
 
   async function selectInputFilePath(): Promise<void> {
+    if (importInProgress) {
+      return;
+    }
+
     const filePath = await window.electronAPI.selectFile(fileFormat);
 
     if (filePath) {
@@ -41,6 +46,10 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
   }
 
   async function selectOpossumFilePath(): Promise<void> {
+    if (importInProgress) {
+      return;
+    }
+
     let defaultPath = 'imported.opossum';
     const derivedPath = getDotOpossumFilePath(
       inputFilePath,
@@ -67,6 +76,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
   }
 
   async function onConfirm(): Promise<void> {
+    setImportInProgress(true);
     const success = await window.electronAPI.importFileConvertAndLoad(
       inputFilePath,
       fileFormat.fileType,
@@ -76,6 +86,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
     if (success) {
       dispatch(closePopup());
     }
+    setImportInProgress(false);
   }
 
   return (
@@ -126,6 +137,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
           text={inputFilePath}
           onClick={selectInputFilePath}
           tooltipProps={{ placement: 'top' }}
+          disabled={importInProgress}
         />
         <FilePathInput
           label={text.importDialog.opossumFilePath.textFieldLabel(
@@ -133,6 +145,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
           )}
           text={opossumFilePath}
           onClick={selectOpossumFilePath}
+          disabled={importInProgress}
         />
       </div>
     </NotificationPopup>

--- a/src/Frontend/Components/MergeDialog/MergeDialog.tsx
+++ b/src/Frontend/Components/MergeDialog/MergeDialog.tsx
@@ -22,6 +22,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
   const dispatch = useAppDispatch();
 
   const [inputFilePath, setInputFilePath] = useState<string>('');
+  const [mergeInProgress, setMergeInProgress] = useState<boolean>(false);
 
   const {
     processingStatusUpdatedEvents,
@@ -30,6 +31,10 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
   } = useProcessingStatusUpdated();
 
   async function selectInputFilePath(): Promise<void> {
+    if (mergeInProgress) {
+      return;
+    }
+
     const filePath = await window.electronAPI.selectFile(fileFormat);
 
     if (filePath) {
@@ -43,6 +48,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
   }
 
   async function onConfirm(): Promise<void> {
+    setMergeInProgress(true);
     const success = await window.electronAPI.mergeFileAndLoad(
       inputFilePath,
       fileFormat.fileType,
@@ -51,6 +57,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
     if (success) {
       dispatch(closePopup());
     }
+    setMergeInProgress(false);
   }
 
   return (
@@ -98,6 +105,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
           )}
           text={inputFilePath}
           onClick={selectInputFilePath}
+          disabled={mergeInProgress}
         />
       </div>
     </NotificationPopup>

--- a/src/e2e-tests/__tests__/import-dialog.test.ts
+++ b/src/e2e-tests/__tests__/import-dialog.test.ts
@@ -11,12 +11,8 @@ const [resourceName] = faker.opossum.resourceName();
 test.use({
   data: {
     inputData: faker.opossum.inputData({
-      resources: faker.opossum.resources({
-        [resourceName]: 1,
-      }),
-      metadata: faker.opossum.metadata({
-        projectId: 'test_project',
-      }),
+      resources: faker.opossum.resources({ [resourceName]: 1 }),
+      metadata: faker.opossum.metadata({ projectId: 'test_project' }),
     }),
     outputData: faker.opossum.outputData({}),
   },


### PR DESCRIPTION
### Summary of changes

Disbale input fields and early return in click handler if processing in progress.

### Context and reason for change

Import and Merge dialog currently allow to select a different input and target path while the file is imported or merged. This interrupts the file processing.

### How can the changes be tested

Open OpossumUI, open import or merge dialog, select paths to import/merge, start the process and see that clicking on the input fields is no longer possible and the fields are disabled.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
