### PR TITLE
Feat/move attribution breakpoints

### DIFF
--- a/src/ElectronBackend/api/queries.ts
+++ b/src/ElectronBackend/api/queries.ts
@@ -557,6 +557,15 @@ export const queries = {
       result: baseUrlResult.base_url.replace('{path}', pathToReplaceWith),
     };
   },
+
+  async getAttributionBreakpoints() {
+    const result = await getDb()
+      .selectFrom('resource')
+      .select('path')
+      .where('is_attribution_breakpoint', '=', 1)
+      .execute();
+    return { result: new Set(result.map((r) => r.path)) };
+  },
 } satisfies Record<string, QueryFunction>;
 
 export type Queries = typeof queries;

--- a/src/ElectronBackend/input/__tests__/importFromFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/importFromFile.test.ts
@@ -90,7 +90,6 @@ const testFrontendData: ParsedFrontendFileContent = {
     attributionsToResources: {},
   },
   resolvedExternalAttributions: new Set(),
-  attributionBreakpoints: new Set(),
   filesWithChildren: new Set(),
 };
 

--- a/src/ElectronBackend/input/__tests__/loadFile.test.ts
+++ b/src/ElectronBackend/input/__tests__/loadFile.test.ts
@@ -95,7 +95,6 @@ const expectedFrontendData: ParsedFrontendFileContent = {
     attributionsToResources: {},
   },
   resolvedExternalAttributions: new Set(),
-  attributionBreakpoints: new Set(),
   filesWithChildren: new Set(),
 };
 
@@ -242,9 +241,6 @@ describe('loadFile', () => {
       resourcesToAttributions: { '/a': [manualAttributionUuid] },
       attributionsToResources: { [manualAttributionUuid]: ['/a'] },
     });
-    expect(result.frontendData.attributionBreakpoints).toEqual(
-      new Set(['/some/path/', '/another/path/']),
-    );
     expect(result.frontendData.filesWithChildren).toEqual(
       new Set(['/some/package.json/']),
     );

--- a/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
@@ -29,7 +29,6 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
 import {
   getIsPackageInfoDirty,
-  getIsSelectedResourceBreakpoint,
   getManualAttributionsToResources,
   getSelectedResourceId,
 } from '../../../state/selectors/resource-selectors';
@@ -38,6 +37,7 @@ import { backend } from '../../../util/backendClient';
 import { isPackageInvalid } from '../../../util/input-validation';
 import { useIpcRenderer } from '../../../util/use-ipc-renderer';
 import { useSelectedAttributionPackageInfo } from '../../../util/use-selected-attribution';
+import { useIsSelectedResourceBreakpoint } from '../../../util/use-selected-resource';
 import { ConfirmDeletePopup } from '../../ConfirmDeletePopup/ConfirmDeletePopup';
 import { ConfirmReplacePopup } from '../../ConfirmReplacePopup/ConfirmReplacePopup';
 import { ConfirmSavePopup } from '../../ConfirmSavePopup/ConfirmSavePopup';
@@ -60,9 +60,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
   const manualAttributionsToResources = useAppSelector(
     getManualAttributionsToResources,
   );
