### PR TITLE
feat: add url validation logic

### DIFF
--- a/src/Frontend/util/__tests__/input-validation.test.ts
+++ b/src/Frontend/util/__tests__/input-validation.test.ts
@@ -54,6 +54,13 @@ describe('isPackageInvalid', () => {
   });
 
   describe('URL validation', () => {
+    it('returns false for URLs with ports', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'http://example.com:8080/repo',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(false);
+    });
+
     it('returns false for valid URLs with https protocol', () => {
       const packageInfo = faker.opossum.packageInfo({
         url: 'https://github.com/example/repo',
@@ -113,6 +120,41 @@ describe('isPackageInvalid', () => {
     it('returns true for localhost URLs', () => {
       const packageInfo = faker.opossum.packageInfo({
         url: 'http://localhost:3000',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(true);
+    });
+
+    it('returns true for URLs with non-http/https protocols', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'ftp://example.com/repo',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(true);
+    });
+
+    it('returns true for git protocol URLs', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'git://example.com/repo.git',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(true);
+    });
+
+    it('returns true for file protocol URLs', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'file:///path/to/repo',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(true);
+    });
+
+    it('returns true for IP addresses', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'http://192.168.1.1/repo',
+      });
+      expect(isPackageInvalid(packageInfo)).toBe(true);
+    });
+
+    it('returns true for IPv6 addresses', () => {
+      const packageInfo = faker.opossum.packageInfo({
+        url: 'http://[2001:db8::1]/repo',
       });
       expect(isPackageInvalid(packageInfo)).toBe(true);
     });


### PR DESCRIPTION
 ### Summary of changes

This PR adds validation logic that checks whether the input can be parsed as an URL with some best effort adjustments. Note that this does not break opossum files that already contain bad data. The field will be highlighted but one can still convert a signal to an attribution. Only if the user edits some field, they will need to correct the bad URL in order to proceed.


### Context and reason for change

Previously, the URL field did not have any validation logic.

### How can the changes be tested

- There are unit tests: `yarn test:unit input-validation.test.ts`
- Here is a test file (download -> rename to .opossum) containing two files with one signal each. One has a valid URL the other doesn't. Check out that the workflow works as intended (opossum file opens, signal can be converted to attribution, but upon edits, the URL needs to be corrected)
[test_url_validation.zip](https://github.com/user-attachments/files/23353428/test_url_validation.zip)