### PR TITLE
fix: normalize trailing slashes for files with children

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -274,7 +274,7 @@ describe('Test of loading function', () => {
         },
       },
       resourcesToAttributions: {
-        '/path/1': [testUuid],
+        '/folder/': [testUuid],
       },
       resolvedExternalAttributions: [],
     };
@@ -409,7 +409,7 @@ describe('Test of loading function', () => {
         },
       },
       resourcesToAttributions: {
-        '/path/1': [testUuid],
+        '/folder': [testUuid], // this folder is missing the trailing slash intentionally - it gets sanitized during loading
       },
       resolvedExternalAttributions: [],
     };
@@ -710,10 +710,10 @@ function assertFileLoadedCorrectly(testUuid: string): void {
         },
       },
       resourcesToAttributions: {
-        '/path/1': [testUuid],
+        '/folder/': [testUuid],
       },
       attributionsToResources: {
-        [testUuid]: ['/path/1'],
+        [testUuid]: ['/folder/'],
       },
     },
   };

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -34,6 +34,7 @@ import {
   parseOutputJsonFile,
 } from './parseFile';
 import {
+  addTrailingSlashIfAbsent,
   deserializeAttributions,
   getAttributionsToResources,
   mergeAttributions,
@@ -163,9 +164,20 @@ export async function loadInputAndOutputFromFilePath(
     }
   }
 
+  const filesWithChildrenSet = new Set(
+    parsedInputData.filesWithChildren?.map(addTrailingSlashIfAbsent),
+  );
+
+  processingStatusUpdater.info('Sanitizing map of resources to attributions');
+  const normalizedOutputResourcesToAttributions =
+    sanitizeResourcesToAttributions(
+      parsedInputData.resources,
+      parsedOutputData.resourcesToAttributions,
+    );
+
   processingStatusUpdater.info('Calculating attributions to resources');
   const manualAttributionsToResources = getAttributionsToResources(
-    parsedOutputData.resourcesToAttributions,
+    normalizedOutputResourcesToAttributions,
   );
 
   processingStatusUpdater.info('Deserializing attributions');
