### PR TITLE
Feat/loading animations

### DIFF
--- a/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
@@ -10,9 +10,10 @@ import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
 import SaveIcon from '@mui/icons-material/Save';
 import UndoIcon from '@mui/icons-material/Undo';
 import MuiButton from '@mui/material/Button';
+import MuiCircularProgress from '@mui/material/CircularProgress';
 import MuiFab from '@mui/material/Fab';
 import MuiTooltip from '@mui/material/Tooltip';
-import { skipToken } from '@tanstack/react-query';
+import { skipToken, useIsMutating } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 
 import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
@@ -48,6 +49,14 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
   const isPackageInfoModified = useAppSelector(getIsPackageInfoDirty);
   const isInvalid = useMemo(() => isPackageInvalid(packageInfo), [packageInfo]);
   const initialPackageInfo = useSelectedAttributionPackageInfo();
+
+  const resolveAttributions = backend.resolveAttributions.useMutation();
+  const unresolveAttributions = backend.unresolveAttributions.useMutation();
+  const LinkAttribution = backend.createOrMatchAttribution.useMutation();
+  const updateOrMatch = backend.updateOrMatchAttribution.useMutation();
+  const createOrMatch = backend.createOrMatchAttribution.useMutation();
+  const mutationPending = useIsMutating() > 0;
+
   const { data: resolvedExternalAttributions } =
     backend.resolvedAttributionUuids.useQuery();
   const selectedResourceId = useAppSelector(getSelectedResourceId);
