### PR TITLE
feat: improve package typeahead

### DIFF
--- a/src/Frontend/Components/AttributionForm/PackageSubPanel/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionForm/PackageSubPanel/PackageSubPanel.tsx
@@ -28,24 +28,30 @@ import { AttributionFormConfig } from '../AttributionForm';
 import { attributionColumnClasses } from '../AttributionForm.style';
 import { PackageAutocomplete } from '../PackageAutocomplete/PackageAutocomplete';
 
-/** https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst */
+/** https://github.com/package-url/purl-spec/blob/main/purl-types-index.json */
 const COMMON_PACKAGE_TYPES = [
+  'alpm',
+  'apk',
+  'bazel',
   'bitbucket',
+  'bitnami',
   'cargo',
+  'cocoapods',
   'composer',
   'conan',
   'conda',
+  'cpan',
   'cran',
   'deb',
   'docker',
   'gem',
-  'generic',
   'github',
-  'gitlab',
   'golang',
   'hackage',
   'hex',
   'huggingface',
+  'julia',
+  'luarocks',
   'maven',
   'mlflow',
   'npm',
@@ -54,7 +60,6 @@ const COMMON_PACKAGE_TYPES = [
   'pub',
   'pypi',
   'qpkg',
-  'rpm',
   'rpm',
   'swid',
   'swift',


### PR DESCRIPTION
### Summary of changes

Updated default package typeahed entries by syncing with the purl specification.

Removed generic from the list as a putting a more specific type should be encouraged.

### Context and reason for change

The current list featured a few entries which were no longer up to date as well as one duplicate entry.

### How can the changes be tested

* Start OpossumUI and open an OpossumFile
* Select any attribution and edit the type field
* Watch the typeahead
