### PR TITLE
fix: multiple concurrent saves on bulk delete of attributions

### DIFF
--- a/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
@@ -8,7 +8,7 @@ import { compact, uniq } from 'lodash';
 
 import { text } from '../../../shared/text';
 import {
-  deleteAttributionAndSave,
+  deleteAttributionsAndSave,
   unlinkAttributionAndSave,
 } from '../../state/actions/resource-actions/save-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
@@ -55,9 +55,9 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
     );
 
   const handleDelete = () => {
-    attributionIdsToDelete.forEach((attributionId) => {
-      dispatch(deleteAttributionAndSave(attributionId, selectedAttributionId));
-    });
+    dispatch(
+      deleteAttributionsAndSave(attributionIdsToDelete, selectedAttributionId),
+    );
     onClose();
   };
 

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { isEmpty, isEqual } from 'lodash';
 
-import { Criticality, PackageInfo } from '../../../../shared/shared-types';
+import { PackageInfo } from '../../../../shared/shared-types';
 import { correctFilePathsInResourcesMappingForOutput } from '../../../util/can-resource-have-children';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
@@ -153,21 +153,19 @@ export function addToSelectedResource(
   };
 }
 
-export function deleteAttributionAndSave(
-  attributionId: string,
-  selectedAttributionId?: string,
+export function deleteAttributionsAndSave(
+  attributionIds: Array<string>,
+  selectedAttributionId: string,
 ): AppThunkAction {
   return (dispatch) => {
-    dispatch(
-      savePackageInfo(
-        null,
-        attributionId,
-        { criticality: Criticality.None, id: attributionId },
-        selectedAttributionId
-          ? attributionId !== selectedAttributionId
-          : undefined,
-      ),
-    );
+    attributionIds.forEach((attributionId) => {
+      dispatch(deleteAttribution(attributionId));
+    });
+    if (attributionIds.includes(selectedAttributionId)) {
+      dispatch(setSelectedAttributionId(''));
+      dispatch(resetTemporaryDisplayPackageInfo());
+    }
+    dispatch(saveManualAndResolvedAttributionsToFile());
   };
 }
 


### PR DESCRIPTION
Before this commit, deleting multiple attributions lead to concurring save operations which could lead to problems with the saving and a crash of the OpossumUI. This needs to be fixed.

### Summary of changes

A bulk operation is introduced which saves only once after all state changes have been processed.

### Context and reason for change

Bug as described above

### How can the changes be tested

Load a significantly large `.opossum` file and delete ~20 attributions in one go (just select a folder and use apply to all)

Caution: Larger operations can still take a very long time and can get stuck eventually. The good thing is that in this case the `.opossum` file is not modified so you can just restart OpossumUI and retry.
