### PR TITLE
fix: unlink also checks whether to delete an attribution

### DIFF
--- a/src/ElectronBackend/api/mutations.ts
+++ b/src/ElectronBackend/api/mutations.ts
@@ -202,24 +202,9 @@ export const mutations = {
           resourceIds: [resource.id],
         });
 
-        for (const attributionUuid of params.attributionUuids) {
-          const existingAttribution = await getAttributionOrThrow(
-            trx,
-            attributionUuid,
-          );
+        await ensureAttributionsAreNotExternal(trx, params.attributionUuids);
 
-          if (existingAttribution.is_external) {
-            throw new Error(
-              'Only manual attributions can be unlinked from resources',
-            );
-          }
-
-          await trx
-            .deleteFrom('resource_to_attribution')
-            .where('resource_id', '=', resource.id)
-            .where('attribution_uuid', '=', attributionUuid)
-            .execute();
-        }
+        await unlinkAttributions(trx, resource.id, params.attributionUuids);
 
         await removeRedundantAttributions(trx, { resourceIds: [resource.id] });
       });

--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -556,6 +556,18 @@ export async function unlinkAttributions(
     .where('resource_id', '=', resourceId)
     .where('attribution_uuid', 'in', attributionUuids)
     .execute();
+
+  // delete any of the just-unlinked attributions that no longer link to any resource
+  await trx
+    .deleteFrom('attribution')
+    .where('uuid', 'in', attributionUuids)
+    .where('uuid', 'not in', (eb) =>
+      eb
+        .selectFrom('resource_to_attribution')
+        .select('attribution_uuid')
+        .where('attribution_is_external', '=', 0),
+    )
+    .execute();
 }
 
 export async function linkAttributions(


### PR DESCRIPTION
### Summary of changes
ensure we do not leave empty attributions

Note: Please review the [guidelines for contributing](https://github.com/opossum-tool/OpossumUI/blob/main/CONTRIBUTING.md) to this repository.
