### PR TITLE
Fix/speed up loading db

### DIFF
--- a/src/ElectronBackend/api/__tests__/utils.test.ts
+++ b/src/ElectronBackend/api/__tests__/utils.test.ts
@@ -267,7 +267,7 @@ describe('removeRedundantAttributions', () => {
       });
 
     await expectDbContent(props.expectedResourcesToAttributions);
-    await expectCAAConsistency();
+    await expectCaaConsistency();
   });
 });
 
@@ -342,7 +342,7 @@ async function expectDbContent(
   }
 }
 
-async function expectCAAConsistency() {
+async function expectCaaConsistency() {
   const resources = await getDb()
     .selectFrom('resource')
     .innerJoin(
@@ -370,7 +370,7 @@ async function expectCAAConsistency() {
     ).map((r) => r.resource_id),
   );
 
-  const cAAManualByResourceId = new Map(resources.map((r) => [r.id, r.manual]));
+  const caaManualByResourceId = new Map(resources.map((r) => [r.id, r.manual]));
 
   for (const resource of resources) {
     if (resourcesWithManualAttributions.has(resource.id)) {
@@ -383,7 +383,7 @@ async function expectCAAConsistency() {
       resource.parent_id !== null
     ) {
       const parentManual =
-        cAAManualByResourceId.get(resource.parent_id) ?? null;
+        caaManualByResourceId.get(resource.parent_id) ?? null;
       expect(
         resource.manual,
         `Closest ancestors with manual attributions for '${resource.path}' should match its parent's`,

--- a/src/ElectronBackend/api/__tests__/utils.test.ts
+++ b/src/ElectronBackend/api/__tests__/utils.test.ts
@@ -267,7 +267,7 @@ describe('removeRedundantAttributions', () => {
       });
 
     await expectDbContent(props.expectedResourcesToAttributions);
-    await expectCwaConsistency();
+    await expectCAAConsistency();
   });
 });
 
@@ -342,16 +342,20 @@ async function expectDbContent(
   }
 }
 
-async function expectCwaConsistency() {
+async function expectCAAConsistency() {
   const resources = await getDb()
     .selectFrom('resource')
-    .innerJoin('cwa', 'cwa.resource_id', 'resource.id')
+    .innerJoin(
+      'closest_attributed_ancestors',
+      'closest_attributed_ancestors.resource_id',
+      'resource.id',
+    )
     .select([
       'resource.id',
       'resource.path',
       'resource.parent_id',
       'resource.is_attribution_breakpoint',
-      'cwa.manual',
+      'closest_attributed_ancestors.manual',
     ])
     .execute();
 
@@ -366,28 +370,28 @@ async function expectCwaConsistency() {
     ).map((r) => r.resource_id),
   );
 
-  const cwaManualByResourceId = new Map(resources.map((r) => [r.id, r.manual]));
+  const cAAManualByResourceId = new Map(resources.map((r) => [r.id, r.manual]));
 
   for (const resource of resources) {
     if (resourcesWithManualAttributions.has(resource.id)) {
       expect(
         resource.manual,
-        `CWA manual for '${resource.path}' should point to itself`,
+        `Closest ancestors with manual attributions for '${resource.path}' should point to itself`,
       ).toBe(resource.id);
     } else if (
       resource.is_attribution_breakpoint === 0 &&
       resource.parent_id !== null
     ) {
       const parentManual =
-        cwaManualByResourceId.get(resource.parent_id) ?? null;
+        cAAManualByResourceId.get(resource.parent_id) ?? null;
       expect(
         resource.manual,
-        `CWA manual for '${resource.path}' should match its parent's CWA`,
+        `Closest ancestors with manual attributions for '${resource.path}' should match its parent's`,
       ).toBe(parentManual);
     } else {
       expect(
         resource.manual,
-        `CWA manual for '${resource.path}' should be null`,
+        `Closest_attributed_ancestors manual for '${resource.path}' should be null`,
       ).toBeNull();
     }
   }

--- a/src/ElectronBackend/api/exportCommands.ts
+++ b/src/ElectronBackend/api/exportCommands.ts
@@ -43,11 +43,15 @@ async function exportFollowUp(params: { filePath: string }) {
       (eb) =>
         eb
           .selectFrom('resource')
-          .innerJoin('cwa', 'cwa.resource_id', 'resource.id')
+          .innerJoin(
+            'closest_attributed_ancestors',
+            'closest_attributed_ancestors.resource_id',
+            'resource.id',
+          )
           .innerJoin(
             'resource_to_attribution',
             'resource_to_attribution.resource_id',
-            'cwa.manual',
+            'closest_attributed_ancestors.manual',
           )
           .select(
             sql<string>`json_group_array(resource.path ORDER BY resource.id)`.as(

--- a/src/ElectronBackend/api/getSaveFileArgs.ts
+++ b/src/ElectronBackend/api/getSaveFileArgs.ts
@@ -25,8 +25,15 @@ export async function getPreferredOverOriginIds(trxOrDb: Kysely<DB>) {
             'preferred.uuid',
             'has_preferred.attribution_uuid',
           )
-          .innerJoin('cwa', 'cwa.manual', 'has_preferred.resource_id')
-          .select(['preferred.uuid as attribution_uuid', 'cwa.resource_id'])
+          .innerJoin(
+            'closest_attributed_ancestors',
+            'closest_attributed_ancestors.manual',
+            'has_preferred.resource_id',
+          )
+          .select([
+            'preferred.uuid as attribution_uuid',
+            'closest_attributed_ancestors.resource_id',
+          ])
           .where('is_external', '=', 0)
           .where('preferred', '=', 1),
     )

--- a/src/ElectronBackend/api/mutations.ts
+++ b/src/ElectronBackend/api/mutations.ts
@@ -7,8 +7,8 @@ import { sql } from 'kysely';
 import { type Attributions, type PackageInfo } from '../../shared/shared-types';
 import { getDb } from '../db/db';
 import {
-  addManualOrExternalCAAToResources,
-  removeManualOrExternalCAAFromResources,
+  addManualOrExternalCaaToResources,
+  removeManualOrExternalCaaFromResources,
 } from './progressBarUtils';
 import { type QueryName, type QueryParams } from './queries';
 import {
@@ -45,7 +45,7 @@ export const mutations = {
     await getDb()
       .transaction()
       .execute(async (trx) => {
-        await removeManualOrExternalCAAFromResources(trx, 'manual', {
+        await removeManualOrExternalCaaFromResources(trx, 'manual', {
           attributionUuids: params.attributionUuids,
         });
         const impactedResources = new Set<number>();
@@ -219,7 +219,7 @@ export const mutations = {
           .onConflict((oc) => oc.doNothing())
           .execute();
 
-        await addManualOrExternalCAAToResources(trx, 'manual', {
+        await addManualOrExternalCaaToResources(trx, 'manual', {
           attributionUuids: [params.attributionUuid],
           resourceIds: [resource.id],
         });
@@ -300,7 +300,7 @@ export const mutations = {
           })
           .execute();
 
-        await addManualOrExternalCAAToResources(trx, 'manual', {
+        await addManualOrExternalCaaToResources(trx, 'manual', {
           attributionUuids: [params.attributionUuid],
           resourceIds: [resource.id],
         });
@@ -397,7 +397,7 @@ export const mutations = {
       .transaction()
       .execute(async (trx) => {
         const resource = await getResourceOrThrow(trx, params.resourcePath);
-        await removeManualOrExternalCAAFromResources(trx, 'manual', {
+        await removeManualOrExternalCaaFromResources(trx, 'manual', {
           attributionUuids: params.attributionUuids,
           resourceIds: [resource.id],
         });
@@ -469,11 +469,11 @@ async function setAttributionsResolvedStatus(
     .transaction()
     .execute(async (trx) => {
       if (resolvedStatus) {
-        await removeManualOrExternalCAAFromResources(trx, 'external', {
+        await removeManualOrExternalCaaFromResources(trx, 'external', {
           attributionUuids,
         });
       } else {
-        await addManualOrExternalCAAToResources(trx, 'external', {
+        await addManualOrExternalCaaToResources(trx, 'external', {
           attributionUuids,
         });
       }

--- a/src/ElectronBackend/api/mutations.ts
+++ b/src/ElectronBackend/api/mutations.ts
@@ -7,8 +7,8 @@ import { sql } from 'kysely';
 import { type Attributions, type PackageInfo } from '../../shared/shared-types';
 import { getDb } from '../db/db';
 import {
-  addManualOrExternalCwaToResources,
-  removeManualOrExternalCwaFromResources,
+  addManualOrExternalCAAToResources,
+  removeManualOrExternalCAAFromResources,
 } from './progressBarUtils';
 import { type QueryName, type QueryParams } from './queries';
 import {
@@ -45,7 +45,7 @@ export const mutations = {
     await getDb()
       .transaction()
       .execute(async (trx) => {
-        await removeManualOrExternalCwaFromResources(trx, 'manual', {
+        await removeManualOrExternalCAAFromResources(trx, 'manual', {
           attributionUuids: params.attributionUuids,
         });
         const impactedResources = new Set<number>();
@@ -219,7 +219,7 @@ export const mutations = {
           .onConflict((oc) => oc.doNothing())
           .execute();
 
-        await addManualOrExternalCwaToResources(trx, 'manual', {
+        await addManualOrExternalCAAToResources(trx, 'manual', {
           attributionUuids: [params.attributionUuid],
           resourceIds: [resource.id],
         });
@@ -300,7 +300,7 @@ export const mutations = {
           })
           .execute();
 
-        await addManualOrExternalCwaToResources(trx, 'manual', {
+        await addManualOrExternalCAAToResources(trx, 'manual', {
           attributionUuids: [params.attributionUuid],
           resourceIds: [resource.id],
         });
@@ -397,7 +397,7 @@ export const mutations = {
       .transaction()
       .execute(async (trx) => {
         const resource = await getResourceOrThrow(trx, params.resourcePath);
-        await removeManualOrExternalCwaFromResources(trx, 'manual', {
+        await removeManualOrExternalCAAFromResources(trx, 'manual', {
           attributionUuids: params.attributionUuids,
           resourceIds: [resource.id],
         });
@@ -469,11 +469,11 @@ async function setAttributionsResolvedStatus(
     .transaction()
     .execute(async (trx) => {
       if (resolvedStatus) {
-        await removeManualOrExternalCwaFromResources(trx, 'external', {
+        await removeManualOrExternalCAAFromResources(trx, 'external', {
           attributionUuids,
         });
       } else {
-        await addManualOrExternalCwaToResources(trx, 'external', {
+        await addManualOrExternalCAAToResources(trx, 'external', {
           attributionUuids,
         });
       }

--- a/src/ElectronBackend/api/progressBarQueries.ts
+++ b/src/ElectronBackend/api/progressBarQueries.ts
@@ -126,7 +126,7 @@ export async function getNextFileToReviewForAttribution(props: {
         getOnlyPreSelectedManualFilesQuery,
         (eb: ExpressionBuilder<DB, never>) =>
           eb
-            .selectFrom('cwa')
+            .selectFrom('closest_attributed_ancestors')
             .select('resource_id')
             .where('is_file', '=', 1)
             .where('manual', 'is', null)
@@ -166,7 +166,9 @@ export async function getNextFileToReviewForCriticality(props: {
       ]) {
         const resource = await trx
           .selectFrom((eb) =>
-            getCriticalResourceQuery(eb, criticality).as('cwa'),
+            getCriticalResourceQuery(eb, criticality).as(
+              'closest_attributed_ancestors',
+            ),
           )
           .innerJoin('resource', 'resource_id', 'resource.id')
           .select(['resource_id', GET_LEGACY_RESOURCE_PATH])
@@ -201,7 +203,7 @@ export async function getNextFileToReviewForClassification(props: {
         const resource = await trx
           .selectFrom((eb) =>
             getClassificationResourceQuery(eb, Number(classification)).as(
-              'cwa',
+              'closest_attributed_ancestors',
             ),
           )
           .innerJoin('resource', 'resource_id', 'resource.id')

--- a/src/ElectronBackend/api/progressBarUtils.ts
+++ b/src/ElectronBackend/api/progressBarUtils.ts
@@ -14,28 +14,34 @@ import {
 import { type Criticality } from '../../shared/shared-types';
 import { type DB } from '../db/generated/databaseTypes';
 
-export function getOnlyExternalFilesQuery(eb: ExpressionBuilder<DB, 'cwa'>) {
+export function getOnlyExternalFilesQuery(
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
+) {
   return eb
-    .selectFrom('cwa')
+    .selectFrom('closest_attributed_ancestors')
     .select('resource_id')
-    .where('cwa.is_file', '=', 1)
-    .where('cwa.manual', 'is', null)
-    .where('cwa.external', 'is not', null);
+    .where('closest_attributed_ancestors.is_file', '=', 1)
+    .where('closest_attributed_ancestors.manual', 'is', null)
+    .where('closest_attributed_ancestors.external', 'is not', null);
 }
 
-export function getManualFilesQuery(eb: ExpressionBuilder<DB, 'cwa'>) {
+export function getManualFilesQuery(
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
+) {
   return eb
-    .selectFrom('cwa')
+    .selectFrom('closest_attributed_ancestors')
     .select(['resource_id', 'manual'])
-    .where('cwa.is_file', '=', 1)
-    .where('cwa.manual', 'is not', null);
+    .where('closest_attributed_ancestors.is_file', '=', 1)
+    .where('closest_attributed_ancestors.manual', 'is not', null);
 }
 
 export function getNonPreSelectedManualFilesQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
 ) {
   return eb
-    .selectFrom((eb) => getManualFilesQuery(eb).as('cwa'))
+    .selectFrom((eb) =>
+      getManualFilesQuery(eb).as('closest_attributed_ancestors'),
+    )
     .select('resource_id')
     .where('manual', 'in', (eb) =>
       resourcePreSelectedQuery(eb, { isPreSelected: 0 }),
@@ -43,10 +49,12 @@ export function getNonPreSelectedManualFilesQuery(
 }
 
 export function getOnlyPreSelectedManualFilesQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
 ) {
   return eb
-    .selectFrom((eb) => getManualFilesQuery(eb).as('cwa'))
+    .selectFrom((eb) =>
+      getManualFilesQuery(eb).as('closest_attributed_ancestors'),
+    )
     .select('resource_id')
     .where('manual', 'in', (eb) =>
       resourcePreSelectedQuery(eb, { isPreSelected: 1 }),
@@ -57,7 +65,7 @@ export function getOnlyPreSelectedManualFilesQuery(
 }
 
 function resourcePreSelectedQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   options: { isPreSelected: 0 | 1 },
 ) {
   return eb
@@ -81,11 +89,11 @@ function attributionPreSelectedQuery(
 }
 
 export function getCriticalResourceQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   criticality: Criticality,
 ) {
   return eb
-    .selectFrom('cwa')
+    .selectFrom('closest_attributed_ancestors')
     .select('resource_id')
     .where('manual', 'is', null)
     .where('resource_id', 'in', (eb) =>
@@ -97,7 +105,7 @@ export function getCriticalResourceQuery(
 }
 
 function resourceCriticalityQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   options: { operator: ComparisonOperatorExpression; criticality: Criticality },
 ) {
   return eb
@@ -121,11 +129,11 @@ function attributionCriticalityQuery(
 }
 
 export function getClassificationResourceQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   classification: number,
 ) {
   return eb
-    .selectFrom('cwa')
+    .selectFrom('closest_attributed_ancestors')
     .select('resource_id')
     .where('manual', 'is', null)
     .where('resource_id', 'in', (eb) =>
@@ -143,7 +151,7 @@ export function getClassificationResourceQuery(
 }
 
 function resourceClassificationQuery(
-  eb: ExpressionBuilder<DB, 'cwa'>,
+  eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   options: { operator: ComparisonOperatorExpression; classification: number },
 ) {
   return eb
@@ -167,11 +175,11 @@ function attributionClassificationQuery(
 }
 
 /**
- * Used to keep the cwa table up to date when removing attributions.
+ * Used to keep the closest_attributed_ancestors table up to date when removing attributions.
  * Takes attributionUuids as an input and checks for resources that will have no more manual/external attributions once they are removed.
  * Call BEFORE removing attributions.
  */
-export async function removeManualOrExternalCwaFromResources(
+export async function removeManualOrExternalCAAFromResources(
   trxOrDB: Transaction<DB> | Kysely<DB>,
   type: 'manual' | 'external',
   {
@@ -199,9 +207,13 @@ export async function removeManualOrExternalCwaFromResources(
                 .when('r.is_attribution_breakpoint', '=', 0)
                 .then(
                   eb
-                    .selectFrom('cwa')
+                    .selectFrom('closest_attributed_ancestors')
                     .select(type)
-                    .whereRef('cwa.resource_id', '=', 'r.parent_id'),
+                    .whereRef(
+                      'closest_attributed_ancestors.resource_id',
+                      '=',
+                      'r.parent_id',
+                    ),
                 )
                 .end()
                 .as('replace_with'),
@@ -246,7 +258,7 @@ export async function removeManualOrExternalCwaFromResources(
               ),
           ),
       )
-      .updateTable('cwa')
+      .updateTable('closest_attributed_ancestors')
       .from('impacted_resources')
       .set((eb) => ({
         [type]: eb.ref('impacted_resources.replace_with'),
@@ -262,11 +274,11 @@ export async function removeManualOrExternalCwaFromResources(
 }
 
 /**
- * Used to keep the cwa table up to date when adding attributions.
+ * Used to keep the closest_attributed_ancestors table up to date when adding attributions.
  * Takes attributionUuids as an input and checks for resources that now have manual/external attributions.
  * Call AFTER adding attributions.
  */
-export async function addManualOrExternalCwaToResources(
+export async function addManualOrExternalCAAToResources(
   trxOrDB: Transaction<DB> | Kysely<DB>,
   type: 'manual' | 'external',
   {
@@ -280,12 +292,16 @@ export async function addManualOrExternalCwaToResources(
         db
           .selectFrom('resource_to_attribution as rta')
           .innerJoin('resource as r', 'rta.resource_id', 'r.id')
-          .innerJoin('cwa as previous_cwa', 'previous_cwa.resource_id', 'r.id')
+          .innerJoin(
+            'closest_attributed_ancestors as previous_caa',
+            'previous_caa.resource_id',
+            'r.id',
+          )
           .select([
             'rta.resource_id',
             'r.max_descendant_id',
-            (eb) => eb.ref(`previous_cwa.${type}`).as('previous_value'),
-            'previous_cwa.breakpoint as closest_breakpoint',
+            (eb) => eb.ref(`previous_caa.${type}`).as('previous_value'),
+            'previous_caa.breakpoint as closest_breakpoint',
           ])
           .where('rta.attribution_uuid', 'in', attributionUuids)
           .$if(resourceIds !== undefined, (eb) =>
@@ -317,44 +333,48 @@ export async function addManualOrExternalCwaToResources(
       // Get all children in the same breakpoint-subtree that point to the same resource as the newly added attributions
       .with('impacted_resources', (db) =>
         db
-          .selectFrom('cwa')
+          .selectFrom('closest_attributed_ancestors')
           .innerJoin('newly_attributed_resources', (join) =>
             join
               .onRef(
-                'cwa.resource_id',
+                'closest_attributed_ancestors.resource_id',
                 '>=',
                 'newly_attributed_resources.resource_id',
               )
               .onRef(
-                'cwa.resource_id',
+                'closest_attributed_ancestors.resource_id',
                 '<=',
                 'newly_attributed_resources.max_descendant_id',
               )
               .onRef(
                 'newly_attributed_resources.previous_value',
                 'is',
-                `cwa.${type}`,
+                `closest_attributed_ancestors.${type}`,
               )
               .onRef(
                 'newly_attributed_resources.closest_breakpoint',
                 '=',
-                'cwa.breakpoint',
+                'closest_attributed_ancestors.breakpoint',
               ),
           )
           .select([
-            'cwa.resource_id',
+            'closest_attributed_ancestors.resource_id',
             // Get the closest parent with manual/external attributions
             (eb) =>
               eb.fn.max('newly_attributed_resources.resource_id').as('new_id'),
           ])
-          .groupBy('cwa.resource_id'),
+          .groupBy('closest_attributed_ancestors.resource_id'),
       )
-      .updateTable('cwa')
+      .updateTable('closest_attributed_ancestors')
       .from('impacted_resources')
       .set((eb) => ({
         [type]: eb.ref('impacted_resources.new_id'),
       }))
-      .whereRef('cwa.resource_id', '=', 'impacted_resources.resource_id')
+      .whereRef(
+        'closest_attributed_ancestors.resource_id',
+        '=',
+        'impacted_resources.resource_id',
+      )
       .execute()
   );
 }
@@ -362,7 +382,7 @@ export async function addManualOrExternalCwaToResources(
 export async function getCount(
   trxOrDb: Transaction<DB> | Kysely<DB>,
   from: (
-    eb: ExpressionBuilder<DB, 'cwa'>,
+    eb: ExpressionBuilder<DB, 'closest_attributed_ancestors'>,
   ) => SelectQueryBuilder<DB, never, unknown>,
 ): Promise<number> {
   const { count } = await trxOrDb

--- a/src/ElectronBackend/api/progressBarUtils.ts
+++ b/src/ElectronBackend/api/progressBarUtils.ts
@@ -179,7 +179,7 @@ function attributionClassificationQuery(
  * Takes attributionUuids as an input and checks for resources that will have no more manual/external attributions once they are removed.
  * Call BEFORE removing attributions.
  */
-export async function removeManualOrExternalCAAFromResources(
+export async function removeManualOrExternalCaaFromResources(
   trxOrDB: Transaction<DB> | Kysely<DB>,
   type: 'manual' | 'external',
   {
@@ -278,7 +278,7 @@ export async function removeManualOrExternalCAAFromResources(
  * Takes attributionUuids as an input and checks for resources that now have manual/external attributions.
  * Call AFTER adding attributions.
  */
-export async function addManualOrExternalCAAToResources(
+export async function addManualOrExternalCaaToResources(
   trxOrDB: Transaction<DB> | Kysely<DB>,
   type: 'manual' | 'external',
   {

--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -18,7 +18,7 @@ import { FILTERS } from '../../Frontend/shared-constants';
 import { areAttributionsEqual } from '../../shared/attribution-comparison';
 import { type PackageInfo } from '../../shared/shared-types';
 import { type DB } from '../db/generated/databaseTypes';
-import { removeManualOrExternalCwaFromResources } from './progressBarUtils';
+import { removeManualOrExternalCAAFromResources } from './progressBarUtils';
 import {
   type FilterProperties,
   type FilterPropertiesWithCanonicalLicenseNames,
@@ -62,11 +62,15 @@ export async function removeRedundantAttributions(
                 'resource.id',
                 'rta.resource_id',
               )
-              .leftJoin('cwa', 'resource.id', 'cwa.resource_id')
+              .leftJoin(
+                'closest_attributed_ancestors',
+                'resource.id',
+                'closest_attributed_ancestors.resource_id',
+              )
               .select([
                 'resource.id as resource_id',
                 'resource.max_descendant_id',
-                'cwa.manual',
+                'closest_attributed_ancestors.manual',
               ])
               .distinct()
               .$if(attributionUuids !== undefined, (eb) =>
@@ -80,10 +84,14 @@ export async function removeRedundantAttributions(
           .with('closest_ancestor_above', (db) =>
             db
               .selectFrom('resource')
-              .innerJoin('cwa', 'resource.parent_id', 'cwa.resource_id')
+              .innerJoin(
+                'closest_attributed_ancestors',
+                'resource.parent_id',
+                'closest_attributed_ancestors.resource_id',
+              )
               .select([
                 'resource.id as resource_id',
-                'cwa.manual as ancestor_id',
+                'closest_attributed_ancestors.manual as ancestor_id',
               ])
               .where('is_attribution_breakpoint', '=', 0),
           )
@@ -198,7 +206,7 @@ export async function removeRedundantAttributions(
     // In this case, we need to call this function after removing the attribution-resource-connection, because
     // we don't know which attributionUuid will be affected. That means we can't pass the uuids to this function,
     // so they can't be ignored when checking for remaining attributions on the resources.
-    await removeManualOrExternalCwaFromResources(trx, 'manual', {
+    await removeManualOrExternalCAAFromResources(trx, 'manual', {
       resourceIds: trx
         .withTables<{ duplicate_resources: { resource_id: number } }>()
         .selectFrom('duplicate_resources')

--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -18,7 +18,7 @@ import { FILTERS } from '../../Frontend/shared-constants';
 import { areAttributionsEqual } from '../../shared/attribution-comparison';
 import { type PackageInfo } from '../../shared/shared-types';
 import { type DB } from '../db/generated/databaseTypes';
-import { removeManualOrExternalCAAFromResources } from './progressBarUtils';
+import { removeManualOrExternalCaaFromResources } from './progressBarUtils';
 import {
   type FilterProperties,
   type FilterPropertiesWithCanonicalLicenseNames,
@@ -206,7 +206,7 @@ export async function removeRedundantAttributions(
     // In this case, we need to call this function after removing the attribution-resource-connection, because
     // we don't know which attributionUuid will be affected. That means we can't pass the uuids to this function,
     // so they can't be ignored when checking for remaining attributions on the resources.
-    await removeManualOrExternalCAAFromResources(trx, 'manual', {
+    await removeManualOrExternalCaaFromResources(trx, 'manual', {
       resourceIds: trx
         .withTables<{ duplicate_resources: { resource_id: number } }>()
         .selectFrom('duplicate_resources')

--- a/src/ElectronBackend/db/db.ts
+++ b/src/ElectronBackend/db/db.ts
@@ -31,6 +31,8 @@ function openDb() {
   rawDb = new BetterSqlite3(filename);
 
   rawDb.pragma('foreign_keys = ON');
+  rawDb.pragma('page_size = 8192');
+  rawDb.pragma('cache_size = 8192');
 
   const dialect = new SqliteDialect({ database: rawDb });
   return new Kysely<DB>({

--- a/src/ElectronBackend/db/generated/databaseDiagram.svg
+++ b/src/ElectronBackend/db/generated/databaseDiagram.svg
@@ -183,19 +183,19 @@
 <text xml:space="preserve" text-anchor="start" x="172.48" y="-1005.8" font-family="Times,serif" font-size="14.00">INTEGER</text>
 <polygon fill="none" stroke="black" points="74.68,-977.2 74.68,-1000 98.18,-1000 98.18,-977.2 74.68,-977.2"/>
 <polygon fill="none" stroke="black" points="98.18,-977.2 98.18,-1000 169.48,-1000 169.48,-977.2 98.18,-977.2"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-983" font-family="Times,serif" font-size="14.00">manual</text>
+<text xml:space="preserve" text-anchor="start" x="101.18" y="-983" font-family="Times,serif" font-size="14.00">breakpoint</text>
 <polygon fill="none" stroke="black" points="169.48,-977.2 169.48,-1000 241.57,-1000 241.57,-977.2 169.48,-977.2"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-983" font-family="Times,serif" font-size="14.00">INTEGER?</text>
+<text xml:space="preserve" text-anchor="start" x="172.48" y="-983" font-family="Times,serif" font-size="14.00">INTEGER</text>
 <polygon fill="none" stroke="black" points="74.68,-954.4 74.68,-977.2 98.18,-977.2 98.18,-954.4 74.68,-954.4"/>
 <polygon fill="none" stroke="black" points="98.18,-954.4 98.18,-977.2 169.48,-977.2 169.48,-954.4 98.18,-954.4"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-960.2" font-family="Times,serif" font-size="14.00">external</text>
+<text xml:space="preserve" text-anchor="start" x="101.18" y="-960.2" font-family="Times,serif" font-size="14.00">manual</text>
 <polygon fill="none" stroke="black" points="169.48,-954.4 169.48,-977.2 241.57,-977.2 241.57,-954.4 169.48,-954.4"/>
 <text xml:space="preserve" text-anchor="start" x="172.48" y="-960.2" font-family="Times,serif" font-size="14.00">INTEGER?</text>
 <polygon fill="none" stroke="black" points="74.68,-931.6 74.68,-954.4 98.18,-954.4 98.18,-931.6 74.68,-931.6"/>
 <polygon fill="none" stroke="black" points="98.18,-931.6 98.18,-954.4 169.48,-954.4 169.48,-931.6 98.18,-931.6"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-937.4" font-family="Times,serif" font-size="14.00">breakpoint</text>
+<text xml:space="preserve" text-anchor="start" x="101.18" y="-937.4" font-family="Times,serif" font-size="14.00">external</text>
 <polygon fill="none" stroke="black" points="169.48,-931.6 169.48,-954.4 241.57,-954.4 241.57,-931.6 169.48,-931.6"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-937.4" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<text xml:space="preserve" text-anchor="start" x="172.48" y="-937.4" font-family="Times,serif" font-size="14.00">INTEGER?</text>
 </g>
 <!-- resource -->
 <g id="node5" class="node">
@@ -264,20 +264,20 @@
 <!-- cwa&#45;&gt;resource -->
 <g id="edge1" class="edge">
 <title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-943C304.38,-943 318.97,-973.71 375.06,-977.43"/>
-<polygon fill="black" stroke="black" points="374.83,-980.93 384.94,-977.75 375.05,-973.93 374.83,-980.93"/>
+<path fill="none" stroke="black" d="M242.57,-988.6C302.69,-988.6 320.18,-979.11 374.97,-977.92"/>
+<polygon fill="black" stroke="black" points="374.97,-981.42 384.94,-977.82 374.9,-974.42 374.97,-981.42"/>
 </g>
 <!-- cwa&#45;&gt;resource -->
 <g id="edge2" class="edge">
 <title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-965.8C302.73,-965.8 320.15,-976.35 374.96,-977.67"/>
-<polygon fill="black" stroke="black" points="374.9,-981.16 384.94,-977.78 374.98,-974.17 374.9,-981.16"/>
+<path fill="none" stroke="black" d="M242.57,-943C304.38,-943 318.97,-973.71 375.06,-977.43"/>
+<polygon fill="black" stroke="black" points="374.83,-980.93 384.94,-977.75 375.05,-973.93 374.83,-980.93"/>
 </g>
 <!-- cwa&#45;&gt;resource -->
 <g id="edge3" class="edge">
 <title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-988.6C302.69,-988.6 320.18,-979.11 374.97,-977.92"/>
-<polygon fill="black" stroke="black" points="374.97,-981.42 384.94,-977.82 374.9,-974.42 374.97,-981.42"/>
+<path fill="none" stroke="black" d="M242.57,-965.8C302.73,-965.8 320.15,-976.35 374.96,-977.67"/>
+<polygon fill="black" stroke="black" points="374.9,-981.16 384.94,-977.78 374.98,-974.17 374.9,-981.16"/>
 </g>
 <!-- cwa&#45;&gt;resource -->
 <g id="edge4" class="edge">
@@ -342,93 +342,87 @@
 <!-- resource&#45;&gt;resource -->
 <g id="edge7" class="edge">
 <title>resource:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M630.57,-818.2C718.29,-863.53 718.29,-1034 509.01,-1034 307.9,-1034 300.05,-1022.92 377.58,-982.83"/>
-<polygon fill="black" stroke="black" points="378.78,-986.15 386.1,-978.49 375.6,-979.91 378.78,-986.15"/>
-</g>
-<!-- resource&#45;&gt;resource -->
-<g id="edge8" class="edge">
-<title>resource:e&#45;&gt;resource:w</title>
 <path fill="none" stroke="black" d="M630.57,-909.4C718.29,-954.73 718.29,-1034 509.01,-1034 307.9,-1034 300.05,-1022.92 377.58,-982.83"/>
 <polygon fill="black" stroke="black" points="378.78,-986.15 386.1,-978.49 375.6,-979.91 378.78,-986.15"/>
 </g>
 <!-- resource_to_attribution -->
 <g id="node6" class="node">
 <title>resource_to_attribution</title>
-<polygon fill="none" stroke="black" points="38.31,-819.8 38.31,-842.6 277.94,-842.6 277.94,-819.8 38.31,-819.8"/>
-<text xml:space="preserve" text-anchor="start" x="86.97" y="-828" font-family="Times,serif" font-weight="bold" font-size="14.00">resource_to_attribution</text>
-<polygon fill="none" stroke="black" points="38.31,-797 38.31,-819.8 61.81,-819.8 61.81,-797 38.31,-797"/>
-<text xml:space="preserve" text-anchor="start" x="41.31" y="-802.8" font-family="Times,serif" font-size="14.00">🔑 </text>
-<polygon fill="none" stroke="black" points="61.81,-797 61.81,-819.8 212.06,-819.8 212.06,-797 61.81,-797"/>
-<text xml:space="preserve" text-anchor="start" x="64.81" y="-802.8" font-family="Times,serif" font-size="14.00">resource_id</text>
-<polygon fill="none" stroke="black" points="212.06,-797 212.06,-819.8 277.94,-819.8 277.94,-797 212.06,-797"/>
-<text xml:space="preserve" text-anchor="start" x="215.06" y="-802.8" font-family="Times,serif" font-size="14.00">INTEGER</text>
-<polygon fill="none" stroke="black" points="38.31,-774.2 38.31,-797 61.81,-797 61.81,-774.2 38.31,-774.2"/>
-<text xml:space="preserve" text-anchor="start" x="41.31" y="-780" font-family="Times,serif" font-size="14.00">🔑 </text>
-<polygon fill="none" stroke="black" points="61.81,-774.2 61.81,-797 212.06,-797 212.06,-774.2 61.81,-774.2"/>
-<text xml:space="preserve" text-anchor="start" x="64.81" y="-780" font-family="Times,serif" font-size="14.00">attribution_uuid</text>
-<polygon fill="none" stroke="black" points="212.06,-774.2 212.06,-797 277.94,-797 277.94,-774.2 212.06,-774.2"/>
-<text xml:space="preserve" text-anchor="start" x="215.06" y="-780" font-family="Times,serif" font-size="14.00">TEXT</text>
-<polygon fill="none" stroke="black" points="38.31,-751.4 38.31,-774.2 61.81,-774.2 61.81,-751.4 38.31,-751.4"/>
+<polygon fill="none" stroke="black" points="38.31,-814.8 38.31,-837.6 277.94,-837.6 277.94,-814.8 38.31,-814.8"/>
+<text xml:space="preserve" text-anchor="start" x="86.97" y="-823" font-family="Times,serif" font-weight="bold" font-size="14.00">resource_to_attribution</text>
+<polygon fill="none" stroke="black" points="38.31,-792 38.31,-814.8 61.81,-814.8 61.81,-792 38.31,-792"/>
+<text xml:space="preserve" text-anchor="start" x="41.31" y="-797.8" font-family="Times,serif" font-size="14.00">🔑 </text>
+<polygon fill="none" stroke="black" points="61.81,-792 61.81,-814.8 212.06,-814.8 212.06,-792 61.81,-792"/>
+<text xml:space="preserve" text-anchor="start" x="64.81" y="-797.8" font-family="Times,serif" font-size="14.00">resource_id</text>
+<polygon fill="none" stroke="black" points="212.06,-792 212.06,-814.8 277.94,-814.8 277.94,-792 212.06,-792"/>
+<text xml:space="preserve" text-anchor="start" x="215.06" y="-797.8" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="38.31,-769.2 38.31,-792 61.81,-792 61.81,-769.2 38.31,-769.2"/>
+<text xml:space="preserve" text-anchor="start" x="41.31" y="-775" font-family="Times,serif" font-size="14.00">🔑 </text>
+<polygon fill="none" stroke="black" points="61.81,-769.2 61.81,-792 212.06,-792 212.06,-769.2 61.81,-769.2"/>
+<text xml:space="preserve" text-anchor="start" x="64.81" y="-775" font-family="Times,serif" font-size="14.00">attribution_uuid</text>
+<polygon fill="none" stroke="black" points="212.06,-769.2 212.06,-792 277.94,-792 277.94,-769.2 212.06,-769.2"/>
+<text xml:space="preserve" text-anchor="start" x="215.06" y="-775" font-family="Times,serif" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="38.31,-746.4 38.31,-769.2 61.81,-769.2 61.81,-746.4 38.31,-746.4"/>
 <g id="a_node6_6"><a xlink:title="Denormalized data for faster checking if a resource has manual/external attribution">
-<polygon fill="none" stroke="black" points="61.81,-751.4 61.81,-774.2 212.06,-774.2 212.06,-751.4 61.81,-751.4"/>
-<text xml:space="preserve" text-anchor="start" x="64.81" y="-757.2" font-family="Times,serif" font-size="14.00">attribution_is_external 📝</text>
+<polygon fill="none" stroke="black" points="61.81,-746.4 61.81,-769.2 212.06,-769.2 212.06,-746.4 61.81,-746.4"/>
+<text xml:space="preserve" text-anchor="start" x="64.81" y="-752.2" font-family="Times,serif" font-size="14.00">attribution_is_external 📝</text>
 </a>
 </g>
-<polygon fill="none" stroke="black" points="212.06,-751.4 212.06,-774.2 277.94,-774.2 277.94,-751.4 212.06,-751.4"/>
-<text xml:space="preserve" text-anchor="start" x="215.06" y="-757.2" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="212.06,-746.4 212.06,-769.2 277.94,-769.2 277.94,-746.4 212.06,-746.4"/>
+<text xml:space="preserve" text-anchor="start" x="215.06" y="-752.2" font-family="Times,serif" font-size="14.00">INTEGER</text>
 </g>
 <!-- resource_to_attribution&#45;&gt;attribution -->
 <g id="edge5" class="edge">
 <title>resource_to_attribution:e&#45;&gt;attribution:w</title>
-<path fill="none" stroke="black" d="M278.94,-785.6C319.75,-785.6 315.56,-734.84 347.94,-725.33"/>
-<polygon fill="black" stroke="black" points="348.31,-728.81 357.75,-724 347.37,-721.87 348.31,-728.81"/>
+<path fill="none" stroke="black" d="M278.94,-780.6C318.56,-780.6 316.42,-733.95 348.21,-725.2"/>
+<polygon fill="black" stroke="black" points="348.27,-728.72 357.75,-723.99 347.39,-721.78 348.27,-728.72"/>
 </g>
 <!-- resource_to_attribution&#45;&gt;resource -->
 <g id="edge6" class="edge">
 <title>resource_to_attribution:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M278.94,-808.4C364.1,-808.4 303.32,-962.92 375.37,-976.81"/>
-<polygon fill="black" stroke="black" points="374.67,-980.26 384.94,-977.66 375.29,-973.28 374.67,-980.26"/>
+<path fill="none" stroke="black" d="M278.94,-803.4C365.9,-803.4 301.76,-962.48 375.15,-976.78"/>
+<polygon fill="black" stroke="black" points="374.67,-980.25 384.94,-977.66 375.3,-973.27 374.67,-980.25"/>
 </g>
 <!-- source_for_attribution -->
 <g id="node7" class="node">
 <title>source_for_attribution</title>
-<polygon fill="none" stroke="black" points="8,-431.2 8,-454 308.25,-454 308.25,-431.2 8,-431.2"/>
-<text xml:space="preserve" text-anchor="start" x="90.08" y="-439.4" font-family="Times,serif" font-weight="bold" font-size="14.00">source_for_attribution</text>
-<polygon fill="none" stroke="black" points="8,-408.4 8,-431.2 31.5,-431.2 31.5,-408.4 8,-408.4"/>
-<text xml:space="preserve" text-anchor="start" x="11" y="-414.2" font-family="Times,serif" font-size="14.00">🔑 </text>
-<polygon fill="none" stroke="black" points="31.5,-408.4 31.5,-431.2 236.16,-431.2 236.16,-408.4 31.5,-408.4"/>
-<text xml:space="preserve" text-anchor="start" x="34.5" y="-414.2" font-family="Times,serif" font-size="14.00">attribution_uuid</text>
-<polygon fill="none" stroke="black" points="236.16,-408.4 236.16,-431.2 308.25,-431.2 308.25,-408.4 236.16,-408.4"/>
-<text xml:space="preserve" text-anchor="start" x="239.16" y="-414.2" font-family="Times,serif" font-size="14.00">TEXT</text>
-<polygon fill="none" stroke="black" points="8,-385.6 8,-408.4 31.5,-408.4 31.5,-385.6 8,-385.6"/>
+<polygon fill="none" stroke="black" points="8,-429.2 8,-452 308.25,-452 308.25,-429.2 8,-429.2"/>
+<text xml:space="preserve" text-anchor="start" x="90.08" y="-437.4" font-family="Times,serif" font-weight="bold" font-size="14.00">source_for_attribution</text>
+<polygon fill="none" stroke="black" points="8,-406.4 8,-429.2 31.5,-429.2 31.5,-406.4 8,-406.4"/>
+<text xml:space="preserve" text-anchor="start" x="11" y="-412.2" font-family="Times,serif" font-size="14.00">🔑 </text>
+<polygon fill="none" stroke="black" points="31.5,-406.4 31.5,-429.2 236.16,-429.2 236.16,-406.4 31.5,-406.4"/>
+<text xml:space="preserve" text-anchor="start" x="34.5" y="-412.2" font-family="Times,serif" font-size="14.00">attribution_uuid</text>
+<polygon fill="none" stroke="black" points="236.16,-406.4 236.16,-429.2 308.25,-429.2 308.25,-406.4 236.16,-406.4"/>
+<text xml:space="preserve" text-anchor="start" x="239.16" y="-412.2" font-family="Times,serif" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="8,-383.6 8,-406.4 31.5,-406.4 31.5,-383.6 8,-383.6"/>
 <g id="a_node7_7"><a xlink:title="Mainly contains keys of external_attribution_source, but can also contain unknown values">
-<polygon fill="none" stroke="black" points="31.5,-385.6 31.5,-408.4 236.16,-408.4 236.16,-385.6 31.5,-385.6"/>
-<text xml:space="preserve" text-anchor="start" x="34.5" y="-391.4" font-family="Times,serif" font-size="14.00">external_attribution_source_key 📝</text>
+<polygon fill="none" stroke="black" points="31.5,-383.6 31.5,-406.4 236.16,-406.4 236.16,-383.6 31.5,-383.6"/>
+<text xml:space="preserve" text-anchor="start" x="34.5" y="-389.4" font-family="Times,serif" font-size="14.00">external_attribution_source_key 📝</text>
 </a>
 </g>
-<polygon fill="none" stroke="black" points="236.16,-385.6 236.16,-408.4 308.25,-408.4 308.25,-385.6 236.16,-385.6"/>
-<text xml:space="preserve" text-anchor="start" x="239.16" y="-391.4" font-family="Times,serif" font-size="14.00">TEXT</text>
-<polygon fill="none" stroke="black" points="8,-362.8 8,-385.6 31.5,-385.6 31.5,-362.8 8,-362.8"/>
-<polygon fill="none" stroke="black" points="31.5,-362.8 31.5,-385.6 236.16,-385.6 236.16,-362.8 31.5,-362.8"/>
-<text xml:space="preserve" text-anchor="start" x="34.5" y="-368.6" font-family="Times,serif" font-size="14.00">document_confidence</text>
-<polygon fill="none" stroke="black" points="236.16,-362.8 236.16,-385.6 308.25,-385.6 308.25,-362.8 236.16,-362.8"/>
-<text xml:space="preserve" text-anchor="start" x="239.16" y="-368.6" font-family="Times,serif" font-size="14.00">INTEGER?</text>
-<polygon fill="none" stroke="black" points="8,-340 8,-362.8 31.5,-362.8 31.5,-340 8,-340"/>
-<polygon fill="none" stroke="black" points="31.5,-340 31.5,-362.8 236.16,-362.8 236.16,-340 31.5,-340"/>
-<text xml:space="preserve" text-anchor="start" x="34.5" y="-345.8" font-family="Times,serif" font-size="14.00">additional_name</text>
-<polygon fill="none" stroke="black" points="236.16,-340 236.16,-362.8 308.25,-362.8 308.25,-340 236.16,-340"/>
-<text xml:space="preserve" text-anchor="start" x="239.16" y="-345.8" font-family="Times,serif" font-size="14.00">TEXT?</text>
+<polygon fill="none" stroke="black" points="236.16,-383.6 236.16,-406.4 308.25,-406.4 308.25,-383.6 236.16,-383.6"/>
+<text xml:space="preserve" text-anchor="start" x="239.16" y="-389.4" font-family="Times,serif" font-size="14.00">TEXT</text>
+<polygon fill="none" stroke="black" points="8,-360.8 8,-383.6 31.5,-383.6 31.5,-360.8 8,-360.8"/>
+<polygon fill="none" stroke="black" points="31.5,-360.8 31.5,-383.6 236.16,-383.6 236.16,-360.8 31.5,-360.8"/>
+<text xml:space="preserve" text-anchor="start" x="34.5" y="-366.6" font-family="Times,serif" font-size="14.00">document_confidence</text>
+<polygon fill="none" stroke="black" points="236.16,-360.8 236.16,-383.6 308.25,-383.6 308.25,-360.8 236.16,-360.8"/>
+<text xml:space="preserve" text-anchor="start" x="239.16" y="-366.6" font-family="Times,serif" font-size="14.00">INTEGER?</text>
+<polygon fill="none" stroke="black" points="8,-338 8,-360.8 31.5,-360.8 31.5,-338 8,-338"/>
+<polygon fill="none" stroke="black" points="31.5,-338 31.5,-360.8 236.16,-360.8 236.16,-338 31.5,-338"/>
+<text xml:space="preserve" text-anchor="start" x="34.5" y="-343.8" font-family="Times,serif" font-size="14.00">additional_name</text>
+<polygon fill="none" stroke="black" points="236.16,-338 236.16,-360.8 308.25,-360.8 308.25,-338 236.16,-338"/>
+<text xml:space="preserve" text-anchor="start" x="239.16" y="-343.8" font-family="Times,serif" font-size="14.00">TEXT?</text>
 </g>
 <!-- source_for_attribution&#45;&gt;attribution -->
-<g id="edge9" class="edge">
+<g id="edge8" class="edge">
 <title>source_for_attribution:e&#45;&gt;attribution:w</title>
-<path fill="none" stroke="black" d="M309.25,-419.8C442.03,-419.8 235.55,-705.67 347.79,-722.98"/>
-<polygon fill="black" stroke="black" points="347.52,-726.47 357.74,-723.69 348.01,-719.49 347.52,-726.47"/>
+<path fill="none" stroke="black" d="M309.25,-417.8C443.02,-417.8 234.35,-706.13 348.05,-723.03"/>
+<polygon fill="black" stroke="black" points="347.52,-726.5 357.74,-723.7 348,-719.52 347.52,-726.5"/>
 </g>
 <!-- source_for_attribution&#45;&gt;external_attribution_source -->
-<g id="edge10" class="edge">
+<g id="edge9" class="edge">
 <title>source_for_attribution:e&#45;&gt;external_attribution_source:w</title>
-<path fill="none" stroke="black" stroke-dasharray="5,2" d="M309.25,-397C359.5,-397 331.52,-220.78 352.25,-175 361.4,-154.79 362.25,-135.39 377.79,-129.56"/>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M309.25,-395C359.06,-395 331.66,-220.36 352.25,-175 361.41,-154.8 362.26,-135.39 377.79,-129.56"/>
 <polygon fill="black" stroke="black" points="377.99,-133.08 387.31,-128.04 376.88,-126.16 377.99,-133.08"/>
 </g>
 </g>

--- a/src/ElectronBackend/db/generated/databaseDiagram.svg
+++ b/src/ElectronBackend/db/generated/databaseDiagram.svg
@@ -165,37 +165,37 @@
 <polygon fill="none" stroke="black" points="585.68,-188 585.68,-210.8 657.77,-210.8 657.77,-188 585.68,-188"/>
 <text xml:space="preserve" text-anchor="start" x="588.68" y="-193.8" font-family="Times,serif" font-size="14.00">TEXT?</text>
 </g>
-<!-- cwa -->
+<!-- closest_attributed_ancestors -->
 <g id="node2" class="node">
-<title>cwa</title>
-<polygon fill="none" stroke="black" points="74.68,-1045.6 74.68,-1068.4 241.57,-1068.4 241.57,-1045.6 74.68,-1045.6"/>
-<text xml:space="preserve" text-anchor="start" x="146.46" y="-1053.8" font-family="Times,serif" font-weight="bold" font-size="14.00">cwa</text>
-<polygon fill="none" stroke="black" points="74.68,-1022.8 74.68,-1045.6 98.18,-1045.6 98.18,-1022.8 74.68,-1022.8"/>
-<text xml:space="preserve" text-anchor="start" x="77.68" y="-1028.6" font-family="Times,serif" font-size="14.00">🔑 </text>
-<polygon fill="none" stroke="black" points="98.18,-1022.8 98.18,-1045.6 169.48,-1045.6 169.48,-1022.8 98.18,-1022.8"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-1028.6" font-family="Times,serif" font-size="14.00">resource_id</text>
-<polygon fill="none" stroke="black" points="169.48,-1022.8 169.48,-1045.6 241.57,-1045.6 241.57,-1022.8 169.48,-1022.8"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-1028.6" font-family="Times,serif" font-size="14.00">INTEGER</text>
-<polygon fill="none" stroke="black" points="74.68,-1000 74.68,-1022.8 98.18,-1022.8 98.18,-1000 74.68,-1000"/>
-<polygon fill="none" stroke="black" points="98.18,-1000 98.18,-1022.8 169.48,-1022.8 169.48,-1000 98.18,-1000"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-1005.8" font-family="Times,serif" font-size="14.00">is_file</text>
-<polygon fill="none" stroke="black" points="169.48,-1000 169.48,-1022.8 241.57,-1022.8 241.57,-1000 169.48,-1000"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-1005.8" font-family="Times,serif" font-size="14.00">INTEGER</text>
-<polygon fill="none" stroke="black" points="74.68,-977.2 74.68,-1000 98.18,-1000 98.18,-977.2 74.68,-977.2"/>
-<polygon fill="none" stroke="black" points="98.18,-977.2 98.18,-1000 169.48,-1000 169.48,-977.2 98.18,-977.2"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-983" font-family="Times,serif" font-size="14.00">breakpoint</text>
-<polygon fill="none" stroke="black" points="169.48,-977.2 169.48,-1000 241.57,-1000 241.57,-977.2 169.48,-977.2"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-983" font-family="Times,serif" font-size="14.00">INTEGER</text>
-<polygon fill="none" stroke="black" points="74.68,-954.4 74.68,-977.2 98.18,-977.2 98.18,-954.4 74.68,-954.4"/>
-<polygon fill="none" stroke="black" points="98.18,-954.4 98.18,-977.2 169.48,-977.2 169.48,-954.4 98.18,-954.4"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-960.2" font-family="Times,serif" font-size="14.00">manual</text>
-<polygon fill="none" stroke="black" points="169.48,-954.4 169.48,-977.2 241.57,-977.2 241.57,-954.4 169.48,-954.4"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-960.2" font-family="Times,serif" font-size="14.00">INTEGER?</text>
-<polygon fill="none" stroke="black" points="74.68,-931.6 74.68,-954.4 98.18,-954.4 98.18,-931.6 74.68,-931.6"/>
-<polygon fill="none" stroke="black" points="98.18,-931.6 98.18,-954.4 169.48,-954.4 169.48,-931.6 98.18,-931.6"/>
-<text xml:space="preserve" text-anchor="start" x="101.18" y="-937.4" font-family="Times,serif" font-size="14.00">external</text>
-<polygon fill="none" stroke="black" points="169.48,-931.6 169.48,-954.4 241.57,-954.4 241.57,-931.6 169.48,-931.6"/>
-<text xml:space="preserve" text-anchor="start" x="172.48" y="-937.4" font-family="Times,serif" font-size="14.00">INTEGER?</text>
+<title>closest_attributed_ancestors</title>
+<polygon fill="none" stroke="black" points="70.36,-1045.6 70.36,-1068.4 245.89,-1068.4 245.89,-1045.6 70.36,-1045.6"/>
+<text xml:space="preserve" text-anchor="start" x="73.36" y="-1053.8" font-family="Times,serif" font-weight="bold" font-size="14.00">closest_attributed_ancestors</text>
+<polygon fill="none" stroke="black" points="70.36,-1022.8 70.36,-1045.6 96.74,-1045.6 96.74,-1022.8 70.36,-1022.8"/>
+<text xml:space="preserve" text-anchor="start" x="74.8" y="-1028.6" font-family="Times,serif" font-size="14.00">🔑 </text>
+<polygon fill="none" stroke="black" points="96.74,-1022.8 96.74,-1045.6 170.92,-1045.6 170.92,-1022.8 96.74,-1022.8"/>
+<text xml:space="preserve" text-anchor="start" x="99.74" y="-1028.6" font-family="Times,serif" font-size="14.00">resource_id</text>
+<polygon fill="none" stroke="black" points="170.92,-1022.8 170.92,-1045.6 245.89,-1045.6 245.89,-1022.8 170.92,-1022.8"/>
+<text xml:space="preserve" text-anchor="start" x="173.92" y="-1028.6" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="70.36,-1000 70.36,-1022.8 96.74,-1022.8 96.74,-1000 70.36,-1000"/>
+<polygon fill="none" stroke="black" points="96.74,-1000 96.74,-1022.8 170.92,-1022.8 170.92,-1000 96.74,-1000"/>
+<text xml:space="preserve" text-anchor="start" x="99.74" y="-1005.8" font-family="Times,serif" font-size="14.00">is_file</text>
+<polygon fill="none" stroke="black" points="170.92,-1000 170.92,-1022.8 245.89,-1022.8 245.89,-1000 170.92,-1000"/>
+<text xml:space="preserve" text-anchor="start" x="173.92" y="-1005.8" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="70.36,-977.2 70.36,-1000 96.74,-1000 96.74,-977.2 70.36,-977.2"/>
+<polygon fill="none" stroke="black" points="96.74,-977.2 96.74,-1000 170.92,-1000 170.92,-977.2 96.74,-977.2"/>
+<text xml:space="preserve" text-anchor="start" x="99.74" y="-983" font-family="Times,serif" font-size="14.00">breakpoint</text>
+<polygon fill="none" stroke="black" points="170.92,-977.2 170.92,-1000 245.89,-1000 245.89,-977.2 170.92,-977.2"/>
+<text xml:space="preserve" text-anchor="start" x="173.92" y="-983" font-family="Times,serif" font-size="14.00">INTEGER</text>
+<polygon fill="none" stroke="black" points="70.36,-954.4 70.36,-977.2 96.74,-977.2 96.74,-954.4 70.36,-954.4"/>
+<polygon fill="none" stroke="black" points="96.74,-954.4 96.74,-977.2 170.92,-977.2 170.92,-954.4 96.74,-954.4"/>
+<text xml:space="preserve" text-anchor="start" x="99.74" y="-960.2" font-family="Times,serif" font-size="14.00">manual</text>
+<polygon fill="none" stroke="black" points="170.92,-954.4 170.92,-977.2 245.89,-977.2 245.89,-954.4 170.92,-954.4"/>
+<text xml:space="preserve" text-anchor="start" x="173.92" y="-960.2" font-family="Times,serif" font-size="14.00">INTEGER?</text>
+<polygon fill="none" stroke="black" points="70.36,-931.6 70.36,-954.4 96.74,-954.4 96.74,-931.6 70.36,-931.6"/>
+<polygon fill="none" stroke="black" points="96.74,-931.6 96.74,-954.4 170.92,-954.4 170.92,-931.6 96.74,-931.6"/>
+<text xml:space="preserve" text-anchor="start" x="99.74" y="-937.4" font-family="Times,serif" font-size="14.00">external</text>
+<polygon fill="none" stroke="black" points="170.92,-931.6 170.92,-954.4 245.89,-954.4 245.89,-931.6 170.92,-931.6"/>
+<text xml:space="preserve" text-anchor="start" x="173.92" y="-937.4" font-family="Times,serif" font-size="14.00">INTEGER?</text>
 </g>
 <!-- resource -->
 <g id="node5" class="node">
@@ -261,29 +261,29 @@
 <polygon fill="none" stroke="black" points="558.48,-784 558.48,-806.8 630.57,-806.8 630.57,-784 558.48,-784"/>
 <text xml:space="preserve" text-anchor="start" x="561.48" y="-789.8" font-family="Times,serif" font-size="14.00">TEXT?</text>
 </g>
-<!-- cwa&#45;&gt;resource -->
+<!-- closest_attributed_ancestors&#45;&gt;resource -->
 <g id="edge1" class="edge">
-<title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-988.6C302.69,-988.6 320.18,-979.11 374.97,-977.92"/>
-<polygon fill="black" stroke="black" points="374.97,-981.42 384.94,-977.82 374.9,-974.42 374.97,-981.42"/>
+<title>closest_attributed_ancestors:e&#45;&gt;resource:w</title>
+<path fill="none" stroke="black" d="M246.89,-988.6C305.09,-988.6 322.09,-979.15 374.98,-977.93"/>
+<polygon fill="black" stroke="black" points="374.98,-981.43 384.94,-977.82 374.9,-974.43 374.98,-981.43"/>
 </g>
-<!-- cwa&#45;&gt;resource -->
+<!-- closest_attributed_ancestors&#45;&gt;resource -->
 <g id="edge2" class="edge">
-<title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-943C304.38,-943 318.97,-973.71 375.06,-977.43"/>
-<polygon fill="black" stroke="black" points="374.83,-980.93 384.94,-977.75 375.05,-973.93 374.83,-980.93"/>
+<title>closest_attributed_ancestors:e&#45;&gt;resource:w</title>
+<path fill="none" stroke="black" d="M246.89,-943C306.82,-943 320.85,-973.59 375.05,-977.41"/>
+<polygon fill="black" stroke="black" points="374.82,-980.9 384.94,-977.75 375.06,-973.91 374.82,-980.9"/>
 </g>
-<!-- cwa&#45;&gt;resource -->
+<!-- closest_attributed_ancestors&#45;&gt;resource -->
 <g id="edge3" class="edge">
-<title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-965.8C302.73,-965.8 320.15,-976.35 374.96,-977.67"/>
-<polygon fill="black" stroke="black" points="374.9,-981.16 384.94,-977.78 374.98,-974.17 374.9,-981.16"/>
+<title>closest_attributed_ancestors:e&#45;&gt;resource:w</title>
+<path fill="none" stroke="black" d="M246.89,-965.8C305.13,-965.8 322.06,-976.3 374.97,-977.66"/>
+<polygon fill="black" stroke="black" points="374.89,-981.16 384.94,-977.78 374.98,-974.16 374.89,-981.16"/>
 </g>
-<!-- cwa&#45;&gt;resource -->
+<!-- closest_attributed_ancestors&#45;&gt;resource -->
 <g id="edge4" class="edge">
-<title>cwa:e&#45;&gt;resource:w</title>
-<path fill="none" stroke="black" d="M242.57,-1034.2C307.23,-1034.2 316.79,-984.22 374.99,-978.36"/>
-<polygon fill="black" stroke="black" points="375.12,-981.86 384.94,-977.87 374.78,-974.86 375.12,-981.86"/>
+<title>closest_attributed_ancestors:e&#45;&gt;resource:w</title>
+<path fill="none" stroke="black" d="M246.89,-1034.2C309.87,-1034.2 318.66,-984.22 375.29,-978.36"/>
+<polygon fill="black" stroke="black" points="375.13,-981.87 384.94,-977.88 374.78,-974.88 375.13,-981.87"/>
 </g>
 <!-- external_attribution_source -->
 <g id="node3" class="node">

--- a/src/ElectronBackend/db/generated/databaseTypes.ts
+++ b/src/ElectronBackend/db/generated/databaseTypes.ts
@@ -47,7 +47,7 @@ export interface Attribution {
   canonical_license_name: Generated<string | null>;
 }
 
-export interface Cwa {
+export interface ClosestAttributedAncestors {
   breakpoint: number;
   external: number | null;
   is_file: number;
@@ -115,7 +115,7 @@ export interface SourceForAttribution {
 
 export interface DB {
   attribution: Attribution;
-  cwa: Cwa;
+  closest_attributed_ancestors: ClosestAttributedAncestors;
   external_attribution_source: ExternalAttributionSource;
   frequent_license: FrequentLicense;
   resource: Resource;

--- a/src/ElectronBackend/db/generated/databaseTypes.ts
+++ b/src/ElectronBackend/db/generated/databaseTypes.ts
@@ -81,7 +81,7 @@ export interface Resource {
   /**
    * The highest id of a descendant of this resource. As the resources are numbered depth-first, this enables us to identify the children of resource R by checking if child.id is between R.id and R.max_descendant_id, which is very fast. See https://en.wikipedia.org/wiki/Nested_set_model
    */
-  max_descendant_id: Generated<number>;
+  max_descendant_id: number;
   /**
    * The name of the root resource is the empty string
    */

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -86,7 +86,6 @@ export async function initializeDb(inputFile: ParsedFileContent) {
 
       await initializeProgressBarTable(trx);
     });
-  getRawDb().exec('VACUUM');
 }
 
 async function initializeProgressBarTable(trx: Transaction<DB>) {
@@ -271,15 +270,15 @@ async function initializeResourceTable(
   });
 
   function sortChildren(
-    aIsLeaf: boolean,
+    aIsFile: boolean,
     aName: string,
-    bIsLeaf: boolean,
+    bIsFile: boolean,
     bName: string,
   ) {
-    if (aIsLeaf && !bIsLeaf) {
+    if (aIsFile && !bIsFile) {
       return 1;
     }
-    if (!aIsLeaf && bIsLeaf) {
+    if (!aIsFile && bIsFile) {
       return -1;
     }
     // If both resources are files or both are directories, we sort them alphabetically
@@ -312,12 +311,12 @@ async function initializeResourceTable(
         ([childName, childChildren]) => ({
           name: childName,
           children: childChildren,
-          isLeaf:
+          isFile:
             childChildren === 1 ||
             trimmedFilesWithChildren.has(`${currentPath}/${childName}`),
         }),
       );
-      entries.sort((a, b) => sortChildren(a.isLeaf, a.name, b.isLeaf, b.name));
+      entries.sort((a, b) => sortChildren(a.isFile, a.name, b.isFile, b.name));
       for (const { name, children } of entries) {
         lastDescendantId = recursivelyCollectResource(
           name,
@@ -342,11 +341,11 @@ async function initializeResourceTable(
     return lastDescendantId;
   }
 
-  // The root resource has "" as name and path
-  console.time('collectResources');
   const resourcesToInsert: Array<ResourceRow> = [];
+  // The root resource has '' as name and path
   recursivelyCollectResource('', resources, null, null, resourcesToInsert);
   insertMany(resourcesToInsert);
+
   await trx.schema
     .createIndex('resource_parent_id_covering_idx')
     .on('resource')

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -46,7 +46,6 @@ export const comments: Record<string, Record<string, string>> = {
 
 export async function initializeDb(inputFile: ParsedFileContent) {
   resetDb();
-
   await getDb()
     .transaction()
     .execute(async (trx) => {
@@ -232,9 +231,7 @@ async function initializeResourceTable(
     .addColumn('can_have_children', 'integer', (col) =>
       col.notNull().defaultTo(0),
     )
-    .addColumn('max_descendant_id', 'integer', (col) =>
-      col.notNull().defaultTo(1).references('resource.id'),
-    )
+    .addColumn('max_descendant_id', 'integer', (col) => col.notNull())
     .addColumn('base_url', 'text')
     .execute();
 
@@ -245,14 +242,27 @@ async function initializeResourceTable(
   const rawDb = getRawDb();
   const insertStmt = rawDb.prepare(`
     INSERT INTO resource
-      (id, path, name, parent_id, is_attribution_breakpoint, is_file, can_have_children, base_url)
+      (id, path, name, parent_id, is_attribution_breakpoint, is_file, can_have_children, base_url, max_descendant_id)
     VALUES
-      ($id, $path, $name, $parent_id, $is_attribution_breakpoint, $is_file, $can_have_children, $base_url)
+      ($id, $path, $name, $parent_id, $is_attribution_breakpoint, $is_file, $can_have_children, $base_url, $max_descendant_id)
   `);
-
-  const updateMaxDescendantIdStmt = rawDb.prepare(`
-    UPDATE resource SET max_descendant_id = $max_descendant_id WHERE id = $resource_id
-  `);
+  type ResourceRow = {
+    id: number;
+    path: string;
+    name: string;
+    parent_id: number | null;
+    is_attribution_breakpoint: number;
+    is_file: number;
+    can_have_children: number;
+    base_url: string | null;
+    max_descendant_id: number;
+  };
+  // Inserting many rows in a single transaction increases the speed slightly
+  const insertMany = rawDb.transaction((resources: Array<ResourceRow>) => {
+    for (const resource of resources) {
+      insertStmt.run(resource);
+    }
+  });
 
   const resourceNameCollator = new Intl.Collator('en', {
     sensitivity: 'variant',
@@ -279,21 +289,45 @@ async function initializeResourceTable(
     return aName < bName ? -1 : aName > bName ? 1 : 0;
   }
 
-  function recursivelyInsertResource(
+  function recursivelyCollectResource(
     name: string,
     children: Resources | 1,
     parentId: number | null,
     parentPath: string | null,
-  ) {
+    result: Array<ResourceRow>,
+  ): number {
+    const resourceId = nextId++;
     const currentPath = parentPath === null ? '' : `${parentPath}/${name}`;
-
     const isLeaf = children === 1;
     const isFile = isLeaf || trimmedFilesWithChildren.has(currentPath);
     const isAttributionBreakpoint =
       trimmedAttributionBreakpoints.has(currentPath);
 
-    const resourceId = nextId++;
-    insertStmt.run({
+    resourcePathToId.set(currentPath, resourceId);
+
+    let lastDescendantId = resourceId;
+    if (!isLeaf) {
+      const entries = Object.entries(children).map(
+        ([childName, childChildren]) => ({
+          name: childName,
+          children: childChildren,
+          isLeaf:
+            childChildren === 1 ||
+            trimmedFilesWithChildren.has(`${currentPath}/${childName}`),
+        }),
+      );
+      entries.sort((a, b) => sortChildren(a.isLeaf, a.name, b.isLeaf, b.name));
+      for (const { name, children } of entries) {
+        lastDescendantId = recursivelyCollectResource(
+          name,
+          children,
+          resourceId,
+          currentPath,
+          result,
+        );
+      }
+    }
+    result[resourceId - 1] = {
       id: resourceId,
       path: currentPath,
       name,
@@ -302,43 +336,16 @@ async function initializeResourceTable(
       is_file: Number(isFile),
       can_have_children: Number(!isLeaf),
       base_url: trimmedBaseUrlsForSources[currentPath],
-    });
-
-    resourcePathToId.set(currentPath, resourceId);
-
-    let last_inserted_id = resourceId;
-
-    if (!isLeaf) {
-      for (const [childName, childChildren] of Object.entries(
-        children,
-      ).toSorted((a, b) =>
-        sortChildren(
-          a[1] === 1 || trimmedFilesWithChildren.has(`${currentPath}/${a[0]}`),
-          a[0],
-          b[1] === 1 || trimmedFilesWithChildren.has(`${currentPath}/${b[0]}`),
-          b[0],
-        ),
-      )) {
-        last_inserted_id = recursivelyInsertResource(
-          childName,
-          childChildren,
-          resourceId,
-          currentPath,
-        );
-      }
-    }
-
-    updateMaxDescendantIdStmt.run({
-      resource_id: resourceId,
-      max_descendant_id: last_inserted_id,
-    });
-
-    return last_inserted_id;
+      max_descendant_id: lastDescendantId,
+    };
+    return lastDescendantId;
   }
 
   // The root resource has "" as name and path
-  recursivelyInsertResource('', resources, null, null);
-
+  console.time('collectResources');
+  const resourcesToInsert: Array<ResourceRow> = [];
+  recursivelyCollectResource('', resources, null, null, resourcesToInsert);
+  insertMany(resourcesToInsert);
   await trx.schema
     .createIndex('resource_parent_id_covering_idx')
     .on('resource')

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -13,6 +13,7 @@ import {
   type PackageInfo,
   type ParsedFileContent,
   type Resources,
+  type ResourcesToAttributions,
 } from '../../shared/shared-types';
 import { removeTrailingSlash, toCanonicalLicenseName } from '../api/utils';
 import { getDb, getRawDb, resetDb } from './db';
@@ -544,22 +545,32 @@ async function initializeResourceToAttributionTable(
     INSERT OR IGNORE INTO resource_to_attribution
       (resource_id, attribution_uuid, attribution_is_external)
     VALUES
-      ($resource_id, $attribution_uuid, (select is_external from attribution where uuid = $attribution_uuid))
+      ($resource_id, $attribution_uuid, $attribution_is_external)
   `);
+  const insertMany = rawDb.transaction(
+    (resourcesToAttributions: ResourcesToAttributions, is_external: 0 | 1) => {
+      const rows = Object.entries(resourcesToAttributions).flatMap(
+        ([resourcePath, attributionUuids]) => {
+          const resourceId = resourcePathToId.get(
+            removeTrailingSlash(resourcePath),
+          );
+          return resourceId === undefined
+            ? []
+            : attributionUuids.map((uuid) => ({
+                resource_id: resourceId,
+                attribution_uuid: uuid,
+                attribution_is_external: is_external,
+              }));
+        },
+      );
+      for (const row of rows) {
+        insertStmt.run(row);
+      }
+    },
+  );
 
-  for (const [resourcePath, attributionUuids] of [
-    ...Object.entries(externalAttributions.resourcesToAttributions),
-    ...Object.entries(manualAttributions.resourcesToAttributions),
-  ]) {
-    const normalizedPath = removeTrailingSlash(resourcePath);
-    const resourceId = resourcePathToId.get(normalizedPath);
-    if (resourceId === undefined) {
-      continue;
-    }
-    for (const uuid of attributionUuids) {
-      insertStmt.run({ resource_id: resourceId, attribution_uuid: uuid });
-    }
-  }
+  insertMany(externalAttributions.resourcesToAttributions, 1);
+  insertMany(manualAttributions.resourcesToAttributions, 0);
 
   await trx.schema
     .createIndex('resource_to_attribution_attribution_uuid_resource_id_idx')

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -91,7 +91,7 @@ export async function initializeDb(inputFile: ParsedFileContent) {
 
 async function initializeProgressBarTable(trx: Transaction<DB>) {
   await trx.schema
-    .createTable('cwa')
+    .createTable('closest_attributed_ancestors')
     .addColumn('resource_id', 'integer', (col) =>
       col.primaryKey().notNull().references('resource.id'),
     )
@@ -104,8 +104,7 @@ async function initializeProgressBarTable(trx: Transaction<DB>) {
     .execute();
 
   await sql`
-  -- closest with ancestor table
-  INSERT INTO cwa WITH RECURSIVE 
+  INSERT INTO closest_attributed_ancestors WITH RECURSIVE 
   has_manual_attribution AS MATERIALIZED (
     SELECT DISTINCT resource_id
     FROM resource_to_attribution
@@ -116,7 +115,7 @@ async function initializeProgressBarTable(trx: Transaction<DB>) {
     FROM resource_to_attribution
     WHERE attribution_uuid IN (SELECT uuid FROM attribution WHERE is_external = 1 AND is_resolved = 0)
   ),
-  cwa(resource_id, parent_id, is_file, breakpoint, manual, external) AS (
+  closest_attributed_ancestors(resource_id, parent_id, is_file, breakpoint, manual, external) AS (
     SELECT r.id, r.parent_id, r.is_file, r.id,
     IIF(r.id IN has_manual_attribution, r.id, NULL),
     IIF(r.id IN has_unresolved_external_attribution, r.id, NULL)
@@ -134,40 +133,40 @@ async function initializeProgressBarTable(trx: Transaction<DB>) {
         IIF(child.is_attribution_breakpoint, NULL, parent.external)
     )
     FROM resource as child
-    JOIN cwa as parent ON child.parent_id = parent.resource_id
+    JOIN closest_attributed_ancestors as parent ON child.parent_id = parent.resource_id
   )
-  SELECT resource_id, is_file, breakpoint, manual, external FROM cwa
+  SELECT resource_id, is_file, breakpoint, manual, external FROM closest_attributed_ancestors
   `.execute(trx);
 
   await trx.schema
-    .createIndex('cwa_manual_idx')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_manual_idx')
+    .on('closest_attributed_ancestors')
     .columns(['manual', 'is_file', 'resource_id'])
     .execute();
   await trx.schema
-    .createIndex('cwa_external')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_external')
+    .on('closest_attributed_ancestors')
     .columns(['external', 'resource_id'])
     .execute();
   await trx.schema
-    .createIndex('cwa_external_per_file')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_external_per_file')
+    .on('closest_attributed_ancestors')
     .columns(['external', 'is_file', 'resource_id'])
     .execute();
   await trx.schema
-    .createIndex('cwa_manual_and_external')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_manual_and_external')
+    .on('closest_attributed_ancestors')
     .columns(['manual', 'external', 'is_file', 'resource_id'])
     .execute();
   await trx.schema
-    .createIndex('cwa_resource')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_resource')
+    .on('closest_attributed_ancestors')
     .columns(['resource_id', 'manual'])
     .execute();
 
   await trx.schema
-    .createIndex('cwa_breakpoint')
-    .on('cwa')
+    .createIndex('closest_attributed_ancestors_breakpoint')
+    .on('closest_attributed_ancestors')
     .columns(['breakpoint', 'manual', 'resource_id'])
     .execute();
 }

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -540,14 +540,31 @@ async function initializeResourceToAttributionTable(
     ])
     .execute();
 
-  // Prepared statement for fast bulk insert
   const rawDb = getRawDb();
-  const insertStmt = rawDb.prepare(`
-    INSERT OR IGNORE INTO resource_to_attribution
+  function insertRows(
+    rows: {
+      resource_id: number;
+      attribution_uuid: string;
+    }[],
+    attribution_is_external: 0 | 1,
+  ) {
+    const singleValuesSql = attribution_is_external ? '(?, ?, 1)' : '(?, ?, 0)';
+    const multipleValuesSql =
+      `${singleValuesSql}, `.repeat(rows.length - 1) + singleValuesSql;
+    const stmt = rawDb.prepare(`
+      INSERT OR IGNORE INTO resource_to_attribution 
       (resource_id, attribution_uuid, attribution_is_external)
-    VALUES
-      ($resource_id, $attribution_uuid, $attribution_is_external)
-  `);
+      VALUES ${multipleValuesSql}
+      `);
+    const params = rows.flatMap((row) => [
+      row.resource_id,
+      row.attribution_uuid,
+    ]);
+    stmt.run(...params);
+  }
+
+  // SQLite cannot handle more than 30000 parameters, and since we insert an id and a uuid, we can only insert 15000 rows at a time
+  const BATCH_SIZE = 15_000;
   const insertMany = rawDb.transaction(
     (resourcesToAttributions: ResourcesToAttributions, is_external: 0 | 1) => {
       const rows = Object.entries(resourcesToAttributions).flatMap(
@@ -560,12 +577,12 @@ async function initializeResourceToAttributionTable(
             : attributionUuids.map((uuid) => ({
                 resource_id: resourceId,
                 attribution_uuid: uuid,
-                attribution_is_external: is_external,
               }));
         },
       );
-      for (const row of rows) {
-        insertStmt.run(row);
+
+      for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+        insertRows(rows.slice(i, i + BATCH_SIZE), is_external);
       }
     },
   );

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -86,6 +86,7 @@ export async function initializeDb(inputFile: ParsedFileContent) {
 
       await initializeProgressBarTable(trx);
     });
+  getRawDb().exec('VACUUM');
 }
 
 async function initializeProgressBarTable(trx: Transaction<DB>) {

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -95,62 +95,48 @@ async function initializeProgressBarTable(trx: Transaction<DB>) {
       col.primaryKey().notNull().references('resource.id'),
     )
     .addColumn('is_file', 'integer', (col) => col.notNull())
-    .addColumn('manual', 'integer', (col) => col.references('resource.id'))
-    .addColumn('external', 'integer', (col) => col.references('resource.id'))
     .addColumn('breakpoint', 'integer', (col) =>
       col.notNull().references('resource.id'),
     )
+    .addColumn('manual', 'integer', (col) => col.references('resource.id'))
+    .addColumn('external', 'integer', (col) => col.references('resource.id'))
     .execute();
 
   await sql`
   -- closest with ancestor table
-  insert into cwa
-    with recursive
-    has_unresolved_external_attribution as (
-        select distinct resource_id 
-        from resource_to_attribution 
-        where attribution_uuid in (select uuid from attribution where is_external = 1 and is_resolved = 0)
+  INSERT INTO cwa WITH RECURSIVE 
+  has_manual_attribution AS MATERIALIZED (
+    SELECT DISTINCT resource_id
+    FROM resource_to_attribution
+    WHERE attribution_is_external = 0
+  ),
+  has_unresolved_external_attribution AS MATERIALIZED (
+    SELECT DISTINCT resource_id
+    FROM resource_to_attribution
+    WHERE attribution_uuid IN (SELECT uuid FROM attribution WHERE is_external = 1 AND is_resolved = 0)
+  ),
+  cwa(resource_id, parent_id, is_file, breakpoint, manual, external) AS (
+    SELECT r.id, r.parent_id, r.is_file, r.id,
+    IIF(r.id IN has_manual_attribution, r.id, NULL),
+    IIF(r.id IN has_unresolved_external_attribution, r.id, NULL)
+    FROM resource as r
+    WHERE path = ''
+
+    UNION ALL
+    
+    SELECT child.id, child.parent_id, child.is_file,
+    IIF(child.is_attribution_breakpoint, child.id, parent.breakpoint),
+    IIF(child.id IN has_manual_attribution, child.id, 
+        IIF(child.is_attribution_breakpoint, NULL, parent.manual)
     ),
-    closest_ancestor_with_external_attributions(resource_id, ancestor) as (
-            select distinct resource_id, resource_id
-            from has_unresolved_external_attribution
-        union all
-            select id, parent.ancestor
-            from resource
-            join closest_ancestor_with_external_attributions as parent on resource.parent_id = parent.resource_id
-            where resource.id not in has_unresolved_external_attribution and is_attribution_breakpoint = 0
-    ),
-    closest_ancestor_with_manual_attributions(resource_id, ancestor) as (
-            select distinct resource_id, resource_id
-            from resource_to_attribution
-            where attribution_is_external = 0
-        union all
-            select id, parent.ancestor
-            from resource
-            join closest_ancestor_with_manual_attributions as parent on resource.parent_id = parent.resource_id
-            where resource.id not in (select resource_id from resource_to_attribution where attribution_is_external = 0) and is_attribution_breakpoint = 0
-    ),
-    closest_ancestor_with_breakpoint(resource_id, ancestor) as (
-            select id, id
-            from resource
-            where is_attribution_breakpoint = 1 or path = ''
-        union all
-            select id, parent.ancestor
-            from resource
-            join closest_ancestor_with_breakpoint as parent on resource.parent_id = parent.resource_id
-            where is_attribution_breakpoint = 0
+    IIF(child.id IN has_unresolved_external_attribution, child.id, 
+        IIF(child.is_attribution_breakpoint, NULL, parent.external)
     )
-    select 
-      id,
-      is_file,
-      closest_ancestor_with_manual_attributions.ancestor,
-      closest_ancestor_with_external_attributions.ancestor,
-      closest_ancestor_with_breakpoint.ancestor
-    from resource
-    left join closest_ancestor_with_manual_attributions on resource.id = closest_ancestor_with_manual_attributions.resource_id
-    left join closest_ancestor_with_external_attributions on resource.id = closest_ancestor_with_external_attributions.resource_id
-    left join closest_ancestor_with_breakpoint on resource.id = closest_ancestor_with_breakpoint.resource_id
-    `.execute(trx);
+    FROM resource as child
+    JOIN cwa as parent ON child.parent_id = parent.resource_id
+  )
+  SELECT resource_id, is_file, breakpoint, manual, external FROM cwa
+  `.execute(trx);
 
   await trx.schema
     .createIndex('cwa_manual_idx')
@@ -266,7 +252,7 @@ async function initializeResourceTable(
 
   const updateMaxDescendantIdStmt = rawDb.prepare(`
     UPDATE resource SET max_descendant_id = $max_descendant_id WHERE id = $resource_id
-    `);
+  `);
 
   const resourceNameCollator = new Intl.Collator('en', {
     sensitivity: 'variant',
@@ -472,6 +458,14 @@ async function initializeAttributionTable(
       'criticality',
       'classification',
     ])
+    .where('is_resolved', '=', 0)
+    .execute();
+
+  await trx.schema
+    .createIndex('attribution_is_external_covering_idx')
+    .on('attribution')
+    .columns(['is_external', 'is_resolved'])
+    .where('is_external', '=', 1)
     .where('is_resolved', '=', 0)
     .execute();
 }

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -546,7 +546,7 @@ async function initializeResourceToAttributionTable(
     }[],
     attribution_is_external: 0 | 1,
   ) {
-    const singleValuesSql = attribution_is_external ? '(?, ?, 1)' : '(?, ?, 0)';
+    const singleValuesSql = `(?, ?, ${attribution_is_external})`;
     const multipleValuesSql =
       `${singleValuesSql}, `.repeat(rows.length - 1) + singleValuesSql;
     const stmt = rawDb.prepare(`


### PR DESCRIPTION
### Summary of changes

Speed up the loading time of the DB. The changes are to the progressBar, the insertion of resources, the insertion of resource_to_attribution values, and some DB settings.

### Context and reason for change

We want the db loading time to be smaller than the sending of data to the FE. This way we can state that our startup time has gone down.

### How can the changes be tested

All the preexisting tests ensure that nothing has broken

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
