### PR TITLE
fix: prevent unwanted scroll when clicking back into resource tree

### DIFF
--- a/src/Frontend/Components/VirtualizedTree/VirtualizedTreeNode/VirtualizedTreeNode.tsx
+++ b/src/Frontend/Components/VirtualizedTree/VirtualizedTreeNode/VirtualizedTreeNode.tsx
@@ -97,7 +97,7 @@ export function VirtualizedTreeNode({
 
   useEffect(() => {
     if (focused) {
-      ref.current?.focus();
+      ref.current?.focus({ preventScroll: true });
     }
   }, [focused]);
 


### PR DESCRIPTION
## Problem

When selecting a root-level resource, then clicking an attribution or signal in the middle column, subsequent clicks in the resource tree would scroll back to the previously selected resource instead of selecting the newly clicked one.

## Root Cause

When clicking back into the tree, the browser fires `focusin` (during mousedown) before `click`. For expandable nodes, the `await getNodeIdsToExpand()` in the click handler breaks React 18's automatic batching, causing the focus-restoration effect to flush with the **old** `selectedId`. This programmatically calls `focus()` on the old resource's DOM element, and the browser auto-scrolls to it before the new selection takes effect.

## Fix

Add `{ preventScroll: true }` to the `focus()` call in `VirtualizedTreeNode`. This prevents the browser from scrolling when focus is programmatically restored, while keyboard navigation remains unaffected since it uses explicit `scrollIntoView` calls.