### PR TITLE
fix(electron): confirm before opening external files

### DIFF
--- a/src/ElectronBackend/app.ts
+++ b/src/ElectronBackend/app.ts
@@ -5,17 +5,13 @@
 import { app } from 'electron';
 
 import { main } from './main/main';
+import { queueMacOsOpenFile } from './main/openFileRequests';
 
 // allow opening a file when double-clicking it in mac-os. Has to be called before the ready event is emitted
 app.on('open-file', (event, filePath) => {
   event.preventDefault();
   if (filePath.endsWith('.opossum')) {
-    for (const arg of process.argv) {
-      if (arg.endsWith('.opossum')) {
-        return;
-      }
-    }
-    process.argv.push(filePath);
+    queueMacOsOpenFile(filePath);
   }
 });
 

--- a/src/ElectronBackend/main/__tests__/listeners.test.ts
+++ b/src/ElectronBackend/main/__tests__/listeners.test.ts
@@ -10,9 +10,11 @@ import {
   AllowedFrontendChannels,
   IpcChannel,
 } from '../../../shared/ipc-channels';
+import { loadInputAndOutputFromFilePath } from '../../input/importFromFile';
 import { createWindow } from '../createWindow';
 import {
   openNonOpossumFileDialog,
+  openOpossumFileDialog,
   saveFileDialog,
   selectBaseURLDialog,
 } from '../dialogs';
