### PR TITLE
docs: mention AppImageLauncher in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Note that for ubuntu versions 22.04+ you will run into a sandboxing issue with a
 ./OpossumUI-for-linux.AppImage --no-sandbox
 ```
 
+Alternatively, you can install [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) and use it to install the _OpossumUI-for-linux.AppImage_ by double-clicking on it.
+Then you can open OpossumUI via the start menu of your distribution, or by double-clicking on an _.opossum_ file.
+
 #### snap
 
 Install the snap file locally using


### PR DESCRIPTION
### Summary of changes

mention AppImageLauncher as a possible installation method for .AppImag on Linux

### Context and reason for change

When installing OpossumUI on Ubuntu 25.10, the other installation methods caused issues.

### How can the changes be tested

<!-- optional -->

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
