### PR TITLE
ci: cache electron-builder downloads to avoid flaky ENOENT

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -46,6 +46,17 @@ jobs:
 
       - run: yarn install --immutable
 
+      # Cache electron-builder's download cache (electron, snap templates, AppImage
+      # tools, ...) to avoid flaky re-downloads. The cache key is keyed on the
+      # electron-builder version so it invalidates on upgrades.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/electron-builder
+            ~/AppData/Local/electron-builder/Cache
+          key: electron-builder-${{ matrix.os }}-${{ hashFiles('yarn.lock', 'package.json') }}
+        if: matrix.os != 'macos-15-intel'
+
       - run: yarn ship:auto
         if: matrix.os != 'macos-15-intel'
 


### PR DESCRIPTION
## Summary

The E2E CI sometimes fails with an obscure `ENOENT: no such file or directory, mkdir` error during the `yarn ship:auto` build step, before any E2E test runs (see e.g. #3182 - [run](https://github.com/opossum-tool/OpossumUI/actions/runs/29090536441/job/86354527307?pr=3182)). Re-triggering almost always fixes it.

This caches electron-builder's download cache (electron binary, snap template, AppImage tools, ...) via `actions/cache` so that the flaky concurrent download/extract code path is skipped entirely on subsequent runs — once the tools are downloaded and extracted successfully, later runs use the cached result and never hit the race.

## Root cause: a known race condition in electron-builder

The failure is a known race condition in electron-builder's `downloadAndExtract` function ([`app-builder-lib/src/util/electronGet.ts`](https://github.com/electron-userland/electron-builder/blob/v26.15.3/packages/app-builder-lib/src/util/electronGet.ts)): when building the snap + AppImage targets concurrently, parallel builds/targets first populate a cold cache tree and recursive `mkdir` spuriously throws `ENOENT` (and occasionally `EEXIST`) when the parent directory doesn't exist yet.

This was fixed upstream in [electron-builder PR #9899](https://github.com/electron-userland/electron-builder/pull/9899) (commit `ef61dd5f`) by adding a retry-tolerant `ensureDir` and moving `extractDir`'s whole lifecycle inside a `proper-lockfile` lock. However, the fix landed after the v26.x line — it is only available in the ESM-only v27 alpha — so we cannot upgrade to pick it up without a major migration. Caching the populated cache directory itself is the pragmatic workaround until v27 stabilises.

## Changes

- `actions/cache@v6.1.0` (SHA-pinned, matching the existing pinning convention) caches `~/.cache/electron-builder` (Linux/macOS) and `~/AppData/Local/electron-builder/Cache` (Windows), keyed on `yarn.lock` + `package.json` + OS so it invalidates on dependency upgrades.
- Applies to all non-`macos-15-intel` jobs (the Intel smoke test already uses a separate, lighter build path).

## Checklist

- [x] `yarn format-check`
- [x] `yarn lint-check`
- [x] `yarn copyright-lint-check`
- [x] `yarn knip`
- [x] Pre-commit hook passed (copyright, knip, prettier)
