### PR TITLE
feat: show the count when you click on a selected resource

### DIFF
--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -6,6 +6,7 @@ import {
   CaseWhenBuilder,
   ExpressionBuilder,
   expressionBuilder,
+  Kysely,
   sql,
   Transaction,
 } from 'kysely';
@@ -134,7 +135,7 @@ export function removeTrailingSlash(path: string) {
 }
 
 export async function getResourceOrThrow(
-  trx: Transaction<DB>,
+  trx: Kysely<DB>,
   resourcePath: string,
 ) {
   const strippedResourcePath = removeTrailingSlash(resourcePath);

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -227,10 +227,10 @@ export const text = {
     discard: 'Discard and Proceed',
   },
   resourceBrowser: {
-    allResources: (count: number) =>
-      `All Resources (${new Intl.NumberFormat().format(count)})`,
-    linkedResources: (count: number) =>
-      `Linked Resources (${new Intl.NumberFormat().format(count)})`,
+    allResources: (selectedResources: number, totalCount: number) =>
+      `Resources (${new Intl.NumberFormat().format(selectedResources)} / ${new Intl.NumberFormat().format(totalCount)})`,
+    linkedResources: (selectedResources: number, totalCount: number) =>
+      `Linked Resources (${new Intl.NumberFormat().format(selectedResources)} / ${new Intl.NumberFormat().format(totalCount)})`,
     hasHighlyCriticalSignals: 'Has highly critical signals',
     hasMediumCriticalSignals: 'Has medium critical signals',
     hasSignals: 'Has signals',


### PR DESCRIPTION
### Summary of changes

You can now get the count of resources under a selected file/folder

### How can the changes be tested

Tests have been added, otherwise open opossumUi and search and select resources

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
