### PR TITLE
chore: fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,5 +198,8 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.12.0",
+  "resolutions": {
+    "dpdm/glob": "^10.5.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8609,9 +8609,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.12, glob@npm:^10.3.4":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.12, glob@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^3.1.2"
@@ -8621,7 +8621,7 @@ __metadata:
     path-scurry: "npm:^1.11.1"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10/698dfe11828b7efd0514cd11e573eaed26b2dff611f0400907281ce3eab0c1e56143ef9b35adc7c77ecc71fba74717b510c7c223d34ca8a98ec81777b293d4ac
+  checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary of changes

Fix a vulnerability detected by socket.dev.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins dpdm’s glob dependency to 10.5.0 and updates the lockfile accordingly.
> 
> - **Dependencies**:
>   - Add `resolutions` in `package.json` to pin `dpdm/glob` to `^10.5.0`.
> - **Lockfile**:
>   - Update `glob` to `10.5.0` and adjust resolution entries/checksum in `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5035cb81b6ddfc5fd4fccba5f4fed1dfe770ab38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->