@@ -181,7 +193,7 @@ export async function loadInputAndOutputFromFilePath(
     config: configuration,
     manualAttributions: {
       attributions: manualAttributions,
-      resourcesToAttributions: parsedOutputData.resourcesToAttributions,
+      resourcesToAttributions: normalizedOutputResourcesToAttributions,
       attributionsToResources: manualAttributionsToResources,
     },
     externalAttributions: {
@@ -194,7 +206,7 @@ export async function loadInputAndOutputFromFilePath(
       parsedOutputData.resolvedExternalAttributions,
     ),
     attributionBreakpoints: new Set(parsedInputData.attributionBreakpoints),
-    filesWithChildren: new Set(parsedInputData.filesWithChildren),
+    filesWithChildren: filesWithChildrenSet,
     baseUrlsForSources: sanitizeRawBaseUrlsForSources(
       parsedInputData.baseUrlsForSources,
     ),

--- a/src/ElectronBackend/input/parseInputData.ts
+++ b/src/ElectronBackend/input/parseInputData.ts
@@ -22,7 +22,7 @@ import {
 } from '../../shared/shared-types';
 import { RawFrequentLicense } from '../types/types';
 
-function addTrailingSlashIfAbsent(resourcePath: string): string {
+export function addTrailingSlashIfAbsent(resourcePath: string): string {
   return resourcePath.endsWith('/') ? resourcePath : resourcePath.concat('/');
 }
 
@@ -63,12 +63,16 @@ export function sanitizeResourcesToAttributions(
         accumulatedResult: Array<[string, Array<string>]>,
         [path, attributions],
       ) => {
-        const pathWithSlashes = addTrailingSlashIfAbsent(path);
+        const pathWithSlash = addTrailingSlashIfAbsent(path);
+        const pathWithoutSlash = pathWithSlash.slice(
+          0,
+          pathWithSlash.length - 1,
+        );
 
-        if (allResourcePaths.has(path)) {
-          accumulatedResult.push([path, attributions]);
-        } else if (allResourcePaths.has(pathWithSlashes)) {
-          accumulatedResult.push([pathWithSlashes, attributions]);
+        if (allResourcePaths.has(pathWithSlash)) {
+          accumulatedResult.push([pathWithSlash, attributions]);
+        } else if (allResourcePaths.has(pathWithoutSlash)) {
+          accumulatedResult.push([pathWithoutSlash, attributions]);
         }
 
         return accumulatedResult;

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -6,7 +6,7 @@
 import { isEmpty, isEqual } from 'lodash';
 
 import { Criticality, PackageInfo } from '../../../../shared/shared-types';
-import { correctFilePathsInResourcesMapping } from '../../../util/can-resource-have-children';
+import { correctFilePathsInResourcesMappingForOutput } from '../../../util/can-resource-have-children';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
   getFilesWithChildren,
@@ -99,7 +99,7 @@ export function saveManualAndResolvedAttributionsToFile(): AppThunkAction {
   return (_, getState) => {
     window.electronAPI.saveFile({
       manualAttributions: getManualAttributions(getState()),
-      resourcesToAttributions: correctFilePathsInResourcesMapping(
+      resourcesToAttributions: correctFilePathsInResourcesMappingForOutput(
         getResourcesToManualAttributions(getState()),
         getFilesWithChildren(getState()),
       ),

--- a/src/Frontend/util/__tests__/can-have-children.test.ts
+++ b/src/Frontend/util/__tests__/can-have-children.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../shared/shared-types';
 import {
   canResourceHaveChildren,
-  correctFilePathsInResourcesMapping,
+  correctFilePathsInResourcesMappingForOutput,
   isIdOfResourceWithChildren,
 } from '../can-resource-have-children';
 
@@ -40,7 +40,7 @@ describe('isIdOfResourceWithChildren', () => {
   });
 });
 
-describe('correctFilePathsInResourcesMapping', () => {
+describe('correctFilePathsInResourcesMappingForOutput', () => {
   const testResourcesToAttributions: ResourcesToAttributions = {
     '/file': ['id1'],
     '/folder/': ['id2'],
@@ -51,7 +51,7 @@ describe('correctFilePathsInResourcesMapping', () => {
   it('does nothing to paths not in files with children', () => {
     const filesWithChildren = new Set<string>();
     expect(
-      correctFilePathsInResourcesMapping(
+      correctFilePathsInResourcesMappingForOutput(
         testResourcesToAttributions,
         filesWithChildren,
       ),
@@ -59,10 +59,10 @@ describe('correctFilePathsInResourcesMapping', () => {
   });
 
   it('removes trailing slashes for files with children', () => {
-    const filesWithChildren = new Set(['/fileWithChildren']);
+    const filesWithChildren = new Set(['/fileWithChildren/']);
 
     expect(
-      correctFilePathsInResourcesMapping(
+      correctFilePathsInResourcesMappingForOutput(
         testResourcesToAttributions,
         filesWithChildren,
       ),

--- a/src/Frontend/util/can-resource-have-children.ts
+++ b/src/Frontend/util/can-resource-have-children.ts
@@ -16,15 +16,16 @@ export function isIdOfResourceWithChildren(resourceId: string): boolean {
   return resourceId.slice(-1) === '/';
 }
 
-export function correctFilePathsInResourcesMapping(
+export function correctFilePathsInResourcesMappingForOutput(
   resourcesToAttributions: ResourcesToAttributions,
   filesWithChildren: Set<string>,
 ): ResourcesToAttributions {
   // For legacy reasons, we need every resource that can have children to have a path that ends with '/' (see function above).
   // However, when we write the resourceToAttribution mapping, then resources that are files with children should not
   // have a trailing '/' in their path because that is inconsistent with the input file.
+
   return mapKeys(resourcesToAttributions, (_, path) => {
-    if (path.endsWith('/') && filesWithChildren.has(path.slice(0, -1))) {
+    if (filesWithChildren.has(path)) {
       return path.slice(0, -1);
     }
     return path;


### PR DESCRIPTION
### Summary of changes

This PR adds more sanitization/normalization to the input:
- paths in `filesWithChildren` are normalized to end with a slash
- path from `resourceToAttributions` from the output file get the same sanitization as `resourcesToAttributions` in the input file

### Context and reason for change

OpossumUI is quite fragile w.r.t. to paths in .opossum files. Especially confusing are the requirements of resourcesToAttributions (sanitized, so it does not matter if paths have trailing slashes or not) and filesWithChildren (requires a trailing slash although it is a file). After the last change in #2912 OpossumUI does not properly parse its own .opossum files.

### How can the changes be tested
Open a file that has filesWithChildren, add an attribution to the file with children and then reopen the file. Everything should work.
[fwc_slash_atr_noslash.zip](https://github.com/user-attachments/files/21714272/fwc_slash_atr_noslash.zip)

