### PR TITLE
fix: don't show attribution count on ancestors or same resource

### DIFF
--- a/src/ElectronBackend/api/__tests__/listAttributions.test.ts
+++ b/src/ElectronBackend/api/__tests__/listAttributions.test.ts
@@ -65,7 +65,6 @@ describe('listAttributions', () => {
 
     expect(result['on-parent']).toMatchObject({
       relation: 'resource',
-      count: 1,
     });
     expect(result['on-child']).toMatchObject({
       relation: 'children',

--- a/src/ElectronBackend/api/listAttributions.ts
+++ b/src/ElectronBackend/api/listAttributions.ts
@@ -161,6 +161,21 @@ export async function listAttributions(props: {
     unrelated: 'unrelated',
   } as const;
 
+  function getCount(attribution: (typeof attributions)[number]) {
+    if (
+      attribution.relationship === 'same' ||
+      attribution.relationship === 'ancestor'
+    ) {
+      return undefined;
+    }
+
+    if (attribution.relationship === 'descendant') {
+      return attribution.resource_count_below ?? 0;
+    }
+
+    return attribution.resource_count ?? 0;
+  }
+
   return {
     result: Object.fromEntries(
       attributions.map((a) => [
@@ -168,10 +183,7 @@ export async function listAttributions(props: {
         {
           ...(JSON.parse(a.data) as PackageInfo),
           relation: backendToFrontendRelationship[a.relationship],
-          count:
-            a.relationship !== 'unrelated' && 'resource_count_below' in a
-              ? (a.resource_count_below ?? 0)
-              : (a.resource_count ?? 0),
+          count: getCount(a),
         },
       ]),
     ),


### PR DESCRIPTION
### Summary of changes

<!-- required -->

### Context and reason for change

<!-- required -->

### How can the changes be tested

<!-- optional -->

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
