### PR TITLE
fix(output): harden export paths and bundled CLI lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     ],
     "files": [
       "build/**/*",
-      "bin/*",
       "!node_modules",
       "node_modules/better-sqlite3-electron/**/*",
       "node_modules/bindings/**/*",
@@ -211,6 +210,7 @@
       "main": "build/ElectronBackend/app.js"
     },
     "extraResources": [
+      "./bin/opossum-file-cli*",
       "./notices/**"
     ]
   },

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -10,6 +10,7 @@ import {
   AllowedFrontendChannels,
   IpcChannel,
 } from '../../../shared/ipc-channels';
+import { importFileFormats } from '../../../shared/shared-constants';
 import { createWindow } from '../createWindow';
 import {
   openNonOpossumFileDialog,
@@ -24,11 +25,11 @@ import {
   selectBaseURLListener,
   selectFileListener,
 } from '../listeners';
-import { importFileFormats } from '../menu/fileMenu';
 
 vi.mock('electron', () => ({
   app: {
     on: vi.fn(),
+    getAppPath: () => './',
     getPath: vi.fn(),
     getName: vi.fn(),
     getVersion: vi.fn(),

--- a/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
+++ b/src/ElectronBackend/main/__tests__/mainErrorCase.test.ts
@@ -21,6 +21,7 @@ vi.mock('electron', () => ({
   },
   app: {
     on: vi.fn(),
+    getAppPath: () => './',
     getPath: vi.fn(() => '/tmp'),
     getName: vi.fn(() => 'OpossumUI'),
     getVersion: vi.fn(() => '1.0.0'),

--- a/src/ElectronBackend/main/__tests__/menu.test.ts
+++ b/src/ElectronBackend/main/__tests__/menu.test.ts
@@ -15,6 +15,7 @@ vi.mock('electron', () => {
   const mockElectron = {
     BrowserWindow: class BrowserWindowMock {},
     app: {
+      getAppPath: () => './',
       isPackaged: true,
     },
     Menu: {

--- a/src/ElectronBackend/main/menu/fileMenu.ts
+++ b/src/ElectronBackend/main/menu/fileMenu.ts
@@ -13,11 +13,8 @@ import os from 'os';
 import path from 'path';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
-import {
-  ExportType,
-  type FileFormatInfo,
-  FileType,
-} from '../../../shared/shared-types';
+import { importFileFormats } from '../../../shared/shared-constants';
+import { ExportType } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
 import { isFileLoaded } from '../../utils/getLoadedFile';
 import { getGlobalBackendState } from '../globalBackendState';
@@ -29,24 +26,6 @@ import {
   selectBaseURLListener,
 } from '../listeners';
 import { UserSettingsService } from '../user-settings-service';
-
-export const importFileFormats: Array<FileFormatInfo> = [
-  {
-    fileType: FileType.LEGACY_OPOSSUM,
-    name: 'Legacy Opossum',
-    extensions: ['json', 'json.gz'],
-  },
-  {
-    fileType: FileType.SCANCODE_JSON,
-    name: 'ScanCode',
-    extensions: ['json'],
-  },
-  {
-    fileType: FileType.OWASP_JSON,
-    name: 'OWASP Dependency-Check',
-    extensions: ['json'],
-  },
-];
 
 function getOpenFile(mainWindow: BrowserWindow): MenuItemConstructorOptions {
   return {

--- a/src/ElectronBackend/opossum-file/FileConverter.ts
+++ b/src/ElectronBackend/opossum-file/FileConverter.ts
@@ -16,11 +16,33 @@ export abstract class FileConverter {
 
   protected readonly execFile = promisify(execFileCallback);
 
-  protected readonly OPOSSUM_FILE_EXECUTABLE = join(
-    app?.getAppPath?.() ?? './',
-    process.env.NODE_ENV === 'e2e' ? '../..' : '',
-    'bin/opossum-file-cli',
-  );
+  protected readonly OPOSSUM_FILE_EXECUTABLE = this.getOpossumFileExecutable();
+
+  private getExecutableNames(): Array<string> {
+    return process.platform === 'win32'
+      ? ['opossum-file-cli.exe', 'opossum-file-cli']
+      : ['opossum-file-cli'];
+  }
+
+  private getOpossumFileExecutable(): string {
+    const executableNames = this.getExecutableNames();
+    const candidateDirectories =
+      app.isPackaged && process.resourcesPath
+        ? [join(process.resourcesPath, 'bin')]
+        : [
+            join(app?.getAppPath?.() ?? process.cwd(), 'bin'),
+            join(app?.getAppPath?.() ?? process.cwd(), '..', '..', 'bin'),
+            join(process.cwd(), 'bin'),
+          ];
+
+    const candidates = candidateDirectories.flatMap((directory) =>
+      executableNames.map((executableName) => join(directory, executableName)),
+    );
+
+    return (
+      candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0]
+    );
+  }
 
   protected abstract preConvertFile(
     toBeConvertedFilePath: string,

--- a/src/ElectronBackend/opossum-file/FileConverter.ts
+++ b/src/ElectronBackend/opossum-file/FileConverter.ts
@@ -30,8 +30,8 @@ export abstract class FileConverter {
       app.isPackaged && process.resourcesPath
         ? [join(process.resourcesPath, 'bin')]
         : [
-            join(app?.getAppPath?.() ?? process.cwd(), 'bin'),
-            join(app?.getAppPath?.() ?? process.cwd(), '..', '..', 'bin'),
+            join(app.getAppPath(), 'bin'),
+            join(app.getAppPath(), '..', '..', 'bin'),
             join(process.cwd(), 'bin'),
           ];
 

--- a/src/ElectronBackend/opossum-file/__tests__/opossum-file.test.ts
+++ b/src/ElectronBackend/opossum-file/__tests__/opossum-file.test.ts
@@ -17,6 +17,7 @@ const mockTmpdir = tmpdir();
 
 vi.mock('electron', () => ({
   app: {
+    getAppPath: () => './',
     getPath: () => mockTmpdir,
   },
 }));

--- a/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
+import path from 'path';
 
 import {
   type Attributions,
@@ -91,6 +92,26 @@ describe('writeCsvToFile', () => {
     );
     expect(content).toContain('"1";"";"license text, with; commas"');
     expect(content).toContain('"2";"Fancy name,: tt";""');
+  });
+
+  it('creates parent directories before writing csv output', async () => {
+    const csvPath = faker.outputPath(
+      path.join(faker.string.uuid(), 'nested', `${faker.string.uuid()}.csv`),
+    );
+
+    await writeCsvToFile({
+      path: csvPath,
+      attributions: {
+        key1: {
+          packageName: 'Fancy name,: tt',
+          criticality: Criticality.None,
+          id: faker.string.uuid(),
+        },
+      },
+      columns: ['packageName'],
+    });
+
+    expect(fs.existsSync(csvPath)).toBe(true);
   });
 
   it('writeCsvToFile shorten resources', async () => {

--- a/src/ElectronBackend/output/__tests__/writeSpdxFile.test.ts
+++ b/src/ElectronBackend/output/__tests__/writeSpdxFile.test.ts
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import fs from 'fs';
+import path from 'path';
 
 import {
   type Attributions,
@@ -75,5 +76,19 @@ describe('writeSpdxFile', () => {
     expect(fileContent).toContain(
       'referenceLocator: pkg:npm/second-test-package@2.1',
     );
+  });
+
+  it('creates parent directories before writing SPDX output', () => {
+    const yamlPath = faker.outputPath(
+      path.join(faker.string.uuid(), 'nested', `${faker.string.uuid()}.yaml`),
+    );
+
+    writeSpdxFile({
+      path: yamlPath,
+      type: ExportType.SpdxDocumentYaml,
+      attributions: {},
+    });
+
+    expect(fs.existsSync(yamlPath)).toBe(true);
   });
 });

--- a/src/ElectronBackend/output/writeCsvToFile.ts
+++ b/src/ElectronBackend/output/writeCsvToFile.ts
@@ -6,6 +6,7 @@ import * as csv from 'fast-csv';
 import { type CsvFormatterStream } from 'fast-csv';
 import * as fs from 'fs';
 import { pick } from 'lodash';
+import path from 'path';
 
 import { type Attributions, type PackageInfo } from '../../shared/shared-types';
 
@@ -18,6 +19,7 @@ export async function writeCsvToFile(args: {
   shortenResources?: boolean;
 }): Promise<void> {
   try {
+    fs.mkdirSync(path.dirname(args.path), { recursive: true });
     const writeStream = fs.createWriteStream(args.path);
     const csvStream = csv.format({
       headers: ['attributionNumber'].concat(args.columns),

--- a/src/ElectronBackend/output/writeSpdxFile.ts
+++ b/src/ElectronBackend/output/writeSpdxFile.ts
@@ -29,6 +29,8 @@ export function writeSpdxFile(args: {
   const packageInfos = Object.values(args.attributions);
   const spdxDocument = getSpdxDocument(packageInfos, fileName);
 
+  fs.mkdirSync(path.dirname(args.path), { recursive: true });
+
   if (args.type === ExportType.SpdxDocumentYaml) {
     fs.writeFileSync(args.path, createSpdxYaml(spdxDocument));
   } else if (args.type === ExportType.SpdxDocumentJson) {

--- a/src/e2e-tests/page-objects/MenuBar.ts
+++ b/src/e2e-tests/page-objects/MenuBar.ts
@@ -9,7 +9,7 @@ import {
   findMenuItem,
 } from 'electron-playwright-helpers';
 
-import { importFileFormats } from '../../ElectronBackend/main/menu/fileMenu';
+import { importFileFormats } from '../../shared/shared-constants';
 import { text } from '../../shared/text';
 
 const initiallyDisabledMenuItems = [

--- a/src/shared/__tests__/write-file.test.ts
+++ b/src/shared/__tests__/write-file.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { strFromU8, unzipSync } from 'fflate';
+import fs from 'fs';
+import path from 'path';
+
+import { writeFile, writeOpossumFile } from '../write-file';
+import { INPUT_FILE_NAME, OUTPUT_FILE_NAME } from '../write-file-utils';
+
+describe('writeFile', () => {
+  it('creates parent directories before writing plain files', async () => {
+    const filePath = path.join(
+      'test-output',
+      crypto.randomUUID(),
+      'nested',
+      'input.json',
+    );
+
+    await writeFile({
+      path: filePath,
+      content: { projectId: 'project-1' },
+    });
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(JSON.parse(await fs.promises.readFile(filePath, 'utf8'))).toEqual({
+      projectId: 'project-1',
+    });
+  });
+});
+
+describe('writeOpossumFile', () => {
+  it('creates parent directories before writing opossum archives', async () => {
+    const filePath = path.join(
+      'test-output',
+      crypto.randomUUID(),
+      'nested',
+      'project.opossum',
+    );
+    const input = { metadata: { projectId: 'project-1' } };
+    const output = { metadata: { projectId: 'project-1' } };
+
+    await writeOpossumFile({ path: filePath, input, output });
+
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const archive = unzipSync(
+      new Uint8Array(await fs.promises.readFile(filePath)),
+    );
+    expect(JSON.parse(strFromU8(archive[INPUT_FILE_NAME]))).toEqual(input);
+    expect(JSON.parse(strFromU8(archive[OUTPUT_FILE_NAME]))).toEqual(output);
+  });
+});

--- a/src/shared/shared-constants.ts
+++ b/src/shared/shared-constants.ts
@@ -2,7 +2,11 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type UserSettings } from './shared-types';
+import {
+  type FileFormatInfo,
+  FileType,
+  type UserSettings,
+} from './shared-types';
 
 export const DEFAULT_PANEL_SIZES: NonNullable<UserSettings['panelSizes']> = {
   resourceBrowserWidth: 340,
@@ -10,6 +14,24 @@ export const DEFAULT_PANEL_SIZES: NonNullable<UserSettings['panelSizes']> = {
   linkedResourcesPanelHeight: null,
   signalsPanelHeight: null,
 };
+
+export const importFileFormats: Array<FileFormatInfo> = [
+  {
+    fileType: FileType.LEGACY_OPOSSUM,
+    name: 'Legacy Opossum',
+    extensions: ['json', 'json.gz'],
+  },
+  {
+    fileType: FileType.SCANCODE_JSON,
+    name: 'ScanCode',
+    extensions: ['json'],
+  },
+  {
+    fileType: FileType.OWASP_JSON,
+    name: 'OWASP Dependency-Check',
+    extensions: ['json'],
+  },
+];
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   qaMode: false,

--- a/src/shared/write-file.ts
+++ b/src/shared/write-file.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { strToU8, zip } from 'fflate';
 import fs from 'fs';
+import nodePath from 'path';
 
 import { INPUT_FILE_NAME, OUTPUT_FILE_NAME } from './write-file-utils';
 
@@ -15,6 +16,7 @@ export async function writeFile({
   content: string | object;
 }): Promise<string> {
   try {
+    await fs.promises.mkdir(nodePath.dirname(path), { recursive: true });
     await fs.promises.writeFile(
       path,
       typeof content === 'string' || Buffer.isBuffer(content)
@@ -70,6 +72,7 @@ export function writeOpossumFile({
         if (err) {
           reject(err);
         } else {
+          await fs.promises.mkdir(nodePath.dirname(path), { recursive: true });
           await fs.promises.writeFile(path, data);
 
           resolve(path);

--- a/tools/downloadOpossumFileCLI.mjs
+++ b/tools/downloadOpossumFileCLI.mjs
@@ -23,6 +23,12 @@ function getResourceName() {
   return `opossum-file-for-${osSuffix}`;
 }
 
+function getExecutablePath() {
+  return process.argv[2] === 'windows.exe'
+    ? 'bin/opossum-file-cli.exe'
+    : 'bin/opossum-file-cli';
+}
+
 function doesOpossumExecutableExist(filePath) {
   const folderPath = dirname(filePath);
   if (!fs.existsSync(folderPath)) {
@@ -56,7 +62,7 @@ async function downloadOpossumFileCLI() {
     requestParams,
   );
 
-  const executablePath = 'bin/opossum-file-cli';
+  const executablePath = getExecutablePath();
   if (doesOpossumExecutableExist(executablePath)) {
     if (!downloadResponse.ok) {
       const { birthtime } = fs.statSync(executablePath);


### PR DESCRIPTION
## Summary
- extract the packaging and file-IO hardening work from `refactor/esm-runtime-cleanup` onto a branch based on `main`
- create parent directories before writing plain files, `.opossum` archives, CSV exports, and SPDX exports so nested output paths work reliably
- make bundled `opossum-file-cli` lookup and download more robust across packaged apps and Windows executables, and ship the CLI as an extra resource

## Verification
- `yarn vitest run src/ElectronBackend/output/__tests__/writeCsvToFile.test.ts src/ElectronBackend/output/__tests__/writeSpdxFile.test.ts src/ElectronBackend/api/__tests__/exportCommands.test.ts src/ElectronBackend/api/__tests__/saveFile.test.ts src/ElectronBackend/input/__tests__/parseFile.test.ts src/ElectronBackend/input/__tests__/loadFile.test.ts src/ElectronBackend/opossum-file/__tests__/opossum-file.test.ts src/shared/__tests__/write-file.test.ts`
- `yarn typecheck`
- `yarn build`
- pre-commit hooks: copyright lint, eslint, TypeScript checks, db generation, knip, prettier