### PR TITLE
fix/handle-file-not-found-errors

### DIFF
--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -21,13 +21,17 @@ import {
   setGlobalBackendState,
 } from '../../main/globalBackendState';
 import {
+  FileNotFoundError,
   JsonParsingError,
   OpossumOutputFile,
   ParsedOpossumInputFile,
+  UnzipError,
 } from '../../types/types';
 import {
+  getMessageBoxForFileNotFoundError,
   getMessageBoxForInvalidDotOpossumFileError,
   getMessageBoxForParsingError,
+  getMessageBoxForUnzipError,
   loadInputAndOutputFromFilePath,
 } from '../importFromFile';
 
@@ -810,6 +814,46 @@ describe('getMessageBoxForParsingError', () => {
         type: 'error',
         message: 'Error parsing the input file.',
         detail: `parsingErrorMessage\n${text.errorBoundary.outdatedAppVersion}`,
+        buttons: ['OK'],
+      }),
+    );
+  });
+});
+
+describe('getMessageBoxForFileNotFoundError', () => {
+  it('returns a messageBox', async () => {
+    const fileNotFoundError: FileNotFoundError = {
+      message: 'fileNotFoundErrorMessage',
+      type: 'fileNotFoundError',
+    };
+
+    await getMessageBoxForFileNotFoundError(fileNotFoundError.message);
+
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: 'An error occurred while trying to open the file.',
+        detail: 'fileNotFoundErrorMessage',
+        buttons: ['OK'],
+      }),
+    );
+  });
+});
+
+describe('getMessageBoxForUnzipError', () => {
+  it('returns a messageBox', async () => {
+    const unzipError: UnzipError = {
+      message: 'unzipErrorMessage',
+      type: 'unzipError',
+    };
+
+    await getMessageBoxForUnzipError(unzipError.message);
+
+    expect(dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: 'An error occurred while trying to unzip the file.',
+        detail: 'unzipErrorMessage',
         buttons: ['OK'],
       }),
     );

--- a/src/ElectronBackend/input/importFromFile.ts
+++ b/src/ElectronBackend/input/importFromFile.ts
@@ -60,8 +60,12 @@ async function handleParsingError(
 ) {
   processingStatusUpdater.info('Invalid input file');
   switch (parsingError.type) {
-    case 'unZippingError':
+    case 'unzipError':
+      await getMessageBoxForUnzipError(parsingError.message);
+      return;
     case 'fileNotFoundError':
+      await getMessageBoxForFileNotFoundError(parsingError.message);
+      return;
     case 'jsonParsingError':
       await getMessageBoxForParsingError(parsingError.message);
       return;
@@ -343,6 +347,32 @@ export async function getMessageBoxForParsingError(
     title: 'Parsing Error',
     message: 'Error parsing the input file.',
     detail: `${errorMessage}\n${text.errorBoundary.outdatedAppVersion}`,
+  });
+}
+
+export async function getMessageBoxForFileNotFoundError(
+  errorMessage: string,
+): Promise<void> {
+  await dialog.showMessageBox({
+    type: 'error',
+    buttons: ['OK'],
+    defaultId: 0,
+    title: 'File Not Found Error',
+    message: 'An error occurred while trying to open the file.',
+    detail: `${errorMessage}`,
+  });
+}
+
+export async function getMessageBoxForUnzipError(
+  errorMessage: string,
+): Promise<void> {
+  await dialog.showMessageBox({
+    type: 'error',
+    buttons: ['OK'],
+    defaultId: 0,
+    title: 'Unzipping Error',
+    message: 'An error occurred while trying to unzip the file.',
+    detail: `${errorMessage}`,
   });
 }
 

--- a/src/ElectronBackend/input/parseFile.ts
+++ b/src/ElectronBackend/input/parseFile.ts
@@ -20,7 +20,7 @@ import {
   ParsedOpossumInputAndOutput,
   ParsedOpossumInputFile,
   ParsedOpossumOutputFile,
-  UnZipError,
+  UnzipError,
 } from '../types/types';
 import * as OpossumInputFileSchema from './OpossumInputFileSchema.json';
 import * as OpossumOutputFileSchema from './OpossumOutputFileSchema.json';
@@ -34,7 +34,7 @@ export async function parseOpossumFile(
   opossumFilePath: string,
 ): Promise<
   | ParsedOpossumInputAndOutput
-  | UnZipError
+  | UnzipError
   | JsonParsingError
   | InvalidDotOpossumFileError
 > {
@@ -47,8 +47,8 @@ export async function parseOpossumFile(
   } catch (err) {
     return {
       message: `Error: ${opossumFilePath} could not be unzipped.\n Original error message: ${err?.toString()}`,
-      type: 'unZippingError',
-    } satisfies UnZipError;
+      type: 'unzipError',
+    } satisfies UnzipError;
   }
 
   if (!zip[INPUT_FILE_NAME]) {

--- a/src/ElectronBackend/types/types.ts
+++ b/src/ElectronBackend/types/types.ts
@@ -18,15 +18,15 @@ export interface ParsingError {
     | 'fileNotFoundError'
     | 'jsonParsingError'
     | 'invalidDotOpossumFileError'
-    | 'unZippingError';
+    | 'unzipError';
 }
 
 export interface FileNotFoundError extends ParsingError {
   type: 'fileNotFoundError';
 }
 
-export interface UnZipError extends ParsingError {
-  type: 'unZippingError';
+export interface UnzipError extends ParsingError {
+  type: 'unzipError';
 }
 
 export interface JsonParsingError extends ParsingError {


### PR DESCRIPTION
### Summary of changes

We introduce checks that ensure a file exists, before trying to parse it. We also refactor some of the error handling and introduce a `removeDeletedRecentlyOpenedPaths` function which cleans up your recently opened paths.

### Context and reason for change

Clicking on a recently opened path that did not exist anymore, caused the application to hang.

### How can the changes be tested

By running opossum ui, opening a file, deleting the file, and clicking on the file in your recently opened tab. You will get an error that leads you to the home screen and also your recently opened contracts will have been cleaned up.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
