### PR TITLE
Add license based filtering to file tree

### DIFF
--- a/src/Frontend/Components/FilterButton/FilterButton.style.ts
+++ b/src/Frontend/Components/FilterButton/FilterButton.style.ts
@@ -4,16 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import ClearIcon from '@mui/icons-material/Clear';
 import { styled } from '@mui/material';
-import MuiIconButton from '@mui/material/IconButton';
 
 import { OpossumColors } from '../../shared-styles';
 
 export const ClearMenuIcon = styled(ClearIcon)({
   color: OpossumColors.darkBlue,
-});
-
-export const IconButton = styled(MuiIconButton)({
-  '&:hover': {
-    background: OpossumColors.lightestGrey,
-  },
 });

--- a/src/Frontend/Components/FilterButton/FilterButton.style.ts
+++ b/src/Frontend/Components/FilterButton/FilterButton.style.ts
@@ -8,19 +8,12 @@ import MuiIconButton from '@mui/material/IconButton';
 
 import { OpossumColors } from '../../shared-styles';
 
-export const ClearButton = styled(ClearIcon)({
-  padding: '2px',
-  borderRadius: '50%',
-  cursor: 'pointer',
+export const ClearMenuIcon = styled(ClearIcon)({
+  color: OpossumColors.darkBlue,
+});
+
+export const IconButton = styled(MuiIconButton)({
   '&:hover': {
     background: OpossumColors.lightestGrey,
   },
 });
-
-export const IconButton = styled(MuiIconButton, {
-  shouldForwardProp: (name: string) => !['isClearHovered'].includes(name),
-})<{ isClearHovered: boolean }>(({ isClearHovered }) => ({
-  '&:hover': {
-    background: isClearHovered ? 'none' : OpossumColors.lightestGrey,
-  },
-}));

--- a/src/Frontend/Components/FilterButton/FilterButton.tsx
+++ b/src/Frontend/Components/FilterButton/FilterButton.tsx
@@ -6,10 +6,10 @@ import Filter3Icon from '@mui/icons-material/Filter3';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
 import SentimentSatisfied from '@mui/icons-material/SentimentSatisfied';
-import type { SxProps } from '@mui/material';
-import MuiBadge from '@mui/material/Badge';
+import MuiBadge, { type BadgeProps } from '@mui/material/Badge';
+import MuiIconButton from '@mui/material/IconButton';
 import MuiTooltip from '@mui/material/Tooltip';
-import { type CSSProperties, useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { text } from '../../../shared/text';
 import type { Filter } from '../../shared-constants';
@@ -35,7 +35,7 @@ import {
   type SelectMenuOption,
   type SelectMenuProps,
 } from '../SelectMenu/SelectMenu';
-import { ClearMenuIcon, IconButton } from './FilterButton.style';
+import { ClearMenuIcon } from './FilterButton.style';
 import { LicenseAutocomplete } from './LicenseAutocomplete/LicenseAutocomplete';
 
 const FILTER_ICONS: Record<Filter, React.ReactElement<unknown>> = {
@@ -62,6 +62,13 @@ const FILTER_ICONS: Record<Filter, React.ReactElement<unknown>> = {
   [text.filters.modifiedPreferred]: <ModifiedPreferredIcon noTooltip />,
 };
 
+export interface FilterButtonTriggerProps {
+  content: React.ReactElement;
+  disabled: boolean;
+  isSomeFilterActive: boolean;
+  onClick: React.MouseEventHandler<HTMLElement>;
+}
+
 interface Props extends Pick<
   SelectMenuProps,
   'anchorArrow' | 'anchorPosition'
@@ -70,10 +77,9 @@ interface Props extends Pick<
   availableFilters: Array<Filter>;
   disabled?: boolean;
   emptyAttributions?: boolean;
-  activeIconSx?: SxProps;
-  activeBadgeStyle?: CSSProperties;
-  iconSx?: SxProps;
+  badgeColor?: BadgeProps['color'];
   mode: FilterPropsMode;
+  renderTrigger?: (props: FilterButtonTriggerProps) => React.ReactNode;
 }
 
 export const FilterButton: React.FC<Props> = ({
@@ -83,15 +89,15 @@ export const FilterButton: React.FC<Props> = ({
   useFilteredData,
   disabled,
   emptyAttributions,
-  activeIconSx,
-  activeBadgeStyle,
-  iconSx,
+  badgeColor = 'primary',
   mode,
+  renderTrigger,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const [{ filters, selectedLicense }, setFilteredAttributions] =
     useFilteredData();
   const isSomeFilterActive = !!filters.length || !!selectedLicense;
+  const isDisabled = !!(disabled || (emptyAttributions && !isSomeFilterActive));
 
   const clearFilters = useCallback(() => {
     setFilteredAttributions((prev) => ({
@@ -164,44 +170,25 @@ export const FilterButton: React.FC<Props> = ({
     ],
   );
 
+  const triggerProps: Omit<FilterButtonTriggerProps, 'content'> = {
+    disabled: isDisabled,
+    isSomeFilterActive,
+    onClick: (event) => setAnchorEl(event.currentTarget),
+  };
+
   return (
     <>
-      <IconButton
-        aria-label={'filter button'}
-        onClick={(event) => setAnchorEl(event.currentTarget)}
-        disabled={disabled || (emptyAttributions && !isSomeFilterActive)}
-        size={'small'}
-        color={iconSx ? undefined : isSomeFilterActive ? 'primary' : undefined}
-      >
-        <MuiBadge
-          color={'primary'}
-          variant={'dot'}
-          invisible={!isSomeFilterActive}
-          anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
-          slotProps={{
-            badge: {
-              style: {
-                minWidth: '8px',
-                width: '8px',
-                height: '8px',
-                top: '4px',
-                right: '4px',
-                ...activeBadgeStyle,
-              },
-            },
-          }}
-        >
-          <MuiTooltip
-            title={text.buttons.filter}
-            disableInteractive
-            placement={'top'}
-          >
-            <FilterAltIcon
-              sx={isSomeFilterActive ? (activeIconSx ?? iconSx) : iconSx}
-            />
-          </MuiTooltip>
-        </MuiBadge>
-      </IconButton>
+      {renderTrigger?.({
+        ...triggerProps,
+        content: renderFilterButtonContent({ badgeColor, isSomeFilterActive }),
+      }) ??
+        renderDefaultTrigger({
+          ...triggerProps,
+          content: renderFilterButtonContent({
+            badgeColor,
+            isSomeFilterActive,
+          }),
+        })}
       <SelectMenu
         anchorArrow={anchorArrow}
         anchorEl={anchorEl}
@@ -214,3 +201,57 @@ export const FilterButton: React.FC<Props> = ({
     </>
   );
 };
+
+function renderDefaultTrigger({
+  content,
+  disabled,
+  isSomeFilterActive,
+  onClick,
+}: FilterButtonTriggerProps) {
+  return (
+    <MuiIconButton
+      aria-label={'filter button'}
+      onClick={onClick}
+      disabled={disabled}
+      size={'small'}
+      color={isSomeFilterActive ? 'primary' : undefined}
+    >
+      {content}
+    </MuiIconButton>
+  );
+}
+
+function renderFilterButtonContent({
+  badgeColor,
+  isSomeFilterActive,
+}: Pick<FilterButtonTriggerProps, 'isSomeFilterActive'> & {
+  badgeColor: BadgeProps['color'];
+}) {
+  return (
+    <MuiBadge
+      color={badgeColor}
+      variant={'dot'}
+      invisible={!isSomeFilterActive}
+      anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+      slotProps={{
+        badge: {
+          style: {
+            minWidth: '8px',
+            width: '8px',
+            height: '8px',
+            top: '4px',
+            right: '4px',
+          },
+        },
+      }}
+    >
+      <MuiTooltip
+        title={text.buttons.filter}
+        disableInteractive
+        placement={'top'}
+      >
+        <FilterAltIcon />
+      </MuiTooltip>
+    </MuiBadge>
+  );
+}

--- a/src/Frontend/Components/FilterButton/FilterButton.tsx
+++ b/src/Frontend/Components/FilterButton/FilterButton.tsx
@@ -8,6 +8,7 @@ import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied
 import SentimentSatisfied from '@mui/icons-material/SentimentSatisfied';
 import MuiBadge, { type BadgeProps } from '@mui/material/Badge';
 import MuiIconButton from '@mui/material/IconButton';
+import type { SxProps, Theme } from '@mui/material/styles';
 import MuiTooltip from '@mui/material/Tooltip';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -62,13 +63,6 @@ const FILTER_ICONS: Record<Filter, React.ReactElement<unknown>> = {
   [text.filters.modifiedPreferred]: <ModifiedPreferredIcon noTooltip />,
 };
 
-export interface FilterButtonTriggerProps {
-  content: React.ReactElement;
-  disabled: boolean;
-  isSomeFilterActive: boolean;
-  onClick: React.MouseEventHandler<HTMLElement>;
-}
-
 interface Props extends Pick<
   SelectMenuProps,
   'anchorArrow' | 'anchorPosition'
@@ -79,7 +73,7 @@ interface Props extends Pick<
   emptyAttributions?: boolean;
   badgeColor?: BadgeProps['color'];
   mode: FilterPropsMode;
-  renderTrigger?: (props: FilterButtonTriggerProps) => React.ReactNode;
+  triggerStyle?: (isSomeFilterActive: boolean) => SxProps<Theme>;
 }
 
 export const FilterButton: React.FC<Props> = ({
@@ -91,7 +85,7 @@ export const FilterButton: React.FC<Props> = ({
   emptyAttributions,
   badgeColor = 'primary',
   mode,
-  renderTrigger,
+  triggerStyle,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const [{ filters, selectedLicense }, setFilteredAttributions] =
@@ -170,25 +164,18 @@ export const FilterButton: React.FC<Props> = ({
     ],
   );
 
-  const triggerProps: Omit<FilterButtonTriggerProps, 'content'> = {
-    disabled: isDisabled,
-    isSomeFilterActive,
-    onClick: (event) => setAnchorEl(event.currentTarget),
-  };
-
   return (
     <>
-      {renderTrigger?.({
-        ...triggerProps,
-        content: renderFilterButtonContent({ badgeColor, isSomeFilterActive }),
-      }) ??
-        renderDefaultTrigger({
-          ...triggerProps,
-          content: renderFilterButtonContent({
-            badgeColor,
-            isSomeFilterActive,
-          }),
-        })}
+      <MuiIconButton
+        aria-label={'filter button'}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        disabled={isDisabled}
+        size={'small'}
+        color={isSomeFilterActive ? 'primary' : undefined}
+        sx={triggerStyle?.(isSomeFilterActive)}
+      >
+        {renderFilterButtonContent({ badgeColor, isSomeFilterActive })}
+      </MuiIconButton>
       <SelectMenu
         anchorArrow={anchorArrow}
         anchorEl={anchorEl}
@@ -202,29 +189,11 @@ export const FilterButton: React.FC<Props> = ({
   );
 };
 
-function renderDefaultTrigger({
-  content,
-  disabled,
-  isSomeFilterActive,
-  onClick,
-}: FilterButtonTriggerProps) {
-  return (
-    <MuiIconButton
-      aria-label={'filter button'}
-      onClick={onClick}
-      disabled={disabled}
-      size={'small'}
-      color={isSomeFilterActive ? 'primary' : undefined}
-    >
-      {content}
-    </MuiIconButton>
-  );
-}
-
 function renderFilterButtonContent({
   badgeColor,
   isSomeFilterActive,
-}: Pick<FilterButtonTriggerProps, 'isSomeFilterActive'> & {
+}: {
+  isSomeFilterActive: boolean;
   badgeColor: BadgeProps['color'];
 }) {
   return (

--- a/src/Frontend/Components/FilterButton/FilterButton.tsx
+++ b/src/Frontend/Components/FilterButton/FilterButton.tsx
@@ -6,9 +6,10 @@ import Filter3Icon from '@mui/icons-material/Filter3';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
 import SentimentSatisfied from '@mui/icons-material/SentimentSatisfied';
+import type { SxProps } from '@mui/material';
 import MuiBadge from '@mui/material/Badge';
 import MuiTooltip from '@mui/material/Tooltip';
-import { useMemo, useState } from 'react';
+import { type CSSProperties, useCallback, useMemo, useState } from 'react';
 
 import { text } from '../../../shared/text';
 import type { Filter } from '../../shared-constants';
@@ -34,7 +35,7 @@ import {
   type SelectMenuOption,
   type SelectMenuProps,
 } from '../SelectMenu/SelectMenu';
-import { ClearButton, IconButton } from './FilterButton.style';
+import { ClearMenuIcon, IconButton } from './FilterButton.style';
 import { LicenseAutocomplete } from './LicenseAutocomplete/LicenseAutocomplete';
 
 const FILTER_ICONS: Record<Filter, React.ReactElement<unknown>> = {
@@ -69,6 +70,9 @@ interface Props extends Pick<
   availableFilters: Array<Filter>;
   disabled?: boolean;
   emptyAttributions?: boolean;
+  activeIconSx?: SxProps;
+  activeBadgeStyle?: CSSProperties;
+  iconSx?: SxProps;
   mode: FilterPropsMode;
 }
 
@@ -79,13 +83,23 @@ export const FilterButton: React.FC<Props> = ({
   useFilteredData,
   disabled,
   emptyAttributions,
+  activeIconSx,
+  activeBadgeStyle,
+  iconSx,
   mode,
 }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
-  const [isClearHovered, setIsClearHovered] = useState(false);
   const [{ filters, selectedLicense }, setFilteredAttributions] =
     useFilteredData();
   const isSomeFilterActive = !!filters.length || !!selectedLicense;
+
+  const clearFilters = useCallback(() => {
+    setFilteredAttributions((prev) => ({
+      ...prev,
+      filters: [],
+      selectedLicense: '',
+    }));
+  }, [setFilteredAttributions]);
 
   const { filterProps } = useFilterProperties({ mode, enabled: !!anchorEl });
 
@@ -127,9 +141,22 @@ export const FilterButton: React.FC<Props> = ({
               }
             />
           ),
-        }),
+        })
+        .concat(
+          isSomeFilterActive
+            ? {
+                selected: false,
+                id: 'clear-filters',
+                label: text.packageLists.clearFilters,
+                icon: <ClearMenuIcon />,
+                onAdd: () => clearFilters(),
+              }
+            : [],
+        ),
     [
       availableFilters,
+      clearFilters,
+      isSomeFilterActive,
       selectedLicense,
       filters,
       filterProps,
@@ -143,31 +170,35 @@ export const FilterButton: React.FC<Props> = ({
         aria-label={'filter button'}
         onClick={(event) => setAnchorEl(event.currentTarget)}
         disabled={disabled || (emptyAttributions && !isSomeFilterActive)}
-        isClearHovered={isClearHovered}
         size={'small'}
-        color={isSomeFilterActive ? 'primary' : undefined}
+        color={iconSx ? undefined : isSomeFilterActive ? 'primary' : undefined}
       >
         <MuiBadge
-          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+          color={'primary'}
+          variant={'dot'}
           invisible={!isSomeFilterActive}
+          anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
           slotProps={{
             badge: {
               style: {
-                padding: 0,
-                minWidth: 'unset',
-                width: 'fit-content',
-                height: 'fit-content',
+                minWidth: '8px',
+                width: '8px',
+                height: '8px',
+                top: '4px',
+                right: '4px',
+                ...activeBadgeStyle,
               },
             },
           }}
-          badgeContent={renderClearButton()}
         >
           <MuiTooltip
             title={text.buttons.filter}
             disableInteractive
             placement={'top'}
           >
-            <FilterAltIcon />
+            <FilterAltIcon
+              sx={isSomeFilterActive ? (activeIconSx ?? iconSx) : iconSx}
+            />
           </MuiTooltip>
         </MuiBadge>
       </IconButton>
@@ -182,32 +213,4 @@ export const FilterButton: React.FC<Props> = ({
       />
     </>
   );
-
-  function renderClearButton() {
-    return (
-      <MuiTooltip
-        title={text.packageLists.clearFilters}
-        disableInteractive
-        placement={'top'}
-        enterDelay={500}
-        enterNextDelay={500}
-      >
-        <ClearButton
-          color={'error'}
-          fontSize={'inherit'}
-          onMouseEnter={() => setIsClearHovered(true)}
-          onMouseLeave={() => setIsClearHovered(false)}
-          onMouseDown={(event) => event.stopPropagation()}
-          onClick={(event) => {
-            event.stopPropagation();
-            setFilteredAttributions((prev) => ({
-              ...prev,
-              filters: [],
-              selectedLicense: '',
-            }));
-          }}
-        />
-      </MuiTooltip>
-    );
-  }
 };

--- a/src/Frontend/Components/FilterButton/__tests__/FilterButton.test.tsx
+++ b/src/Frontend/Components/FilterButton/__tests__/FilterButton.test.tsx
@@ -208,12 +208,14 @@ describe('FilterButton', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'filter button' }),
     );
-    await userEvent.click(screen.getByLabelText('clear button'));
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: text.packageLists.clearFilters }),
+    );
 
     expect(result!.selectedLicense).toBe('');
   });
 
-  it('removes all selected filters via clear button', async () => {
+  it('removes all selected filters via clear menu entry', async () => {
     let result: AttributionFilters;
     const prev: AttributionFilters = initialFilters;
     const setFilteredData = vi.fn((fn) => {
@@ -241,7 +243,7 @@ describe('FilterButton', () => {
       screen.getByRole('button', { name: 'filter button' }),
     );
     await userEvent.click(
-      screen.getByLabelText(text.packageLists.clearFilters),
+      screen.getByRole('menuitem', { name: text.packageLists.clearFilters }),
     );
 
     expect(result!.filters).toEqual([]);

--- a/src/Frontend/Components/ResizePanels/ResizeButton/ResizeButton.tsx
+++ b/src/Frontend/Components/ResizePanels/ResizeButton/ResizeButton.tsx
@@ -2,12 +2,10 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { alpha } from '@mui/material';
-import MuiFab from '@mui/material/Fab';
 
-import { OpossumColors, TRANSITION } from '../../../shared-styles';
+import { TRANSITION } from '../../../shared-styles';
+import { HeaderIconButton } from '../ResizePanels.style';
 
 interface ResizeButtonProps {
   onClick: () => void;
@@ -21,23 +19,7 @@ export const ResizeButton: React.FC<ResizeButtonProps> = ({
   disabled,
 }) => {
   return (
-    <MuiFab
-      size={'small'}
-      disabled={disabled}
-      sx={{
-        boxShadow: 'none',
-        width: '24px',
-        minWidth: '24px',
-        height: '24px',
-        minHeight: '24px',
-        backgroundColor: alpha(OpossumColors.white, 0.15),
-        '&:hover': {
-          backgroundColor: alpha(OpossumColors.white, 0.25),
-        },
-        transition: TRANSITION,
-      }}
-      onClick={onClick}
-    >
+    <HeaderIconButton size={'small'} disabled={disabled} onClick={onClick}>
       <ExpandMoreIcon
         aria-label={invert ? 'go up' : 'go down'}
         fontSize={'small'}
@@ -47,6 +29,6 @@ export const ResizeButton: React.FC<ResizeButtonProps> = ({
           transform: invert ? 'rotate(180deg)' : undefined,
         }}
       />
-    </MuiFab>
+    </HeaderIconButton>
   );
 };

--- a/src/Frontend/Components/ResizePanels/ResizePanels.style.ts
+++ b/src/Frontend/Components/ResizePanels/ResizePanels.style.ts
@@ -5,6 +5,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import ClearIcon from '@mui/icons-material/Clear';
 import { alpha, styled } from '@mui/material';
+import MuiFab from '@mui/material/Fab';
 import MuiInputBase from '@mui/material/InputBase';
 import MuiPaper from '@mui/material/Paper';
 import MuiTypography from '@mui/material/Typography';
@@ -12,6 +13,19 @@ import MuiTypography from '@mui/material/Typography';
 import { OpossumColors, TRANSITION } from '../../shared-styles';
 
 export const HEADER_HEIGHT = 32;
+
+export const HeaderIconButton = styled(MuiFab)({
+  boxShadow: 'none',
+  width: '24px',
+  minWidth: '24px',
+  height: '24px',
+  minHeight: '24px',
+  backgroundColor: alpha(OpossumColors.white, 0.15),
+  '&:hover': {
+    backgroundColor: alpha(OpossumColors.white, 0.25),
+  },
+  transition: TRANSITION,
+});
 
 export const Header = styled(MuiPaper)({
   background: OpossumColors.middleBlue,

--- a/src/Frontend/Components/ResizePanels/ResizePanels.tsx
+++ b/src/Frontend/Components/ResizePanels/ResizePanels.tsx
@@ -28,6 +28,7 @@ const GOLDEN_RATIO = 1.61803398875;
 interface ResizePanel {
   component: React.ReactNode;
   title: string;
+  headerActions?: React.ReactNode;
   search: {
     value: string;
     setValue: (search: string) => void;
@@ -202,12 +203,16 @@ export const ResizePanels: React.FC<ResizePanelsProps> = ({
 
   function renderHeader({
     title,
+    headerActions,
     search,
     showResizeButtons,
     searchRef,
     showSearch,
     headerTestId,
-  }: Pick<ResizePanel, 'title' | 'search' | 'headerTestId'> & {
+  }: Pick<
+    ResizePanel,
+    'title' | 'search' | 'headerActions' | 'headerTestId'
+  > & {
     title: string;
     showResizeButtons?: boolean;
     showSearch: boolean;
@@ -217,6 +222,7 @@ export const ResizePanels: React.FC<ResizePanelsProps> = ({
       <Header data-testid={headerTestId} square>
         <HeaderText>{title}</HeaderText>
         {showSearch && renderSearchButton({ search, searchRef })}
+        {showSearch && headerActions}
         {showResizeButtons && renderDownResizeButton()}
         {showResizeButtons && renderUpResizeButton()}
       </Header>

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.style.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.style.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { alpha, styled } from '@mui/material';
+import MuiIconButton from '@mui/material/IconButton';
+
+import { OpossumColors, TRANSITION } from '../../shared-styles';
+
+export const FilterIconButton = styled(MuiIconButton, {
+  shouldForwardProp: (name: string) => name !== 'isFilterActive',
+})<{ isFilterActive: boolean }>(({ isFilterActive }) => ({
+  padding: '2px',
+  color: isFilterActive ? OpossumColors.white : OpossumColors.lightBlue,
+  '&:hover': {
+    backgroundColor: alpha(OpossumColors.white, 0.15),
+  },
+  transition: TRANSITION,
+}));

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.style.ts
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.style.ts
@@ -3,18 +3,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { alpha, styled } from '@mui/material';
-import MuiIconButton from '@mui/material/IconButton';
+import { alpha, type SxProps, type Theme } from '@mui/material/styles';
 
 import { OpossumColors, TRANSITION } from '../../shared-styles';
 
-export const FilterIconButton = styled(MuiIconButton, {
-  shouldForwardProp: (name: string) => name !== 'isFilterActive',
-})<{ isFilterActive: boolean }>(({ isFilterActive }) => ({
+export const resourceBrowserFilterButtonStyle = (
+  isFilterActive: boolean,
+): SxProps<Theme> => ({
   padding: '2px',
   color: isFilterActive ? OpossumColors.white : OpossumColors.lightBlue,
   '&:hover': {
     backgroundColor: alpha(OpossumColors.white, 0.15),
   },
   transition: TRANSITION,
-}));
+});

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from 'react';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { text } from '../../../shared/text';
+import { OpossumColors } from '../../shared-styles';
 import { useAppSelector } from '../../state/hooks';
 import {
   getExpandedIds,
@@ -120,6 +121,13 @@ export function ResourceBrowser() {
             mode={'resourceTree'}
             useFilteredData={useResourceTreeFilters}
             availableFilters={[]}
+            anchorPosition={'right'}
+            activeBadgeStyle={{
+              backgroundColor: OpossumColors.white,
+              boxShadow: 'none',
+            }}
+            activeIconSx={{ color: OpossumColors.white }}
+            iconSx={{ color: OpossumColors.lightBlue }}
           />
         ),
         component: (

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -7,7 +7,6 @@ import { useCallback, useMemo } from 'react';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { text } from '../../../shared/text';
-import { OpossumColors } from '../../shared-styles';
 import { useAppSelector } from '../../state/hooks';
 import {
   getExpandedIds,
@@ -19,14 +18,37 @@ import { usePanelSizes } from '../../state/variables/use-panel-sizes';
 import { useVariable } from '../../state/variables/use-variable';
 import { backend } from '../../util/backendClient';
 import { useDebouncedInput } from '../../util/use-debounced-input';
-import { FilterButton } from '../FilterButton/FilterButton';
+import {
+  FilterButton,
+  type FilterButtonTriggerProps,
+} from '../FilterButton/FilterButton';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
 import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
+import { FilterIconButton } from './ResourceBrowser.style';
 import { ResourcesTree } from './ResourcesTree/ResourcesTree';
 
 const ALL_RESOURCES_SEARCH = 'all-resources-search';
 const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
+
+function renderResourceBrowserFilterTrigger({
+  content,
+  disabled,
+  isSomeFilterActive,
+  onClick,
+}: FilterButtonTriggerProps) {
+  return (
+    <FilterIconButton
+      aria-label={'filter button'}
+      onClick={onClick}
+      disabled={disabled}
+      isFilterActive={isSomeFilterActive}
+      size={'small'}
+    >
+      {content}
+    </FilterIconButton>
+  );
+}
 
 export function ResourceBrowser() {
   const { panelSizes, setPanelSizes } = usePanelSizes();
@@ -49,8 +71,8 @@ export function ResourceBrowser() {
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
   // All resources
-  const [{ selectedLicense: resourceTreeSelectedLicense }] =
-    useResourceTreeFilters();
+  const [resourceTreeFilters] = useResourceTreeFilters();
+  const { selectedLicense: resourceTreeSelectedLicense } = resourceTreeFilters;
   const [searchAll, setSearchAll] = useVariable(ALL_RESOURCES_SEARCH, '');
   const debouncedSearchAll = useDebouncedInput(searchAll);
   const expandedIdsAll = useAppSelector(getExpandedIds);
@@ -122,12 +144,8 @@ export function ResourceBrowser() {
             useFilteredData={useResourceTreeFilters}
             availableFilters={[]}
             anchorPosition={'right'}
-            activeBadgeStyle={{
-              backgroundColor: OpossumColors.white,
-              boxShadow: 'none',
-            }}
-            activeIconSx={{ color: OpossumColors.white }}
-            iconSx={{ color: OpossumColors.lightBlue }}
+            badgeColor={'secondary'}
+            renderTrigger={renderResourceBrowserFilterTrigger}
           />
         ),
         component: (

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -13,10 +13,12 @@ import {
   getSelectedAttributionId,
   getSelectedResourceId,
 } from '../../state/selectors/resource-selectors';
+import { useResourceTreeFilters } from '../../state/variables/use-filters';
 import { usePanelSizes } from '../../state/variables/use-panel-sizes';
 import { useVariable } from '../../state/variables/use-variable';
 import { backend } from '../../util/backendClient';
 import { useDebouncedInput } from '../../util/use-debounced-input';
+import { FilterButton } from '../FilterButton/FilterButton';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
 import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
@@ -46,12 +48,33 @@ export function ResourceBrowser() {
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
   // All resources
+  const [{ selectedLicense: resourceTreeSelectedLicense }] =
+    useResourceTreeFilters();
   const [searchAll, setSearchAll] = useVariable(ALL_RESOURCES_SEARCH, '');
   const debouncedSearchAll = useDebouncedInput(searchAll);
   const expandedIdsAll = useAppSelector(getExpandedIds);
+  const resourceTreeAttributionsWithSelectedLicense =
+    backend.listAttributions.useQuery(
+      {
+        external: false,
+        license: resourceTreeSelectedLicense,
+      },
+      { enabled: !!resourceTreeSelectedLicense },
+    );
+  const resourceTreeAttributionUuids = useMemo(
+    () =>
+      resourceTreeSelectedLicense
+        ? Object.keys(resourceTreeAttributionsWithSelectedLicense.data ?? {})
+        : undefined,
+    [
+      resourceTreeSelectedLicense,
+      resourceTreeAttributionsWithSelectedLicense.data,
+    ],
+  );
   const resourceTreeAll = backend.getResourceTree.useQuery(
     {
       expandedNodes: expandedIdsAll,
+      onAttributionUuids: resourceTreeAttributionUuids,
       search: debouncedSearchAll,
       selectedResourcePath: selectedResourceId,
     },
@@ -92,6 +115,13 @@ export function ResourceBrowser() {
           setValue: setSearchAll,
           channel: AllowedFrontendChannels.SearchResources,
         },
+        headerActions: (
+          <FilterButton
+            mode={'resourceTree'}
+            useFilteredData={useResourceTreeFilters}
+            availableFilters={[]}
+          />
+        ),
         component: (
           <ResourcesTree resources={resourceTreeAll.data?.treeNodes ?? []} />
         ),

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -18,37 +18,15 @@ import { usePanelSizes } from '../../state/variables/use-panel-sizes';
 import { useVariable } from '../../state/variables/use-variable';
 import { backend } from '../../util/backendClient';
 import { useDebouncedInput } from '../../util/use-debounced-input';
-import {
-  FilterButton,
-  type FilterButtonTriggerProps,
-} from '../FilterButton/FilterButton';
+import { FilterButton } from '../FilterButton/FilterButton';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
 import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
-import { FilterIconButton } from './ResourceBrowser.style';
+import { resourceBrowserFilterButtonStyle } from './ResourceBrowser.style';
 import { ResourcesTree } from './ResourcesTree/ResourcesTree';
 
 const ALL_RESOURCES_SEARCH = 'all-resources-search';
 const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
-
-function renderResourceBrowserFilterTrigger({
-  content,
-  disabled,
-  isSomeFilterActive,
-  onClick,
-}: FilterButtonTriggerProps) {
-  return (
-    <FilterIconButton
-      aria-label={'filter button'}
-      onClick={onClick}
-      disabled={disabled}
-      isFilterActive={isSomeFilterActive}
-      size={'small'}
-    >
-      {content}
-    </FilterIconButton>
-  );
-}
 
 export function ResourceBrowser() {
   const { panelSizes, setPanelSizes } = usePanelSizes();
@@ -145,7 +123,7 @@ export function ResourceBrowser() {
             availableFilters={[]}
             anchorPosition={'right'}
             badgeColor={'secondary'}
-            renderTrigger={renderResourceBrowserFilterTrigger}
+            triggerStyle={resourceBrowserFilterButtonStyle}
           />
         ),
         component: (

--- a/src/Frontend/state/reducers/variables-reducer.ts
+++ b/src/Frontend/state/reducers/variables-reducer.ts
@@ -10,6 +10,7 @@ import {
   EXTERNAL_ATTRIBUTION_FILTERS,
   MANUAL_ATTRIBUTION_FILTERS_AUDIT,
   MANUAL_ATTRIBUTION_FILTERS_REPORT,
+  RESOURCE_TREE_FILTERS,
 } from '../variables/use-filters';
 
 export type VariablesState = Record<string, unknown>;
@@ -24,6 +25,7 @@ export function variablesState(
         MANUAL_ATTRIBUTION_FILTERS_AUDIT,
         MANUAL_ATTRIBUTION_FILTERS_REPORT,
         EXTERNAL_ATTRIBUTION_FILTERS,
+        RESOURCE_TREE_FILTERS,
       ]);
     case SET_VARIABLE:
       return {

--- a/src/Frontend/state/variables/use-filters.ts
+++ b/src/Frontend/state/variables/use-filters.ts
@@ -11,6 +11,7 @@ export const MANUAL_ATTRIBUTION_FILTERS_AUDIT =
 export const MANUAL_ATTRIBUTION_FILTERS_REPORT =
   'manual-attribution-filters-report';
 export const EXTERNAL_ATTRIBUTION_FILTERS = 'external-attribution-filters';
+export const RESOURCE_TREE_FILTERS = 'resource-tree-filters';
 
 export interface AttributionFilters {
   filters: Array<Filter>;
@@ -45,6 +46,13 @@ export function useAttributionFiltersInReportView() {
 export function useExternalAttributionFilters() {
   return useVariable<AttributionFilters>(
     EXTERNAL_ATTRIBUTION_FILTERS,
+    structuredClone(initialFilters),
+  );
+}
+
+export function useResourceTreeFilters() {
+  return useVariable<AttributionFilters>(
+    RESOURCE_TREE_FILTERS,
     structuredClone(initialFilters),
   );
 }

--- a/src/Frontend/util/use-filter-properties.ts
+++ b/src/Frontend/util/use-filter-properties.ts
@@ -11,11 +11,13 @@ import {
   useAttributionFiltersInReportView,
   useExternalAttributionFilters,
   useManualAttributionFilters,
+  useResourceTreeFilters,
 } from '../state/variables/use-filters';
 import { useUserSettings } from '../state/variables/use-user-setting';
 import { backend } from './backendClient';
 
-export type FilterPropsMode = 'external' | 'manual' | 'reportTable';
+export type FilterPropsMode =
+  'external' | 'manual' | 'reportTable' | 'resourceTree';
 
 export function useFilterProperties({
   mode,
@@ -28,6 +30,7 @@ export function useFilterProperties({
     manual: useManualAttributionFilters,
     external: useExternalAttributionFilters,
     reportTable: useAttributionFiltersInReportView,
+    resourceTree: useResourceTreeFilters,
   }[mode];
 
   const [{ filters, search, selectedLicense }] = useFilters();
@@ -41,10 +44,16 @@ export function useFilterProperties({
     {
       external: mode === 'external',
       filters,
-      search: mode === 'reportTable' ? undefined : search,
-      license: mode === 'reportTable' ? undefined : selectedLicense,
+      search:
+        mode === 'reportTable' || mode === 'resourceTree' ? undefined : search,
+      license:
+        mode === 'reportTable' || mode === 'resourceTree'
+          ? undefined
+          : selectedLicense,
       resourcePathForRelationships:
-        mode === 'reportTable' ? ROOT_PATH : selectedResourceId,
+        mode === 'reportTable' || mode === 'resourceTree'
+          ? ROOT_PATH
+          : selectedResourceId,
       showResolved: mode === 'external' ? areHiddenSignalsVisible : undefined,
     },
     { enabled, placeholderData: keepPreviousData },
@@ -55,6 +64,7 @@ export function useFilterProperties({
       manual: 'all',
       external: 'sameOrDescendant',
       reportTable: 'descendant',
+      resourceTree: 'all',
     } as const
   )[mode];
 

--- a/src/e2e-tests/__tests__/interacting-with-resources.test.ts
+++ b/src/e2e-tests/__tests__/interacting-with-resources.test.ts
@@ -13,9 +13,15 @@ const [
   resourceName6,
   resourceName7,
 ] = faker.opossum.resourceNames({ count: 7 });
-const [attributionId1, packageInfo1] = faker.opossum.rawAttribution();
-const [attributionId2, packageInfo2] = faker.opossum.rawAttribution();
-const [attributionId3, packageInfo3] = faker.opossum.rawAttribution();
+const [attributionId1, packageInfo1] = faker.opossum.rawAttribution({
+  licenseName: 'MIT',
+});
+const [attributionId2, packageInfo2] = faker.opossum.rawAttribution({
+  licenseName: 'Apache-2.0',
+});
+const [attributionId3, packageInfo3] = faker.opossum.rawAttribution({
+  licenseName: 'BSD-3-Clause',
+});
 
 test.use({
   data: {
@@ -158,4 +164,27 @@ test('shows only resources matching search', async ({
   await window.keyboard.type(resourceName4);
   await resourcesTree.assert.resourceIsHidden(resourceName1);
   await resourcesTree.assert.resourceIsVisible(resourceName4);
+});
+
+test('shows only resources matching selected manual attribution license', async ({
+  resourcesTree,
+  signalsPanel,
+}) => {
+  await resourcesTree.goto(resourceName1, resourceName2, resourceName3);
+  await signalsPanel.packageCard.click(packageInfo1);
+  await signalsPanel.linkButton.click();
+
+  await resourcesTree.goto(resourceName4, resourceName5, resourceName6);
+  await signalsPanel.packageCard.click(packageInfo2);
+  await signalsPanel.linkButton.click();
+
+  await resourcesTree.gotoRoot();
+  await resourcesTree.filterButton.click();
+  await resourcesTree.selectLicenseName(packageInfo1.licenseName!);
+  await resourcesTree.closeMenu();
+  await resourcesTree.closeMenu();
+
+  await resourcesTree.assert.resourceIsVisible(resourceName1);
+  await resourcesTree.assert.resourceIsHidden(resourceName4);
+  await resourcesTree.assert.resourceIsHidden(resourceName7);
 });

--- a/src/e2e-tests/page-objects/ResourcesTree.ts
+++ b/src/e2e-tests/page-objects/ResourcesTree.ts
@@ -5,14 +5,26 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 export class ResourcesTree {
+  private readonly window: Page;
   private readonly node: Locator;
   private readonly header: Locator;
+  readonly filterButton: Locator;
+  readonly filters: {
+    readonly license: Locator;
+  };
   readonly searchField: Locator;
   readonly clearSearchButton: Locator;
 
   constructor(window: Page) {
+    this.window = window;
     this.node = window.getByTestId('resources-tree');
     this.header = window.getByTestId('resources-tree-header');
+    this.filterButton = this.header.getByLabel('filter button', {
+      exact: true,
+    });
+    this.filters = {
+      license: window.getByLabel('license names'),
+    };
     this.searchField = this.header.getByRole('searchbox');
     this.clearSearchButton = this.header.getByLabel('clear search');
   }
@@ -44,5 +56,15 @@ export class ResourcesTree {
     for (const resourceName of resourceNames) {
       await this.node.getByText(resourceName, { exact: true }).click();
     }
+  }
+
+  async closeMenu(): Promise<void> {
+    await this.window.keyboard.press('Escape');
+  }
+
+  async selectLicenseName(licenseName: string): Promise<void> {
+    await this.filters.license.fill(licenseName);
+    await this.window.keyboard.press('ArrowUp');
+    await this.window.keyboard.press('Enter');
   }
 }


### PR DESCRIPTION
### Summary of changes

- License filter for resource tree
- Moved clear filter button into dropdown

### Context and reason for change
#3178
I tried multiple approaches with the clear filter button. Either it was too small to comfortably click (imho the existing button was already too small), or it needed too much space and caused layout issues. I opted to move it into the dropdown, and introduced a new visual indicator for active filters.
