### PR TITLE
feat: multi-edit auditing options

### DIFF
--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsPanel.tsx
@@ -22,6 +22,7 @@ import { ConfirmButton } from './ConfirmButton/ConfirmButton';
 import { CreateButton } from './CreateButton/CreateButton';
 import { DeleteButton } from './DeleteButton/DeleteButton';
 import { LinkButton } from './LinkButton/LinkButton';
+import { MoreActionsButton } from './MoreActionsButton/MoreActionsButton';
 import { ReplaceButton } from './ReplaceButton/ReplaceButton';
 
 export function AttributionsPanel() {
@@ -73,6 +74,7 @@ export function AttributionsPanel() {
           <ConfirmButton {...props} />
           <ReplaceButton {...props} />
           <DeleteButton {...props} />
+          <MoreActionsButton {...props} />
         </>
       )}
       useFilteredData={useFilteredAttributions}

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/MoreActionsButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/MoreActionsButton.tsx
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import MuiIconButton from '@mui/material/IconButton';
+import MuiTooltip from '@mui/material/Tooltip';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Attributions, PackageInfo } from '../../../../../shared/shared-types';
+import { text } from '../../../../../shared/text';
+import { updateAttributionsAndSave } from '../../../../state/actions/resource-actions/save-actions';
+import { useAppDispatch } from '../../../../state/hooks';
+import { useAttributionIdsForReplacement } from '../../../../state/variables/use-attribution-ids-for-replacement';
+import {
+  ExcludeFromNoticeIcon,
+  FollowUpIcon,
+  NeedsReviewIcon,
+} from '../../../Icons/Icons';
+import { SelectMenu, SelectMenuOption } from '../../../SelectMenu/SelectMenu';
+import { PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPanel';
+
+type UpdatablePropertyType = keyof Pick<
+  PackageInfo,
+  'needsReview' | 'followUp' | 'excludeFromNotice'
+>;
+
+interface MenuItemConfig {
+  property: UpdatablePropertyType;
+  icon: React.ReactElement;
+}
+
+const menuItemConfigs: Array<MenuItemConfig> = [
+  {
+    property: 'needsReview',
+    icon: <NeedsReviewIcon />,
+  },
+  {
+    property: 'followUp',
+    icon: <FollowUpIcon />,
+  },
+  {
+    property: 'excludeFromNotice',
+    icon: <ExcludeFromNoticeIcon />,
+  },
+];
+
+export const MoreActionsButton: React.FC<PackagesPanelChildrenProps> = ({
+  attributions,
+  selectedAttributionIds,
+}) => {
+  const dispatch = useAppDispatch();
+  const [attributionIdsForReplacement] = useAttributionIdsForReplacement();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(undefined);
+  };
+
+  const propertyStates = useMemo(() => {
+    const checkProperty = (property: UpdatablePropertyType): boolean => {
+      if (
+        !attributions ||
+        !selectedAttributionIds.length ||
+        selectedAttributionIds.some((id) => !attributions[id])
+      ) {
+        return false;
+      }
+
+      return selectedAttributionIds.every((id) => attributions[id]?.[property]);
+    };
+
+    return {
+      needsReview: checkProperty('needsReview'),
+      followUp: checkProperty('followUp'),
+      excludeFromNotice: checkProperty('excludeFromNotice'),
+    };
+  }, [attributions, selectedAttributionIds]);
+
+  const getMenuItemText = useCallback(
+    (property: UpdatablePropertyType): string => {
+      const isSet = propertyStates[property];
+      const baseText = (
+        {
+          needsReview: text.auditingOptions.needsReview,
+          followUp: text.auditingOptions.followUp,
+          excludeFromNotice: text.auditingOptions.excludedFromNotice,
+        } satisfies Record<UpdatablePropertyType, string>
+      )[property];
+      return isSet ? `Unmark as ${baseText}` : `Mark as ${baseText}`;
+    },
+    [propertyStates],
+  );
+
+  const handlePropertyToggle = useCallback(
+    (property: UpdatablePropertyType) => {
+      if (!attributions) {
+        return;
+      }
+
+      const newState = !propertyStates[property];
+
+      const updatedAttributions = selectedAttributionIds.reduce(
+        (acc, attributionId) => {
+          const attribution = attributions[attributionId];
+          acc[attributionId] = {
+            ...attribution,
+            [property]: newState,
+          };
+          return acc;
+        },
+        {} as Attributions,
+      );
+
+      dispatch(updateAttributionsAndSave(updatedAttributions));
+
+      handleClose();
+    },
+    [attributions, dispatch, selectedAttributionIds, propertyStates],
+  );
+
+  const menuOptions = useMemo<Array<SelectMenuOption>>(
+    () =>
+      menuItemConfigs.map((config) => ({
+        id: config.property,
+        label: getMenuItemText(config.property),
+        icon: config.icon,
+        selected: false, // No checkmarks for action menu
+        onAdd: () => handlePropertyToggle(config.property),
+      })),
+    [getMenuItemText, handlePropertyToggle],
+  );
+
+  return (
+    <>
+      <MuiIconButton
+        aria-label={text.packageLists.moreActions}
+        disabled={
+          !selectedAttributionIds.length ||
+          !!attributionIdsForReplacement.length
+        }
+        onClick={handleClick}
+        size={'small'}
+      >
+        <MuiTooltip
+          title={text.packageLists.moreActions}
+          disableInteractive
+          placement={'top'}
+        >
+          <MoreHorizIcon />
+        </MuiTooltip>
+      </MuiIconButton>
+      <SelectMenu
+        anchorEl={anchorEl}
+        anchorPosition="center"
+        options={menuOptions}
+        setAnchorEl={setAnchorEl}
+      />
+    </>
+  );
+};

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/__tests__/MoreActionsButton.test.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/__tests__/MoreActionsButton.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { text } from '../../../../../../shared/text';
+import { faker } from '../../../../../../testing/Faker';
+import { renderComponent } from '../../../../../test-helpers/render';
+import { PackagesPanelChildrenProps } from '../../../PackagesPanel/PackagesPanel';
+import { MoreActionsButton } from '../MoreActionsButton';
+
+describe('MoreActionsButton', () => {
+  const mockSetMultiSelectedAttributionIds = jest.fn();
+
+  const defaultProps: PackagesPanelChildrenProps = {
+    activeAttributionIds: ['attr1', 'attr2'],
+    activeRelation: 'children',
+    attributionIds: ['attr1', 'attr2'],
+    attributions: {
+      attr1: faker.opossum.packageInfo({
+        id: 'attr1',
+        needsReview: false,
+        followUp: false,
+        excludeFromNotice: false,
+      }),
+      attr2: faker.opossum.packageInfo({
+        id: 'attr2',
+        needsReview: true,
+        followUp: false,
+        excludeFromNotice: false,
+      }),
+    },
+    contentHeight: '100px',
+    loading: false,
+    multiSelectedAttributionIds: ['attr1', 'attr2'],
+    selectedAttributionId: 'attr1',
+    selectedAttributionIds: ['attr1', 'attr2'],
+    setMultiSelectedAttributionIds: mockSetMultiSelectedAttributionIds,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the more actions button', () => {
+    renderComponent(<MoreActionsButton {...defaultProps} />);
+
+    expect(
+      screen.getByRole('button', { name: text.packageLists.moreActions }),
+    ).toBeInTheDocument();
+  });
+
+  it('is disabled when no attributions are selected', () => {
+    const props = {
+      ...defaultProps,
+      selectedAttributionIds: [],
+    };
+
+    renderComponent(<MoreActionsButton {...props} />);
+
+    expect(
+      screen.getByRole('button', { name: text.packageLists.moreActions }),
+    ).toBeDisabled();
+  });
+
+  it('opens menu when clicked', async () => {
+    const user = userEvent.setup();
+    renderComponent(<MoreActionsButton {...defaultProps} />);
+
+    const button = screen.getByRole('button', {
+      name: text.packageLists.moreActions,
+    });
+    await user.click(button);
+
+    expect(screen.getByText('Mark as Needs Review by QA')).toBeInTheDocument();
+    expect(screen.getByText('Mark as Needs Follow-Up')).toBeInTheDocument();
+    expect(
+      screen.getByText('Mark as Excluded from Notice'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows correct text when all selected attributions have needsReview', async () => {
+    const user = userEvent.setup();
+    const props = {
+      ...defaultProps,
+      attributions: {
+        attr1: faker.opossum.packageInfo({
+          id: 'attr1',
+          needsReview: true,
+        }),
+        attr2: faker.opossum.packageInfo({
+          id: 'attr2',
+          needsReview: true,
+        }),
+      },
+    };
+
+    renderComponent(<MoreActionsButton {...props} />);
+
+    const button = screen.getByRole('button', {
+      name: text.packageLists.moreActions,
+    });
+    await user.click(button);
+
+    expect(
+      screen.getByText('Unmark as Needs Review by QA'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { isEmpty, isEqual } from 'lodash';
 
-import { PackageInfo } from '../../../../shared/shared-types';
+import { Attributions, PackageInfo } from '../../../../shared/shared-types';
 import { correctFilePathsInResourcesMappingForOutput } from '../../../util/can-resource-have-children';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
@@ -183,6 +183,27 @@ export function removeResolvedExternalAttributionAndSave(
 ): AppThunkAction {
   return (dispatch) => {
     dispatch(removeResolvedExternalAttributions(attributionIds));
+    dispatch(saveManualAndResolvedAttributionsToFile());
+  };
+}
+
+export function updateAttributionsAndSave(
+  updatedAttributions: Attributions,
+): AppThunkAction {
+  return (dispatch, getState) => {
+    const selectedAttributionId = getSelectedAttributionId(getState());
+
+    Object.entries(updatedAttributions).forEach(
+      ([attributionId, updatedPackageInfo]) => {
+        dispatch(updateAttribution(attributionId, updatedPackageInfo, false));
+      },
+    );
+
+    // Reset temporary display package info if the currently selected attribution was updated
+    if (Object.keys(updatedAttributions).includes(selectedAttributionId)) {
+      dispatch(resetTemporaryDisplayPackageInfo());
+    }
+
     dispatch(saveManualAndResolvedAttributionsToFile());
   };
 }

--- a/src/shared/shared-constants.ts
+++ b/src/shared/shared-constants.ts
@@ -6,7 +6,7 @@ import { UserSettings } from './shared-types';
 
 export const DEFAULT_PANEL_SIZES: NonNullable<UserSettings['panelSizes']> = {
   resourceBrowserWidth: 340,
-  packageListsWidth: 340,
+  packageListsWidth: 360,
   linkedResourcesPanelHeight: null,
   signalsPanelHeight: null,
 };

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -148,6 +148,7 @@ export const text = {
     showDeleted: 'Show deleted',
     signal: 'signal',
     signalsPanelTitle: 'Signals',
+    moreActions: 'More actions',
   },
   buttons: {
     cancel: 'Cancel',


### PR DESCRIPTION
### Summary of changes

Extend the multi-select options with a new menu that allows a user to toggle the auditing options (needs follow-up, needs review, exclude from notice) of all selected attributions.

<img width="900" height="452" alt="image" src="https://github.com/user-attachments/assets/e2269cf9-6d50-4a57-9d72-fd8428d52cde" />

### Context and reason for change

Our users requested to be able to apply "Needs follow-up" and "Exclude from notice" to many attributions at once.

### How can the changes be tested

Open a file in OpossumUI and try out the feature.
