### PR TITLE
feat: remove manualAttributionsToResources selector

### DIFF
--- a/src/ElectronBackend/api/mutations.ts
+++ b/src/ElectronBackend/api/mutations.ts
@@ -185,6 +185,7 @@ export const mutations = {
         { queryName: 'manualAttributionStatistics' },
         { queryName: 'licenseTable' },
         { queryName: 'resourceHasIncompleteManualAttributions' },
+        { queryName: 'getResourceCountOnAttribution' },
       ],
     };
   },
@@ -254,6 +255,7 @@ export const mutations = {
         { queryName: 'manualAttributionStatistics' },
         { queryName: 'licenseTable' },
         { queryName: 'resourceHasIncompleteManualAttributions' },
+        { queryName: 'getResourceCountOnAttribution' },
       ],
     };
   },
@@ -445,6 +447,7 @@ export const mutations = {
         { queryName: 'manualAttributionStatistics' },
         { queryName: 'licenseTable' },
         { queryName: 'resourceHasIncompleteManualAttributions' },
+        { queryName: 'getResourceCountOnAttribution' },
       ],
     };
   },

--- a/src/ElectronBackend/api/queries.ts
+++ b/src/ElectronBackend/api/queries.ts
@@ -566,6 +566,22 @@ export const queries = {
       .execute();
     return { result: new Set(result.map((r) => r.path)) };
   },
+  async getResourceCountOnAttribution(props: { attributionUuid: string }) {
+    const resourceCount = await getDb()
+      .selectFrom('resource_to_attribution')
+      .select((eb) => [
+        eb.fn.countAll<number>().as('count'),
+        'attribution_is_external',
+      ])
+      .where('attribution_uuid', '=', props.attributionUuid)
+      .executeTakeFirstOrThrow();
+    return {
+      result: {
+        resourceCount: resourceCount.count,
+        isManual: resourceCount.attribution_is_external === 0,
+      },
+    };
+  },
 } satisfies Record<string, QueryFunction>;
 
 export type Queries = typeof queries;

--- a/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
@@ -90,13 +90,13 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
   const hasMultipleResources =
     attributionData?.isManual && attributionData?.resourceCount > 1;
 
-  const { data: isLinkedToAttribution } =
-    backend.isResourceLinkedOnAllAttributions.useQuery({
-      resourcePath: selectedResourceId,
-      attributionUuids: [packageInfo.id],
-    });
+  const { data: attributions } = backend.listAttributions.useQuery({
+    resourcePathForRelationships: selectedResourceId,
+    uuids: [packageInfo.id],
+  });
   const isSelectedResourceOnSelectedAttribution =
-    attributionData?.isManual && isLinkedToAttribution;
+    attributionData?.isManual &&
+    attributions?.[packageInfo.id]?.relation === 'resource';
 
   const isCreatingNewAttribution = !packageInfo.id;
 
@@ -201,7 +201,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
     if (
       isSelectedResourceBreakpoint ||
       isCreatingNewAttribution ||
-      (isEditable && isSelectedResourceOnSelectedAttribution)
+      (isEditable && isSelectedResourceOnSelectedAttribution !== false)
     ) {
       return null;
     }

--- a/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
@@ -29,7 +29,6 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
 import {
   getIsPackageInfoDirty,
-  getManualAttributionsToResources,
   getSelectedResourceId,
 } from '../../../state/selectors/resource-selectors';
 import { useAttributionIdsForReplacement } from '../../../state/variables/use-attribution-ids-for-replacement';
@@ -57,9 +56,6 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
   const { data: resolvedExternalAttributions } =
     backend.resolvedAttributionUuids.useQuery();
   const selectedResourceId = useAppSelector(getSelectedResourceId);
