### PR TITLE
fix: remove trailing slashes for paths to files with childern

### DIFF
--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -96,7 +96,7 @@ async function writeOutputJsonToFile(
   if (fileLoadedType === LoadedFileFormat.Opossum) {
     await writeOpossumFile({
       path: globalBackendState.opossumFilePath as string,
-      input: getGlobalBackendState().inputFileRaw,
+      input: globalBackendState.inputFileRaw,
       output: outputFileContent,
     });
   } else {

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -6,8 +6,10 @@
 import { isEmpty, isEqual } from 'lodash';
 
 import { Criticality, PackageInfo } from '../../../../shared/shared-types';
+import { correctFilePathsInResourcesMapping } from '../../../util/can-resource-have-children';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
+  getFilesWithChildren,
   getManualAttributions,
   getManualAttributionsToResources,
   getResolvedExternalAttributions,
@@ -97,7 +99,10 @@ export function saveManualAndResolvedAttributionsToFile(): AppThunkAction {
   return (_, getState) => {
     window.electronAPI.saveFile({
       manualAttributions: getManualAttributions(getState()),
-      resourcesToAttributions: getResourcesToManualAttributions(getState()),
+      resourcesToAttributions: correctFilePathsInResourcesMapping(
+        getResourcesToManualAttributions(getState()),
+        getFilesWithChildren(getState()),
+      ),
       resolvedExternalAttributions: getResolvedExternalAttributions(getState()),
     });
   };

--- a/src/Frontend/util/__tests__/can-have-children.test.ts
+++ b/src/Frontend/util/__tests__/can-have-children.test.ts
@@ -2,9 +2,13 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Resources } from '../../../shared/shared-types';
+import {
+  Resources,
+  ResourcesToAttributions,
+} from '../../../shared/shared-types';
 import {
   canResourceHaveChildren,
+  correctFilePathsInResourcesMapping,
   isIdOfResourceWithChildren,
 } from '../can-resource-have-children';
 
@@ -33,5 +37,41 @@ describe('isIdOfResourceWithChildren', () => {
     const testFilePath = '/some_folder/some_file';
 
     expect(isIdOfResourceWithChildren(testFilePath)).toBe(false);
+  });
+});
+
+describe('correctFilePathsInResourcesMapping', () => {
+  const testResourcesToAttributions: ResourcesToAttributions = {
+    '/file': ['id1'],
+    '/folder/': ['id2'],
+    '/folder/file2': ['id2', 'id3'],
+    '/fileWithChildren/': ['id4'],
+    '/fileWithChildren/file3': ['id4', 'id5'],
+  };
+  it('does nothing to paths not in files with children', () => {
+    const filesWithChildren = new Set<string>();
+    expect(
+      correctFilePathsInResourcesMapping(
+        testResourcesToAttributions,
+        filesWithChildren,
+      ),
+    ).toEqual(testResourcesToAttributions);
+  });
+
+  it('removes trailing slashes for files with children', () => {
+    const filesWithChildren = new Set(['/fileWithChildren']);
+
+    expect(
+      correctFilePathsInResourcesMapping(
+        testResourcesToAttributions,
+        filesWithChildren,
+      ),
+    ).toEqual({
+      '/file': ['id1'],
+      '/folder/': ['id2'],
+      '/folder/file2': ['id2', 'id3'],
+      '/fileWithChildren': ['id4'],
+      '/fileWithChildren/file3': ['id4', 'id5'],
+    });
   });
 });

--- a/src/Frontend/util/can-resource-have-children.ts
+++ b/src/Frontend/util/can-resource-have-children.ts
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Resources } from '../../shared/shared-types';
+import { mapKeys } from 'lodash';
+
+import { Resources, ResourcesToAttributions } from '../../shared/shared-types';
 
 export function canResourceHaveChildren(
   resource: Resources | 1 | undefined,
@@ -12,4 +14,19 @@ export function canResourceHaveChildren(
 
 export function isIdOfResourceWithChildren(resourceId: string): boolean {
   return resourceId.slice(-1) === '/';
+}
+
+export function correctFilePathsInResourcesMapping(
+  resourcesToAttributions: ResourcesToAttributions,
+  filesWithChildren: Set<string>,
+): ResourcesToAttributions {
+  // For legacy reasons, we need every resource that can have children to have a path that ends with '/' (see function above).
+  // However, when we write the resourceToAttribution mapping, then resources that are files with children should not
+  // have a trailing '/' in their path because that is inconsistent with the input file.
+  return mapKeys(resourcesToAttributions, (_, path) => {
+    if (path.endsWith('/') && filesWithChildren.has(path.slice(0, -1))) {
+      return path.slice(0, -1);
+    }
+    return path;
+  });
 }


### PR DESCRIPTION
### Summary of changes

Before writing the `resourcesToAttributions`  to the opossum output file, remove the trailing slashes for all paths that correspond to `filesWithChildren`.

### Context and reason for change
Currently, input and output formats are inconsistent: 
- In the input.json, we have paths in `resourcesToAttributions` with trailing slashes if and only if the resource is a folder. The list `filesWithChildren` contains the paths without trailing slashes accordingly.
- In the output.json, we write paths to files with children with a trailing slash as if they were a folder.

### How can the changes be tested
Open this file in OpossumUI and attach an attribution to `fileWithChildren.zip`, then inspect the `output.json` in the opossum file. Before this change it contains `"/fileWithChildren.zip/"` as path. After this change it contains `"/fileWithChildren.zip"`.