### PR TITLE
Preferred over origin ids not written

### DIFF
--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,13 +9,19 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
+const openDevTools = (mainWindow: BrowserWindow) => {
+  const devtools = new BrowserWindow();
+  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
+  mainWindow.webContents.openDevTools({ mode: 'detach' });
+};
+
 export async function loadWebApp(
   mainWindow: Electron.CrossProcessExports.BrowserWindow,
 ) {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    mainWindow.webContents.openDevTools();
+    openDevTools(mainWindow);
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/ElectronBackend/main/createWindow.ts
+++ b/src/ElectronBackend/main/createWindow.ts
@@ -9,19 +9,13 @@ import upath from 'upath';
 
 import { getIconPath } from './iconHelpers';
 
-const openDevTools = (mainWindow: BrowserWindow) => {
-  const devtools = new BrowserWindow();
-  mainWindow.webContents.setDevToolsWebContents(devtools.webContents);
-  mainWindow.webContents.openDevTools({ mode: 'detach' });
-};
-
 export async function loadWebApp(
   mainWindow: Electron.CrossProcessExports.BrowserWindow,
 ) {
   if (!app.isPackaged) {
     await mainWindow.loadURL('http://localhost:5173/');
 
-    openDevTools(mainWindow);
+    mainWindow.webContents.openDevTools();
   } else {
     await mainWindow.loadURL(
       `file://${path.join(upath.toUnix(__dirname), '../../index.html')}`,

--- a/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
+++ b/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
@@ -129,7 +129,7 @@ describe('The updateManualAttribution function', () => {
     expect(changedAttribution.preferredOverOriginIds).toHaveLength(0);
   });
 
-  it('does not set preferred over origin ids if only the selected element has a manual attribution', () => {
+  it('sets preferred over origin ids over the manual attribution of the selected element', () => {
     const testStore = createAppStore();
     testStore.dispatch(
       loadFromFile(
@@ -183,7 +183,7 @@ describe('The updateManualAttribution function', () => {
 
     const changedAttribution = newManualData.attributions['manualUuid2'];
     expect(changedAttribution.preferred).toBe(true);
-    expect(changedAttribution.preferredOverOriginIds).toBeFalsy();
+    expect(changedAttribution.preferredOverOriginIds).toEqual(['originId']);
   });
 
   it('takes the preferred over origin ids only from the higher manual attribution', () => {
@@ -265,7 +265,7 @@ describe('The updateManualAttribution function', () => {
 
     const changedAttribution = newManualData.attributions['manualUuid2'];
     expect(changedAttribution.preferred).toBe(true);
-    expect(changedAttribution.preferredOverOriginIds).toBeFalsy();
+    expect(changedAttribution.preferredOverOriginIds).toEqual(['originId']);
     const unchangedAttribution = newManualData.attributions['manualUuid1'];
     expect(unchangedAttribution.preferredOverOriginIds).toHaveLength(2);
     expect(unchangedAttribution.preferredOverOriginIds).toEqual([

--- a/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
+++ b/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
@@ -201,7 +201,7 @@ describe('The updateManualAttribution function', () => {
           },
           resourcesToExternalAttributions: {
             '/folder/folder2/child': ['externalUuid'],
-            '/folder/file1': ['externalUuid1'],
+            '/folder/file': ['externalUuid1'],
           },
           externalAttributions: {
             externalUuid: {
@@ -267,6 +267,11 @@ describe('The updateManualAttribution function', () => {
     expect(changedAttribution.preferred).toBe(true);
     expect(changedAttribution.preferredOverOriginIds).toBeFalsy();
     const unchangedAttribution = newManualData.attributions['manualUuid1'];
-    expect(unchangedAttribution.preferredOverOriginIds).toEqual(['originId']);
+    expect(unchangedAttribution.preferredOverOriginIds).toHaveLength(2);
+    expect(unchangedAttribution.preferredOverOriginIds).toEqual([
+      'originId1',
+      'originId',
+    ]);
+    expect(unchangedAttribution.preferred).toBe(true);
   });
 });

--- a/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
+++ b/src/Frontend/state/helpers/__tests__/preferred-over-origin-id.test.ts
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AttributionData,
+  Criticality,
+  PackageInfo,
+} from '../../../../shared/shared-types';
+import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
+import { loadFromFile } from '../../actions/resource-actions/load-actions';
+import { getCalculatePreferredOverOriginIds } from '../../actions/resource-actions/preference-actions';
+import { createAppStore } from '../../configure-store';
+import { getManualData } from '../../selectors/resource-selectors';
+import { updateManualAttribution } from '../save-action-helpers';
+
+describe('The updateManualAttribution function', () => {
+  it('sets a preferred flag to the manual attribution', () => {
+    const testStore = createAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: { folder: { child: 1 } },
+          resourcesToExternalAttributions: {
+            '/folder/child': ['externalUuid'],
+          },
+          externalAttributions: {
+            externalUuid: {
+              source: { name: 'testSource', documentConfidence: 0 },
+              originIds: ['originId'],
+              criticality: Criticality.None,
+              id: 'externalUuid',
+            },
+          },
+          externalAttributionSources: {
+            testSource: {
+              name: 'Test source',
+              priority: 0,
+              isRelevantForPreferred: true,
+            },
+          },
+          manualAttributions: {
+            manualUuid2: {
+              criticality: Criticality.None,
+              id: 'manualUuid2',
+            },
+          },
+          resourcesToManualAttributions: {
+            '/folder/': ['manualUuid2'],
+          },
+        }),
+      ),
+    );
+    const resourceState = testStore.getState().resourceState;
+    const testManualData = getManualData(testStore.getState());
+    const testTemporaryDisplayPackageInfo: PackageInfo = {
+      id: 'manualUuid2',
+      preferred: true,
+      criticality: Criticality.None,
+    };
+
+    const newManualData: AttributionData = updateManualAttribution(
+      'manualUuid2',
+      testManualData,
+      testTemporaryDisplayPackageInfo,
+      '/folder/child',
+      getCalculatePreferredOverOriginIds(resourceState),
+    );
+
+    const changedAttribution = newManualData.attributions['manualUuid2'];
+    expect(changedAttribution.preferred).toBe(true);
+    expect(changedAttribution.preferredOverOriginIds).toEqual(['originId']);
+  });
+
+  it('does not set preferred over origin ids if the isRelevantForPreferred flag is false', () => {
+    const testStore = createAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: { folder: { child: 1 } },
+          resourcesToExternalAttributions: {
+            '/folder/child': ['externalUuid'],
+          },
+          externalAttributions: {
+            externalUuid: {
+              source: { name: 'testSource', documentConfidence: 0 },
+              originIds: ['originId'],
+              criticality: Criticality.None,
+              id: 'externalUuid',
+            },
+          },
+          externalAttributionSources: {
+            testSource: {
+              name: 'Test source',
+              priority: 0,
+              isRelevantForPreferred: false,
+            },
+          },
+          manualAttributions: {
+            manualUuid2: {
+              criticality: Criticality.None,
+              id: 'manualUuid2',
+            },
+          },
+          resourcesToManualAttributions: {
+            '/folder/': ['manualUuid2'],
+          },
+        }),
+      ),
+    );
+    const resourceState = testStore.getState().resourceState;
+    const testManualData = getManualData(testStore.getState());
+    const testTemporaryDisplayPackageInfo: PackageInfo = {
+      id: 'manualUuid2',
+      preferred: true,
+      criticality: Criticality.None,
+    };
+
+    const newManualData: AttributionData = updateManualAttribution(
+      'manualUuid2',
+      testManualData,
+      testTemporaryDisplayPackageInfo,
+      '/folder/child',
+      getCalculatePreferredOverOriginIds(resourceState),
+    );
+
+    const changedAttribution = newManualData.attributions['manualUuid2'];
+    expect(changedAttribution.preferred).toBe(true);
+    expect(changedAttribution.preferredOverOriginIds).toHaveLength(0);
+  });
+
+  it('does not set preferred over origin ids if only the selected element has a manual attribution', () => {
+    const testStore = createAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: { folder: { child: 1 } },
+          resourcesToExternalAttributions: {
+            '/folder/child': ['externalUuid'],
+          },
+          externalAttributions: {
+            externalUuid: {
+              source: { name: 'testSource', documentConfidence: 0 },
+              originIds: ['originId'],
+              criticality: Criticality.None,
+              id: 'externalUuid',
+            },
+          },
+          externalAttributionSources: {
+            testSource: {
+              name: 'Test source',
+              priority: 0,
+              isRelevantForPreferred: true,
+            },
+          },
+          manualAttributions: {
+            manualUuid2: {
+              criticality: Criticality.None,
+              id: 'manualUuid2',
+            },
+          },
+          resourcesToManualAttributions: {
+            '/folder/child': ['manualUuid2'],
+          },
+        }),
+      ),
+    );
+    const resourceState = testStore.getState().resourceState;
+    const testManualData = getManualData(testStore.getState());
+    const testTemporaryDisplayPackageInfo: PackageInfo = {
+      id: 'manualUuid2',
+      preferred: true,
+      criticality: Criticality.None,
+    };
+
+    const newManualData: AttributionData = updateManualAttribution(
+      'manualUuid2',
+      testManualData,
+      testTemporaryDisplayPackageInfo,
+      '/folder/child',
+      getCalculatePreferredOverOriginIds(resourceState),
+    );
+
+    const changedAttribution = newManualData.attributions['manualUuid2'];
+    expect(changedAttribution.preferred).toBe(true);
+    expect(changedAttribution.preferredOverOriginIds).toBeFalsy();
+  });
+
+  it('takes the preferred over origin ids only from the higher manual attribution', () => {
+    const testStore = createAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: {
+            folder: {
+              file: 1,
+              folder2: {
+                child: 1,
+              },
+            },
+          },
+          resourcesToExternalAttributions: {
+            '/folder/folder2/child': ['externalUuid'],
+            '/folder/file1': ['externalUuid1'],
+          },
+          externalAttributions: {
+            externalUuid: {
+              source: { name: 'testSource', documentConfidence: 0 },
+              originIds: ['originId'],
+              criticality: Criticality.None,
+              id: 'externalUuid',
+            },
+            externalUuid1: {
+              source: { name: 'testSource1', documentConfidence: 0 },
+              originIds: ['originId1'],
+              criticality: Criticality.None,
+              id: 'externalUuid1',
+            },
+          },
+          externalAttributionSources: {
+            testSource: {
+              name: 'testSource',
+              priority: 0,
+              isRelevantForPreferred: true,
+            },
+            testSource1: {
+              name: 'testSource1',
+              priority: 0,
+              isRelevantForPreferred: true,
+            },
+          },
+          manualAttributions: {
+            manualUuid2: {
+              criticality: Criticality.None,
+              id: 'manualUuid2',
+            },
+            manualUuid1: {
+              criticality: Criticality.None,
+              id: 'manualUuid1',
+              preferred: true,
+            },
+          },
+          resourcesToManualAttributions: {
+            '/folder/': ['manualUuid1'],
+            '/folder/folder2/': ['manualUuid2'],
+          },
+        }),
+      ),
+    );
+    const resourceState = testStore.getState().resourceState;
+    const testManualData = getManualData(testStore.getState());
+    const testTemporaryDisplayPackageInfo: PackageInfo = {
+      id: 'manualUuid2',
+      preferred: true,
+      criticality: Criticality.None,
+    };
+
+    const newManualData: AttributionData = updateManualAttribution(
+      'manualUuid2',
+      testManualData,
+      testTemporaryDisplayPackageInfo,
+      '/folder/folder2/child',
+      getCalculatePreferredOverOriginIds(resourceState),
+    );
+
+    const changedAttribution = newManualData.attributions['manualUuid2'];
+    expect(changedAttribution.preferred).toBe(true);
+    expect(changedAttribution.preferredOverOriginIds).toBeFalsy();
+    const unchangedAttribution = newManualData.attributions['manualUuid1'];
+    expect(unchangedAttribution.preferredOverOriginIds).toEqual(['originId']);
+  });
+});

