### PR TITLE
fix: remove copyright & license info when first party is true

### DIFF
--- a/src/ElectronBackend/api/getSaveFileArgs.ts
+++ b/src/ElectronBackend/api/getSaveFileArgs.ts
@@ -134,8 +134,18 @@ export async function getSaveFileArgs(): Promise<{ result: SaveFileArgs }> {
   );
 
   for (const id of Object.keys(manualAttributions)) {
-    manualAttributions[id].preferredOverOriginIds =
-      queryResults.preferredOver[id];
+    const attribution = manualAttributions[id];
+    attribution.preferredOverOriginIds = queryResults.preferredOver[id];
+
+    if (attribution.firstParty) {
+      // First-party attributions can't have copyright/license info,
+      // but we keep it in the DB in case the user wants to switch back
+      // to third-party without losing their input.
+      // So we have to remove it here.
+      attribution.copyright = undefined;
+      attribution.licenseName = undefined;
+      attribution.licenseText = undefined;
+    }
   }
 
   const resourcesToAttributions: ResourcesToAttributions = Object.fromEntries(


### PR DESCRIPTION
First-party attributions can't have a copyright or license information. But previously, when you entered them and switched to first party, they did have it in the database, we exported it to the opossum file and it caused an error when importing it.