-  const isSelectedResourceBreakpoint = useAppSelector(
-    getIsSelectedResourceBreakpoint,
-  );
+  const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
 
   const originalAttributionQuery = backend.getAttributionData.useQuery(
     packageInfo.originalAttributionId

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/CreateButton/CreateButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/CreateButton/CreateButton.tsx
@@ -8,9 +8,9 @@ import MuiTooltip from '@mui/material/Tooltip';
 
 import { text } from '../../../../../shared/text';
 import { changeSelectedAttributionOrOpenUnsavedPopup } from '../../../../state/actions/popup-actions/popup-actions';
-import { useAppDispatch, useAppSelector } from '../../../../state/hooks';
-import { getIsSelectedResourceBreakpoint } from '../../../../state/selectors/resource-selectors';
+import { useAppDispatch } from '../../../../state/hooks';
 import { useAttributionIdsForReplacement } from '../../../../state/variables/use-attribution-ids-for-replacement';
+import { useIsSelectedResourceBreakpoint } from '../../../../util/use-selected-resource';
 import { type PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPanel';
 
 export const CreateButton: React.FC<PackagesPanelChildrenProps> = ({
@@ -18,9 +18,7 @@ export const CreateButton: React.FC<PackagesPanelChildrenProps> = ({
 }) => {
   const dispatch = useAppDispatch();
   const [attributionIdsForReplacement] = useAttributionIdsForReplacement();
-  const isSelectedResourceBreakpoint = useAppSelector(
-    getIsSelectedResourceBreakpoint,
-  );
+  const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
 
   return (
     <MuiIconButton

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
@@ -9,11 +9,9 @@ import MuiTooltip from '@mui/material/Tooltip';
 import { text } from '../../../../../shared/text';
 import { addToSelectedResource } from '../../../../state/actions/resource-actions/save-actions';
 import { useAppDispatch, useAppSelector } from '../../../../state/hooks';
-import {
-  getIsPackageInfoDirty,
-  getIsSelectedResourceBreakpoint,
-} from '../../../../state/selectors/resource-selectors';
+import { getIsPackageInfoDirty } from '../../../../state/selectors/resource-selectors';
 import { useAttributionIdsForReplacement } from '../../../../state/variables/use-attribution-ids-for-replacement';
+import { useIsSelectedResourceBreakpoint } from '../../../../util/use-selected-resource';
 import { type PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPanel';
 
 export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
@@ -25,9 +23,7 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
   const dispatch = useAppDispatch();
   const [attributionIdsForReplacement] = useAttributionIdsForReplacement();
   const isPackageInfoModified = useAppSelector(getIsPackageInfoDirty);
-  const isSelectedResourceBreakpoint = useAppSelector(
-    getIsSelectedResourceBreakpoint,
-  );
+  const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
 
   return (
     <MuiIconButton

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/LinkButton/LinkButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/LinkButton/LinkButton.tsx
@@ -8,8 +8,8 @@ import MuiTooltip from '@mui/material/Tooltip';
 
 import { text } from '../../../../../shared/text';
 import { addToSelectedResource } from '../../../../state/actions/resource-actions/save-actions';
-import { useAppDispatch, useAppSelector } from '../../../../state/hooks';
-import { getIsSelectedResourceBreakpoint } from '../../../../state/selectors/resource-selectors';
+import { useAppDispatch } from '../../../../state/hooks';
+import { useIsSelectedResourceBreakpoint } from '../../../../util/use-selected-resource';
 import { type PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPanel';
 
 export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
@@ -18,9 +18,7 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
   setMultiSelectedAttributionIds,
 }) => {
   const dispatch = useAppDispatch();
-  const isSelectedResourceBreakpoint = useAppSelector(
-    getIsSelectedResourceBreakpoint,
-  );
+  const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
 
   return (
     <MuiIconButton

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -72,7 +72,6 @@ describe('loadFromFile', () => {
         attributionsToResources: testManualAttributionsToResources,
       },
       resolvedExternalAttributions: new Set(['test_id']),
-      attributionBreakpoints: new Set(['/third-party/package/']),
       filesWithChildren: new Set(['/third-party/package.json/']),
     };
     const expectedConfig: ProjectConfig = {

--- a/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
+++ b/src/Frontend/state/actions/resource-actions/__tests__/load-actions.test.ts
@@ -20,7 +20,6 @@ import { OpossumColors } from '../../../../shared-styles';
 import { createAppStore } from '../../../configure-store';
 import { initialResourceState } from '../../../reducers/resource-reducer';
 import {
-  getAttributionBreakpoints,
   getClassifications,
   getFilesWithChildren,
   getManualData,
@@ -120,9 +119,6 @@ describe('loadFromFile', () => {
       expectedConfig.classifications,
     );
     expect(getManualData(testStore.getState())).toEqual(expectedManualData);
-    expect(getAttributionBreakpoints(testStore.getState())).toEqual(
-      new Set(['/third-party/package/']),
-    );
     expect(getFilesWithChildren(testStore.getState())).toEqual(
       new Set(['/third-party/package.json/']),
     );

--- a/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/all-views-simple-actions.ts
@@ -13,7 +13,6 @@ import {
 import { computeChildrenWithAttributions } from '../../helpers/save-action-helpers';
 import {
   ACTION_RESET_RESOURCE_STATE,
-  ACTION_SET_ATTRIBUTION_BREAKPOINTS,
   ACTION_SET_FILES_WITH_CHILDREN,
   ACTION_SET_IS_PACKAGE_INFO_DIRTY,
   ACTION_SET_MANUAL_ATTRIBUTION_DATA,
@@ -21,7 +20,6 @@ import {
   ACTION_SET_PROJECT_METADATA,
   ACTION_SET_TEMPORARY_PACKAGE_INFO,
   type ResetResourceStateAction,
-  type SetAttributionBreakpoints,
   type SetFilesWithChildren,
   type SetIsPackageInfoDirtyAction,
   type SetManualDataAction,
@@ -60,15 +58,6 @@ export function setTemporaryDisplayPackageInfo(
   packageInfo: PackageInfo,
 ): SetTemporaryDisplayPackageInfoAction {
   return { type: ACTION_SET_TEMPORARY_PACKAGE_INFO, payload: packageInfo };
-}
-
-export function setAttributionBreakpoints(
-  attributionBreakpoints: Set<string>,
-): SetAttributionBreakpoints {
-  return {
-    type: ACTION_SET_ATTRIBUTION_BREAKPOINTS,
-    payload: attributionBreakpoints,
-  };
 }
 
 export function setFilesWithChildren(

--- a/src/Frontend/state/actions/resource-actions/load-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/load-actions.ts
@@ -15,7 +15,6 @@ import {
 import { OpossumColors } from '../../../shared-styles';
 import { type AppThunkAction } from '../../types';
 import {
-  setAttributionBreakpoints,
   setConfig,
   setFilesWithChildren,
   setManualData,
@@ -91,10 +90,6 @@ export function loadFromFile(
       setResolvedExternalAttributions(
         parsedFileContent.resolvedExternalAttributions,
       ),
-    );
-
-    dispatch(
-      setAttributionBreakpoints(parsedFileContent.attributionBreakpoints),
     );
 
     dispatch(setFilesWithChildren(parsedFileContent.filesWithChildren));

--- a/src/Frontend/state/actions/resource-actions/save-actions.ts
+++ b/src/Frontend/state/actions/resource-actions/save-actions.ts
@@ -55,10 +55,12 @@ export function savePackageInfo(
         (ignorePreSelected || !attribution.preSelected) &&
         isEqual(getStrippedPackageInfo(attribution), strippedPackageInfo),
     );
+    const attributionBreakpoints =
+      await backend.getAttributionBreakpoints.query();
 
     if (attributionId && isEmpty(strippedPackageInfo)) {
       // DELETE
-      dispatch(deleteAttribution(attributionId));
+      dispatch(deleteAttribution(attributionId, attributionBreakpoints));
       await backend.deleteAttributions.mutate({
         attributionUuids: [attributionId],
       });
@@ -69,6 +71,7 @@ export function savePackageInfo(
           attributionId,
           matchedPackageInfo.id,
           !isSavedPackageInactive,
+          attributionBreakpoints,
         ),
       );
       await backend.replaceAttribution.mutate({
@@ -82,6 +85,7 @@ export function savePackageInfo(
           resourceId,
           matchedPackageInfo.id,
           !isSavedPackageInactive,
+          attributionBreakpoints,
         ),
       );
       await backend.linkAttribution.mutate({
@@ -181,8 +185,10 @@ export function deleteAttributionsAndSave(
   selectedAttributionId: string,
 ): AsyncAppThunkAction {
   return async (dispatch) => {
+    const attributionBreakpoints =
+      await backend.getAttributionBreakpoints.query();
     attributionIds.forEach((attributionId) => {
-      dispatch(deleteAttribution(attributionId));
+      dispatch(deleteAttribution(attributionId, attributionBreakpoints));
     });
     await backend.deleteAttributions.mutate({
       attributionUuids: attributionIds,
@@ -259,10 +265,13 @@ function updateAttribution(
   };
 }
 
-function deleteAttribution(attributionIdToDelete: string): DeleteAttribution {
+function deleteAttribution(
+  attributionIdToDelete: string,
+  attributionBreakpoints: Set<string>,
+): DeleteAttribution {
   return {
     type: ACTION_DELETE_ATTRIBUTION,
-    payload: attributionIdToDelete,
+    payload: { attributionId: attributionIdToDelete, attributionBreakpoints },
   };
 }
 
@@ -270,6 +279,7 @@ function replaceAttributionWithMatchingAttribution(
   attributionIdToReplace: string,
   attributionIdToReplaceWith: string,
   jumpToMatchingAttribution = true,
+  attributionBreakpoints: Set<string>,
 ): ReplaceAttributionWithMatchingAttributionAction {
   return {
     type: ACTION_REPLACE_ATTRIBUTION_WITH_MATCHING,
@@ -277,6 +287,7 @@ function replaceAttributionWithMatchingAttribution(
       attributionIdToReplace,
       attributionIdToReplaceWith,
       jumpToMatchingAttribution,
+      attributionBreakpoints,
     },
   };
 }
@@ -285,10 +296,16 @@ function linkToAttribution(
   resourceId: string,
   attributionId: string,
   jumpToMatchingAttribution = true,
+  attributionBreakpoints: Set<string>,
 ): LinkToAttributionAction {
   return {
     type: ACTION_LINK_TO_ATTRIBUTION,
-    payload: { resourceId, attributionId, jumpToMatchingAttribution },
+    payload: {
+      resourceId,
+      attributionId,
+      jumpToMatchingAttribution,
+      attributionBreakpoints,
+    },
   };
 }
 

--- a/src/Frontend/state/actions/resource-actions/types.ts
+++ b/src/Frontend/state/actions/resource-actions/types.ts
@@ -23,8 +23,6 @@ export const ACTION_SET_SELECTED_RESOURCE_ID =
 export const ACTION_SET_EXPANDED_IDS = 'ACTION_SET_EXPANDED_IDS';
 export const ACTION_SET_TARGET_SELECTED_RESOURCE_ID =
   'ACTION_SET_TARGET_SELECTED_RESOURCE_ID';
-export const ACTION_SET_ATTRIBUTION_BREAKPOINTS =
-  'ACTION_SET_ATTRIBUTION_BREAKPOINTS';
 export const ACTION_SET_FILES_WITH_CHILDREN = 'ACTION_SET_FILES_WITH_CHILDREN';
 export const ACTION_UPDATE_ATTRIBUTION =
   'ACTION_UPDATE_ATTRIBUTION_FOR_SELECTED';
@@ -60,7 +58,6 @@ export type ResourceAction =
   | SetExpandedIdsAction
   | SetTargetSelectedResourceId
   | SetSelectedAttributionId
-  | SetAttributionBreakpoints
   | SetFilesWithChildren
   | UpdateAttribution
   | DeleteAttribution
@@ -120,11 +117,6 @@ export interface SetTargetSelectedAttributionIdAction {
   payload: string | null;
 }
 
-export interface SetAttributionBreakpoints {
-  type: typeof ACTION_SET_ATTRIBUTION_BREAKPOINTS;
-  payload: Set<string>;
-}
-
 export interface SetFilesWithChildren {
   type: typeof ACTION_SET_FILES_WITH_CHILDREN;
   payload: Set<string>;
@@ -149,7 +141,10 @@ export interface UpdateAttribution {
 
 export interface DeleteAttribution {
   type: typeof ACTION_DELETE_ATTRIBUTION;
-  payload: string;
+  payload: {
+    attributionId: string;
+    attributionBreakpoints: Set<string>;
+  };
 }
 
 export interface ReplaceAttributionWithMatchingAttributionAction {
@@ -158,6 +153,7 @@ export interface ReplaceAttributionWithMatchingAttributionAction {
     attributionIdToReplace: string;
     attributionIdToReplaceWith: string;
     jumpToMatchingAttribution: boolean;
+    attributionBreakpoints: Set<string>;
   };
 }
 
@@ -167,6 +163,7 @@ export interface LinkToAttributionAction {
     resourceId: string;
     attributionId: string;
     jumpToMatchingAttribution: boolean;
+    attributionBreakpoints: Set<string>;
   };
 }
 

--- a/src/Frontend/state/reducers/resource-reducer.ts
+++ b/src/Frontend/state/reducers/resource-reducer.ts
@@ -24,7 +24,6 @@ import {
   ACTION_REMOVE_RESOLVED_EXTERNAL_ATTRIBUTIONS,
   ACTION_REPLACE_ATTRIBUTION_WITH_MATCHING,
   ACTION_RESET_RESOURCE_STATE,
-  ACTION_SET_ATTRIBUTION_BREAKPOINTS,
   ACTION_SET_BASE_URLS_FOR_SOURCES,
   ACTION_SET_EXPANDED_IDS,
   ACTION_SET_FILES_WITH_CHILDREN,
@@ -52,7 +51,6 @@ import {
 } from '../helpers/save-action-helpers';
 
 export const initialResourceState: ResourceState = {
-  attributionBreakpoints: new Set(),
   baseUrlsForSources: {},
   expandedIds: [ROOT_PATH],
   filesWithChildren: new Set(),
@@ -70,7 +68,6 @@ export const initialResourceState: ResourceState = {
 };
 
 export type ResourceState = {
-  attributionBreakpoints: Set<string>;
   baseUrlsForSources: BaseUrlsForSources;
   expandedIds: Array<string>;
   filesWithChildren: Set<string>;
@@ -139,11 +136,6 @@ export const resourceState = (
         ...state,
         targetSelectedAttributionId: action.payload,
       };
-    case ACTION_SET_ATTRIBUTION_BREAKPOINTS:
-      return {
-        ...state,
-        attributionBreakpoints: action.payload,
-      };
     case ACTION_SET_FILES_WITH_CHILDREN:
       return {
         ...state,
@@ -183,8 +175,8 @@ export const resourceState = (
     case ACTION_DELETE_ATTRIBUTION: {
       const manualData = deleteManualAttribution(
         state.manualData,
-        action.payload,
-        state.attributionBreakpoints,
+        action.payload.attributionId,
+        action.payload.attributionBreakpoints,
         state.resolvedExternalAttributions,
       );
 
@@ -192,7 +184,7 @@ export const resourceState = (
         ...state,
         manualData,
         selectedAttributionId:
-          state.selectedAttributionId === action.payload
+          state.selectedAttributionId === action.payload.attributionId
             ? ''
             : state.selectedAttributionId,
       };
@@ -202,7 +194,7 @@ export const resourceState = (
         state.manualData,
         action.payload.attributionIdToReplaceWith,
         action.payload.attributionIdToReplace,
-        state.attributionBreakpoints,
+        action.payload.attributionBreakpoints,
       );
 
       return {
@@ -218,7 +210,7 @@ export const resourceState = (
         state.manualData,
         action.payload.resourceId,
         action.payload.attributionId,
-        state.attributionBreakpoints,
+        action.payload.attributionBreakpoints,
       );
 
       return {

--- a/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
+++ b/src/Frontend/state/selectors/__tests__/all-views-resource-selectors.test.ts
@@ -5,34 +5,14 @@
 import { type ProjectMetadata } from '../../../../shared/shared-types';
 import { EMPTY_PROJECT_METADATA } from '../../../shared-constants';
 import {
-  setAttributionBreakpoints,
   setFilesWithChildren,
   setProjectMetadata,
 } from '../../actions/resource-actions/all-views-simple-actions';
 import { createAppStore } from '../../configure-store';
 import {
-  getAttributionBreakpoints,
   getFilesWithChildren,
   getProjectMetadata,
 } from '../resource-selectors';
-
-describe('Attribution breakpoints', () => {
-  const testAttributionBreakpoints: Set<string> = new Set([
-    '/path/breakpoint/',
-    '/node_modules/',
-  ]);
-
-  it('can be created and listed.', () => {
-    const testStore = createAppStore();
-    expect(getAttributionBreakpoints(testStore.getState())).toEqual(new Set());
-
-    testStore.dispatch(setAttributionBreakpoints(testAttributionBreakpoints));
-
-    expect(getAttributionBreakpoints(testStore.getState())).toEqual(
-      testAttributionBreakpoints,
-    );
-  });
-});
 
 describe('Files with children', () => {
   const testFileWithChildren = '/package.json/';

--- a/src/Frontend/state/selectors/resource-selectors.ts
+++ b/src/Frontend/state/selectors/resource-selectors.ts
@@ -57,10 +57,6 @@ export function getTemporaryDisplayPackageInfo(state: State): PackageInfo {
   return state.resourceState.temporaryDisplayPackageInfo;
 }
 
-export function getAttributionBreakpoints(state: State): Set<string> {
-  return state.resourceState.attributionBreakpoints;
-}
-
 export function getFilesWithChildren(state: State): Set<string> {
   return state.resourceState.filesWithChildren;
 }
@@ -75,11 +71,4 @@ export function getClassifications(state: State): ClassificationsConfig {
 
 export function getIsPackageInfoDirty(state: State): boolean {
   return state.resourceState.isPackageInfoDirty;
-}
-
-export function getIsSelectedResourceBreakpoint(state: State) {
-  const breakpoints = getAttributionBreakpoints(state);
-  const selectedResourceId = getSelectedResourceId(state);
-
-  return breakpoints.has(selectedResourceId);
 }

--- a/src/Frontend/util/use-selected-resource.ts
+++ b/src/Frontend/util/use-selected-resource.ts
@@ -8,7 +8,8 @@ import { backend } from './backendClient';
 
 export function useIsSelectedResourceBreakpoint(): boolean {
   const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const trimmedSelectedResourceId = selectedResourceId.replace(/\/$/, '');
   const { data: attributionBreakpoints } =
     backend.getAttributionBreakpoints.useQuery();
-  return attributionBreakpoints?.has(selectedResourceId) ?? false;
+  return attributionBreakpoints?.has(trimmedSelectedResourceId) ?? false;
 }

--- a/src/Frontend/util/use-selected-resource.ts
+++ b/src/Frontend/util/use-selected-resource.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { useAppSelector } from '../state/hooks';
+import { getSelectedResourceId } from '../state/selectors/resource-selectors';
+import { backend } from './backendClient';
+
+export function useIsSelectedResourceBreakpoint(): boolean {
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const { data: attributionBreakpoints } =
+    backend.getAttributionBreakpoints.useQuery();
+  return attributionBreakpoints?.has(selectedResourceId) ?? false;
+}

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -192,6 +192,7 @@ export const EXCLUDED_FROM_FRONTEND_FILE_CONTENT = [
   'frequentLicenses',
   'externalAttributionSources',
   'baseUrlsForSources',
+  'attributionBreakpoints',
 ] as const;
 export type ParsedFrontendFileContent = Omit<
   ParsedFileContent,


### PR DESCRIPTION
### Summary of changes

Move attribution breakpoints to the BE and remove the resource selector, as described in https://github.com/opossum-tool/OpossumUI/issues/3094

### How can the changes be tested

The existing behavior is still tested with tests like: `disables link button when selected resource is a breakpoint`

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
