### PR TITLE
chore: mark originId field as deprecated in output schema

### DIFF
--- a/src/ElectronBackend/input/OpossumOutputFileSchema.json
+++ b/src/ElectronBackend/input/OpossumOutputFileSchema.json
@@ -97,7 +97,8 @@
           },
           "originId": {
             "type": "string",
-            "description": "Can be set to track a signal from the tooling that generated the input file. Copied from the input file"
+            "description": "Deprecated - Use originIds instead. Can be set to track a signal from the tooling that generated the input file. Copied from the input file",
+            "deprecated": true
           },
           "originIds": {
             "type": "array",


### PR DESCRIPTION
### Summary of changes

see title

### Context and reason for change

This is already included in `OpossumInputFileSchema.json` but was never added to the `OpossumOutputFileSchema.json`
