### PR TITLE
fix: don't update caa table in modifyOrMatchOnlyOneResource

### DIFF
--- a/src/ElectronBackend/api/mutations.ts
+++ b/src/ElectronBackend/api/mutations.ts
@@ -382,11 +382,6 @@ export const mutations = {
           preconditions: { isExternal: false, minimumResources: 2 },
         });
 
-        await removeManualOrExternalCaaFromResources(trx, 'manual', {
-          attributionUuids: [params.packageInfo.id],
-          resourceIds: [resource.id],
-        });
-
         await trx
           .deleteFrom('resource_to_attribution')
           .where('resource_id', '=', resource.id)
@@ -400,11 +395,6 @@ export const mutations = {
 
         await linkAttribution(trx, resource.id, attributionToLink, {
           ignoreExisting: true,
-        });
-
-        await addManualOrExternalCaaToResources(trx, 'manual', {
-          attributionUuids: [attributionToLink],
-          resourceIds: [resource.id],
         });
 
         await removeRedundantAttributions(trx, { resourceIds: [resource.id] });


### PR DESCRIPTION
### Summary of changes

<!-- required -->

### Context and reason for change

<!-- required -->

### How can the changes be tested

<!-- optional -->

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
