### PR TITLE
chore: use children prop in notification popups

### DIFF
--- a/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
@@ -70,7 +70,6 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
 
   return (
     <StyledNotificationPopup
-      content={renderContent()}
       header={text.deleteAttributionsPopup.title}
       centerLeftButtonConfig={{
         onClick: handleDelete,
@@ -97,7 +96,9 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
       isOpen={open}
       aria-label={'confirm delete popup'}
       width={580}
-    />
+    >
+      {renderContent()}
+    </StyledNotificationPopup>
   );
 
   function renderContent() {

--- a/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
+++ b/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
@@ -57,7 +57,6 @@ export const ConfirmReplacePopup = ({
 
   return (
     <StyledNotificationPopup
-      content={renderContent()}
       header={text.replaceAttributionsPopup.title}
       leftButtonConfig={{
         onClick: handleReplace,
@@ -72,7 +71,9 @@ export const ConfirmReplacePopup = ({
       isOpen={open}
       aria-label={'confirm replace popup'}
       width={500}
-    />
+    >
+      {renderContent()}
+    </StyledNotificationPopup>
   );
 
   function renderContent() {

--- a/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
+++ b/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
@@ -88,7 +88,6 @@ export const ConfirmSavePopup: React.FC<Props> = ({
 
   return (
     <StyledNotificationPopup
-      content={renderContent()}
       header={
         areAllAttributionsPreselected
           ? text.saveAttributionsPopup.titleConfirm
@@ -124,7 +123,9 @@ export const ConfirmSavePopup: React.FC<Props> = ({
       isOpen={open}
       aria-label={'confirm save popup'}
       width={580}
-    />
+    >
+      {renderContent()}
+    </StyledNotificationPopup>
   );
 
   function renderContent() {

--- a/src/Frontend/Components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/Frontend/Components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -112,7 +112,6 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
 
   return (
     <NotificationPopup
-      content={message}
       header={title}
       isOpen={open}
       rightButtonConfig={{
@@ -125,6 +124,8 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
         onClick: () => resolveRef.current?.(true),
       }}
       aria-label={'confirmation dialog'}
-    />
+    >
+      {message}
+    </NotificationPopup>
   );
 };

--- a/src/Frontend/Components/DiffPopup/DiffPopup.tsx
+++ b/src/Frontend/Components/DiffPopup/DiffPopup.tsx
@@ -69,7 +69,6 @@ export function DiffPopup({
   return (
     <NotificationPopup
       header={text.diffPopup.title}
-      content={renderDiffView()}
       leftButtonConfig={{
         disabled: isEqual(
           getComparableAttributes(bufferPackageInfo),
@@ -108,7 +107,9 @@ export function DiffPopup({
       background={'lightestBlue'}
       fullWidth={true}
       aria-label={'diff popup'}
-    />
+    >
+      {renderDiffView()}
+    </NotificationPopup>
   );
 
   function renderDiffView() {

--- a/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
+++ b/src/Frontend/Components/ErrorPopup/ErrorPopup.tsx
@@ -23,12 +23,13 @@ export const ErrorPopup: React.FC<ErrorPopupProps> = (props) => {
 
   return (
     <NotificationPopup
-      content={props.content}
       header={'Error'}
       onBackdropClick={close}
       isOpen={true}
       onEscapeKeyDown={close}
       aria-label={'error popup'}
-    />
+    >
+      {props.content}
+    </NotificationPopup>
   );
 };

--- a/src/Frontend/Components/ImportDialog/ImportDialog.tsx
+++ b/src/Frontend/Components/ImportDialog/ImportDialog.tsx
@@ -84,30 +84,6 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
       width={'80vw'}
       minWidth={'300px'}
       maxWidth={'700px'}
-      content={
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <MuiTypography>{text.importDialog.explanationText[0]}</MuiTypography>
-          <MuiTypography sx={{ marginBottom: '10px' }}>
-            {text.importDialog.explanationText[1]}
-          </MuiTypography>
-          <FilePathInput
-            label={text.importDialog.inputFilePath.textFieldLabel(
-              fileFormat,
-              !!inputFilePath,
-            )}
-            text={inputFilePath}
-            onClick={selectInputFilePath}
-            tooltipProps={{ placement: 'top' }}
-          />
-          <FilePathInput
-            label={text.importDialog.opossumFilePath.textFieldLabel(
-              !!opossumFilePath,
-            )}
-            text={opossumFilePath}
-            onClick={selectOpossumFilePath}
-          />
-        </div>
-      }
       isOpen={true}
       customAction={
         processingStatusUpdatedEvents.length ? (
@@ -120,9 +96,7 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
             isInProgress={processing}
             showDate={false}
             useEllipsis={true}
-            sx={{
-              marginLeft: '10px',
-            }}
+            sx={{ marginLeft: '10px' }}
           />
         ) : undefined
       }
@@ -138,6 +112,29 @@ export const ImportDialog: React.FC<ImportDialogProps> = ({ fileFormat }) => {
         disabled: processing,
       }}
       aria-label={'import dialog'}
-    />
+    >
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <MuiTypography>{text.importDialog.explanationText[0]}</MuiTypography>
+        <MuiTypography sx={{ marginBottom: '10px' }}>
+          {text.importDialog.explanationText[1]}
+        </MuiTypography>
+        <FilePathInput
+          label={text.importDialog.inputFilePath.textFieldLabel(
+            fileFormat,
+            !!inputFilePath,
+          )}
+          text={inputFilePath}
+          onClick={selectInputFilePath}
+          tooltipProps={{ placement: 'top' }}
+        />
+        <FilePathInput
+          label={text.importDialog.opossumFilePath.textFieldLabel(
+            !!opossumFilePath,
+          )}
+          text={opossumFilePath}
+          onClick={selectOpossumFilePath}
+        />
+      </div>
+    </NotificationPopup>
   );
 };

--- a/src/Frontend/Components/MergeDialog/MergeDialog.tsx
+++ b/src/Frontend/Components/MergeDialog/MergeDialog.tsx
@@ -59,20 +59,6 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
       width={'80vw'}
       minWidth={'300px'}
       maxWidth={'730px'}
-      content={
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <MuiTypography>{text.mergeDialog.explanationText}</MuiTypography>
-          <MuiTypography>{text.mergeDialog.warningText}</MuiTypography>
-          <FilePathInput
-            label={text.mergeDialog.inputFilePath.textFieldLabel(
-              fileFormat,
-              !!inputFilePath,
-            )}
-            text={inputFilePath}
-            onClick={selectInputFilePath}
-          />
-        </div>
-      }
       isOpen={true}
       customAction={
         processingStatusUpdatedEvents.length ? (
@@ -85,9 +71,7 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
             isInProgress={processing}
             showDate={false}
             useEllipsis={true}
-            sx={{
-              marginLeft: '10px',
-            }}
+            sx={{ marginLeft: '10px' }}
           />
         ) : undefined
       }
@@ -103,6 +87,19 @@ export const MergeDialog: React.FC<MergeDialogProps> = ({ fileFormat }) => {
         disabled: processing,
       }}
       aria-label={'merge dialog'}
-    />
+    >
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <MuiTypography>{text.mergeDialog.explanationText}</MuiTypography>
+        <MuiTypography>{text.mergeDialog.warningText}</MuiTypography>
+        <FilePathInput
+          label={text.mergeDialog.inputFilePath.textFieldLabel(
+            fileFormat,
+            !!inputFilePath,
+          )}
+          text={inputFilePath}
+          onClick={selectInputFilePath}
+        />
+      </div>
+    </NotificationPopup>
   );
 };

--- a/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
+++ b/src/Frontend/Components/NotSavedPopup/NotSavedPopup.tsx
@@ -15,7 +15,6 @@ export function NotSavedPopup() {
 
   return (
     <NotificationPopup
-      content={text.unsavedChangesPopup.message}
       header={text.unsavedChangesPopup.title}
       leftButtonConfig={{
         onClick: () => dispatch(proceedFromUnsavedPopup()),
@@ -28,6 +27,8 @@ export function NotSavedPopup() {
       }}
       isOpen
       aria-label={'unsaved changes popup'}
-    />
+    >
+      {text.unsavedChangesPopup.message}
+    </NotificationPopup>
   );
 }

--- a/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
+++ b/src/Frontend/Components/NotificationPopup/NotificationPopup.tsx
@@ -16,7 +16,6 @@ import { OpossumColors } from '../../shared-styles';
 
 interface NotificationPopupProps {
   header: string;
-  content: React.ReactNode;
   leftButtonConfig?: ButtonProps & { buttonText: string };
   rightButtonConfig?: ButtonProps & { buttonText: string };
   centerLeftButtonConfig?: ButtonProps & { buttonText: string };
@@ -36,7 +35,9 @@ interface NotificationPopupProps {
   className?: string;
 }
 
-export function NotificationPopup(props: NotificationPopupProps) {
+export function NotificationPopup(
+  props: React.PropsWithChildren<NotificationPopupProps>,
+) {
   useHotkeys('esc', props.onEscapeKeyDown || noop, [props.onEscapeKeyDown]);
 
   return (
@@ -65,10 +66,10 @@ export function NotificationPopup(props: NotificationPopupProps) {
     >
       <MuiDialogTitle>{props.header}</MuiDialogTitle>
       <MuiDialogContent className={props.className} sx={props.sx}>
-        {typeof props.content === 'string' ? (
-          <MuiDialogContentText>{props.content}</MuiDialogContentText>
+        {typeof props.children === 'string' ? (
+          <MuiDialogContentText>{props.children}</MuiDialogContentText>
         ) : (
-          props.content
+          props.children
         )}
       </MuiDialogContent>
       <MuiDialogActions>

--- a/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
+++ b/src/Frontend/Components/NotificationPopup/__tests__/NotificationPopup.test.tsx
@@ -15,7 +15,6 @@ describe('NotificationPopup', () => {
 
     render(
       <NotificationPopup
-        content={'content text'}
         header={'header text'}
         leftButtonConfig={{
           onClick: onLeftButtonClick,
@@ -34,7 +33,9 @@ describe('NotificationPopup', () => {
           buttonText: 'centerRightButtonText',
         }}
         isOpen={true}
-      />,
+      >
+        content text
+      </NotificationPopup>,
     );
 
     expect(screen.getByText('header text')).toBeInTheDocument();
@@ -52,11 +53,9 @@ describe('NotificationPopup', () => {
 
   it('renders open popup with component', () => {
     render(
-      <NotificationPopup
-        content={<div>{'test component'}</div>}
-        header={'header text'}
-        isOpen={true}
-      />,
+      <NotificationPopup header={'header text'} isOpen={true}>
+        <div>test component</div>
+      </NotificationPopup>,
     );
 
     expect(screen.getByText('header text')).toBeInTheDocument();
@@ -67,11 +66,12 @@ describe('NotificationPopup', () => {
     const onEscapeKeyDown = jest.fn();
     render(
       <NotificationPopup
-        content={<div>{'test component'}</div>}
         header={'header text'}
         isOpen={true}
         onEscapeKeyDown={onEscapeKeyDown}
-      />,
+      >
+        <div>{'test component'}</div>
+      </NotificationPopup>,
     );
 
     fireEvent.keyDown(screen.getByText('test component'), {

--- a/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
+++ b/src/Frontend/Components/ProjectMetadataPopup/ProjectMetadataPopup.tsx
@@ -17,17 +17,15 @@ export const ProjectMetadataPopup: React.FC = () => {
 
   return (
     <NotificationPopup
-      content={<ProjectMetadataTable />}
       header={'Project Metadata'}
       isOpen={true}
       fullWidth={false}
-      rightButtonConfig={{
-        onClick: close,
-        buttonText: text.buttons.close,
-      }}
+      rightButtonConfig={{ onClick: close, buttonText: text.buttons.close }}
       onBackdropClick={close}
       onEscapeKeyDown={close}
       aria-label={'project metadata'}
-    />
+    >
+      <ProjectMetadataTable />
+    </NotificationPopup>
   );
 };

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -98,110 +98,11 @@ export const ProjectStatisticsPopup: React.FC = () => {
 
   return (
     <NotificationPopup
-      content={
-        <MuiBox
-          sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
-        >
-          <MuiTabs
-            value={selectedTab}
-            onChange={(_, tab) => setSelectedTab(tab)}
-            sx={{
-              marginBottom: '12px',
-              borderBottom: 1,
-              borderColor: 'divider',
-            }}
-          >
-            <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
-            <MuiTab label={text.projectStatisticsPopup.tabs.details} />
-          </MuiTabs>
-          <TabPanel tabIndex={0} selectedTab={selectedTab}>
-            <ChartGrid>
-              <ChartGridItem testId={'attributionBarChart'}>
-                <MuiTypography variant="subtitle1">
-                  {
-                    text.projectStatisticsPopup.charts.attributionProperties
-                      .title
-                  }
-                </MuiTypography>
-                <BarChart data={attributionBarChartData} />
-              </ChartGridItem>
-              <ChartGridItem
-                shouldRender={mostFrequentLicenseCountData.length > 0}
-                testId={'mostFrequentLicenseCountPieChart'}
-              >
-                <MuiTypography variant="subtitle1">
-                  {
-                    text.projectStatisticsPopup.charts
-                      .mostFrequentLicenseCountPieChart
-                  }
-                </MuiTypography>
-                <PieChart segments={mostFrequentLicenseCountData} />
-              </ChartGridItem>
-              <ChartGridItem
-                shouldRender={
-                  criticalSignalsCount.length > 0 && showCriticality
-                }
-                testId={'criticalSignalsCountPieChart'}
-              >
-                <MuiTypography variant="subtitle1">
-                  {
-                    text.projectStatisticsPopup.charts
-                      .criticalSignalsCountPieChart.title
-                  }
-                </MuiTypography>
-                <PieChart
-                  segments={criticalSignalsCount}
-                  colorMap={CRITICALITY_COLORS}
-                />
-              </ChartGridItem>
-              <ChartGridItem
-                shouldRender={
-                  signalCountByClassification.length > 0 && showClassifications
-                }
-                testId={'signalCountByClassificationPieChart'}
-              >
-                <MuiTypography variant="subtitle1">
-                  {
-                    text.projectStatisticsPopup.charts
-                      .signalCountByClassificationPieChart.title
-                  }
-                </MuiTypography>
-                <PieChart
-                  segments={signalCountByClassification}
-                  colorMap={classificationColorMap}
-                />
-              </ChartGridItem>
-              <ChartGridItem
-                shouldRender={incompleteAttributionsData.length > 0}
-                testId={'incompleteAttributionsPieChart'}
-              >
-                <MuiTypography variant="subtitle1">
-                  {
-                    text.projectStatisticsPopup.charts
-                      .incompleteAttributionsPieChart.title
-                  }
-                </MuiTypography>
-                <PieChart segments={incompleteAttributionsData} />
-              </ChartGridItem>
-            </ChartGrid>
-          </TabPanel>
-          <TabPanel tabIndex={1} selectedTab={selectedTab}>
-            <AttributionCountPerSourcePerLicenseTable
-              licenseCounts={licenseCounts}
-              licenseNamesWithCriticality={licenseNamesWithCriticality}
-              licenseNamesWithClassification={licenseNamesWithClassification}
-            />
-          </TabPanel>
-        </MuiBox>
-      }
       header={text.projectStatisticsPopup.title}
       isOpen={true}
       width={'min(95vw, max(550px, 85vw))'}
       height={'min(95vh, max(550px, 75vh))'}
-      rightButtonConfig={{
-        onClick: close,
-        buttonText: text.buttons.close,
-      }}
+      rightButtonConfig={{ onClick: close, buttonText: text.buttons.close }}
       onBackdropClick={close}
       onEscapeKeyDown={close}
       aria-label={'project statistics'}
@@ -209,14 +110,96 @@ export const ProjectStatisticsPopup: React.FC = () => {
         <Checkbox
           checked={showProjectStatistics}
           onChange={(event) =>
-            updateUserSettings({
-              showProjectStatistics: event.target.checked,
-            })
+            updateUserSettings({ showProjectStatistics: event.target.checked })
           }
           label={text.projectStatisticsPopup.toggleStartupCheckbox}
         />
       }
-    />
+    >
+      <MuiBox sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <MuiTabs
+          value={selectedTab}
+          onChange={(_, tab) => setSelectedTab(tab)}
+          sx={{ marginBottom: '12px', borderBottom: 1, borderColor: 'divider' }}
+        >
+          <MuiTab label={text.projectStatisticsPopup.tabs.overview} />
+          <MuiTab label={text.projectStatisticsPopup.tabs.details} />
+        </MuiTabs>
+        <TabPanel tabIndex={0} selectedTab={selectedTab}>
+          <ChartGrid>
+            <ChartGridItem testId={'attributionBarChart'}>
+              <MuiTypography variant="subtitle1">
+                {text.projectStatisticsPopup.charts.attributionProperties.title}
+              </MuiTypography>
+              <BarChart data={attributionBarChartData} />
+            </ChartGridItem>
+            <ChartGridItem
+              shouldRender={mostFrequentLicenseCountData.length > 0}
+              testId={'mostFrequentLicenseCountPieChart'}
+            >
+              <MuiTypography variant="subtitle1">
+                {
+                  text.projectStatisticsPopup.charts
+                    .mostFrequentLicenseCountPieChart
+                }
+              </MuiTypography>
+              <PieChart segments={mostFrequentLicenseCountData} />
+            </ChartGridItem>
+            <ChartGridItem
+              shouldRender={criticalSignalsCount.length > 0 && showCriticality}
+              testId={'criticalSignalsCountPieChart'}
+            >
+              <MuiTypography variant="subtitle1">
+                {
+                  text.projectStatisticsPopup.charts
+                    .criticalSignalsCountPieChart.title
+                }
+              </MuiTypography>
+              <PieChart
+                segments={criticalSignalsCount}
+                colorMap={CRITICALITY_COLORS}
+              />
+            </ChartGridItem>
+            <ChartGridItem
+              shouldRender={
+                signalCountByClassification.length > 0 && showClassifications
+              }
+              testId={'signalCountByClassificationPieChart'}
+            >
+              <MuiTypography variant="subtitle1">
+                {
+                  text.projectStatisticsPopup.charts
+                    .signalCountByClassificationPieChart.title
+                }
+              </MuiTypography>
+              <PieChart
+                segments={signalCountByClassification}
+                colorMap={classificationColorMap}
+              />
+            </ChartGridItem>
+            <ChartGridItem
+              shouldRender={incompleteAttributionsData.length > 0}
+              testId={'incompleteAttributionsPieChart'}
+            >
+              <MuiTypography variant="subtitle1">
+                {
+                  text.projectStatisticsPopup.charts
+                    .incompleteAttributionsPieChart.title
+                }
+              </MuiTypography>
+              <PieChart segments={incompleteAttributionsData} />
+            </ChartGridItem>
+          </ChartGrid>
+        </TabPanel>
+        <TabPanel tabIndex={1} selectedTab={selectedTab}>
+          <AttributionCountPerSourcePerLicenseTable
+            licenseCounts={licenseCounts}
+            licenseNamesWithCriticality={licenseNamesWithCriticality}
+            licenseNamesWithClassification={licenseNamesWithClassification}
+          />
+        </TabPanel>
+      </MuiBox>
+    </NotificationPopup>
   );
 };
 
@@ -231,14 +214,7 @@ const TabPanel: React.FC<TabPanelProps> = (props) => {
     return null;
   }
   return (
-    <MuiBox
-      sx={{
-        flexGrow: 1,
-        overflowY: 'auto',
-      }}
-    >
-      {props.children}
-    </MuiBox>
+    <MuiBox sx={{ flexGrow: 1, overflowY: 'auto' }}>{props.children}</MuiBox>
   );
 };
 
@@ -247,15 +223,7 @@ const ChartGrid: React.FC<PropsWithChildren> = (props) => {
     <ThemeProvider
       theme={createTheme({
         ...useTheme(),
-        breakpoints: {
-          values: {
-            xs: 0,
-            sm: 0,
-            md: 1200,
-            lg: 1725,
-            xl: 2000,
-          },
-        },
+        breakpoints: { values: { xs: 0, sm: 0, md: 1200, lg: 1725, xl: 2000 } },
       })}
     >
       <MuiGrid

--- a/src/Frontend/Components/UpdateAppPopup/UpdateAppPopup.tsx
+++ b/src/Frontend/Components/UpdateAppPopup/UpdateAppPopup.tsx
@@ -26,7 +26,6 @@ export function UpdateAppPopup() {
 
   return (
     <NotificationPopup
-      content={renderContent()}
       header={text.updateAppPopup.title}
       isOpen
       width={600}
@@ -36,7 +35,9 @@ export function UpdateAppPopup() {
       }}
       onBackdropClick={handleClose}
       onEscapeKeyDown={handleClose}
-    />
+    >
+      {renderContent()}
+    </NotificationPopup>
   );
 
   function renderContent() {


### PR DESCRIPTION
### Summary of changes

Use react's children prop instead of additional content prop in `NotificationPopup`.

### Context and reason for change

The content prop is legacy behaviour and there is no need for it anymore.

### How can the changes be tested

e2e tests and manual tests in the UI.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
