### PR TITLE
fix: prevent attribution list from jumping when loading or empty

### DIFF
--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
@@ -255,7 +255,7 @@ export const PackagesPanel = ({
 
   function renderTabs() {
     if (!availableRelations?.length) {
-      return null;
+      return <Tabs centered variant={'fullWidth'} value={-1}></Tabs>;
     }
 
     const activeTabIndex = availableRelations.findIndex(


### PR DESCRIPTION
### Summary of changes

<!-- required -->

### Context and reason for change

<!-- required -->

### How can the changes be tested

<!-- optional -->

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
