### PR TITLE
fix: add the right os for the tests

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -29,6 +29,8 @@ jobs:
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
           - os: macos-latest
             E2E: yarn test:e2e:ci
+          - os: macos-15-intel
+            E2E: yarn test:e2e:ci
           - os: windows-latest
             E2E: yarn test:e2e:ci
     env:

--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -29,8 +29,9 @@ jobs:
             E2E: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn test:e2e:ci
           - os: macos-latest
             E2E: yarn test:e2e:ci
+            # We only want to run a single smoketest on macOS-Intel to avoid long pipeline durations
           - os: macos-15-intel
-            E2E: yarn test:e2e:ci
+            E2E: yarn test:e2e:ci --grep "opens Opossum file and shows project as recently opened"
           - os: windows-latest
             E2E: yarn test:e2e:ci
     env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ jobs:
             FILES: |
               release/linux/OpossumUI-for-linux.AppImage
               release/linux/OpossumUI-for-linux.snap
-          - os: macos-latest
+          - os: macos-15-intel
             build-command: yarn ship-mac:x64
             FILES: release/mac/OpossumUI-for-mac-intel.zip
           - os: macos-latest


### PR DESCRIPTION
### Summary of changes

Fix os version, so that we do not break mac intel.
Also added a step that runs mac intel in the E2E tests

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
