### PR TITLE
feat: additional documenation for installing in mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ from the command line
 
 Run _OpossumUI_ in _OpossumUI-for-mac.zip_.
 
+Note: As this app is not officially signed, you need to explicitly allow execution of this app via the `System Settings`.
+
 #### Windows
 
 Run _OpossumUI-for-win.exe_ to install the OpossumUI. Then open _OpossumUI_ from the start menu.


### PR DESCRIPTION
### Summary of changes

Added additional documentation to explain how to use the app on a mac (basically explicitly allow executing this app)

### Context and reason for change

Users are irritated about not being able to run the app directly on the mac.
Closes #3042

### How can the changes be tested

Look at the README, installation section

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