@@ -21,6 +23,7 @@ import {
   importFileListener,
   importFileSelectSaveLocationListener,
   linkHasHttpSchema,
+  openFileListener,
   openLinkListener,
   selectBaseURLListener,
   selectFileListener,
@@ -36,28 +39,20 @@ vi.mock('electron', () => ({
     whenReady: async (): Promise<unknown> => Promise.resolve(true),
   },
   BrowserWindow: class BrowserWindowMock {
-    constructor() {
-      return {
-        loadURL: vi.fn(() => {
-          return Promise.resolve(null);
-        }),
-        setTitle: vi.fn(),
-        getFocusedWindow: vi.fn(),
-        webContents: {
-          openDevTools: vi.fn(),
-          send: vi.fn(),
-          close: vi.fn(),
-          session: {
-            webRequest: {
-              onHeadersReceived: vi.fn(),
-            },
-          },
+    loadURL = vi.fn(() => Promise.resolve(null));
+    setTitle = vi.fn();
+    getFocusedWindow = vi.fn();
+    webContents = {
+      openDevTools: vi.fn(),
+      send: vi.fn(),
+      close: vi.fn(),
+      session: {
+        webRequest: {
+          onHeadersReceived: vi.fn(),
         },
-        close: vi.fn(() => {
-          return Promise.resolve(null);
-        }),
-      };
-    }
+      },
+    };
+    close = vi.fn(() => Promise.resolve(null));
   },
   Menu: {
     setApplicationMenu: vi.fn(),
@@ -84,6 +79,13 @@ vi.mock('../dialogs', () => ({
   openNonOpossumFileDialog: vi.fn(),
   saveFileDialog: vi.fn(),
   selectBaseURLDialog: vi.fn(),
+}));
+
+vi.mock('../user-settings-service', () => ({
+  UserSettingsService: {
+    get: vi.fn().mockResolvedValue([]),
+    update: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 describe('getSelectBaseURLListener', () => {
@@ -132,6 +134,23 @@ describe('getImportFileListener', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledWith(
       AllowedFrontendChannels.ShowImportDialog,
       fileFormat,
+    );
+  });
+});
+
+describe('openFileListener', () => {
+  it('opens the provided file path without showing the dialog', async () => {
+    const mainWindow = initWindowAndBackendState();
+    const updateMenu = vi.fn().mockResolvedValue(undefined);
+    const listener = openFileListener(mainWindow, updateMenu);
+    const filePath = '/home/input.opossum';
+
+    await listener({} as Electron.IpcMainInvokeEvent, filePath);
+
+    expect(openOpossumFileDialog).not.toHaveBeenCalled();
+    expect(loadInputAndOutputFromFilePath).toHaveBeenCalledWith(
+      mainWindow,
+      filePath,
     );
   });
 });

--- a/src/ElectronBackend/main/__tests__/openFileFromCliOrEnvVariableIfProvided.test.ts
+++ b/src/ElectronBackend/main/__tests__/openFileFromCliOrEnvVariableIfProvided.test.ts
@@ -6,6 +6,10 @@ import { type BrowserWindow } from 'electron';
 import { cloneDeep } from 'lodash';
 
 import { openFileFromCliOrEnvVariableIfProvided } from '../openFileFromCliOrEnvVariableIfProvided';
+import {
+  queueMacOsOpenFile,
+  resetMacOsOpenFileHandlingForTests,
+} from '../openFileRequests';
 
 const mockHandleOpeningFile = vi.fn();
 vi.mock('../listeners', () => ({
@@ -14,6 +18,11 @@ vi.mock('../listeners', () => ({
 
 describe('openFileFromCli', () => {
   let oldProcessArgv: Array<string>;
+
+  beforeEach(() => {
+    mockHandleOpeningFile.mockClear();
+    resetMacOsOpenFileHandlingForTests();
+  });
 
   beforeAll(() => {
     oldProcessArgv = process.argv;
@@ -84,6 +93,8 @@ describe('openFileFromEnvVariable', () => {
   beforeEach(() => {
     process.env = cloneDeep(oldEnvVariables);
     process.argv = cloneDeep(oldProcessArgv);
+    mockHandleOpeningFile.mockClear();
+    resetMacOsOpenFileHandlingForTests();
   });
 
   afterAll(() => {
@@ -121,6 +132,24 @@ describe('openFileFromEnvVariable', () => {
     const inputFileName = 'path/to/file/inputfile.opossum';
     process.argv = ['app'];
     process.argv.push(inputFileName);
+
+    const updateMenu = vi.fn();
+    await openFileFromCliOrEnvVariableIfProvided(
+      'mockBrowserWindow' as unknown as BrowserWindow,
+      updateMenu,
+    );
+
+    expect(mockHandleOpeningFile).toHaveBeenCalledWith([
+      'mockBrowserWindow',
+      inputFileName,
+      updateMenu,
+    ]);
+  });
+
+  it('opens a queued macOS startup file before env variables', async () => {
+    const inputFileName = '/path/queuedFile.opossum';
+    queueMacOsOpenFile(inputFileName);
+    process.env.OPOSSUM_FILE = '/path/envFile.opossum';
 
     const updateMenu = vi.fn();
     await openFileFromCliOrEnvVariableIfProvided(

--- a/src/ElectronBackend/main/__tests__/openFileRequests.test.ts
+++ b/src/ElectronBackend/main/__tests__/openFileRequests.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  queueMacOsOpenFile,
+  resetMacOsOpenFileHandlingForTests,
+  setRuntimeMacOsOpenFileHandler,
+} from '../openFileRequests';
+
+describe('openFileRequests', () => {
+  beforeEach(() => {
+    resetMacOsOpenFileHandlingForTests();
+  });
+
+  it('delivers queued file-open requests once the runtime handler is registered', () => {
+    const runtimeOpenFileHandler = vi.fn();
+    const filePath = '/path/to/project.opossum';
+
+    queueMacOsOpenFile(filePath);
+    setRuntimeMacOsOpenFileHandler(runtimeOpenFileHandler);
+
+    expect(runtimeOpenFileHandler).toHaveBeenCalledWith(filePath);
+  });
+
+  it('forwards file-open requests directly after the runtime handler is registered', () => {
+    const runtimeOpenFileHandler = vi.fn();
+    const filePath = '/path/to/project.opossum';
+
+    setRuntimeMacOsOpenFileHandler(runtimeOpenFileHandler);
+    queueMacOsOpenFile(filePath);
+
+    expect(runtimeOpenFileHandler).toHaveBeenCalledWith(filePath);
+  });
+});

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -99,13 +99,15 @@ export const exportFileListener =
 
 export const openFileListener =
   (mainWindow: BrowserWindow, updateMenu: () => Promise<void>) =>
-  async (): Promise<void> => {
+  async (
+    _: Electron.IpcMainInvokeEvent,
+    requestedFilePath?: string,
+  ): Promise<void> => {
     try {
-      const filePaths = openOpossumFileDialog();
-      if (!filePaths || filePaths.length < 1) {
+      const filePath = requestedFilePath ?? openOpossumFileDialog()?.[0];
+      if (!filePath) {
         return;
       }
-      const filePath = filePaths[0];
 
       await handleOpeningFile(mainWindow, filePath, updateMenu);
     } catch (error) {

--- a/src/ElectronBackend/main/main.ts
+++ b/src/ElectronBackend/main/main.ts
@@ -5,6 +5,7 @@
 import { dialog, systemPreferences } from 'electron';
 import os from 'os';
 
+import { AllowedFrontendChannels } from '../../shared/ipc-channels';
 import {
   FRONTEND_TO_DB_PROCESS_PORT,
   getDbProcessPort,
@@ -13,6 +14,7 @@ import { getMessageBoxContentForErrorsWrapper } from '../errorHandling/errorHand
 import { createWindow, loadWebApp } from './createWindow';
 import { createMenu } from './menu';
 import { openFileFromCliOrEnvVariableIfProvided } from './openFileFromCliOrEnvVariableIfProvided';
+import { setRuntimeMacOsOpenFileHandler } from './openFileRequests';
 import { setupIpcHandling } from './setUpIpcHandling';
 import { UserSettingsService } from './user-settings-service';
 
@@ -64,6 +66,13 @@ export async function main(): Promise<void> {
     await loadWebApp(mainWindow);
 
     await openFileFromCliOrEnvVariableIfProvided(mainWindow, updateMenu);
+
+    setRuntimeMacOsOpenFileHandler((filePath) => {
+      mainWindow.webContents.send(
+        AllowedFrontendChannels.OpenFileWithUnsavedCheck,
+        filePath,
+      );
+    });
   } catch (error) {
     if (error instanceof Error) {
       await dialog.showMessageBox(

--- a/src/ElectronBackend/main/openFileFromCliOrEnvVariableIfProvided.ts
+++ b/src/ElectronBackend/main/openFileFromCliOrEnvVariableIfProvided.ts
@@ -6,6 +6,10 @@ import { type BrowserWindow } from 'electron';
 import log from 'electron-log';
 
 import { handleOpeningFile } from './listeners';
+import {
+  clearPendingMacOsOpenFilePaths,
+  consumeStartupMacOsOpenFilePath,
+} from './openFileRequests';
 
 export async function openFileFromCliOrEnvVariableIfProvided(
   mainWindow: BrowserWindow,
@@ -20,8 +24,13 @@ export async function openFileFromCliOrEnvVariableIfProvided(
   for (const arg of process.argv) {
     if (fileHasValidEnding(arg)) {
       inputFileName = arg;
+      clearPendingMacOsOpenFilePaths();
       break;
     }
+  }
+
+  if (!inputFileName) {
+    inputFileName = consumeStartupMacOsOpenFilePath();
   }
 
   const inputFileFromEnvVariable: string | undefined = process.env.OPOSSUM_FILE;

--- a/src/ElectronBackend/main/openFileRequests.ts
+++ b/src/ElectronBackend/main/openFileRequests.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const pendingMacOsOpenFilePaths: Array<string> = [];
+
+let runtimeMacOsOpenFileHandler: ((filePath: string) => void) | null = null;
+
+export function queueMacOsOpenFile(filePath: string): void {
+  if (runtimeMacOsOpenFileHandler) {
+    runtimeMacOsOpenFileHandler(filePath);
+    return;
+  }
+
+  pendingMacOsOpenFilePaths.push(filePath);
+}
+
+export function consumeStartupMacOsOpenFilePath(): string | null {
+  return pendingMacOsOpenFilePaths.shift() ?? null;
+}
+
+export function clearPendingMacOsOpenFilePaths(): void {
+  pendingMacOsOpenFilePaths.length = 0;
+}
+
+export function setRuntimeMacOsOpenFileHandler(
+  handler: (filePath: string) => void,
+): void {
+  runtimeMacOsOpenFileHandler = handler;
+
+  for (const filePath of pendingMacOsOpenFilePaths.splice(0)) {
+    runtimeMacOsOpenFileHandler(filePath);
+  }
+}
+
+export function resetMacOsOpenFileHandlingForTests(): void {
+  clearPendingMacOsOpenFilePaths();
+  runtimeMacOsOpenFileHandler = null;
+}

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -35,7 +35,7 @@ const electronAPI: ElectronAPI = {
   quit: () => ipcRenderer.invoke(IpcChannel.Quit),
   relaunch: () => ipcRenderer.invoke(IpcChannel.Relaunch),
   openLink: (link) => ipcRenderer.invoke(IpcChannel.OpenLink, { link }),
-  openFile: () => ipcRenderer.invoke(IpcChannel.OpenFile),
+  openFile: (filePath) => ipcRenderer.invoke(IpcChannel.OpenFile, filePath),
   selectFile: (fileFormat) =>
     ipcRenderer.invoke(IpcChannel.SelectFile, fileFormat),
   importFileSelectSaveLocation: (defaultPath) =>

--- a/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
+++ b/src/Frontend/Components/BackendCommunication/BackendCommunication.tsx
@@ -23,6 +23,7 @@ import { backend, setDatabaseInitialized } from '../../util/backendClient';
 import {
   type ExportFileRequestListener,
   type LoggingListener,
+  type OpenFileWithUnsavedCheckListener,
   type SetBaseURLForRootListener,
   type SetDatabaseInitializedListener,
   type ShowImportDialogListener,
@@ -120,9 +121,9 @@ export const BackendCommunication: React.FC = () => {
     showUpdateAppPopupListener,
     [dispatch],
   );
-  useIpcRenderer(
+  useIpcRenderer<OpenFileWithUnsavedCheckListener>(
     AllowedFrontendChannels.OpenFileWithUnsavedCheck,
-    () => dispatch(openFileOrOpenUnsavedPopup()),
+    (_, filePath) => dispatch(openFileOrOpenUnsavedPopup(filePath)),
     [dispatch],
   );
   useIpcRenderer<ShowImportDialogListener>(

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { type IpcRendererEvent } from 'electron';
+
+import { AllowedFrontendChannels } from '../../../../shared/ipc-channels';
+import { PopupType } from '../../../enums/enums';
+import { setIsPackageInfoDirty } from '../../../state/actions/resource-actions/all-views-simple-actions';
+import {
+  getOpenFileRequest,
+  getOpenPopup,
+} from '../../../state/selectors/view-selector';
+import { renderComponent } from '../../../test-helpers/render';
+import { BackendCommunication } from '../BackendCommunication';
+
+describe('BackendCommunication', () => {
+  it('stores the external file path in the unsaved-changes flow', async () => {
+    const listeners = new Map<
+      AllowedFrontendChannels,
+      (event: IpcRendererEvent, ...args: Array<unknown>) => void
+    >();
+
+    vi.mocked(window.electronAPI.on).mockImplementation((channel, listener) => {
+      listeners.set(
+        channel,
+        listener as (event: IpcRendererEvent, ...args: Array<unknown>) => void,
+      );
+      return vi.fn();
+    });
+
+    const { store } = await renderComponent(<BackendCommunication />, {
+      actions: [setIsPackageInfoDirty(true)],
+    });
+    const filePath = '/path/to/project.opossum';
+
+    listeners.get(AllowedFrontendChannels.OpenFileWithUnsavedCheck)?.(
+      {} as IpcRendererEvent,
+      filePath,
+    );
+
+    expect(getOpenPopup(store.getState())?.popup).toBe(PopupType.NotSavedPopup);
+    expect(getOpenFileRequest(store.getState())).toEqual({ filePath });
+  });
+});

--- a/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
+++ b/src/Frontend/Components/BackendCommunication/__tests__/BackendCommunication.test.tsx
@@ -40,6 +40,9 @@ describe('BackendCommunication', () => {
     );
 
     expect(getOpenPopup(store.getState())?.popup).toBe(PopupType.NotSavedPopup);
-    expect(getOpenFileRequest(store.getState())).toEqual({ filePath });
+    expect(getOpenFileRequest(store.getState())).toEqual({
+      kind: 'path',
+      filePath,
+    });
   });
 });

--- a/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
+++ b/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
@@ -100,12 +100,17 @@ describe('NotSavedPopup', () => {
   });
 
   it('handles request to open a file', async () => {
+    const filePath = '/path/to/project.opossum';
+
     await renderComponent(<NotSavedPopup />, {
-      actions: [openPopup(PopupType.NotSavedPopup), setOpenFileRequest(true)],
+      actions: [
+        openPopup(PopupType.NotSavedPopup),
+        setOpenFileRequest({ filePath }),
+      ],
     });
 
     await userEvent.click(screen.getByText(text.unsavedChangesPopup.discard));
 
-    expect(global.window.electronAPI.openFile).toHaveBeenCalledTimes(1);
+    expect(global.window.electronAPI.openFile).toHaveBeenCalledWith(filePath);
   });
 });

--- a/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
+++ b/src/Frontend/Components/NotSavedPopup/__tests__/NotSavedPopup.test.tsx
@@ -105,7 +105,7 @@ describe('NotSavedPopup', () => {
     await renderComponent(<NotSavedPopup />, {
       actions: [
         openPopup(PopupType.NotSavedPopup),
-        setOpenFileRequest({ filePath }),
+        setOpenFileRequest({ kind: 'path', filePath }),
       ],
     });
 

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -58,6 +58,7 @@ import {
   changeSelectedAttributionOrOpenUnsavedPopup,
   closePopupAndUnsetTargets,
   navigateToSelectedPathOrOpenUnsavedPopup,
+  openFileOrOpenUnsavedPopup,
   proceedFromUnsavedPopup,
   setSelectedResourceIdOrOpenUnsavedPopup,
   setViewOrOpenUnsavedPopup,
@@ -374,14 +375,15 @@ describe('proceedFromUnsavedPopup', () => {
 
   it('proceeds with open file request', () => {
     vi.spyOn(window.electronAPI, 'openFile').mockResolvedValue({});
+    const filePath = '/path/to/project.opossum';
 
     const testStore = createAppStore();
-    testStore.dispatch(setOpenFileRequest(true));
+    testStore.dispatch(setOpenFileRequest({ filePath }));
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(proceedFromUnsavedPopup());
 
-    expect(window.electronAPI.openFile).toHaveBeenCalled();
-    expect(getOpenFileRequest(testStore.getState())).toBe(false);
+    expect(window.electronAPI.openFile).toHaveBeenCalledWith(filePath);
+    expect(getOpenFileRequest(testStore.getState())).toBeNull();
   });
 
   it('proceeds with import file request', () => {
@@ -421,11 +423,12 @@ describe('proceedFromUnsavedPopup', () => {
 describe('closePopupAndUnsetTargets', () => {
   it('closes popup and unsets targets', () => {
     const testStore = createAppStore();
+    const filePath = '/path/to/project.opossum';
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(setTargetView(View.Audit));
     testStore.dispatch(setTargetSelectedResourceId('resourceID'));
     testStore.dispatch(setTargetSelectedAttributionId('attributionID'));
-    testStore.dispatch(setOpenFileRequest(true));
+    testStore.dispatch(setOpenFileRequest({ filePath }));
     testStore.dispatch(
       setImportFileRequest({
         fileType: FileType.LEGACY_OPOSSUM,
@@ -440,9 +443,50 @@ describe('closePopupAndUnsetTargets', () => {
     expect(getTargetView(testStore.getState())).toBeNull();
     expect(getTargetSelectedResourceId(testStore.getState())).toBeNull();
     expect(getTargetSelectedAttributionId(testStore.getState())).toBeNull();
-    expect(getOpenFileRequest(testStore.getState())).toBe(false);
+    expect(getOpenFileRequest(testStore.getState())).toBeNull();
     expect(getImportFileRequest(testStore.getState())).toBeNull();
     expect(getExportFileRequest(testStore.getState())).toBeNull();
     expect(getOpenPopup(testStore.getState())).toBeNull();
+  });
+
+  it('stores the requested file path in the unsaved flow', () => {
+    const testStore = createAppStore();
+    const filePath = '/path/to/project.opossum';
+
+    testStore.dispatch(setIsPackageInfoDirty(true));
+    testStore.dispatch(openFileOrOpenUnsavedPopup(filePath));
+
+    expect(getOpenPopup(testStore.getState())?.popup).toBe(
+      PopupType.NotSavedPopup,
+    );
+    expect(getOpenFileRequest(testStore.getState())).toEqual({ filePath });
+  });
+
+  it('replaces an existing pending action with the requested file open', () => {
+    const testStore = createAppStore();
+    const filePath = '/path/to/project.opossum';
+    const fileFormat = {
+      fileType: FileType.LEGACY_OPOSSUM,
+      extensions: [],
+      name: '',
+    };
+
+    testStore.dispatch(setIsPackageInfoDirty(true));
+    testStore.dispatch(setImportFileRequest(fileFormat));
+    testStore.dispatch(setTargetView(View.Audit));
+    testStore.dispatch(setTargetSelectedResourceId('resourceId'));
+    testStore.dispatch(setTargetSelectedAttributionId('attributionId'));
+    testStore.dispatch(openPopup(PopupType.NotSavedPopup));
+
+    testStore.dispatch(openFileOrOpenUnsavedPopup(filePath));
+
+    expect(getOpenPopup(testStore.getState())?.popup).toBe(
+      PopupType.NotSavedPopup,
+    );
+    expect(getOpenFileRequest(testStore.getState())).toEqual({ filePath });
+    expect(getImportFileRequest(testStore.getState())).toBeNull();
+    expect(getTargetView(testStore.getState())).toBeNull();
+    expect(getTargetSelectedResourceId(testStore.getState())).toBeNull();
+    expect(getTargetSelectedAttributionId(testStore.getState())).toBeNull();
   });
 });

--- a/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
+++ b/src/Frontend/state/actions/popup-actions/__tests__/popup-actions.test.ts
@@ -375,14 +375,13 @@ describe('proceedFromUnsavedPopup', () => {
 
   it('proceeds with open file request', () => {
     vi.spyOn(window.electronAPI, 'openFile').mockResolvedValue({});
-    const filePath = '/path/to/project.opossum';
 
     const testStore = createAppStore();
-    testStore.dispatch(setOpenFileRequest({ filePath }));
+    testStore.dispatch(setOpenFileRequest({ kind: 'dialog' }));
     testStore.dispatch(openPopup(PopupType.NotSavedPopup));
     testStore.dispatch(proceedFromUnsavedPopup());
 
-    expect(window.electronAPI.openFile).toHaveBeenCalledWith(filePath);
+    expect(window.electronAPI.openFile).toHaveBeenCalledWith();
     expect(getOpenFileRequest(testStore.getState())).toBeNull();
   });
 
@@ -428,7 +427,7 @@ describe('closePopupAndUnsetTargets', () => {
     testStore.dispatch(setTargetView(View.Audit));
     testStore.dispatch(setTargetSelectedResourceId('resourceID'));
     testStore.dispatch(setTargetSelectedAttributionId('attributionID'));
-    testStore.dispatch(setOpenFileRequest({ filePath }));
+    testStore.dispatch(setOpenFileRequest({ kind: 'path', filePath }));
     testStore.dispatch(
       setImportFileRequest({
         fileType: FileType.LEGACY_OPOSSUM,
@@ -459,7 +458,10 @@ describe('closePopupAndUnsetTargets', () => {
     expect(getOpenPopup(testStore.getState())?.popup).toBe(
       PopupType.NotSavedPopup,
     );
-    expect(getOpenFileRequest(testStore.getState())).toEqual({ filePath });
+    expect(getOpenFileRequest(testStore.getState())).toEqual({
+      kind: 'path',
+      filePath,
+    });
   });
 
   it('replaces an existing pending action with the requested file open', () => {
@@ -483,7 +485,10 @@ describe('closePopupAndUnsetTargets', () => {
     expect(getOpenPopup(testStore.getState())?.popup).toBe(
       PopupType.NotSavedPopup,
     );
-    expect(getOpenFileRequest(testStore.getState())).toEqual({ filePath });
+    expect(getOpenFileRequest(testStore.getState())).toEqual({
+      kind: 'path',
+      filePath,
+    });
     expect(getImportFileRequest(testStore.getState())).toBeNull();
     expect(getTargetView(testStore.getState())).toBeNull();
     expect(getTargetSelectedResourceId(testStore.getState())).toBeNull();

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -124,10 +124,18 @@ export function showMergeDialogOrOpenUnsavedPopup(
   });
 }
 
-export function openFileOrOpenUnsavedPopup(): AppThunkAction {
+export function openFileOrOpenUnsavedPopup(filePath?: string): AppThunkAction {
   return withUnsavedCheck({
-    executeImmediately: () => void window.electronAPI.openFile(),
-    requestContinuation: (dispatch) => dispatch(setOpenFileRequest(true)),
+    executeImmediately: () => void window.electronAPI.openFile(filePath),
+    requestContinuation: (dispatch) => {
+      dispatch(setTargetView(null));
+      dispatch(setTargetSelectedResourceId(null));
+      dispatch(setTargetSelectedAttributionId(null));
+      dispatch(setImportFileRequest(null));
+      dispatch(setMergeRequest(null));
+      dispatch(setExportFileRequest(null));
+      dispatch(setOpenFileRequest({ filePath }));
+    },
   });
 }
 
@@ -153,8 +161,8 @@ export function proceedFromUnsavedPopup(): AppThunkAction {
     dispatch(closePopup());
 
     if (openFileRequest) {
-      void window.electronAPI.openFile();
-      dispatch(setOpenFileRequest(false));
+      void window.electronAPI.openFile(openFileRequest.filePath);
+      dispatch(setOpenFileRequest(null));
     }
 
     if (importFileRequest) {
@@ -185,7 +193,7 @@ export function closePopupAndUnsetTargets(): AppThunkAction {
     dispatch(setTargetSelectedResourceId(null));
     dispatch(setTargetSelectedAttributionId(null));
     dispatch(closePopup());
-    dispatch(setOpenFileRequest(false));
+    dispatch(setOpenFileRequest(null));
     dispatch(setImportFileRequest(null));
     dispatch(setExportFileRequest(null));
     window.electronAPI.stopLoading();

--- a/src/Frontend/state/actions/popup-actions/popup-actions.ts
+++ b/src/Frontend/state/actions/popup-actions/popup-actions.ts
@@ -134,7 +134,11 @@ export function openFileOrOpenUnsavedPopup(filePath?: string): AppThunkAction {
       dispatch(setImportFileRequest(null));
       dispatch(setMergeRequest(null));
       dispatch(setExportFileRequest(null));
-      dispatch(setOpenFileRequest({ filePath }));
+      dispatch(
+        setOpenFileRequest(
+          filePath ? { kind: 'path', filePath } : { kind: 'dialog' },
+        ),
+      );
     },
   });
 }
@@ -161,7 +165,12 @@ export function proceedFromUnsavedPopup(): AppThunkAction {
     dispatch(closePopup());
 
     if (openFileRequest) {
-      void window.electronAPI.openFile(openFileRequest.filePath);
+      if (openFileRequest.kind === 'path') {
+        void window.electronAPI.openFile(openFileRequest.filePath);
+      } else {
+        void window.electronAPI.openFile();
+      }
+
       dispatch(setOpenFileRequest(null));
     }
 

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -19,6 +19,10 @@ export const ACTION_SET_IMPORT_FILE_REQUEST = 'ACTION_SET_IMPORT_FILE_REQUEST';
 export const ACTION_SET_MERGE_REQUEST = 'ACTION_SET_MERGE_REQUEST';
 export const ACTION_SET_EXPORT_FILE_REQUEST = 'ACTION_SET_EXPORT_FILE_REQUEST';
 
+export interface OpenFileRequest {
+  filePath?: string;
+}
+
 export type ViewAction =
   | SetView
   | SetTargetView
@@ -55,7 +59,7 @@ export interface OpenPopupAction {
 
 export interface SetOpenFileRequestAction {
   type: typeof ACTION_SET_OPEN_FILE_REQUEST;
-  payload: boolean;
+  payload: OpenFileRequest | null;
 }
 
 export interface SetImportFileRequestAction {

--- a/src/Frontend/state/actions/view-actions/types.ts
+++ b/src/Frontend/state/actions/view-actions/types.ts
@@ -19,9 +19,9 @@ export const ACTION_SET_IMPORT_FILE_REQUEST = 'ACTION_SET_IMPORT_FILE_REQUEST';
 export const ACTION_SET_MERGE_REQUEST = 'ACTION_SET_MERGE_REQUEST';
 export const ACTION_SET_EXPORT_FILE_REQUEST = 'ACTION_SET_EXPORT_FILE_REQUEST';
 
-export interface OpenFileRequest {
-  filePath?: string;
-}
+export type OpenFileRequest =
+  | { kind: 'dialog' }
+  | { kind: 'path'; filePath: string };
 
 export type ViewAction =
   | SetView

--- a/src/Frontend/state/actions/view-actions/view-actions.ts
+++ b/src/Frontend/state/actions/view-actions/view-actions.ts
@@ -22,6 +22,7 @@ import {
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
   type ClosePopupAction,
+  type OpenFileRequest,
   type OpenPopupAction,
   type ResetViewStateAction,
   type SetExportFileRequestAction,
@@ -92,7 +93,7 @@ export function closePopup(): ClosePopupAction {
 }
 
 export function setOpenFileRequest(
-  openFileRequest: boolean,
+  openFileRequest: OpenFileRequest | null,
 ): SetOpenFileRequestAction {
   return { type: ACTION_SET_OPEN_FILE_REQUEST, payload: openFileRequest };
 }

--- a/src/Frontend/state/reducers/view-reducer.ts
+++ b/src/Frontend/state/reducers/view-reducer.ts
@@ -19,6 +19,7 @@ import {
   ACTION_SET_OPEN_FILE_REQUEST,
   ACTION_SET_TARGET_VIEW,
   ACTION_SET_VIEW,
+  type OpenFileRequest,
   type ViewAction,
 } from '../actions/view-actions/types';
 
@@ -26,7 +27,7 @@ export interface ViewState {
   view: View;
   targetView: View | null;
   popupInfo: Array<PopupInfo>;
-  openFileRequest: boolean;
+  openFileRequest: OpenFileRequest | null;
   importFileRequest: FileFormatInfo | null;
   mergeRequest: FileFormatInfo | null;
   exportFileRequest: ExportType | null;
@@ -36,7 +37,7 @@ const initialViewState: ViewState = {
   view: View.Audit,
   targetView: null,
   popupInfo: [],
-  openFileRequest: false,
+  openFileRequest: null,
   importFileRequest: null,
   mergeRequest: null,
   exportFileRequest: null,

--- a/src/Frontend/state/selectors/view-selector.ts
+++ b/src/Frontend/state/selectors/view-selector.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../shared/shared-types';
 import { View } from '../../enums/enums';
 import { type PopupInfo, type State } from '../../types/types';
+import { type OpenFileRequest } from '../actions/view-actions/types';
 
 export function isAuditViewSelected(state: State): boolean {
   return state.viewState.view === View.Audit;
@@ -38,7 +39,7 @@ export function getPopupAttributionId(state: State): string | null {
   return (popup.length === 1 && popup[0].attributionId) || null;
 }
 
-export function getOpenFileRequest(state: State): boolean {
+export function getOpenFileRequest(state: State): OpenFileRequest | null {
   return state.viewState.openFileRequest;
 }
 

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -53,6 +53,11 @@ export type ShowMergeDialogListener = (
   fileFormat: FileFormatInfo,
 ) => void;
 
+export type OpenFileWithUnsavedCheckListener = (
+  event: IpcRendererEvent,
+  filePath?: string,
+) => void;
+
 export type UserSettingsChangedListener = (
   event: IpcRendererEvent,
   payload: Partial<UserSettings>,
@@ -69,6 +74,7 @@ type Listener =
   | LoggingListener
   | ExportFileRequestListener
   | SetBaseURLForRootListener
+  | OpenFileWithUnsavedCheckListener
   | ShowImportDialogListener
   | ProcessingStateChangedListener
   | ShowMergeDialogListener
@@ -87,5 +93,5 @@ export function useIpcRenderer<T extends Listener>(
       removeListener();
     };
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, dependencies);
+  }, [...dependencies]);
 }

--- a/src/Frontend/util/use-ipc-renderer.ts
+++ b/src/Frontend/util/use-ipc-renderer.ts
@@ -93,5 +93,5 @@ export function useIpcRenderer<T extends Listener>(
       removeListener();
     };
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [...dependencies]);
+  }, dependencies);
 }

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -260,7 +260,7 @@ export interface ElectronAPI {
   quit: () => void;
   relaunch: () => void;
   openLink: (link: string) => Promise<unknown>;
-  openFile: () => Promise<unknown>;
+  openFile: (filePath?: string) => Promise<unknown>;
   selectFile: (fileFormat: FileFormatInfo) => Promise<string>;
   importFileSelectSaveLocation: (defaultPath: string) => Promise<string>;
   importFileConvertAndLoad: (


### PR DESCRIPTION
## Summary
- before this change, double-clicking a second `.opossum` file from Finder while OpossumUI was already open could do nothing because the external open path did not reliably reach the app's existing open-file flow
- that external path also bypassed the existing unsaved-changes confirmation, so there was no clear user choice between keeping the current file and replacing it with the newly clicked one
- after this change, external `.opossum` opens are routed through the same discard-or-cancel flow as in-app opens, so users can explicitly keep their current work or discard local edits and continue opening the new file
- add regression coverage for startup/runtime macOS open-file handling and the path-aware unsaved-popup flow

## Testing
1. Launch OpossumUI and open an `.opossum` file.
2. Make a local change without saving, for example by editing attribution/package details.
3. While OpossumUI is still open, double-click a different `.opossum` file in Finder.
4. Verify that the existing unsaved-changes dialog appears instead of the second file being ignored.
5. Click **Cancel** and verify that the currently open file stays in place and the unsaved local change is still there.
6. Repeat steps 2-4, then click **Discard and Proceed**.
7. Verify that the newly clicked `.opossum` file opens and the previous unsaved local change is discarded.
8. Optional regression check: with no unsaved changes, double-click a different `.opossum` file and verify it opens immediately.