### PR TITLE
fix: auto-rebuild better-sqlite3 for Node ABI when db:generate runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "start:win32": "tools/start_windows.bat",
     "build": "yarn generate-notice && vite build",
     "circular-import-check": "find src/ | xargs dpdm --circular -T --tree false --warning false --exit-code circular:1",
-    "db:generate": "npx tsx ./src/ElectronBackend/db/generate.ts",
+    "db:generate": "node tools/ensureNodeSqlite.mjs && npx tsx ./src/ElectronBackend/db/generate.ts",
     "typecheck": "yarn db:generate && tsc -p ./ && tsc --noEmit -p src/ElectronBackend",
     "test:unit": "vitest",
     "test:changed": "vitest --onlyChanged",

--- a/tools/ensureNodeSqlite.mjs
+++ b/tools/ensureNodeSqlite.mjs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Probes whether the better-sqlite3 native module was compiled for the
+// current Node.js ABI. If it was built for Electron instead (a different
+// ABI version), rebuilds it automatically.
+//
+// This is needed because `yarn db:generate` (run by the pre-commit hook and
+// `yarn typecheck`) requires the Node-compiled variant, but `yarn install`
+// or `yarn rebuild:electron` may leave the Electron-compiled binary in place.
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const nativeBinary = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  'better-sqlite3',
+  'build',
+  'Release',
+  'better_sqlite3.node',
+);
+
+function readAbiVersion(filePath) {
+  // The Node.js module version is stored as a uint32 at a fixed offset
+  // in the .node binary. We read it from the binary's export table.
+  // However, the simplest cross-platform approach is to compare against
+  // process.versions.modules using a child process probe.
+  return null;
+}
+
+function probeInChildProcess() {
+  try {
+    const result = execSync(
+      "node -e \"new (require('better-sqlite3'))(':memory:')\"",
+      { encoding: 'utf-8', stdio: 'pipe' },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!probeInChildProcess()) {
+  console.log(
+    'better-sqlite3 native module has wrong ABI, rebuilding for Node…',
+  );
+  execSync('npm rebuild better-sqlite3', { stdio: 'inherit' });
+
+  if (!probeInChildProcess()) {
+    console.error(
+      'better-sqlite3 still fails after rebuild. ' +
+        'Try `npm rebuild better-sqlite3` manually.',
+    );
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Problem

The pre-commit hook (via lint-staged) and `yarn typecheck` both run `yarn db:generate`, which requires the **Node-compiled** `better-sqlite3` native module. However, after `yarn install` or `yarn rebuild:electron`, the binary may be compiled for Electron's V8 ABI instead, causing an `ERR_DLOPEN_FAILED` crash:

```
Error: The module .../better-sqlite3/build/Release/better_sqlite3.node
was compiled against a different Node.js version using
NODE_MODULE_VERSION 137. This version of Node.js requires
NODE_MODULE_VERSION 141.
```

This happens because:

1. `better-sqlite3` and `better-sqlite3-electron` are the **same npm package** installed under two names, each with their own native binary compiled for a different ABI.
2. `yarn install` runs the postinstall script (`yarn rebuild:electron`) which recompiles only `better-sqlite3-electron` for Electron. If postinstall fails partway (e.g. GitHub rate limit on the opossum-file CLI download), the state is indeterminate.
3. The pre-commit hook's `yarn db:generate` runs with the **system Node**, so it needs the Node-compiled binary. If the Electron one is present, it crashes.

### Manual workaround before this fix

```bash
npm rebuild better-sqlite3    # rebuild for Node (fixes the hook)
git commit ...                 # commit succeeds
yarn rebuild:electron          # restore Electron binary for runtime
```

## Solution

Add a guard script (`tools/ensureNodeSqlite.mjs`) that **probes** the `better-sqlite3` binary in a child process before `db:generate` runs. If the ABI doesn't match, it automatically runs `npm rebuild better-sqlite3` and verifies the rebuild succeeded.

The guard is wired into the `db:generate` npm script:

```json
"db:generate": "node tools/ensureNodeSqlite.mjs && npx tsx ./src/ElectronBackend/db/generate.ts"
```

### Why probe in a child process?

Once Node's `dlopen` fails on a `.node` binary with the wrong ABI, the module cache is corrupted — a subsequent `require` of the rebuilt binary in the same process segfaults. Running the probe in a child process avoids this: the rebuild happens, and the actual `db:generate` script runs in a fresh process that loads the correct binary.

### Why not just always rebuild?

`npm rebuild better-sqlite3` takes ~3-5 seconds. The probe is near-instant when the binary is already correct, so this adds zero overhead to the common case.

## Documentation updates

This PR also updates the skill and AGENTS.md added in #3163 to reflect the auto-healing behavior:

- **`.opencode/skills/electron-backend-change/SKILL.md`**: Rewrote the "Dual better-sqlite3 builds" section to document that `db:generate` auto-heals, and added clear instructions for manual fixes when Vitest or the Electron app hit ABI errors.
- **`AGENTS.md`**: Updated the "Critical quirks" bullet for `better-sqlite3` to mention auto-healing and the two manual fix commands.

## Testing

Reproduced the failure by copying the Electron binary over the Node one, then verified the commit hook passes with the fix in place:

```bash
# Break the Node binary
cp node_modules/better-sqlite3-electron/build/Release/better_sqlite3.node \
   node_modules/better-sqlite3/build/Release/better_sqlite3.node

# Commit any ElectronBackend change — hook now passes (auto-rebuilds)
git commit -s -m "test: ..."  # ✅ passes

# Also verified: yarn typecheck auto-heals the same way
yarn typecheck  # ✅ passes
```