### PR TITLE
fix: do not parse opossum file twice

### DIFF
--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -22,7 +22,6 @@ import {
   InvalidDotOpossumFileError,
   JsonParsingError,
   OpossumOutputFile,
-  ParsedOpossumInputAndOutput,
   ParsedOpossumInputFile,
   ParsedOpossumOutputFile,
 } from '../types/types';
@@ -237,11 +236,7 @@ async function createOutputInOpossumFile(
     input: getGlobalBackendState().inputFileRaw,
     output: attributionJSON,
   });
-  processingStatusUpdater.info('Parsing output');
-  const parsingResult = (await parseOpossumFile(
-    filePath,
-  )) as ParsedOpossumInputAndOutput;
-  return parsingResult.output as ParsedOpossumOutputFile;
+  return attributionJSON as ParsedOpossumOutputFile;
 }
 
 async function parseOrCreateOutputJsonFile(


### PR DESCRIPTION


### Summary of changes

Reuse the freshly generated opossum output data instead of parsing the opossum file again.

### Context and reason for change

Before this change, for opossum files that contain no output part, we would create one, write it out and then parse the whole file again.  This commit instead uses the generated data directly (but still writes it out of course).

### How can the changes be tested

Open a reasonably large opossum file that does not contain an output section already and compare the times. I got these times for an opossum file with ~8.5MB (before opening):

**OLD: 16.2s**
```
15:45:54.333 › Initializing global backend state
15:45:54.340 › Reading file example_2-no-output-old.opossum
15:45:58.574 › Sanitizing map of resources to signals
15:45:58.907 › Deserializing signals
15:45:58.934 › Calculating signals to resources
15:45:59.050 › Merging similar signals
15:46:00.097 › Parsing frequent licenses from input
15:46:00.098 › Checking and converting configuration
15:46:00.105 › Creating output file
15:46:00.105 › Preparing output
15:46:01.472 › Parsing output
15:46:06.236 › Sanitizing map of resources to attributions
15:46:06.457 › Calculating attributions to resources
15:46:06.516 › Deserializing attributions
15:46:10.117 › Sending data to user interface
15:46:10.557 › Finalizing global state
```

**NEW: 11.4s**
```
15:44:00.773 › Initializing global backend state
15:44:00.779 › Reading file example_2-no-output-new.opossum
15:44:05.121 › Sanitizing map of resources to signals
15:44:05.418 › Deserializing signals
15:44:05.445 › Calculating signals to resources
15:44:05.567 › Merging similar signals
15:44:06.628 › Parsing frequent licenses from input
15:44:06.628 › Checking and converting configuration
15:44:06.632 › Creating output file
15:44:06.632 › Preparing output
15:44:08.001 › Sanitizing map of resources to attributions
15:44:08.262 › Calculating attributions to resources
15:44:08.311 › Deserializing attributions
15:44:11.892 › Sending data to user interface
15:44:12.326 › Finalizing global state
```