--- a/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
@@ -335,6 +335,8 @@ describe('The updateManualAttribution function', () => {
       testUuid,
       testManualData,
       testTemporaryDisplayPackageInfo,
+      '/something.js',
+      getCalculatePreferredOverOriginIds(initialResourceState),
     );
 
     expect(newManualData.attributions).toEqual({

--- a/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
@@ -349,6 +349,68 @@ describe('The updateManualAttribution function', () => {
       expectedManualAttributionsToResources,
     );
   });
+
+  it('sets a preferred flag to the manual attribution', () => {
+    const testStore = createAppStore();
+    testStore.dispatch(
+      loadFromFile(
+        getParsedInputFileEnrichedWithTestData({
+          resources: { child: 1 },
+          resourcesToExternalAttributions: {
+            '/child': ['externalUuid'],
+          },
+          externalAttributions: {
+            externalUuid: {
+              source: { name: 'testSource', documentConfidence: 0 },
+              originIds: ['originId'],
+              criticality: Criticality.None,
+              id: 'externalUuid',
+            },
+          },
+          externalAttributionSources: {
+            testSource: {
+              name: 'Test source',
+              priority: 0,
+              isRelevantForPreferred: true,
+            },
+          },
+          manualAttributions: {
+            manualUuid1: {
+              criticality: Criticality.None,
+              id: 'manualUuid1',
+            },
+            manualUuid2: {
+              criticality: Criticality.None,
+              id: 'manualUuid2',
+            },
+          },
+          resourcesToManualAttributions: {
+            '/': ['manualUuid1'],
+            '/child/': ['manualUuid2'],
+          },
+        }),
+      ),
+    );
+    const resourceState = testStore.getState().resourceState;
+    const testManualData = getManualData(testStore.getState());
+    const testTemporaryDisplayPackageInfo: PackageInfo = {
+      id: 'manualUuid2',
+      preferred: true,
+      criticality: Criticality.None,
+    };
+
+    const newManualData: AttributionData = updateManualAttribution(
+      'manualUuid1',
+      testManualData,
+      testTemporaryDisplayPackageInfo,
+      '/something.js',
+      getCalculatePreferredOverOriginIds(resourceState),
+    );
+
+    const changedAttribution = newManualData.attributions['manualUuid1'];
+    expect(changedAttribution.preferred).toBe(true);
+    expect(changedAttribution.preferredOverOriginIds).toEqual(['originId']);
+  });
 });
 
 describe('The linkToAttributionManualData function', () => {

--- a/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
+++ b/src/Frontend/state/helpers/__tests__/save-action-helpers.test.ts
@@ -349,68 +349,6 @@ describe('The updateManualAttribution function', () => {
       expectedManualAttributionsToResources,
     );
   });
-
-  it('sets a preferred flag to the manual attribution', () => {
-    const testStore = createAppStore();
-    testStore.dispatch(
-      loadFromFile(
-        getParsedInputFileEnrichedWithTestData({
-          resources: { child: 1 },
-          resourcesToExternalAttributions: {
-            '/child': ['externalUuid'],
-          },
-          externalAttributions: {
-            externalUuid: {
-              source: { name: 'testSource', documentConfidence: 0 },
-              originIds: ['originId'],
-              criticality: Criticality.None,
-              id: 'externalUuid',
-            },
-          },
-          externalAttributionSources: {
-            testSource: {
-              name: 'Test source',
-              priority: 0,
-              isRelevantForPreferred: true,
-            },
-          },
-          manualAttributions: {
-            manualUuid1: {
-              criticality: Criticality.None,
-              id: 'manualUuid1',
-            },
-            manualUuid2: {
-              criticality: Criticality.None,
-              id: 'manualUuid2',
-            },
-          },
-          resourcesToManualAttributions: {
-            '/': ['manualUuid1'],
-            '/child/': ['manualUuid2'],
-          },
-        }),
-      ),
-    );
-    const resourceState = testStore.getState().resourceState;
-    const testManualData = getManualData(testStore.getState());
-    const testTemporaryDisplayPackageInfo: PackageInfo = {
-      id: 'manualUuid2',
-      preferred: true,
-      criticality: Criticality.None,
-    };
-
-    const newManualData: AttributionData = updateManualAttribution(
-      'manualUuid1',
-      testManualData,
-      testTemporaryDisplayPackageInfo,
-      '/something.js',
-      getCalculatePreferredOverOriginIds(resourceState),
-    );
-
-    const changedAttribution = newManualData.attributions['manualUuid1'];
-    expect(changedAttribution.preferred).toBe(true);
-    expect(changedAttribution.preferredOverOriginIds).toEqual(['originId']);
-  });
 });
 
 describe('The linkToAttributionManualData function', () => {

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -90,8 +90,10 @@ export function updateManualAttribution(
   attributionIdToUpdate: string,
   manualData: AttributionData,
   packageInfo: PackageInfo,
+  selectedResource: string,
+  calculatePreferredOverOriginIds: CalculatePreferredOverOriginIds,
 ): AttributionData {
-  return {
+  const newManualData = {
     ...manualData,
     attributions: {
       ...manualData.attributions,
@@ -102,6 +104,13 @@ export function updateManualAttribution(
       },
     },
   };
+  recalculatePreferencesOfParents(
+    selectedResource,
+    newManualData,
+    calculatePreferredOverOriginIds,
+  );
+
+  return newManualData;
 }
 
 export function deleteManualAttribution(

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -93,7 +93,7 @@ export function updateManualAttribution(
   selectedResource: string,
   calculatePreferredOverOriginIds: CalculatePreferredOverOriginIds,
 ): AttributionData {
-  const newManualData = {
+  const newManualData: AttributionData = {
     ...manualData,
     attributions: {
       ...manualData.attributions,

--- a/src/Frontend/state/helpers/save-action-helpers.ts
+++ b/src/Frontend/state/helpers/save-action-helpers.ts
@@ -37,8 +37,6 @@ function calculateNewPackageInfo(
   selectedResourceId: string,
   manualData: AttributionData,
 ) {
-  console.log('calculateNewPackageInfo');
-  console.log(packageInfo);
   const newAttribution: PackageInfo = {
     ...getStrippedPackageInfo(packageInfo),
     criticality: Criticality.None,
@@ -50,7 +48,6 @@ function calculateNewPackageInfo(
       manualData.attributionsToResources,
     ).filter((value) => !packageInfo.originIds?.includes(value));
   }
-  console.log(newAttribution);
   return newAttribution;
 }
 
@@ -60,7 +57,6 @@ export function createManualAttribution(
   packageInfo: PackageInfo,
   calculatePreferredOverOriginIds: CalculatePreferredOverOriginIds,
 ): { newManualData: AttributionData; newAttributionId: string } {
-  console.log('createManualAttribution');
   const newAttributionId = uuid4();
 
   const attributionIdsOfSelectedResource: Array<string> = manualData
@@ -120,7 +116,6 @@ export function updateManualAttribution(
   selectedResource: string,
   calculatePreferredOverOriginIds: CalculatePreferredOverOriginIds,
 ): AttributionData {
-  console.log('updateManualAttribution');
   const newManualData: AttributionData = {
     ...manualData,
     attributions: {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -219,13 +219,11 @@ export const resourceState = (
       };
     }
     case ACTION_UPDATE_ATTRIBUTION: {
-      const attributionIdToUpdate = action.payload.attributionId;
-      const selectedResourceId = state.selectedResourceId;
       const manualData = updateManualAttribution(
-        attributionIdToUpdate,
+        action.payload.attributionId,
         state.manualData,
         action.payload.packageInfo,
-        selectedResourceId,
+        state.selectedResourceId,
         getCalculatePreferredOverOriginIds(state),
       );
       return {

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -219,12 +219,15 @@ export const resourceState = (
       };
     }
     case ACTION_UPDATE_ATTRIBUTION: {
+      const attributionIdToUpdate = action.payload.attributionId;
+      const selectedResourceId = state.selectedResourceId;
       const manualData = updateManualAttribution(
-        action.payload.attributionId,
+        attributionIdToUpdate,
         state.manualData,
         action.payload.packageInfo,
+        selectedResourceId,
+        getCalculatePreferredOverOriginIds(state),
       );
-
       return {
         ...state,
         manualData,

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -111,6 +111,7 @@ export const resourceState = (
   state: ResourceState = initialResourceState,
   action: ResourceAction,
 ): ResourceState => {
+  console.log(action);
   switch (action.type) {
     case ACTION_RESET_RESOURCE_STATE:
       return initialResourceState;

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -111,7 +111,6 @@ export const resourceState = (
   state: ResourceState = initialResourceState,
   action: ResourceAction,
 ): ResourceState => {
-  console.log(action);
   switch (action.type) {
     case ACTION_RESET_RESOURCE_STATE:
       return initialResourceState;


### PR DESCRIPTION
### Summary of changes
On attribution update, also check for changes in preferred status and update preferredOverOriginIds accordingly

### Context and reason for change

Currently, preferred over origin ids are not properly written to the output part of the opossum file

### How can the changes be tested

* Take an oppossum file
* Mark an attribution as preferred and safe
* Unzip the opossum file and check that preferredOverOriginIds are present in resulting output file