-  const manualAttributionsToResources = useAppSelector(
-    getManualAttributionsToResources,
-  );
   const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
 
   const originalAttributionQuery = backend.getAttributionData.useQuery(
@@ -86,10 +82,22 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
   const selectedSignalIsResolved = resolvedExternalAttributions?.has(
     packageInfo.id,
   );
+
+  const { data: attributionData } =
+    backend.getResourceCountOnAttribution.useQuery({
+      attributionUuid: packageInfo.id,
+    });
   const hasMultipleResources =
-    (manualAttributionsToResources[packageInfo.id]?.length ?? 0) > 1;
+    attributionData?.isManual && attributionData?.resourceCount > 1;
+
+  const { data: isLinkedToAttribution } =
+    backend.isResourceLinkedOnAllAttributions.useQuery({
+      resourcePath: selectedResourceId,
+      attributionUuids: [packageInfo.id],
+    });
   const isSelectedResourceOnSelectedAttribution =
-    manualAttributionsToResources[packageInfo.id]?.includes(selectedResourceId);
+    attributionData?.isManual && isLinkedToAttribution;
+
   const isCreatingNewAttribution = !packageInfo.id;
 
   const handleSave = useCallback(async () => {

--- a/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/all-views-simple-actions.test.ts
@@ -16,7 +16,7 @@ import { createAppStore } from '../../../configure-store';
 import { initialResourceState } from '../../../reducers/resource-reducer';
 import {
   getManualAttributions,
-  getManualAttributionsToResources,
+  getManualData,
   getResourcesWithManualAttributedChildren,
   getTemporaryDisplayPackageInfo,
 } from '../../../selectors/resource-selectors';
@@ -121,7 +121,9 @@ describe('The load and navigation simple actions', () => {
 
     const testStore = createAppStore();
     expect(getManualAttributions(testStore.getState())).toEqual({});
-    expect(getManualAttributionsToResources(testStore.getState())).toEqual({});
+    expect(getManualData(testStore.getState()).attributionsToResources).toEqual(
+      {},
+    );
     expect(
       getResourcesWithManualAttributedChildren(testStore.getState()),
     ).toEqual({
@@ -140,7 +142,7 @@ describe('The load and navigation simple actions', () => {
     expect(getManualAttributions(testStore.getState())).toEqual(
       testAttributions,
     );
-    expect(getManualAttributionsToResources(testStore.getState())).toEqual(
+    expect(getManualData(testStore.getState()).attributionsToResources).toEqual(
       testAttributionsToResources,
     );
     expect(

--- a/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/save-actions.test.ts
@@ -27,7 +27,6 @@ import { createTestStore } from '../../../../test-helpers/render';
 import { createAppStore } from '../../../configure-store';
 import {
   getManualAttributions,
-  getManualAttributionsToResources,
   getManualData,
   getResourcesWithManualAttributedChildren,
   getSelectedAttributionId,
@@ -775,8 +774,9 @@ describe('The unlinkAttributionAndSave action', () => {
       testStore.getState(),
     );
     expect(Object.keys(startingManualAttributions)).toHaveLength(1);
-    const startingManualAttributionsToResources =
-      getManualAttributionsToResources(testStore.getState());
+    const startingManualAttributionsToResources = getManualData(
+      testStore.getState(),
+    ).attributionsToResources;
     expect(startingManualAttributionsToResources.reactUuid).toEqual([
       '/something.js',
       '/somethingElse.js',
@@ -1039,7 +1039,7 @@ describe('The addToSelectedResource action', () => {
     testStore.dispatch(setSelectedResourceId('/root/'));
     testStore.dispatch(setSelectedAttributionId(testPackageInfo.id));
     expect(
-      getManualAttributionsToResources(testStore.getState())[
+      getManualData(testStore.getState()).attributionsToResources[
         testManualAttributionUuid_1
       ],
     ).toEqual(['/root/src/something.js']);

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -14,7 +14,6 @@ import { backend } from '../../../util/backendClient';
 import { getStrippedPackageInfo } from '../../../util/get-stripped-package-info';
 import {
   getManualAttributions,
-  getManualAttributionsToResources,
   getSelectedAttributionId,
   getSelectedResourceId,
 } from '../../selectors/resource-selectors';
@@ -149,11 +148,12 @@ export function unlinkAttributionAndCreateNew(
   resourceId: string,
   packageInfo: PackageInfo,
 ): AsyncAppThunkAction {
-  return async (dispatch, getState) => {
-    const attributionsToResources =
-      getManualAttributionsToResources(getState());
+  return async (dispatch) => {
+    const result = await backend.getResourceCountOnAttribution.query({
+      attributionUuid: packageInfo.id,
+    });
 
-    if (attributionsToResources[packageInfo.id]?.length > 1) {
+    if (result?.isManual && result.resourceCount > 1) {
       await backend.unlinkResourceFromAttributions.mutate({
         resourcePath: resourceId,
         attributionUuids: [packageInfo.id],

--- a/src/Frontend/state/selectors/resource-selectors.ts
+++ b/src/Frontend/state/selectors/resource-selectors.ts
@@ -5,7 +5,6 @@
 import {
   type AttributionData,
   type Attributions,
-  type AttributionsToResources,
   type ClassificationsConfig,
   type PackageInfo,
   type ProjectMetadata,
@@ -39,12 +38,6 @@ export function getTargetSelectedResourceId(state: State): string | null {
 
 export function getSelectedResourceId(state: State): string {
   return state.resourceState.selectedResourceId;
-}
-
-export function getManualAttributionsToResources(
-  state: State,
-): AttributionsToResources {
-  return state.resourceState.manualData.attributionsToResources;
 }
 
 export function getResourcesWithManualAttributedChildren(


### PR DESCRIPTION
### Summary of changes

We remove another selector from the Redux store making the FE cleaner and taking another step towords finishing the migration

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