@@ -101,15 +110,14 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
       if (hasMultipleResources) {
         setIsConfirmSavePopupOpen(true);
       } else if (packageInfo.id) {
-        const { matchedAttribution } =
-          await backend.updateOrMatchAttribution.mutate({
-            packageInfo,
-          });
+        const { matchedAttribution } = await updateOrMatch.mutateAsync({
+          packageInfo,
+        });
         if (matchedAttribution) {
           dispatch(setSelectedAttributionId(matchedAttribution));
         }
       } else {
-        const result = await backend.createOrMatchAttribution.mutate({
+        const result = await createOrMatch.mutateAsync({
           packageInfo,
           resourcePath: selectedResourceId,
         });
@@ -119,10 +127,12 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
     }
   }, [
     packageInfo,
+    updateOrMatch,
+    createOrMatch,
     isPackageInfoModified,
     hasMultipleResources,
-    dispatch,
     selectedResourceId,
+    dispatch,
   ]);
 
   useIpcRenderer(AllowedFrontendChannels.SaveFileRequest, () => handleSave(), [
@@ -156,6 +166,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
         <MuiButton
           variant={'contained'}
           color={'success'}
+          loading={mutationPending}
           onClick={() => setIsReplaceAttributionsPopupOpen(true)}
         >
           {text.attributionColumn.replace}
@@ -190,10 +201,17 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
               onClick={handleSave}
               disabled={
                 isInvalid ||
-                (!packageInfo.preSelected && !isPackageInfoModified)
+                (!packageInfo.preSelected && !isPackageInfoModified) ||
+                mutationPending
               }
             >
-              {isConfirming ? <CheckIcon /> : <SaveIcon />}
+              {updateOrMatch.isPending || createOrMatch.isPending ? (
+                <MuiCircularProgress size={16} color={'inherit'} />
+              ) : isConfirming ? (
+                <CheckIcon />
+              ) : (
+                <SaveIcon />
+              )}
             </MuiFab>
           </span>
         </MuiTooltip>
@@ -222,16 +240,20 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
             aria-label={text.attributionColumn.link}
             size={'small'}
             color={'secondary'}
-            disabled={isPackageInfoModified}
+            disabled={isPackageInfoModified || mutationPending}
             onClick={async () => {
-              const result = await backend.createOrMatchAttribution.mutate({
+              const result = await LinkAttribution.mutateAsync({
                 resourcePath: selectedResourceId,
                 packageInfo,
               });
               dispatch(setSelectedAttributionId(result.attribution));
             }}
           >
-            <CallMergeIcon />
+            {LinkAttribution.isPending ? (
+              <MuiCircularProgress size={16} color={'inherit'} />
+            ) : (
+              <CallMergeIcon />
+            )}
           </MuiFab>
         </span>
       </MuiTooltip>
@@ -251,6 +273,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
               aria-label={text.attributionColumn.delete}
               size={'small'}
               color={'secondary'}
+              disabled={mutationPending}
               onClick={() => setIsConfirmDeletionPopupOpen(true)}
             >
               <DeleteIcon />
@@ -278,7 +301,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
             aria-label={text.attributionColumn.revert}
             size={'small'}
             color={'secondary'}
-            disabled={!isPackageInfoModified}
+            disabled={!isPackageInfoModified || mutationPending}
             onClick={() => {
               dispatch(
                 setTemporaryDisplayPackageInfo(
@@ -310,17 +333,21 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
             aria-label={label}
             size={'small'}
             color={'secondary'}
+            disabled={mutationPending}
             onClick={async () => {
               selectedSignalIsResolved
-                ? await backend.unresolveAttributions.mutate({
+                ? await unresolveAttributions.mutateAsync({
                     attributionUuids: [packageInfo.id],
                   })
-                : await backend.resolveAttributions.mutate({
+                : await resolveAttributions.mutateAsync({
                     attributionUuids: [packageInfo.id],
                   });
             }}
           >
-            {selectedSignalIsResolved ? (
+            {unresolveAttributions.isPending ||
+            resolveAttributions.isPending ? (
+              <MuiCircularProgress size={16} color={'inherit'} />
+            ) : selectedSignalIsResolved ? (
               <RestoreFromTrashIcon />
             ) : (
               <DeleteIcon />
@@ -348,6 +375,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
               size={'small'}
               color={'secondary'}
               onClick={() => setIsDiffPopupOpen(true)}
+              disabled={mutationPending}
             >
               <CompareIcon />
             </MuiFab>

--- a/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
+++ b/src/Frontend/Components/AttributionDetails/ButtonRow/ButtonRow.tsx
@@ -52,7 +52,7 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
 
   const resolveAttributions = backend.resolveAttributions.useMutation();
   const unresolveAttributions = backend.unresolveAttributions.useMutation();
-  const LinkAttribution = backend.createOrMatchAttribution.useMutation();
+  const linkAttribution = backend.createOrMatchAttribution.useMutation();
   const updateOrMatch = backend.updateOrMatchAttribution.useMutation();
   const createOrMatch = backend.createOrMatchAttribution.useMutation();
   const mutationPending = useIsMutating() > 0;
@@ -242,14 +242,14 @@ export function ButtonRow({ packageInfo, isEditable }: Props) {
             color={'secondary'}
             disabled={isPackageInfoModified || mutationPending}
             onClick={async () => {
-              const result = await LinkAttribution.mutateAsync({
+              const result = await linkAttribution.mutateAsync({
                 resourcePath: selectedResourceId,
                 packageInfo,
               });
               dispatch(setSelectedAttributionId(result.attribution));
             }}
           >
-            {LinkAttribution.isPending ? (
+            {linkAttribution.isPending ? (
               <MuiCircularProgress size={16} color={'inherit'} />
             ) : (
               <CallMergeIcon />

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/ConfirmButton/ConfirmButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/ConfirmButton/ConfirmButton.tsx
@@ -5,6 +5,7 @@
 import CheckIcon from '@mui/icons-material/Check';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { text } from '../../../../../shared/text';
@@ -21,6 +22,7 @@ export const ConfirmButton: React.FC<PackagesPanelChildrenProps> = ({
   const preSelectedAttributionIds = selectedAttributionIds.filter(
     (id) => attributions?.[id]?.preSelected,
   );
+  const mutationsPending = useIsMutating() > 0;
 
   return (
     <>
@@ -28,7 +30,8 @@ export const ConfirmButton: React.FC<PackagesPanelChildrenProps> = ({
         aria-label={text.packageLists.confirm}
         disabled={
           !preSelectedAttributionIds.length ||
-          !!attributionIdsForReplacement.length
+          !!attributionIdsForReplacement.length ||
+          mutationsPending
         }
         onClick={() => setIsConfirmSavePopupOpen(true)}
         size={'small'}

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/DeleteButton/DeleteButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/DeleteButton/DeleteButton.tsx
@@ -5,6 +5,7 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { text } from '../../../../../shared/text';
@@ -19,13 +20,16 @@ export const DeleteButton: React.FC<PackagesPanelChildrenProps> = ({
   const [isConfirmDeletionPopupOpen, setIsConfirmDeletionPopupOpen] =
     useState(false);
 
+  const mutationsPending = useIsMutating() > 0;
+
   return (
     <>
       <MuiIconButton
         aria-label={text.packageLists.delete}
         disabled={
           !selectedAttributionIds.length ||
-          !!attributionIdsForReplacement.length
+          !!attributionIdsForReplacement.length ||
+          mutationsPending
         }
         onClick={() => setIsConfirmDeletionPopupOpen(true)}
         size={'small'}

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/LinkButton/LinkButton.tsx
@@ -5,6 +5,7 @@
 import CallMergeIcon from '@mui/icons-material/CallMerge';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 
 import { text } from '../../../../../shared/text';
 import { useAppSelector } from '../../../../state/hooks';
@@ -28,6 +29,23 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
   const isSelectedResourceBreakpoint = useIsSelectedResourceBreakpoint();
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
+  const createOrMatch = backend.createOrMatchAttribution.useMutation();
+  const mutationsPending = useIsMutating() > 0;
+
+  const handleLink = async () => {
+    if (attributions) {
+      await Promise.all(
+        selectedAttributionIds.map(async (attributionId) => {
+          await createOrMatch.mutateAsync({
+            resourcePath: selectedResourceId,
+            packageInfo: attributions[attributionId],
+          });
+        }),
+      );
+    }
+    setMultiSelectedAttributionIds([]);
+  };
+
   return (
     <MuiIconButton
       aria-label={text.packageLists.linkAsAttribution}
@@ -36,19 +54,12 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
         !selectedAttributionIds.length ||
         isPackageInfoModified ||
         activeRelation === 'resource' ||
-        !!attributionIdsForReplacement.length
+        !!attributionIdsForReplacement.length ||
+        mutationsPending
       }
+      loading={createOrMatch.isPending}
       size={'small'}
-      onClick={() => {
-        attributions &&
-          selectedAttributionIds.forEach(async (attributionId) => {
-            await backend.createOrMatchAttribution.mutate({
-              resourcePath: selectedResourceId,
-              packageInfo: attributions[attributionId],
-            });
-          });
-        setMultiSelectedAttributionIds([]);
-      }}
+      onClick={handleLink}
     >
       <MuiTooltip
         title={text.packageLists.linkAsAttribution}

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/MoreActionsButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/MoreActionsButton/MoreActionsButton.tsx
@@ -5,6 +5,7 @@
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 
 import {
@@ -58,6 +59,8 @@ export const MoreActionsButton: React.FC<PackagesPanelChildrenProps> = ({
   const dispatch = useAppDispatch();
   const [attributionIdsForReplacement] = useAttributionIdsForReplacement();
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+
+  const mutationsPending = useIsMutating() > 0;
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -149,7 +152,8 @@ export const MoreActionsButton: React.FC<PackagesPanelChildrenProps> = ({
         aria-label={text.packageLists.moreActions}
         disabled={
           !selectedAttributionIds.length ||
-          !!attributionIdsForReplacement.length
+          !!attributionIdsForReplacement.length ||
+          mutationsPending
         }
         onClick={handleClick}
         size={'small'}

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/ReplaceButton/ReplaceButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/ReplaceButton/ReplaceButton.tsx
@@ -5,6 +5,7 @@
 import ChangeCircleIcon from '@mui/icons-material/ChangeCircle';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 import { text } from '../../../../../shared/text';
@@ -23,6 +24,8 @@ export const ReplaceButton: React.FC<PackagesPanelChildrenProps> = ({
   const label = attributionIdsForReplacement.length
     ? text.packageLists.cancelReplace
     : text.packageLists.replace;
+
+  const mutationsPending = useIsMutating() > 0;
 
   const selectedAttributionIsExternal = useSelectedAttributionIsExternal();
 
@@ -43,7 +46,8 @@ export const ReplaceButton: React.FC<PackagesPanelChildrenProps> = ({
         !attributionIds ||
         !selectedAttributionIds.length ||
         !(attributionIds.length - multiSelectedAttributionIds.length) ||
-        attributionIds.length < 2
+        attributionIds.length < 2 ||
+        mutationsPending
       }
       size={'small'}
       onClick={() => {

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/DeleteButton/DeleteButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/DeleteButton/DeleteButton.tsx
@@ -5,6 +5,7 @@
 import DeleteIcon from '@mui/icons-material/Delete';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { text } from '../../../../../shared/text';
@@ -14,6 +15,8 @@ import { type PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPan
 export const DeleteButton: React.FC<PackagesPanelChildrenProps> = ({
   selectedAttributionIds,
 }) => {
+  const resolveAttributions = backend.resolveAttributions.useMutation();
+  const mutationsPending = useIsMutating() > 0;
   const { data: resolvedExternalAttributionIds } =
     backend.resolvedAttributionUuids.useQuery();
   const someSelectedAttributionsAreVisible = useMemo(
@@ -28,13 +31,14 @@ export const DeleteButton: React.FC<PackagesPanelChildrenProps> = ({
   return (
     <MuiIconButton
       aria-label={text.packageLists.delete}
-      disabled={!someSelectedAttributionsAreVisible}
+      disabled={!someSelectedAttributionsAreVisible || mutationsPending}
       size={'small'}
       onClick={() =>
-        backend.resolveAttributions.mutate({
+        resolveAttributions.mutateAsync({
           attributionUuids: selectedAttributionIds,
         })
       }
+      loading={resolveAttributions.isPending}
     >
       <MuiTooltip
         title={text.packageLists.delete}

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/LinkButton/LinkButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/LinkButton/LinkButton.tsx
@@ -5,6 +5,7 @@
 import CallMergeIcon from '@mui/icons-material/CallMerge';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 
 import { text } from '../../../../../shared/text';
 import { setSelectedAttributionId } from '../../../../state/actions/resource-actions/audit-view-simple-actions';
@@ -28,24 +29,39 @@ export const LinkButton: React.FC<PackagesPanelChildrenProps> = ({
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
 
+  const createOrMatch = backend.createOrMatchAttribution.useMutation({
+    scope: { id: 'signalsPanel' },
+  });
+  const mutationsPending = useIsMutating() > 0;
+
+  const handleLink = async () => {
+    if (attributions) {
+      await Promise.all(
+        selectedAttributionIds.map(async (attributionId) => {
+          const result = await createOrMatch.mutateAsync({
+            resourcePath: selectedResourceId,
+            packageInfo: attributions[attributionId],
+          });
+          if (attributionId === selectedAttributionId) {
+            dispatch(setSelectedAttributionId(result.attribution));
+          }
+        }),
+      );
+    }
+    setMultiSelectedAttributionIds([]);
+  };
+
   return (
     <MuiIconButton
       aria-label={text.packageLists.linkAsAttribution}
-      disabled={isSelectedResourceBreakpoint || !selectedAttributionIds.length}
+      disabled={
+        isSelectedResourceBreakpoint ||
+        !selectedAttributionIds.length ||
+        mutationsPending
+      }
+      loading={createOrMatch.isPending}
       size={'small'}
-      onClick={() => {
-        attributions &&
-          selectedAttributionIds.forEach(async (attributionId) => {
-            const result = await backend.createOrMatchAttribution.mutate({
-              resourcePath: selectedResourceId,
-              packageInfo: attributions[attributionId],
-            });
-            if (attributionId === selectedAttributionId) {
-              dispatch(setSelectedAttributionId(result.attribution));
-            }
-          });
-        setMultiSelectedAttributionIds([]);
-      }}
+      onClick={handleLink}
     >
       <MuiTooltip
         title={text.packageLists.linkAsAttribution}

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/RestoreButton/RestoreButton.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/RestoreButton/RestoreButton.tsx
@@ -5,6 +5,7 @@
 import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
 import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
+import { useIsMutating } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { text } from '../../../../../shared/text';
@@ -15,6 +16,10 @@ import { type PackagesPanelChildrenProps } from '../../PackagesPanel/PackagesPan
 export const RestoreButton: React.FC<PackagesPanelChildrenProps> = ({
   selectedAttributionIds,
 }) => {
+  const unresolveAttributions = backend.unresolveAttributions.useMutation({
+    scope: { id: 'signalsPanel' },
+  });
+  const mutationsPending = useIsMutating() > 0;
   const { data: resolvedExternalAttributionIds } =
     backend.resolvedAttributionUuids.useQuery();
   const [userSettings] = useUserSettings();
@@ -35,13 +40,14 @@ export const RestoreButton: React.FC<PackagesPanelChildrenProps> = ({
   return (
     <MuiIconButton
       aria-label={text.packageLists.restore}
-      disabled={!someSelectedAttributionsAreHidden}
+      disabled={!someSelectedAttributionsAreHidden || mutationsPending}
       size={'small'}
       onClick={async () => {
-        await backend.unresolveAttributions.mutate({
+        await unresolveAttributions.mutateAsync({
           attributionUuids: selectedAttributionIds,
         });
       }}
+      loading={unresolveAttributions.isPending}
     >
       <MuiTooltip
         title={text.packageLists.restore}

--- a/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
+++ b/src/Frontend/Components/ConfirmDeletePopup/ConfirmDeletePopup.tsx
@@ -35,8 +35,16 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
   const dispatch = useAppDispatch();
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
+
+  const deleteAttributions = backend.deleteAttributions.useMutation();
+  const unlinkResourceFromAttributions =
+    backend.unlinkResourceFromAttributions.useMutation();
+
+  const isDeleting =
+    deleteAttributions.isPending || unlinkResourceFromAttributions.isPending;
+
   const { data: attributionsToDelete } = backend.listAttributions.useQuery(
-    open && selectedResourceId
+    open && !isDeleting && selectedResourceId
       ? {
           resourcePathForRelationships: selectedResourceId,
           uuids: attributionIdsToDelete,
@@ -48,7 +56,6 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
     onAttributionUuids: attributionIdsToDelete,
     enabled: open,
   });
-  const linkedResourceCount = linkedResourcesTreeState?.count;
 
   const isResourceLinkedOnAllAttributions = attributionsToDelete
     ? Object.values(attributionsToDelete).every(
@@ -56,13 +63,14 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
       )
     : undefined;
 
+  const linkedResourceCount = linkedResourcesTreeState?.count;
   const isOptionToDeleteOnSelectedResourceOnlyAvailable =
     linkedResourceCount &&
     linkedResourceCount > 1 &&
     isResourceLinkedOnAllAttributions;
 
   const handleDelete = async () => {
-    await backend.deleteAttributions.mutate({
+    await deleteAttributions.mutateAsync({
       attributionUuids: attributionIdsToDelete,
     });
     if (attributionIdsToDelete.includes(selectedAttributionId)) {
@@ -72,7 +80,7 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
   };
 
   const handleDeleteOnResource = async () => {
-    await backend.unlinkResourceFromAttributions.mutate({
+    await unlinkResourceFromAttributions.mutateAsync({
       resourcePath: selectedResourceId,
       attributionUuids: attributionIdsToDelete,
     });
@@ -85,7 +93,21 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
   return (
     <StyledNotificationPopup
       header={text.deleteAttributionsPopup.title}
+      leftButtonConfig={
+        isOptionToDeleteOnSelectedResourceOnlyAvailable ||
+        unlinkResourceFromAttributions.isPending
+          ? {
+              disabled: isDeleting,
+              loading: unlinkResourceFromAttributions.isPending,
+              onClick: handleDeleteOnResource,
+              buttonText: text.deleteAttributionsPopup.deleteLocally,
+              color: 'primary',
+            }
+          : undefined
+      }
       centerLeftButtonConfig={{
+        disabled: isDeleting,
+        loading: deleteAttributions.isPending,
         onClick: handleDelete,
         buttonText:
           linkedResourceCount && linkedResourceCount > 1
@@ -93,16 +115,8 @@ export const ConfirmDeletePopup: React.FC<Props> = ({
             : text.deleteAttributionsPopup.delete,
         color: 'error',
       }}
-      leftButtonConfig={
-        isOptionToDeleteOnSelectedResourceOnlyAvailable
-          ? {
-              onClick: handleDeleteOnResource,
-              buttonText: text.deleteAttributionsPopup.deleteLocally,
-              color: 'primary',
-            }
-          : undefined
-      }
       rightButtonConfig={{
+        disabled: isDeleting,
         onClick: onClose,
         buttonText: text.buttons.cancel,
         color: 'secondary',

--- a/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
+++ b/src/Frontend/Components/ConfirmReplacePopup/ConfirmReplacePopup.tsx
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiDivider from '@mui/material/Divider';
 import MuiTypography from '@mui/material/Typography';
+import { skipToken } from '@tanstack/react-query';
 
 import { type PackageInfo } from '../../../shared/shared-types';
 import { text } from '../../../shared/text';
@@ -32,17 +33,23 @@ export const ConfirmReplacePopup = ({
   const [attributionIdsForReplacement, setAttributionIdsForReplacement] =
     useAttributionIdsForReplacement();
 
+  const updateAttributions = backend.updateAttributions.useMutation();
+  const replaceAttribution = backend.replaceAttribution.useMutation();
+  const isReplacing =
+    updateAttributions.isPending || replaceAttribution.isPending;
+
   const { data: attributionsForReplacement } =
-    backend.listAttributions.useQuery({
-      uuids: attributionIdsForReplacement,
-    });
+    backend.listAttributions.useQuery(
+      open && !isReplacing
+        ? {
+            uuids: attributionIdsForReplacement,
+          }
+        : skipToken,
+    );
 
   const handleReplace = async () => {
-    setAttributionIdsForReplacement([]);
-    onClose();
-    dispatch(changeSelectedAttributionOrOpenUnsavedPopup(selectedAttribution));
     if (selectedAttribution.preSelected) {
-      await backend.updateAttributions.mutate({
+      await updateAttributions.mutateAsync({
         attributions: {
           [selectedAttribution.id]: {
             ...selectedAttribution,
@@ -51,23 +58,30 @@ export const ConfirmReplacePopup = ({
         },
       });
     }
-    attributionIdsForReplacement.forEach(async (attributionId) => {
-      await backend.replaceAttribution.mutate({
-        attributionIdToReplace: attributionId,
-        attributionIdToReplaceWith: selectedAttribution.id,
-      });
-    });
+    await Promise.all(
+      attributionIdsForReplacement.map(async (attributionId) => {
+        await replaceAttribution.mutateAsync({
+          attributionIdToReplace: attributionId,
+          attributionIdToReplaceWith: selectedAttribution.id,
+        });
+      }),
+    );
+    setAttributionIdsForReplacement([]);
+    dispatch(changeSelectedAttributionOrOpenUnsavedPopup(selectedAttribution));
+    onClose();
   };
 
   return (
     <StyledNotificationPopup
       header={text.replaceAttributionsPopup.title}
       leftButtonConfig={{
+        loading: isReplacing,
         onClick: handleReplace,
         buttonText: text.replaceAttributionsPopup.replace,
         color: 'error',
       }}
       rightButtonConfig={{
+        disabled: isReplacing,
         onClick: () => onClose(),
         buttonText: text.buttons.cancel,
         color: 'secondary',

--- a/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
+++ b/src/Frontend/Components/ConfirmSavePopup/ConfirmSavePopup.tsx
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import MuiDivider from '@mui/material/Divider';
 import MuiTypography from '@mui/material/Typography';
+import { skipToken } from '@tanstack/react-query';
 
 import { text } from '../../../shared/text';
 import { setSelectedAttributionId } from '../../state/actions/resource-actions/audit-view-simple-actions';
@@ -37,14 +38,19 @@ export const ConfirmSavePopup: React.FC<Props> = ({
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
+  const updateOrMatch = backend.updateOrMatchAttribution.useMutation();
+  const modifyOrMatchOnlyOnOneResource =
+    backend.modifyOrMatchOnlyOnOneResource.useMutation();
+  const isSaving =
+    updateOrMatch.isPending || modifyOrMatchOnlyOnOneResource.isPending;
+
   const { data: attributionsToSave } = backend.listAttributions.useQuery(
-    {
-      resourcePathForRelationships: selectedResourceId,
-      uuids: attributionIdsToSave,
-    },
-    {
-      enabled: open,
-    },
+    open && !isSaving
+      ? {
+          resourcePathForRelationships: selectedResourceId,
+          uuids: attributionIdsToSave,
+        }
+      : skipToken,
   );
 
   const temporaryDisplayPackageInfo = useAppSelector(
@@ -71,45 +77,50 @@ export const ConfirmSavePopup: React.FC<Props> = ({
     ? Object.values(attributionsToSave).every((a) => a.preSelected)
     : undefined;
 
-  const handleSaveGlobally = () => {
-    attributionsToSave &&
-      Object.entries(attributionsToSave).forEach(
-        async ([attributionId, attributionData]) => {
-          const result = await backend.updateOrMatchAttribution.mutate({
-            packageInfo:
-              attributionId === selectedAttributionId
-                ? temporaryDisplayPackageInfo
-                : attributionData,
-          });
-          if (
-            attributionId === selectedAttributionId &&
-            result.matchedAttribution
-          ) {
-            dispatch(setSelectedAttributionId(result.matchedAttribution));
-          }
-        },
+  const handleSaveGlobally = async () => {
+    if (attributionsToSave) {
+      await Promise.all(
+        Object.entries(attributionsToSave).map(
+          async ([attributionId, attributionData]) => {
+            const result = await updateOrMatch.mutateAsync({
+              packageInfo:
+                attributionId === selectedAttributionId
+                  ? temporaryDisplayPackageInfo
+                  : attributionData,
+            });
+            if (
+              attributionId === selectedAttributionId &&
+              result.matchedAttribution
+            ) {
+              dispatch(setSelectedAttributionId(result.matchedAttribution));
+            }
+          },
+        ),
       );
-
+    }
     onClose();
   };
 
-  const handleSaveOnResource = () => {
-    attributionsToSave &&
-      Object.entries(attributionsToSave).forEach(
-        async ([attributionId, attributionData]) => {
-          const result = await backend.modifyOrMatchOnlyOnOneResource.mutate({
-            resourcePath: selectedResourceId,
-            packageInfo:
-              attributionId === selectedAttributionId
-                ? temporaryDisplayPackageInfo
-                : attributionData,
-          });
+  const handleSaveOnResource = async () => {
+    if (attributionsToSave) {
+      await Promise.all(
+        Object.entries(attributionsToSave).map(
+          async ([attributionId, attributionData]) => {
+            const result = await modifyOrMatchOnlyOnOneResource.mutateAsync({
+              resourcePath: selectedResourceId,
+              packageInfo:
+                attributionId === selectedAttributionId
+                  ? temporaryDisplayPackageInfo
+                  : attributionData,
+            });
 
-          if (attributionId === selectedAttributionId) {
-            dispatch(setSelectedAttributionId(result.attribution));
-          }
-        },
+            if (attributionId === selectedAttributionId) {
+              dispatch(setSelectedAttributionId(result.attribution));
+            }
+          },
+        ),
       );
+    }
     onClose();
   };
 
@@ -120,7 +131,22 @@ export const ConfirmSavePopup: React.FC<Props> = ({
           ? text.saveAttributionsPopup.titleConfirm
           : text.saveAttributionsPopup.titleSave
       }
+      leftButtonConfig={
+        hasMultipleResourcesWhichContainSelected ||
+        modifyOrMatchOnlyOnOneResource.isPending
+          ? {
+              disabled: isSaving,
+              loading: modifyOrMatchOnlyOnOneResource.isPending,
+              onClick: handleSaveOnResource,
+              buttonText: areAllAttributionsPreselected
+                ? text.saveAttributionsPopup.confirmLocally
+                : text.saveAttributionsPopup.saveLocally,
+            }
+          : undefined
+      }
       centerLeftButtonConfig={{
+        disabled: isSaving,
+        loading: updateOrMatch.isPending,
         onClick: handleSaveGlobally,
         color: 'error',
         buttonText:
@@ -132,17 +158,8 @@ export const ConfirmSavePopup: React.FC<Props> = ({
               ? text.saveAttributionsPopup.confirm
               : text.saveAttributionsPopup.save,
       }}
-      leftButtonConfig={
-        hasMultipleResourcesWhichContainSelected
-          ? {
-              onClick: handleSaveOnResource,
-              buttonText: areAllAttributionsPreselected
-                ? text.saveAttributionsPopup.confirmLocally
-                : text.saveAttributionsPopup.saveLocally,
-            }
-          : undefined
-      }
       rightButtonConfig={{
+        disabled: isSaving,
         onClick: onClose,
         buttonText: text.buttons.cancel,
         color: 'secondary',

--- a/src/e2e-tests/__tests__/confirming-preselected-attributions.test.ts
+++ b/src/e2e-tests/__tests__/confirming-preselected-attributions.test.ts
@@ -65,6 +65,7 @@ test('updates progress bar when user confirms pre-selected attributions', async 
 
   await attributionDetails.confirmButton.click();
   await confirmSavePopup.confirmLocallyButton.click();
+  await confirmSavePopup.assert.isHidden();
   await linkedResourcesTree.assert.resourceIsVisible(resourceName1);
   await linkedResourcesTree.assert.resourceIsHidden(resourceName2);
   await linkedResourcesTree.assert.resourceIsHidden(resourceName3);


### PR DESCRIPTION
### Summary of changes

Add loading animations to the buttons, this way we do not need to worry about users triggering multiple mutations at once that do not work together.

### Context and reason for change

In large files with long waiting times the UI felt broken sometimes.

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
