### PR TITLE
docs: update 'how to contribute' guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,11 @@ Clone the OpossumUI repo. E.g. run the following command in a terminal:
 git clone git@github.com:opossum-tool/OpossumUI.git
 ```
 
+In order to download opossum files for development, you will need to add a
+github token to you env. Copy `.env.sample` to a new file called `.env`.
+Generate a token from https://github.com/settings/tokens, with a lifetime no
+longer than 1 year, and add it to the `.env` file.
+
 To install dependencies and set up the working environment, go to the repository root directory and run:
 
 ```bash


### PR DESCRIPTION
### Summary of changes

Add instructions on how to set up your .env file to CONTRIBUTING.md. 

### Context and reason for change

I set up the repo on a new laptop recently and encountered these error messages when running `yarn install`:
```
Error: API rate limit exceeded for 193.30.133.7. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
    at downloadOpossumFile (file:///home/mobendrauf/OpossumUI/tools/downloadOpossumFile.mjs:54:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async file:///home/mobendrauf/OpossumUI/tools/downloadOpossumFile.mjs:85:1
```
and
```
Error: The 'opossum-tool' organization forbids access via a fine-grained personal access tokens if the token's lifetime is greater than 366 days. Please adjust your token's lifetime at the following URL: https://github.com/settings/personal-access-tokens/9489005
    at downloadOpossumFile (file:///home/mobendrauf/OpossumUI/tools/downloadOpossumFile.mjs:54:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async file:///home/mobendrauf/OpossumUI/tools/downloadOpossumFile.mjs:85:1
```

The updated CONTRIBUTING.md gives instructions on how to fix this.