### PR TITLE
fix: jump to section buttons not working after selecting a signal

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -204,6 +204,15 @@ export default tseslint.config(
         { avoidEscape: true, allowTemplateLiterals: false },
       ],
       yoda: 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            ':function VariableDeclarator[init.callee.callee.name="styled"]',
+          message:
+            'Do not call styled() inside functions. It creates a new component type on every render, causing React to remount DOM elements and break event handlers. Move styled() calls to module scope or a .style.ts file, or use the sx prop.',
+        },
+      ],
     },
   },
   {

--- a/src/Frontend/Components/GroupedList/GroupedList.tsx
+++ b/src/Frontend/Components/GroupedList/GroupedList.tsx
@@ -6,7 +6,6 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
-import { styled } from '@mui/material';
 import MuiBox from '@mui/material/Box';
 import MuiTooltip from '@mui/material/Tooltip';
 import { type SxProps } from '@mui/system';
@@ -146,18 +145,8 @@ export function GroupedList({
     const isFirstItemVisible = startIndex === 0;
     const isFirstItemInGroupVisible =
       startIndex <= groups.counts.slice(0, index).reduce((a, b) => a + b, 0);
-    const Icon = styled(
-      isFirstGroup ? KeyboardDoubleArrowUpIcon : KeyboardArrowUpIcon,
-    )({
-      cursor: isFirstGroup && isFirstItemVisible ? undefined : 'pointer',
-      borderRadius: '50%',
-      '&:hover': {
-        background:
-          isFirstGroup && isFirstItemVisible
-            ? undefined
-            : OpossumColors.lightGrey,
-      },
-    });
+    const Icon = isFirstGroup ? KeyboardDoubleArrowUpIcon : KeyboardArrowUpIcon;
+    const disabled = isFirstGroup && isFirstItemVisible;
 
     return (
       <MuiTooltip
@@ -173,8 +162,15 @@ export function GroupedList({
         enterDelay={500}
       >
         <Icon
+          sx={{
+            cursor: disabled ? undefined : 'pointer',
+            borderRadius: '50%',
+            '&:hover': {
+              background: disabled ? undefined : OpossumColors.lightGrey,
+            },
+          }}
           fontSize={'inherit'}
-          color={isFirstGroup && isFirstItemVisible ? 'disabled' : undefined}
+          color={disabled ? 'disabled' : undefined}
           onClick={
             isFirstGroup
               ? isFirstItemVisible
@@ -197,18 +193,10 @@ export function GroupedList({
 
     const isLastGroup = index === groups.counts.length - 1;
     const isLastItemVisible = endIndex === groups.ids.length - 1;
-    const Icon = styled(
-      isLastGroup ? KeyboardDoubleArrowDownIcon : KeyboardArrowDownIcon,
-    )({
-      cursor: isLastGroup && isLastItemVisible ? undefined : 'pointer',
-      borderRadius: '50%',
-      '&:hover': {
-        background:
-          isLastGroup && isLastItemVisible
-            ? undefined
-            : OpossumColors.lightGrey,
-      },
-    });
+    const Icon = isLastGroup
+      ? KeyboardDoubleArrowDownIcon
+      : KeyboardArrowDownIcon;
+    const disabled = isLastGroup && isLastItemVisible;
 
     return (
       <MuiTooltip
@@ -222,8 +210,15 @@ export function GroupedList({
         enterDelay={500}
       >
         <Icon
+          sx={{
+            cursor: disabled ? undefined : 'pointer',
+            borderRadius: '50%',
+            '&:hover': {
+              background: disabled ? undefined : OpossumColors.lightGrey,
+            },
+          }}
           fontSize={'inherit'}
-          color={isLastGroup && isLastItemVisible ? 'disabled' : undefined}
+          color={disabled ? 'disabled' : undefined}
           onClick={
             isLastGroup
               ? isLastItemVisible


### PR DESCRIPTION
## Problem

The jump to next/previous section buttons in the signals panel had no effect once a signal was selected. They worked correctly before any selection was made.

## Root Cause

`styled()` was called **inside the render functions** (`renderJumpUp` / `renderJumpDown`), creating a new React component type on every render. React treated each render's `Icon` as a completely different component, unmounting the old DOM element and mounting a new one. This destroyed the button the user was clicking mid-interaction, silently swallowing the click event.

The MUI Tooltip `anchorEl` warning confirmed this — the anchor element was being removed from the document during re-renders triggered by selection state changes.

## Fix

Replaced inline `styled()` calls with the raw MUI icon components (`KeyboardArrowUpIcon`, etc.) and the `sx` prop for dynamic styles. The component type is now stable across renders, so the DOM element persists and click handlers fire correctly.