### PR TITLE
feat: readd generic

### DIFF
--- a/src/Frontend/Components/AttributionForm/PackageSubPanel/PackageSubPanel.tsx
+++ b/src/Frontend/Components/AttributionForm/PackageSubPanel/PackageSubPanel.tsx
@@ -45,6 +45,7 @@ const COMMON_PACKAGE_TYPES = [
   'deb',
   'docker',
   'gem',
+  'generic',
   'github',
   'golang',
   'hackage',


### PR DESCRIPTION
### Summary of changes

Re-add generic to typeahead in order to avoid typos when entering it

### Context and reason for change

We want to keep it as it is part of the purl specification

### How can the changes be tested

Start opossum ui, open a package and look for the type typeahead
