### PR TITLE
3179 filter unreviewed files

### DIFF
--- a/src/ElectronBackend/api/__tests__/listAttributions.test.ts
+++ b/src/ElectronBackend/api/__tests__/listAttributions.test.ts
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Criticality } from '../../../shared/shared-types';
-import { text } from '../../../shared/text';
 import {
   initializeDbWithTestData,
   pathsToResources,
@@ -266,7 +265,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.needsFollowUp],
+      filters: ['needsFollowUp'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -295,7 +294,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.preSelected],
+      filters: ['preSelected'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -324,7 +323,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.excludedFromNotice],
+      filters: ['excludedFromNotice'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -357,7 +356,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.lowConfidence],
+      filters: ['lowConfidence'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -386,7 +385,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.firstParty],
+      filters: ['firstParty'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -415,7 +414,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.thirdParty],
+      filters: ['thirdParty'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -444,7 +443,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.needsReview],
+      filters: ['needsReview'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -473,7 +472,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.currentlyPreferred],
+      filters: ['currentlyPreferred'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -502,7 +501,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.previouslyPreferred],
+      filters: ['previouslyPreferred'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -533,7 +532,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.incompleteCoordinates],
+      filters: ['incompleteCoordinates'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -563,7 +562,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.incompleteLegal],
+      filters: ['incompleteLegal'],
       resourcePathForRelationships: '/resource',
     });
 
@@ -592,7 +591,7 @@ describe('listAttributions', () => {
 
     const { result } = await listAttributions({
       external: false,
-      filters: [text.filters.modifiedPreferred],
+      filters: ['modifiedPreferred'],
       resourcePathForRelationships: '/resource',
     });
 

--- a/src/ElectronBackend/api/__tests__/queries.test.ts
+++ b/src/ElectronBackend/api/__tests__/queries.test.ts
@@ -3,7 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Criticality } from '../../../shared/shared-types';
-import { text } from '../../../shared/text';
 import {
   initializeDbWithTestData,
   pathsToResources,
@@ -99,9 +98,9 @@ describe('filterProperties', () => {
       resourcePathForRelationships: '/parent/target',
     });
 
-    expect(result.all[text.filters.firstParty]).toBe(1);
-    expect(result.all[text.filters.thirdParty]).toBe(3);
-    expect(result.all[text.filters.needsFollowUp]).toBe(1);
+    expect(result.all.firstParty).toBe(1);
+    expect(result.all.thirdParty).toBe(3);
+    expect(result.all.needsFollowUp).toBe(1);
   });
 
   it('applies active filters to narrow results', async () => {
@@ -109,7 +108,7 @@ describe('filterProperties', () => {
 
     const { result } = await queries.filterProperties({
       external: true,
-      filters: [text.filters.firstParty],
+      filters: ['firstParty'],
       resourcePathForRelationships: '/parent/target',
     });
 

--- a/src/ElectronBackend/api/__tests__/resourceTree.test.ts
+++ b/src/ElectronBackend/api/__tests__/resourceTree.test.ts
@@ -10,7 +10,10 @@ import {
   type ResourcesToAttributions,
 } from '../../../shared/shared-types';
 import { initializeDbWithTestData } from '../../../testing/global-test-helpers';
-import { getResourceTree } from '../resourceTree';
+import {
+  getResourceTree,
+  getResourceTreeUnreviewedCount,
+} from '../resourceTree';
 
 function makeAttributionData(
   attributions: Attributions,
@@ -502,46 +505,350 @@ describe('getResourceTree', () => {
     });
   });
 
-  describe('onAttributionUuids filtering', () => {
-    it('only shows resources linked to the given attribution', async () => {
-      const uuid = 'target-uuid';
-      const otherUuid = 'other-uuid';
+  describe('license filtering', () => {
+    it('only shows resources linked to matching manual attributions once', async () => {
+      const firstMitUuid = 'first-mit-uuid';
+      const secondMitUuid = 'second-mit-uuid';
+      const apacheUuid = 'apache-uuid';
 
       await initializeDbWithTestData({
         resources: {
           linked: { 'file.ts': 1 },
           unlinked: { 'other.ts': 1 },
         },
-        externalAttributions: makeAttributionData(
+        manualAttributions: makeAttributionData(
           {
-            [uuid]: {
-              packageName: 'target',
+            [firstMitUuid]: {
+              packageName: 'first MIT package',
               criticality: Criticality.None,
-              id: uuid,
+              id: firstMitUuid,
+              licenseName: 'MIT',
             },
-            [otherUuid]: {
-              packageName: 'other',
+            [secondMitUuid]: {
+              packageName: 'second MIT package',
               criticality: Criticality.None,
-              id: otherUuid,
+              id: secondMitUuid,
+              licenseName: 'MIT',
+            },
+            [apacheUuid]: {
+              packageName: 'Apache package',
+              criticality: Criticality.None,
+              id: apacheUuid,
+              licenseName: 'Apache-2.0',
             },
           },
           {
-            '/linked/file.ts': [uuid],
-            '/unlinked/other.ts': [otherUuid],
+            '/linked/file.ts': [firstMitUuid, secondMitUuid],
+            '/unlinked/other.ts': [apacheUuid],
           },
         ),
       });
 
       const { result } = await getResourceTree({
         expandedNodes: 'expandAll',
-        onAttributionUuids: [uuid],
+        license: 'MIT',
       });
 
+      expect(result.count).toBe(1);
       const labels = result.treeNodes.map((n) => n.labelText);
       expect(labels).toContain('linked');
       expect(labels).toContain('file.ts');
       expect(labels).not.toContain('unlinked');
       expect(labels).not.toContain('other.ts');
+    });
+  });
+
+  describe('onlyUnreviewedFiles filtering', () => {
+    it('shows files with only external attributions', async () => {
+      await initializeDbWithTestData({
+        resources: { src: { 'external.ts': 1, 'manual.ts': 1 } },
+        externalAttributions: makeAttributionData(
+          {
+            'external-uuid': {
+              packageName: 'external',
+              criticality: Criticality.None,
+              id: 'external-uuid',
+            },
+          },
+          { '/src/external.ts': ['external-uuid'] },
+        ),
+        manualAttributions: makeAttributionData(
+          {
+            'manual-uuid': {
+              packageName: 'manual',
+              criticality: Criticality.None,
+              id: 'manual-uuid',
+            },
+          },
+          { '/src/manual.ts': ['manual-uuid'] },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        onlyUnreviewedFiles: true,
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.treeNodes.map((node) => node.labelText)).toEqual([
+        '/',
+        'src',
+        'external.ts',
+      ]);
+    });
+
+    it('shows files with only pre-selected attributions', async () => {
+      await initializeDbWithTestData({
+        resources: { src: { 'preselected.ts': 1, 'manual.ts': 1 } },
+        manualAttributions: makeAttributionData(
+          {
+            'preselected-uuid': {
+              packageName: 'preselected',
+              criticality: Criticality.None,
+              id: 'preselected-uuid',
+              preSelected: true,
+            },
+            'manual-uuid': {
+              packageName: 'manual',
+              criticality: Criticality.None,
+              id: 'manual-uuid',
+            },
+          },
+          {
+            '/src/preselected.ts': ['preselected-uuid'],
+            '/src/manual.ts': ['manual-uuid'],
+          },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        onlyUnreviewedFiles: true,
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.treeNodes.map((node) => node.labelText)).toEqual([
+        '/',
+        'src',
+        'preselected.ts',
+      ]);
+    });
+
+    it('excludes files with non-pre-selected manual attributions', async () => {
+      await initializeDbWithTestData({
+        resources: { src: { 'manual.ts': 1 } },
+        manualAttributions: makeAttributionData(
+          {
+            'manual-uuid': {
+              packageName: 'manual',
+              criticality: Criticality.None,
+              id: 'manual-uuid',
+            },
+          },
+          { '/src/manual.ts': ['manual-uuid'] },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        onlyUnreviewedFiles: true,
+      });
+
+      expect(result.count).toBe(0);
+      expect(result.treeNodes).toEqual([]);
+    });
+
+    it('excludes files that also have a non-pre-selected manual attribution', async () => {
+      await initializeDbWithTestData({
+        resources: { src: { 'mixed.ts': 1 } },
+        manualAttributions: makeAttributionData(
+          {
+            'preselected-uuid': {
+              packageName: 'preselected',
+              criticality: Criticality.None,
+              id: 'preselected-uuid',
+              preSelected: true,
+            },
+            'manual-uuid': {
+              packageName: 'manual',
+              criticality: Criticality.None,
+              id: 'manual-uuid',
+            },
+          },
+          { '/src/mixed.ts': ['preselected-uuid', 'manual-uuid'] },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        onlyUnreviewedFiles: true,
+      });
+
+      expect(result.count).toBe(0);
+      expect(result.treeNodes).toEqual([]);
+    });
+
+    it('applies search and unreviewed filtering to the displayed tree', async () => {
+      await initializeDbWithTestData({
+        resources: {
+          src: {
+            'matching-external.ts': 1,
+            'matching-manual.ts': 1,
+            'other-external.ts': 1,
+          },
+        },
+        externalAttributions: makeAttributionData(
+          {
+            'matching-external-uuid': {
+              packageName: 'matching external',
+              criticality: Criticality.None,
+              id: 'matching-external-uuid',
+            },
+            'other-external-uuid': {
+              packageName: 'other external',
+              criticality: Criticality.None,
+              id: 'other-external-uuid',
+            },
+          },
+          {
+            '/src/matching-external.ts': ['matching-external-uuid'],
+            '/src/other-external.ts': ['other-external-uuid'],
+          },
+        ),
+        manualAttributions: makeAttributionData(
+          {
+            'matching-manual-uuid': {
+              packageName: 'matching manual',
+              criticality: Criticality.None,
+              id: 'matching-manual-uuid',
+            },
+          },
+          { '/src/matching-manual.ts': ['matching-manual-uuid'] },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        onlyUnreviewedFiles: true,
+        search: 'matching',
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.treeNodes.map((node) => node.labelText)).toEqual([
+        '/',
+        'src',
+        'matching-external.ts',
+      ]);
+    });
+
+    it('applies license and unreviewed filtering to the displayed tree', async () => {
+      await initializeDbWithTestData({
+        resources: {
+          src: {
+            'preselected-mit.ts': 1,
+            'reviewed-mit.ts': 1,
+            'external.ts': 1,
+          },
+        },
+        externalAttributions: makeAttributionData(
+          {
+            'external-uuid': {
+              packageName: 'external',
+              criticality: Criticality.None,
+              id: 'external-uuid',
+            },
+          },
+          { '/src/external.ts': ['external-uuid'] },
+        ),
+        manualAttributions: makeAttributionData(
+          {
+            'preselected-mit-uuid': {
+              packageName: 'preselected MIT',
+              criticality: Criticality.None,
+              id: 'preselected-mit-uuid',
+              licenseName: 'MIT',
+              preSelected: true,
+            },
+            'reviewed-mit-uuid': {
+              packageName: 'reviewed MIT',
+              criticality: Criticality.None,
+              id: 'reviewed-mit-uuid',
+              licenseName: 'MIT',
+            },
+          },
+          {
+            '/src/preselected-mit.ts': ['preselected-mit-uuid'],
+            '/src/reviewed-mit.ts': ['reviewed-mit-uuid'],
+          },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        license: 'MIT',
+        onlyUnreviewedFiles: true,
+      });
+
+      expect(result.count).toBe(1);
+      expect(result.treeNodes.map((node) => node.labelText)).toEqual([
+        '/',
+        'src',
+        'preselected-mit.ts',
+      ]);
+    });
+
+    it('counts only unreviewed files in the current search context', async () => {
+      await initializeDbWithTestData({
+        resources: {
+          src: { 'external.ts': 1, 'manual.ts': 1, 'preselected.ts': 1 },
+        },
+        externalAttributions: makeAttributionData(
+          {
+            'external-uuid': {
+              packageName: 'external',
+              criticality: Criticality.None,
+              id: 'external-uuid',
+            },
+          },
+          { '/src/external.ts': ['external-uuid'] },
+        ),
+        manualAttributions: makeAttributionData(
+          {
+            'preselected-uuid': {
+              packageName: 'preselected',
+              criticality: Criticality.None,
+              id: 'preselected-uuid',
+              preSelected: true,
+              licenseName: 'MIT',
+            },
+            'manual-uuid': {
+              packageName: 'manual',
+              criticality: Criticality.None,
+              id: 'manual-uuid',
+            },
+          },
+          {
+            '/src/preselected.ts': ['preselected-uuid'],
+            '/src/manual.ts': ['manual-uuid'],
+          },
+        ),
+      });
+
+      await expect(
+        getResourceTreeUnreviewedCount({ search: 'src' }),
+      ).resolves.toEqual({ result: 2 });
+
+      await expect(
+        getResourceTreeUnreviewedCount({ search: 'external' }),
+      ).resolves.toEqual({ result: 1 });
+
+      await expect(
+        getResourceTreeUnreviewedCount({ search: 'manual' }),
+      ).resolves.toEqual({ result: 0 });
+
+      await expect(
+        getResourceTreeUnreviewedCount({ license: 'MIT' }),
+      ).resolves.toEqual({ result: 1 });
     });
   });
 

--- a/src/ElectronBackend/api/filters.ts
+++ b/src/ElectronBackend/api/filters.ts
@@ -9,8 +9,10 @@ import {
   type SqlBool,
 } from 'kysely';
 
-import type { Filter } from '../../Frontend/shared-constants';
-import { text } from '../../shared/text';
+import {
+  ATTRIBUTION_FILTER_KEYS,
+  type AttributionFilterKey,
+} from '../../shared/shared-constants';
 import type { DB } from '../db/generated/databaseTypes';
 
 const LOW_CONFIDENCE_THRESHOLD = 60;
@@ -28,20 +30,21 @@ const TYPES_REQUIRING_NAMESPACE = [
  * Return a kysely expression that is 1 if a column in the table
  * matches the expression, 0 else
  */
-export function getFilterExpression(
-  filter: Filter,
-): OperandExpression<SqlBool> {
+function getFilters(): Record<
+  AttributionFilterKey,
+  OperandExpression<SqlBool>
+> {
   const eb = expressionBuilder<DB, 'attribution'>();
   const filters = {
-    [text.filters.currentlyPreferred]: eb('preferred', '=', 1),
-    [text.filters.excludedFromNotice]: eb('exclude_from_notice', '=', 1),
-    [text.filters.firstParty]: eb('first_party', '=', 1),
-    [text.filters.highConfidence]: eb(
+    currentlyPreferred: eb('preferred', '=', 1),
+    excludedFromNotice: eb('exclude_from_notice', '=', 1),
+    firstParty: eb('first_party', '=', 1),
+    highConfidence: eb(
       'attribution_confidence',
       '>=',
       LOW_CONFIDENCE_THRESHOLD,
     ),
-    [text.filters.incompleteCoordinates]: eb.and([
+    incompleteCoordinates: eb.and([
       eb('exclude_from_notice', '=', 0),
       eb('first_party', '=', 0),
       eb.or([
@@ -60,7 +63,7 @@ export function getFilterExpression(
         ]),
       ]),
     ]),
-    [text.filters.incompleteLegal]: eb.and([
+    incompleteLegal: eb.and([
       eb('exclude_from_notice', '=', 0),
       eb('first_party', '=', 0),
       eb.or([
@@ -75,25 +78,35 @@ export function getFilterExpression(
         ]),
       ]),
     ]),
-    [text.filters.lowConfidence]: eb(
+    lowConfidence: eb(
       'attribution.attribution_confidence',
       '<',
       LOW_CONFIDENCE_THRESHOLD,
     ),
-    [text.filters.needsFollowUp]: eb('follow_up', '=', 1),
-    [text.filters.needsReview]: eb('needs_review', '=', 1),
-    [text.filters.notExcludedFromNotice]: eb('exclude_from_notice', '=', 0),
-    [text.filters.preSelected]: eb('pre_selected', '=', 1),
-    [text.filters.notPreSelected]: eb('pre_selected', '=', 0),
-    [text.filters.previouslyPreferred]: eb('was_preferred', '=', 1),
-    [text.filters.thirdParty]: eb('first_party', '=', 0),
-    [text.filters.modifiedPreferred]: eb.and([
+    needsFollowUp: eb('follow_up', '=', 1),
+    needsReview: eb('needs_review', '=', 1),
+    notExcludedFromNotice: eb('exclude_from_notice', '=', 0),
+    preSelected: eb('pre_selected', '=', 1),
+    notPreSelected: eb('pre_selected', '=', 0),
+    previouslyPreferred: eb('was_preferred', '=', 1),
+    thirdParty: eb('first_party', '=', 0),
+    modifiedPreferred: eb.and([
       eb('original_attribution_was_preferred', '=', 1),
       eb('was_preferred', '=', 0),
     ]),
-  } satisfies Record<Filter, OperandExpression<SqlBool>>;
+  };
 
-  return filters[filter];
+  return filters;
+}
+
+export function getFilterExpression(
+  filter: AttributionFilterKey,
+): OperandExpression<SqlBool> {
+  return getFilters()[filter];
+}
+
+export function getFilterKeys(): ReadonlyArray<AttributionFilterKey> {
+  return ATTRIBUTION_FILTER_KEYS;
 }
 
 export function getSearchExpression(

--- a/src/ElectronBackend/api/listAttributions.ts
+++ b/src/ElectronBackend/api/listAttributions.ts
@@ -5,7 +5,7 @@
 import { sql } from 'kysely';
 
 import type { SortOption } from '../../Frontend/Components/SortButton/useSortingOptions';
-import type { Filter } from '../../Frontend/shared-constants';
+import type { AttributionFilterKey } from '../../shared/shared-constants';
 import type { Attributions, PackageInfo } from '../../shared/shared-types';
 import { getDb } from '../db/db';
 import { getFilterExpression, getSearchExpression } from './filters';
@@ -19,7 +19,7 @@ import {
 
 export async function listAttributions(props: {
   external?: boolean;
-  filters?: Array<Filter>;
+  filters?: Array<AttributionFilterKey>;
   resourcePathForRelationships?: string;
   sort?: SortOption;
   license?: string;

--- a/src/ElectronBackend/api/queries.ts
+++ b/src/ElectronBackend/api/queries.ts
@@ -41,7 +41,6 @@ import {
   GET_LEGACY_RESOURCE_PATH,
   getClosestAncestorWithManualAttributionsBelowBreakpoint,
   getResourceOrThrow,
-  mergeFilterProperties,
   removeParentFromPath,
   removeTrailingSlash,
   type ResourceRelationship,
@@ -82,6 +81,33 @@ type QueryFunction = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   param?: any,
 ) => Promise<{ result: NonNullable<unknown> | null }>; // Tanstack doesn't allow functions to return undefined
+
+function mergeFilterProperties(
+  counts: Array<FilterPropertiesWithCanonicalLicenseNames | undefined>,
+): FilterPropertiesWithCanonicalLicenseNames {
+  const result = {
+    ...Object.fromEntries(['total', ...getFilterKeys()].map((key) => [key, 0])),
+    licenses: [] as Array<{ name: string; canonical_name: string }>,
+  } as FilterPropertiesWithCanonicalLicenseNames;
+
+  for (const count of counts.filter((count) => count !== undefined)) {
+    for (const [key, value] of Object.entries(count)) {
+      if (key === 'licenses') {
+        result.licenses = [
+          ...new Set([
+            ...result.licenses,
+            ...(value as Array<{ name: string; canonical_name: string }>),
+          ]),
+        ];
+      } else {
+        const filterKey = key as AttributionFilterKey | 'total';
+        result[filterKey] = (result[filterKey] ?? 0) + (value as number);
+      }
+    }
+  }
+
+  return result;
+}
 
 export const queries = {
   listAttributions,

--- a/src/ElectronBackend/api/queries.ts
+++ b/src/ElectronBackend/api/queries.ts
@@ -27,7 +27,10 @@ import {
   getNextFileToReviewForClassification,
   getNextFileToReviewForCriticality,
 } from './progressBarQueries';
-import { getResourceTree } from './resourceTree';
+import {
+  getResourceTree,
+  getResourceTreeUnreviewedCount,
+} from './resourceTree';
 import {
   externalAttributionStatistics,
   licenseTable,
@@ -83,6 +86,7 @@ type QueryFunction = (
 export const queries = {
   listAttributions,
   getResourceTree,
+  getResourceTreeUnreviewedCount,
   manualAttributionStatistics,
   externalAttributionStatistics,
   licenseTable,

--- a/src/ElectronBackend/api/queries.ts
+++ b/src/ElectronBackend/api/queries.ts
@@ -5,20 +5,19 @@
 import { sql } from 'kysely';
 import { omit, uniqBy } from 'lodash-es';
 
-import {
-  type Filter,
-  type FilterCounts,
-  FILTERS,
-} from '../../Frontend/shared-constants';
+import type { AttributionFilterKey } from '../../shared/shared-constants';
 import type {
   ExternalAttributionSources,
   PackageInfo,
   ProjectMetadata,
   RawClassificationsConfig,
 } from '../../shared/shared-types';
-import { text } from '../../shared/text';
 import { getDb } from '../db/db';
-import { getFilterExpression, getSearchExpression } from './filters';
+import {
+  getFilterExpression,
+  getFilterKeys,
+  getSearchExpression,
+} from './filters';
 import { listAttributions } from './listAttributions';
 import {
   getAttributionProgressBarData,
@@ -61,10 +60,10 @@ type AutocompleteOptions = Record<
   Array<{ contained_uuid: string; value: string; count: number }>
 >;
 
-export type FilterProperties = FilterCounts & {
+export type FilterProperties = {
   total: number;
   licenses: Array<string>;
-};
+} & Partial<Record<AttributionFilterKey, number>>;
 
 export type FilterPropertiesWithCanonicalLicenseNames = Omit<
   FilterProperties,
@@ -169,7 +168,7 @@ export const queries = {
 
   async filterProperties(props: {
     external: boolean;
-    filters: Array<Filter>;
+    filters: Array<AttributionFilterKey>;
     resourcePathForRelationships: string;
     license?: string;
     search?: string;
@@ -199,7 +198,7 @@ export const queries = {
       )
       .select((eb) => eb.fn.countAll<number>().as('total'))
       .select((eb) =>
-        FILTERS.map((f) =>
+        getFilterKeys().map((f) =>
           eb.fn
             .sum<number>(
               eb.case().when(getFilterExpression(f)).then(1).else(0).end(),
@@ -421,8 +420,8 @@ export const queries = {
           .where('attribution.is_external', '=', 0)
           .where((eb) =>
             eb.or([
-              getFilterExpression(text.filters.incompleteCoordinates),
-              getFilterExpression(text.filters.incompleteLegal),
+              getFilterExpression('incompleteCoordinates'),
+              getFilterExpression('incompleteLegal'),
             ]),
           )
           .limit(1)

--- a/src/ElectronBackend/api/resourceTree.ts
+++ b/src/ElectronBackend/api/resourceTree.ts
@@ -7,11 +7,20 @@ import {
   expressionBuilder,
   type ExpressionBuilder,
   sql,
+  type Transaction,
 } from 'kysely';
 
 import { getDb } from '../db/db';
 import type { DB, Resource } from '../db/generated/databaseTypes';
-import { getResourceOrThrow, removeTrailingSlash } from './utils';
+import {
+  getOnlyExternalFilesQuery,
+  getOnlyPreSelectedManualFilesQuery,
+} from './progressBarUtils';
+import {
+  getResourceOrThrow,
+  removeTrailingSlash,
+  toCanonicalLicenseName,
+} from './utils';
 
 export type ResourceTreeNodeData = Awaited<
   ReturnType<typeof getResourceTree>
@@ -23,48 +32,37 @@ type FilteredTable = { filtered_resources: { id: number } };
 export function getResourceTree({
   search,
   expandedNodes,
+  onlyUnreviewedFiles,
+  license,
   onAttributionUuids,
   selectedResourcePath,
 }: {
   search?: string;
   expandedNodes: Array<string> | 'expandAll';
+  onlyUnreviewedFiles?: boolean;
+  license?: string;
   onAttributionUuids?: Array<string>;
   selectedResourcePath?: string;
 }) {
   return getDb()
     .transaction()
     .execute(async (trx) => {
+      const hasActiveFilters = Boolean(
+        search || license || onAttributionUuids || onlyUnreviewedFiles,
+      );
       /*
-       * FILTERED_RESOURCE_TEMP_TABLE contains the name of the table that contains all the resources included by the filter on search and onAttributionUuids.
-       * If both are undefined, that is just a view on `resource` with no runtime overhead
+       * FILTERED_RESOURCE_TEMP_TABLE contains the resources included by the active filters.
+       * Without active filters, it is a view on `resource` with no runtime overhead.
        */
 
       let dropTempTable;
-      if (search || onAttributionUuids) {
-        let filterQuery;
-        if (search && onAttributionUuids) {
-          filterQuery = trx
-            .selectFrom('resource as r')
-            .innerJoin(
-              'resource_to_attribution as rta',
-              'r.id',
-              'rta.resource_id',
-            )
-            .select('id')
-            .where('r.path', 'like', `%${search}%`)
-            .where('rta.attribution_uuid', 'in', onAttributionUuids);
-        } else if (search) {
-          filterQuery = trx
-            .selectFrom('resource as r')
-            .select('id')
-            .where('r.path', 'like', `%${search}%`);
-        } else {
-          filterQuery = trx
-            .selectFrom('resource_to_attribution as rta')
-            .select('resource_id as id')
-
-            .where('rta.attribution_uuid', 'in', onAttributionUuids!);
-        }
+      if (hasActiveFilters) {
+        const filterQuery = getFilteredResourcesQuery(trx, {
+          license,
+          onlyUnreviewedFiles,
+          onAttributionUuids,
+          search,
+        });
 
         await trx.schema
           .createTable(FILTERED_RESOURCE_TEMP_TABLE)
@@ -190,7 +188,7 @@ export function getResourceTree({
                 );
               }
 
-              if (search || onAttributionUuids) {
+              if (hasActiveFilters) {
                 query = query.where((eb) =>
                   filteredResourcesContainIdBetween(
                     eb.ref('r.id'),
@@ -256,6 +254,124 @@ export function getResourceTree({
         },
       };
     });
+}
+
+export async function getResourceTreeUnreviewedCount({
+  license,
+  onAttributionUuids,
+  search,
+}: {
+  license?: string;
+  onAttributionUuids?: Array<string>;
+  search?: string;
+}) {
+  const count = await getDb()
+    .transaction()
+    .execute(async (trx) =>
+      countUnreviewedFiles(trx, { license, onAttributionUuids, search }),
+    );
+
+  return { result: count };
+}
+
+async function countUnreviewedFiles(
+  trx: Transaction<DB>,
+  {
+    license,
+    onAttributionUuids,
+    search,
+  }: {
+    license?: string;
+    onAttributionUuids?: Array<string>;
+    search?: string;
+  },
+) {
+  return (
+    await trx
+      .selectFrom(
+        getFilteredResourcesQuery(trx, {
+          license,
+          onlyUnreviewedFiles: true,
+          onAttributionUuids,
+          search,
+        }).as('filtered_resources'),
+      )
+      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .executeTakeFirstOrThrow()
+  ).count;
+}
+
+function getFilteredResourcesQuery(
+  trx: Transaction<DB>,
+  {
+    license,
+    onlyUnreviewedFiles,
+    onAttributionUuids,
+    search,
+  }: {
+    license?: string;
+    onlyUnreviewedFiles?: boolean;
+    onAttributionUuids?: Array<string>;
+    search?: string;
+  },
+) {
+  let query = trx.selectFrom('resource as r').select('r.id as id');
+
+  if (search) {
+    query = query.where('r.path', 'like', `%${search}%`);
+  }
+
+  if (license) {
+    query = query.where('r.id', 'in', (eb) =>
+      eb
+        .selectFrom('attribution as a')
+        .innerJoin(
+          'resource_to_attribution as rta',
+          'rta.attribution_uuid',
+          'a.uuid',
+        )
+        .select('rta.resource_id')
+        .where('a.is_external', '=', 0)
+        .where(
+          'a.canonical_license_name',
+          '=',
+          toCanonicalLicenseName(license),
+        ),
+    );
+  }
+
+  if (onAttributionUuids) {
+    query = query.where((eb) =>
+      eb.exists((eb) =>
+        eb
+          .selectFrom('resource_to_attribution as rta')
+          .select('rta.resource_id')
+          .whereRef('rta.resource_id', '=', 'r.id')
+          .where('rta.attribution_uuid', 'in', onAttributionUuids),
+      ),
+    );
+  }
+
+  if (onlyUnreviewedFiles) {
+    const filterExpressionBuilder = expressionBuilder<
+      DB,
+      'closest_attributed_ancestors'
+    >();
+    query = query
+      .where((eb) =>
+        eb.or([
+          eb('r.id', 'in', getOnlyExternalFilesQuery(filterExpressionBuilder)),
+          eb(
+            'r.id',
+            'in',
+            getOnlyPreSelectedManualFilesQuery(filterExpressionBuilder),
+          ),
+        ]),
+      )
+      .where('r.is_file', '=', 1);
+  }
+
+  return query;
 }
 
 type TreeNodeQueryType = DB & {

--- a/src/ElectronBackend/api/resourceTree.ts
+++ b/src/ElectronBackend/api/resourceTree.ts
@@ -265,40 +265,23 @@ export async function getResourceTreeUnreviewedCount({
   onAttributionUuids?: Array<string>;
   search?: string;
 }) {
-  const count = await getDb()
+  return getDb()
     .transaction()
-    .execute(async (trx) =>
-      countUnreviewedFiles(trx, { license, onAttributionUuids, search }),
-    );
+    .execute(async (trx) => {
+      const count = await trx
+        .selectFrom(
+          getFilteredResourcesQuery(trx, {
+            license,
+            onlyUnreviewedFiles: true,
+            onAttributionUuids,
+            search,
+          }).as('filtered_resources'),
+        )
+        .select((eb) => eb.fn.countAll<number>().as('count'))
+        .executeTakeFirstOrThrow();
 
-  return { result: count };
-}
-
-async function countUnreviewedFiles(
-  trx: Transaction<DB>,
-  {
-    license,
-    onAttributionUuids,
-    search,
-  }: {
-    license?: string;
-    onAttributionUuids?: Array<string>;
-    search?: string;
-  },
-) {
-  return (
-    await trx
-      .selectFrom(
-        getFilteredResourcesQuery(trx, {
-          license,
-          onlyUnreviewedFiles: true,
-          onAttributionUuids,
-          search,
-        }).as('filtered_resources'),
-      )
-      .select((eb) => eb.fn.countAll<number>().as('count'))
-      .executeTakeFirstOrThrow()
-  ).count;
+      return { result: count.count };
+    });
 }
 
 function getFilteredResourcesQuery(

--- a/src/ElectronBackend/api/statistics.ts
+++ b/src/ElectronBackend/api/statistics.ts
@@ -9,7 +9,6 @@ import {
   type SqlBool,
 } from 'kysely';
 
-import { text } from '../../shared/text';
 import { getDb } from '../db/db';
 import type { DB } from '../db/generated/databaseTypes';
 import { getFilterExpression } from './filters';
@@ -33,8 +32,8 @@ export async function manualAttributionStatistics() {
 
   const incompleteManualAttributions = await attributionStats(
     eb.or([
-      getFilterExpression(text.filters.incompleteCoordinates),
-      getFilterExpression(text.filters.incompleteLegal),
+      getFilterExpression('incompleteCoordinates'),
+      getFilterExpression('incompleteLegal'),
     ]),
   );
   const totalManualAttributions = await attributionStats(sql`TRUE`);
@@ -42,21 +41,15 @@ export async function manualAttributionStatistics() {
   const attributionsOverview = [
     {
       name: 'needsReview' as const,
-      count: await attributionStats(
-        getFilterExpression(text.filters.needsReview),
-      ),
+      count: await attributionStats(getFilterExpression('needsReview')),
     },
     {
       name: 'followUp' as const,
-      count: await attributionStats(
-        getFilterExpression(text.filters.needsFollowUp),
-      ),
+      count: await attributionStats(getFilterExpression('needsFollowUp')),
     },
     {
       name: 'firstParty' as const,
-      count: await attributionStats(
-        getFilterExpression(text.filters.firstParty),
-      ),
+      count: await attributionStats(getFilterExpression('firstParty')),
     },
     {
       name: 'incomplete' as const,

--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -16,19 +16,17 @@ import {
 import { escapeRegExp, pickBy, snakeCase } from 'lodash-es';
 import { v4 as uuid4 } from 'uuid';
 
-import { FILTERS } from '../../Frontend/shared-constants';
 import {
   COMPARE_TO_MANUAL_ATTRIBUTION_ATTRIBUTES,
   isEqualToExternalAttribution,
   THIRD_PARTY_KEYS,
 } from '../../shared/attribution-comparison';
+import type { AttributionFilterKey } from '../../shared/shared-constants';
 import type { Attributions, PackageInfo } from '../../shared/shared-types';
 import type { DB } from '../db/generated/databaseTypes';
+import { getFilterKeys } from './filters';
 import { removeManualOrExternalCaaFromResources } from './progressBarUtils';
-import type {
-  FilterProperties,
-  FilterPropertiesWithCanonicalLicenseNames,
-} from './queries';
+import type { FilterPropertiesWithCanonicalLicenseNames } from './queries';
 
 export type ResourceRelationship =
   'same' | 'ancestor' | 'descendant' | 'unrelated';
@@ -461,7 +459,7 @@ export function mergeFilterProperties(
   counts: Array<FilterPropertiesWithCanonicalLicenseNames | undefined>,
 ): FilterPropertiesWithCanonicalLicenseNames {
   const result = {
-    ...Object.fromEntries(['total', ...FILTERS].map((f) => [f, 0])),
+    ...Object.fromEntries(['total', ...getFilterKeys()].map((f) => [f, 0])),
     licenses: [] as Array<{ name: string; canonical_name: string }>,
   } as FilterPropertiesWithCanonicalLicenseNames;
 
@@ -475,7 +473,8 @@ export function mergeFilterProperties(
           ]),
         ];
       } else {
-        result[k as keyof Omit<FilterProperties, 'licenses'>] += v as number;
+        const key = k as AttributionFilterKey | 'total';
+        result[key] = (result[key] ?? 0) + (v as number);
       }
     }
   }

--- a/src/ElectronBackend/api/utils.ts
+++ b/src/ElectronBackend/api/utils.ts
@@ -21,12 +21,9 @@ import {
   isEqualToExternalAttribution,
   THIRD_PARTY_KEYS,
 } from '../../shared/attribution-comparison';
-import type { AttributionFilterKey } from '../../shared/shared-constants';
 import type { Attributions, PackageInfo } from '../../shared/shared-types';
 import type { DB } from '../db/generated/databaseTypes';
-import { getFilterKeys } from './filters';
 import { removeManualOrExternalCaaFromResources } from './progressBarUtils';
-import type { FilterPropertiesWithCanonicalLicenseNames } from './queries';
 
 export type ResourceRelationship =
   'same' | 'ancestor' | 'descendant' | 'unrelated';
@@ -453,33 +450,6 @@ export function toCanonicalLicenseName(
   s: Expression<string | null> | string | null,
 ): RawBuilder<string | null> {
   return sql<string | null>`lower(replace(replace(${s}, '-', ''), ' ', ''))`;
-}
-
-export function mergeFilterProperties(
-  counts: Array<FilterPropertiesWithCanonicalLicenseNames | undefined>,
-): FilterPropertiesWithCanonicalLicenseNames {
-  const result = {
-    ...Object.fromEntries(['total', ...getFilterKeys()].map((f) => [f, 0])),
-    licenses: [] as Array<{ name: string; canonical_name: string }>,
-  } as FilterPropertiesWithCanonicalLicenseNames;
-
-  for (const sum of counts.filter((s) => s !== undefined)) {
-    for (const [k, v] of Object.entries(sum)) {
-      if (k === 'licenses') {
-        result.licenses = [
-          ...new Set([
-            ...result.licenses,
-            ...(v as Array<{ name: string; canonical_name: string }>),
-          ]),
-        ];
-      } else {
-        const key = k as AttributionFilterKey | 'total';
-        result[key] = (result[key] ?? 0) + (v as number);
-      }
-    }
-  }
-
-  return result;
 }
 
 const DEFAULT_BATCH_SIZE = 30000;

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.util.tsx
@@ -37,6 +37,7 @@ import {
 import type { SelectMenuOption } from '../../SelectMenu/SelectMenu';
 
 interface AuditingOption extends SelectMenuOption {
+  id: string;
   interactive: boolean;
 }
 

--- a/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/AttributionsPanel/AttributionsPanel.tsx
@@ -5,13 +5,13 @@
 import { useMemo } from 'react';
 
 import { text } from '../../../../shared/text';
-import { ATTRIBUTION_FILTERS } from '../../../shared-constants';
 import { OpossumColors } from '../../../shared-styles';
 import { useAppSelector } from '../../../state/hooks';
 import { getSelectedResourceId } from '../../../state/selectors/resource-selectors';
 import { useManualAttributionFilters } from '../../../state/variables/use-filters';
 import { usePickerMode } from '../../../state/variables/use-picker-mode';
 import { backend } from '../../../util/backendClient';
+import { attributionFilterOptions } from '../attribution-filter-options';
 import { type Alert, PackagesPanel } from '../PackagesPanel/PackagesPanel';
 import { AttributionsList } from './AttributionsList/AttributionsList';
 import { ConfirmButton } from './ConfirmButton/ConfirmButton';
@@ -60,7 +60,7 @@ export function AttributionsPanel() {
     <PackagesPanel
       external={false}
       alert={alert}
-      availableFilters={ATTRIBUTION_FILTERS}
+      filterOptions={attributionFilterOptions}
       renderActions={(props) => (
         <>
           <CreateButton {...props} />

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
@@ -103,14 +103,14 @@ export const PackagesPanel = ({
     mode: external ? 'external' : 'manual',
   });
   const [filters, setFilteredAttributions] = useFilteredData();
-  const { filterKeys, selectedLicense } = filters;
+  const { filters: attributionFilters, selectedLicense } = filters;
   const menuFilterOptions = useAttributionFilterOptions({
     filterOptions,
     filterProps,
     filters,
     setFilters: setFilteredAttributions,
   });
-  const isFilterActive = !!filterKeys.length || !!selectedLicense;
+  const isFilterActive = !!attributionFilters.length || !!selectedLicense;
   const pickerMode = usePickerMode();
 
   const { attributions, loading } = useFilteredAttributionsList({ external });
@@ -270,13 +270,14 @@ export const PackagesPanel = ({
               onClear={() =>
                 setFilteredAttributions((prev) => ({
                   ...prev,
-                  filterKeys: [],
+                  filters: [],
                   selectedLicense: '',
                 }))
               }
               anchorPosition={'right'}
               disabled={
-                loading || isDisabledDuringReplacement ||
+                loading ||
+                isDisabledDuringReplacement ||
                 (attributionIds !== null &&
                   attributionIds.length === 0 &&
                   !isFilterActive)

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
@@ -15,7 +15,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import type { Attributions, Relation } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
-import type { Filter } from '../../../shared-constants';
 import {
   OpossumColors,
   PICKER_MODE_DISABLED_OPACITY,
@@ -32,10 +31,13 @@ import {
 } from '../../../state/variables/use-picker-mode';
 import { getRelationPriority } from '../../../util/sort-attributions';
 import { useFilteredAttributionsList } from '../../../util/use-attribution-lists';
+import { useFilterProperties } from '../../../util/use-filter-properties';
 import { usePrevious } from '../../../util/use-previous';
 import { Checkbox } from '../../Checkbox/Checkbox';
 import { FilterButton } from '../../FilterButton/FilterButton';
+import { useAttributionFilterOptions } from '../../FilterButton/use-attribution-filter-options';
 import { SortButton } from '../../SortButton/SortButton';
+import type { AttributionFilterOption } from '../attribution-filter-options';
 import {
   ActionBar,
   ActionBarContainer,
@@ -73,7 +75,7 @@ export interface Alert {
 interface Props {
   external: boolean;
   alert?: Alert;
-  availableFilters: Array<Filter>;
+  filterOptions: Array<AttributionFilterOption>;
   children: (props: PackagesPanelChildrenProps) => React.ReactNode;
   useAttributionFilters: UseAttributionFilters;
   renderActions: (props: PackagesPanelChildrenProps) => React.ReactNode;
@@ -83,7 +85,7 @@ interface Props {
 export const PackagesPanel = ({
   external,
   alert,
-  availableFilters,
+  filterOptions,
   children,
   renderActions,
   useAttributionFilters: useFilteredData,
@@ -97,6 +99,18 @@ export const PackagesPanel = ({
   const [multiSelectedAttributionIds, setMultiSelectedAttributionIds] =
     useState<Array<string>>([]);
   const [activeRelation, setActiveRelation] = useState<Relation>('children');
+  const { filterProps } = useFilterProperties({
+    mode: external ? 'external' : 'manual',
+  });
+  const [filters, setFilteredAttributions] = useFilteredData();
+  const { filterKeys, selectedLicense } = filters;
+  const menuFilterOptions = useAttributionFilterOptions({
+    filterOptions,
+    filterProps,
+    filters,
+    setFilters: setFilteredAttributions,
+  });
+  const isFilterActive = !!filterKeys.length || !!selectedLicense;
   const pickerMode = usePickerMode();
 
   const { attributions, loading } = useFilteredAttributionsList({ external });
@@ -251,13 +265,21 @@ export const PackagesPanel = ({
               useFilteredData={useFilteredData}
             />
             <FilterButton
-              mode={external ? 'external' : 'manual'}
-              availableFilters={availableFilters}
+              options={menuFilterOptions}
+              isActive={isFilterActive}
+              onClear={() =>
+                setFilteredAttributions((prev) => ({
+                  ...prev,
+                  filterKeys: [],
+                  selectedLicense: '',
+                }))
+              }
               anchorPosition={'right'}
-              useFilteredData={useFilteredData}
-              disabled={loading || isDisabledDuringReplacement}
-              emptyAttributions={
-                attributionIds !== null && attributionIds.length === 0
+              disabled={
+                loading || isDisabledDuringReplacement ||
+                (attributionIds !== null &&
+                  attributionIds.length === 0 &&
+                  !isFilterActive)
               }
             />
           </ButtonGroup>

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
@@ -12,7 +12,7 @@ import { setSelectedAttributionId } from '../../../../state/actions/resource-act
 import { setVariable } from '../../../../state/actions/variables-actions/variables-actions';
 import type { Action } from '../../../../state/configure-store';
 import { ATTRIBUTION_IDS_FOR_REPLACEMENT } from '../../../../state/variables/use-attribution-ids-for-replacement';
-import { initialFilters } from '../../../../state/variables/use-filters';
+import { initialAttributionFilters } from '../../../../state/variables/use-filters';
 import { renderComponent } from '../../../../test-helpers/render';
 import { useFilteredAttributionsList } from '../../../../util/use-attribution-lists';
 import {
@@ -46,7 +46,7 @@ function renderPackagesPanel({
       external={false}
       filterOptions={[]}
       renderActions={() => null}
-      useAttributionFilters={() => [initialFilters, vi.fn()]}
+      useAttributionFilters={() => [initialAttributionFilters, vi.fn()]}
     >
       {children ?? (() => null)}
     </PackagesPanel>,
@@ -64,7 +64,7 @@ function rerenderPackagesPanel(
       external={false}
       filterOptions={[]}
       renderActions={() => null}
-      useAttributionFilters={() => [initialFilters, vi.fn()]}
+      useAttributionFilters={() => [initialAttributionFilters, vi.fn()]}
     >
       {() => null}
     </PackagesPanel>,

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
@@ -44,7 +44,7 @@ function renderPackagesPanel({
   return renderComponent(
     <PackagesPanel
       external={false}
-      availableFilters={[]}
+      filterOptions={[]}
       renderActions={() => null}
       useAttributionFilters={() => [initialFilters, vi.fn()]}
     >
@@ -62,7 +62,7 @@ function rerenderPackagesPanel(
   rerender(
     <PackagesPanel
       external={false}
-      availableFilters={[]}
+      filterOptions={[]}
       renderActions={() => null}
       useAttributionFilters={() => [initialFilters, vi.fn()]}
     >

--- a/src/Frontend/Components/AttributionPanels/SignalsPanel/SignalsPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/SignalsPanel/SignalsPanel.tsx
@@ -6,11 +6,11 @@ import MuiBox from '@mui/material/Box';
 import { useMemo } from 'react';
 
 import { text } from '../../../../shared/text';
-import { SIGNAL_FILTERS } from '../../../shared-constants';
 import { OpossumColors } from '../../../shared-styles';
 import { useExternalAttributionFilters } from '../../../state/variables/use-filters';
 import { usePickerMode } from '../../../state/variables/use-picker-mode';
 import { useUserSettings } from '../../../state/variables/use-user-setting';
+import { signalFilterOptions } from '../attribution-filter-options';
 import { type Alert, PackagesPanel } from '../PackagesPanel/PackagesPanel';
 import { DeleteButton } from './DeleteButton/DeleteButton';
 import { LinkButton } from './LinkButton/LinkButton';
@@ -38,7 +38,7 @@ export function SignalsPanel() {
     <PackagesPanel
       external={true}
       alert={alert}
-      availableFilters={SIGNAL_FILTERS}
+      filterOptions={signalFilterOptions}
       renderActions={(props) => (
         <>
           <LinkButton {...props} />

--- a/src/Frontend/Components/AttributionPanels/attribution-filter-options.tsx
+++ b/src/Frontend/Components/AttributionPanels/attribution-filter-options.tsx
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import Filter3Icon from '@mui/icons-material/Filter3';
+import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
+import SentimentSatisfiedIcon from '@mui/icons-material/SentimentSatisfied';
+
+import type { AttributionFilterKey } from '../../../shared/shared-constants';
+import { text } from '../../../shared/text';
+import { baseIcon, OpossumColors } from '../../shared-styles';
+import {
+  ExcludeFromNoticeIcon,
+  FirstPartyIcon,
+  FollowUpIcon,
+  IncompleteIcon,
+  ModifiedPreferredIcon,
+  NeedsReviewIcon,
+  PreferredIcon,
+  PreSelectedIcon,
+  WasPreferredIcon,
+} from '../Icons/Icons';
+
+export interface AttributionFilterOption {
+  key: AttributionFilterKey;
+  label: string;
+  icon: React.ReactElement<unknown>;
+}
+
+const firstParty: AttributionFilterOption = {
+  key: 'firstParty',
+  label: text.filters.firstParty,
+  icon: <FirstPartyIcon noTooltip />,
+};
+const thirdParty: AttributionFilterOption = {
+  key: 'thirdParty',
+  label: text.filters.thirdParty,
+  icon: <Filter3Icon sx={{ ...baseIcon, color: OpossumColors.darkBlue }} />,
+};
+const previouslyPreferred: AttributionFilterOption = {
+  key: 'previouslyPreferred',
+  label: text.filters.previouslyPreferred,
+  icon: <WasPreferredIcon noTooltip />,
+};
+
+export const attributionFilterOptions: Array<AttributionFilterOption> = [
+  firstParty,
+  thirdParty,
+  {
+    key: 'incompleteLegal',
+    label: text.filters.incompleteLegal,
+    icon: <IncompleteIcon noTooltip />,
+  },
+  {
+    key: 'incompleteCoordinates',
+    label: text.filters.incompleteCoordinates,
+    icon: <IncompleteIcon noTooltip />,
+  },
+  {
+    key: 'excludedFromNotice',
+    label: text.filters.excludedFromNotice,
+    icon: <ExcludeFromNoticeIcon noTooltip />,
+  },
+  {
+    key: 'lowConfidence',
+    label: text.filters.lowConfidence,
+    icon: <SentimentDissatisfiedIcon color={'error'} sx={baseIcon} />,
+  },
+  {
+    key: 'needsFollowUp',
+    label: text.filters.needsFollowUp,
+    icon: <FollowUpIcon noTooltip />,
+  },
+  {
+    key: 'needsReview',
+    label: text.filters.needsReview,
+    icon: <NeedsReviewIcon noTooltip />,
+  },
+  {
+    key: 'preSelected',
+    label: text.filters.preSelected,
+    icon: <PreSelectedIcon noTooltip />,
+  },
+  {
+    key: 'currentlyPreferred',
+    label: text.filters.currentlyPreferred,
+    icon: <PreferredIcon noTooltip />,
+  },
+  previouslyPreferred,
+  {
+    key: 'modifiedPreferred',
+    label: text.filters.modifiedPreferred,
+    icon: <ModifiedPreferredIcon noTooltip />,
+  },
+];
+
+export const signalFilterOptions: Array<AttributionFilterOption> = [
+  firstParty,
+  thirdParty,
+  {
+    key: 'highConfidence',
+    label: text.filters.highConfidence,
+    icon: <SentimentSatisfiedIcon color={'success'} sx={baseIcon} />,
+  },
+  {
+    key: 'notExcludedFromNotice',
+    label: text.filters.notExcludedFromNotice,
+    icon: <ExcludeFromNoticeIcon noTooltip />,
+  },
+  {
+    key: 'notPreSelected',
+    label: text.filters.notPreSelected,
+    icon: <PreSelectedIcon noTooltip />,
+  },
+  previouslyPreferred,
+];

--- a/src/Frontend/Components/Autocomplete/Autocomplete.tsx
+++ b/src/Frontend/Components/Autocomplete/Autocomplete.tsx
@@ -21,7 +21,7 @@ import useMuiAutocomplete, {
   type UseAutocompleteProps as MuiUseAutocompleteProps,
 } from '@mui/material/useAutocomplete';
 import { compact } from 'lodash-es';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type Ref, useCallback, useEffect, useRef, useState } from 'react';
 import type { VirtuosoHandle } from 'react-virtuoso';
 
 import { text } from '../../../shared/text';
@@ -55,6 +55,7 @@ type AutocompleteProps<
     background?: string;
     endAdornment?: React.ReactNode | Array<React.ReactNode>;
     highlighting?: 'error' | 'warning';
+    inputRef?: Ref<HTMLInputElement>;
     inputProps?: MuiInputProps;
     onInputChange?: (
       event: React.SyntheticEvent | undefined,
@@ -89,6 +90,7 @@ export function Autocomplete<
   groupBy,
   groupProps,
   hidePopupIndicator,
+  inputRef,
   inputProps: customInputProps,
   multiple,
   optionText,
@@ -174,6 +176,13 @@ export function Autocomplete<
   const isPopupOpen = !!groupedOptions.length && popupOpen;
 
   const { ref, color, ...inputProps } = getInputProps();
+  const mergedInputRef = useCallback(
+    (element: HTMLInputElement | null) => {
+      setRef(ref, element);
+      setRef(inputRef, element);
+    },
+    [inputRef, ref],
+  );
 
   const tooltipTitle = (() => {
     if (highlighting === 'error') {
@@ -206,7 +215,7 @@ export function Autocomplete<
               ]).length
             }
             size={'small'}
-            inputRef={ref}
+            inputRef={mergedInputRef}
             slotProps={{
               input: {
                 startAdornment: startAdornment || renderStartAdornment(),
@@ -337,5 +346,13 @@ export function Autocomplete<
         )}
       </StyledPopper>
     );
+  }
+}
+
+function setRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
   }
 }

--- a/src/Frontend/Components/FilterButton/FilterButton.style.ts
+++ b/src/Frontend/Components/FilterButton/FilterButton.style.ts
@@ -4,9 +4,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import ClearIcon from '@mui/icons-material/Clear';
 import { styled } from '@mui/material';
+import MuiIconButton from '@mui/material/IconButton';
 
 import { OpossumColors } from '../../shared-styles';
 
 export const ClearMenuIcon = styled(ClearIcon)({
   color: OpossumColors.darkBlue,
+});
+
+export const IconButton = styled(MuiIconButton)({
+  '&:hover': {
+    background: OpossumColors.lightestGrey,
+  },
 });

--- a/src/Frontend/Components/FilterButton/FilterButton.tsx
+++ b/src/Frontend/Components/FilterButton/FilterButton.tsx
@@ -2,205 +2,72 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import Filter3Icon from '@mui/icons-material/Filter3';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
-import SentimentDissatisfiedIcon from '@mui/icons-material/SentimentDissatisfied';
-import SentimentSatisfied from '@mui/icons-material/SentimentSatisfied';
+import type { SxProps, Theme } from '@mui/material';
 import MuiBadge, { type BadgeProps } from '@mui/material/Badge';
-import MuiIconButton from '@mui/material/IconButton';
-import type { SxProps, Theme } from '@mui/material/styles';
 import MuiTooltip from '@mui/material/Tooltip';
-import { useCallback, useMemo, useState } from 'react';
+import { type CSSProperties, useMemo, useState } from 'react';
 
 import { text } from '../../../shared/text';
-import type { Filter } from '../../shared-constants';
-import { baseIcon, OpossumColors } from '../../shared-styles';
-import type { UseAttributionFilters } from '../../state/variables/use-filters';
-import {
-  type FilterPropsMode,
-  useFilterProperties,
-} from '../../util/use-filter-properties';
-import {
-  ExcludeFromNoticeIcon,
-  FirstPartyIcon,
-  FollowUpIcon,
-  IncompleteIcon,
-  ModifiedPreferredIcon,
-  NeedsReviewIcon,
-  PreferredIcon,
-  PreSelectedIcon,
-  WasPreferredIcon,
-} from '../Icons/Icons';
 import {
   SelectMenu,
   type SelectMenuOption,
   type SelectMenuProps,
 } from '../SelectMenu/SelectMenu';
-import { ClearMenuIcon } from './FilterButton.style';
-import { LicenseAutocomplete } from './LicenseAutocomplete/LicenseAutocomplete';
-
-const FILTER_ICONS: Record<Filter, React.ReactElement<unknown>> = {
-  [text.filters.currentlyPreferred]: <PreferredIcon noTooltip />,
-  [text.filters.excludedFromNotice]: <ExcludeFromNoticeIcon noTooltip />,
-  [text.filters.notExcludedFromNotice]: <ExcludeFromNoticeIcon noTooltip />,
-  [text.filters.firstParty]: <FirstPartyIcon noTooltip />,
-  [text.filters.incompleteCoordinates]: <IncompleteIcon noTooltip />,
-  [text.filters.incompleteLegal]: <IncompleteIcon noTooltip />,
-  [text.filters.lowConfidence]: (
-    <SentimentDissatisfiedIcon color={'error'} sx={baseIcon} />
-  ),
-  [text.filters.highConfidence]: (
-    <SentimentSatisfied color={'success'} sx={baseIcon} />
-  ),
-  [text.filters.needsFollowUp]: <FollowUpIcon noTooltip />,
-  [text.filters.needsReview]: <NeedsReviewIcon noTooltip />,
-  [text.filters.preSelected]: <PreSelectedIcon noTooltip />,
-  [text.filters.notPreSelected]: <PreSelectedIcon noTooltip />,
-  [text.filters.previouslyPreferred]: <WasPreferredIcon noTooltip />,
-  [text.filters.thirdParty]: (
-    <Filter3Icon sx={{ ...baseIcon, color: OpossumColors.darkBlue }} />
-  ),
-  [text.filters.modifiedPreferred]: <ModifiedPreferredIcon noTooltip />,
-};
+import { ClearMenuIcon, IconButton } from './FilterButton.style';
 
 interface Props extends Pick<
   SelectMenuProps,
   'anchorArrow' | 'anchorPosition'
 > {
-  useFilteredData: UseAttributionFilters;
-  availableFilters: Array<Filter>;
+  options: Array<SelectMenuOption>;
+  isActive: boolean;
+  onClear?: () => void;
   disabled?: boolean;
-  emptyAttributions?: boolean;
+  activeIconSx?: SxProps;
+  activeBadgeStyle?: CSSProperties;
   badgeColor?: BadgeProps['color'];
-  mode: FilterPropsMode;
-  triggerStyle?: (isSomeFilterActive: boolean) => SxProps<Theme>;
+  iconSx?: SxProps;
+  triggerStyle?: (isActive: boolean) => SxProps<Theme>;
 }
 
-export const FilterButton: React.FC<Props> = ({
+export function FilterButton({
   anchorArrow,
   anchorPosition,
-  availableFilters,
-  useFilteredData,
+  options,
+  isActive,
+  onClear,
   disabled,
-  emptyAttributions,
+  activeIconSx,
+  activeBadgeStyle,
   badgeColor = 'primary',
-  mode,
+  iconSx,
   triggerStyle,
-}) => {
+}: Props) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
-  const [{ filters, selectedLicense }, setFilteredAttributions] =
-    useFilteredData();
-  const isSomeFilterActive = !!filters.length || !!selectedLicense;
-  const isDisabled = !!(disabled || (emptyAttributions && !isSomeFilterActive));
-
-  const clearFilters = useCallback(() => {
-    setFilteredAttributions((prev) => ({
-      ...prev,
-      filters: [],
-      selectedLicense: '',
-    }));
-  }, [setFilteredAttributions]);
-
-  const { filterProps } = useFilterProperties({ mode, enabled: !!anchorEl });
-
-  const filterOptions = useMemo(
-    () =>
-      availableFilters
-        .map<SelectMenuOption>((option) => ({
-          selected: filters.includes(option),
-          faded: !filterProps?.[option],
-          id: option,
-          label:
-            filterProps?.[option] !== undefined
-              ? `${option} (${new Intl.NumberFormat().format(filterProps[option] ?? 0)})`
-              : option,
-          icon: FILTER_ICONS[option],
-          onAdd: () =>
-            setFilteredAttributions((prev) => ({
-              ...prev,
-              filters: [...prev.filters, option],
-            })),
-          onDelete: () =>
-            setFilteredAttributions((prev) => ({
-              ...prev,
-              filters: prev.filters.filter((filter) => filter !== option),
-            })),
-        }))
-        .concat({
-          selected: false,
-          id: 'license',
-          label: (
-            <LicenseAutocomplete
-              licenses={filterProps?.licenses ?? []}
-              selectedLicense={selectedLicense}
-              setSelectedLicense={(license) =>
-                setFilteredAttributions((prev) => ({
-                  ...prev,
-                  selectedLicense: license || '',
-                }))
-              }
-            />
-          ),
-        })
-        .concat(
-          isSomeFilterActive
-            ? {
-                selected: false,
-                id: 'clear-filters',
-                label: text.packageLists.clearFilters,
-                icon: <ClearMenuIcon />,
-                onAdd: () => clearFilters(),
-              }
-            : [],
-        ),
-    [
-      availableFilters,
-      clearFilters,
-      isSomeFilterActive,
-      selectedLicense,
-      filters,
-      filterProps,
-      setFilteredAttributions,
+  const menuOptions = useMemo<Array<SelectMenuOption>>(
+    () => [
+      ...options,
+      ...(isActive && onClear
+        ? [
+            {
+              id: 'clear-filters',
+              selected: false,
+              label: text.packageLists.clearFilters,
+              icon: <ClearMenuIcon />,
+              onAdd: onClear,
+            },
+          ]
+        : []),
     ],
+    [isActive, onClear, options],
   );
 
-  return (
-    <>
-      <MuiIconButton
-        aria-label={'filter button'}
-        onClick={(event) => setAnchorEl(event.currentTarget)}
-        disabled={isDisabled}
-        size={'small'}
-        color={isSomeFilterActive ? 'primary' : undefined}
-        sx={triggerStyle?.(isSomeFilterActive)}
-      >
-        {renderFilterButtonContent({ badgeColor, isSomeFilterActive })}
-      </MuiIconButton>
-      <SelectMenu
-        anchorArrow={anchorArrow}
-        anchorEl={anchorEl}
-        anchorPosition={anchorPosition}
-        multiple
-        options={filterOptions}
-        setAnchorEl={setAnchorEl}
-        width={336}
-      />
-    </>
-  );
-};
-
-function renderFilterButtonContent({
-  badgeColor,
-  isSomeFilterActive,
-}: {
-  isSomeFilterActive: boolean;
-  badgeColor: BadgeProps['color'];
-}) {
-  return (
+  const content = (
     <MuiBadge
       color={badgeColor}
       variant={'dot'}
-      invisible={!isSomeFilterActive}
+      invisible={!isActive}
       anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
       slotProps={{
         badge: {
@@ -210,6 +77,7 @@ function renderFilterButtonContent({
             height: '8px',
             top: '4px',
             right: '4px',
+            ...activeBadgeStyle,
           },
         },
       }}
@@ -219,8 +87,32 @@ function renderFilterButtonContent({
         disableInteractive
         placement={'top'}
       >
-        <FilterAltIcon />
+        <FilterAltIcon sx={isActive ? (activeIconSx ?? iconSx) : iconSx} />
       </MuiTooltip>
     </MuiBadge>
+  );
+
+  return (
+    <>
+      <IconButton
+        aria-label={'filter button'}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        disabled={!!disabled}
+        size={'small'}
+        color={isActive ? 'primary' : undefined}
+        sx={triggerStyle?.(isActive)}
+      >
+        {content}
+      </IconButton>
+      <SelectMenu
+        anchorArrow={anchorArrow}
+        anchorEl={anchorEl}
+        anchorPosition={anchorPosition}
+        multiple
+        options={menuOptions}
+        setAnchorEl={setAnchorEl}
+        width={336}
+      />
+    </>
   );
 }

--- a/src/Frontend/Components/FilterButton/LicenseAutocomplete/LicenseAutocomplete.tsx
+++ b/src/Frontend/Components/FilterButton/LicenseAutocomplete/LicenseAutocomplete.tsx
@@ -3,24 +3,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import CopyrightIcon from '@mui/icons-material/Copyright';
+import type { Ref } from 'react';
 
 import { text } from '../../../../shared/text';
 import { baseIcon, OpossumColors } from '../../../shared-styles';
 import { Autocomplete } from '../../Autocomplete/Autocomplete';
 
 interface Props {
+  inputRef?: Ref<HTMLInputElement>;
   licenses: Array<string>;
   selectedLicense: string;
   setSelectedLicense: (license: string | null) => void;
 }
 
-export const LicenseAutocomplete: React.FC<Props> = ({
+export const LicenseAutocomplete = ({
+  inputRef,
   licenses,
   selectedLicense,
   setSelectedLicense,
-}) => {
+}: Props) => {
   return (
     <Autocomplete<string, false, false, true>
+      inputRef={inputRef}
       sx={{ height: '38px' }}
       background={'transparent'}
       variant={'filled'}

--- a/src/Frontend/Components/FilterButton/__tests__/FilterButton.test.tsx
+++ b/src/Frontend/Components/FilterButton/__tests__/FilterButton.test.tsx
@@ -1,209 +1,49 @@
 // SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
-// SPDX-FileCopyrightText: Nico Carl <nicocarl@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import type { FilterProperties } from '../../../../ElectronBackend/api/queries';
 import { text } from '../../../../shared/text';
-import { faker } from '../../../../testing/Faker';
-import type { Filter } from '../../../shared-constants';
-import {
-  type AttributionFilters,
-  initialFilters,
-  type UseAttributionFilters,
-} from '../../../state/variables/use-filters';
 import { renderComponent } from '../../../test-helpers/render';
-import { useFilterProperties } from '../../../util/use-filter-properties';
 import { FilterButton } from '../FilterButton';
 
-vi.mock('../../../util/use-filter-properties', () => ({
-  useFilterProperties: vi.fn(),
-}));
-
-function mockFilterProperties(filterProps: FilterProperties | null = null) {
-  vi.mocked(useFilterProperties).mockReturnValue({
-    filterProps,
-    loading: false,
-  });
-}
-
 describe('FilterButton', () => {
-  beforeEach(() => {
-    mockFilterProperties();
-  });
-
-  it('adds selected filter', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const filter: Filter = 'Currently Preferred';
-    const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[filter]}
-      />,
-    );
+  it('adds a filter', async () => {
+    const onAdd = vi.fn();
+    await renderFilterButton({ onAdd });
 
     await userEvent.click(
       screen.getByRole('button', { name: 'filter button' }),
     );
-    await userEvent.click(screen.getByRole('menuitem', { name: filter }));
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'test filter' }),
+    );
 
-    expect(result!.filters).toEqual([filter]);
+    expect(onAdd).toHaveBeenCalledOnce();
   });
 
-  it('removes selected filter', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
+  it('removes a selected filter', async () => {
+    const onDelete = vi.fn();
+    await renderFilterButton({
+      selected: true,
+      onDelete,
     });
-    const filter: Filter = 'Currently Preferred';
-    const useFilteredData: UseAttributionFilters = () => [
-      {
-        ...initialFilters,
-        filters: [filter],
-      },
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[filter]}
-      />,
-    );
 
     await userEvent.click(
       screen.getByRole('button', { name: 'filter button' }),
     );
-    await userEvent.click(screen.getByRole('menuitem', { name: filter }));
-
-    expect(result!.filters).toEqual([]);
-  });
-
-  it('filters by license name via keyboard selection', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const packageInfo = faker.opossum.packageInfo();
-    mockFilterProperties({ total: 0, licenses: [packageInfo.licenseName!] });
-    const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[]}
-      />,
-    );
-
     await userEvent.click(
-      screen.getByRole('button', { name: 'filter button' }),
+      screen.getByRole('menuitem', { name: 'test filter' }),
     );
-    await userEvent.click(screen.getByLabelText('license names'));
-    await userEvent.keyboard('{ArrowUp}');
-    await userEvent.keyboard('{Enter}');
 
-    expect(result!.selectedLicense).toBe(packageInfo.licenseName);
+    expect(onDelete).toHaveBeenCalledOnce();
   });
 
-  it('filters by license name via search', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const licenseName = faker.commerce.productName();
-    const packageInfo = faker.opossum.packageInfo({ licenseName });
-    mockFilterProperties({ total: 0, licenses: [packageInfo.licenseName!] });
-    const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[]}
-      />,
-    );
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'filter button' }),
-    );
-    await userEvent.click(screen.getByLabelText('license names'));
-    await userEvent.paste(licenseName);
-    await userEvent.keyboard('{ArrowUp}');
-    await userEvent.keyboard('{Enter}');
-
-    expect(result!.selectedLicense).toBe(licenseName);
-  });
-
-  it('filters by license name via mouse click', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const packageInfo = faker.opossum.packageInfo();
-    mockFilterProperties({ total: 0, licenses: [packageInfo.licenseName!] });
-    const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[]}
-      />,
-    );
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'filter button' }),
-    );
-    await userEvent.click(screen.getByLabelText('license names'));
-    await userEvent.click(screen.getByText(packageInfo.licenseName!));
-
-    expect(result!.selectedLicense).toBe(packageInfo.licenseName);
-  });
-
-  it('removes filter by license name', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const packageInfo = faker.opossum.packageInfo();
-    const useFilteredData: UseAttributionFilters = () => [
-      {
-        ...initialFilters,
-        selectedLicense: packageInfo.licenseName!,
-      },
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[]}
-      />,
-    );
+  it('clears filters when active', async () => {
+    const onClear = vi.fn();
+    await renderFilterButton({ isActive: true, onClear });
 
     await userEvent.click(
       screen.getByRole('button', { name: 'filter button' }),
@@ -212,60 +52,42 @@ describe('FilterButton', () => {
       screen.getByRole('menuitem', { name: text.packageLists.clearFilters }),
     );
 
-    expect(result!.selectedLicense).toBe('');
+    expect(onClear).toHaveBeenCalledOnce();
   });
 
-  it('removes all selected filters via clear menu entry', async () => {
-    let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
-    const setFilteredData = vi.fn((fn) => {
-      result = fn(prev);
-    });
-    const packageInfo = faker.opossum.packageInfo();
-    const filter: Filter = 'Currently Preferred';
-    const useFilteredData: UseAttributionFilters = () => [
-      {
-        ...initialFilters,
-        filters: [filter],
-        selectedLicense: packageInfo.licenseName!,
-      },
-      setFilteredData,
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[filter]}
-      />,
-    );
+  it('does not show a clear action without a callback', async () => {
+    await renderFilterButton({ isActive: true });
 
     await userEvent.click(
       screen.getByRole('button', { name: 'filter button' }),
-    );
-    await userEvent.click(
-      screen.getByRole('menuitem', { name: text.packageLists.clearFilters }),
-    );
-
-    expect(result!.filters).toEqual([]);
-    expect(result!.selectedLicense).toBe('');
-  });
-
-  it('filter button is disabled when there are no attributions', async () => {
-    const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
-      vi.fn(),
-    ];
-    await renderComponent(
-      <FilterButton
-        mode={'manual'}
-        useFilteredData={useFilteredData}
-        availableFilters={[]}
-        emptyAttributions
-      />,
     );
 
     expect(
-      screen.getByRole('button', { name: 'filter button' }),
-    ).toBeDisabled();
+      screen.queryByRole('menuitem', { name: text.packageLists.clearFilters }),
+    ).not.toBeInTheDocument();
   });
 });
+
+async function renderFilterButton({
+  selected = false,
+  isActive = false,
+  onAdd = vi.fn(),
+  onDelete = vi.fn(),
+  onClear,
+}: {
+  selected?: boolean;
+  isActive?: boolean;
+  onAdd?: () => void;
+  onDelete?: () => void;
+  onClear?: () => void;
+}) {
+  return renderComponent(
+    <FilterButton
+      options={[
+        { id: 'test-filter', label: 'test filter', selected, onAdd, onDelete },
+      ]}
+      isActive={isActive}
+      onClear={onClear}
+    />,
+  );
+}

--- a/src/Frontend/Components/FilterButton/use-attribution-filter-options.tsx
+++ b/src/Frontend/Components/FilterButton/use-attribution-filter-options.tsx
@@ -32,7 +32,7 @@ export function useAttributionFilterOptions({
 
         return {
           id: key,
-          selected: filters.filterKeys.includes(key),
+          selected: filters.filters.includes(key),
           faded: !count,
           label:
             typeof count === 'number'
@@ -42,12 +42,12 @@ export function useAttributionFilterOptions({
           onAdd: () =>
             setFilters((prev) => ({
               ...prev,
-              filterKeys: [...prev.filterKeys, key],
+              filters: [...prev.filters, key],
             })),
           onDelete: () =>
             setFilters((prev) => ({
               ...prev,
-              filterKeys: prev.filterKeys.filter(
+              filters: prev.filters.filter(
                 (activeFilter) => activeFilter !== key,
               ),
             })),

--- a/src/Frontend/Components/FilterButton/use-attribution-filter-options.tsx
+++ b/src/Frontend/Components/FilterButton/use-attribution-filter-options.tsx
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo, useRef } from 'react';
+
+import type { FilterProperties } from '../../../ElectronBackend/api/queries';
+import type {
+  AttributionFilters,
+  SetAttributionFilters,
+} from '../../state/variables/use-filters';
+import type { AttributionFilterOption } from '../AttributionPanels/attribution-filter-options';
+import type { SelectMenuOption } from '../SelectMenu/SelectMenu';
+import { LicenseAutocomplete } from './LicenseAutocomplete/LicenseAutocomplete';
+
+export function useAttributionFilterOptions({
+  filterOptions,
+  filterProps,
+  filters,
+  setFilters,
+}: {
+  filterOptions: Array<AttributionFilterOption>;
+  filterProps: FilterProperties | null;
+  filters: AttributionFilters;
+  setFilters: SetAttributionFilters;
+}): Array<SelectMenuOption> {
+  const licenseInputRef = useRef<HTMLInputElement>(null);
+  return useMemo(
+    () => [
+      ...filterOptions.map(({ key, label, icon }) => {
+        const count = filterProps?.[key];
+
+        return {
+          id: key,
+          selected: filters.filterKeys.includes(key),
+          faded: !count,
+          label:
+            typeof count === 'number'
+              ? `${label} (${new Intl.NumberFormat().format(count)})`
+              : label,
+          icon,
+          onAdd: () =>
+            setFilters((prev) => ({
+              ...prev,
+              filterKeys: [...prev.filterKeys, key],
+            })),
+          onDelete: () =>
+            setFilters((prev) => ({
+              ...prev,
+              filterKeys: prev.filterKeys.filter(
+                (activeFilter) => activeFilter !== key,
+              ),
+            })),
+        };
+      }),
+      {
+        id: 'license',
+        selected: false,
+        focusContent: () => licenseInputRef.current?.focus(),
+        label: (
+          <LicenseAutocomplete
+            inputRef={licenseInputRef}
+            licenses={filterProps?.licenses ?? []}
+            selectedLicense={filters.selectedLicense}
+            setSelectedLicense={(license) =>
+              setFilters((prev) => ({
+                ...prev,
+                selectedLicense: license || '',
+              }))
+            }
+          />
+        ),
+      },
+    ],
+    [filterOptions, filterProps, filters, setFilters],
+  );
+}

--- a/src/Frontend/Components/Icons/Icons.tsx
+++ b/src/Frontend/Components/Icons/Icons.tsx
@@ -174,6 +174,31 @@ export function NeedsReviewIcon({
   );
 }
 
+export function UnreviewedIcon({
+  className,
+  noTooltip,
+  sx,
+  tooltipPlacement,
+}: IconProps) {
+  return (
+    <MuiTooltip
+      title={noTooltip ? undefined : text.filters.unreviewed}
+      placement={tooltipPlacement}
+      disableInteractive
+    >
+      <QuestionMarkIcon
+        aria-label={'Unreviewed icon'}
+        sx={{
+          ...baseIcon,
+          color: `${OpossumColors.orange} !important`,
+          ...sx,
+        }}
+        className={className}
+      />
+    </MuiTooltip>
+  );
+}
+
 export function CriticalityIcon({
   className,
   criticality,

--- a/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
+++ b/src/Frontend/Components/ProjectStatisticsPopup/ProjectStatisticsPopup.tsx
@@ -16,7 +16,7 @@ import { criticalityColor, OpossumColors } from '../../shared-styles';
 import { closePopup } from '../../state/actions/view-actions/view-actions';
 import { useAppDispatch } from '../../state/hooks';
 import {
-  initialFilters,
+  initialAttributionFilters,
   useExternalAttributionFilters,
 } from '../../state/variables/use-filters';
 import { useUserSettings } from '../../state/variables/use-user-setting';
@@ -67,7 +67,7 @@ export const ProjectStatisticsPopup: React.FC = () => {
 
   function handleLicenseClick(licenseName: string): void {
     setFilteredAttributions(() => ({
-      ...initialFilters,
+      ...initialAttributionFilters,
       selectedLicense: licenseName,
     }));
     close();

--- a/src/Frontend/Components/ReportView/TableFilterButton.tsx
+++ b/src/Frontend/Components/ReportView/TableFilterButton.tsx
@@ -2,23 +2,44 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ATTRIBUTION_FILTERS } from '../../shared-constants';
 import { useAttributionFiltersInReportView } from '../../state/variables/use-filters';
 import { useFilteredReportsAttributionsList } from '../../util/use-attribution-lists';
+import { useFilterProperties } from '../../util/use-filter-properties';
+import { attributionFilterOptions } from '../AttributionPanels/attribution-filter-options';
 import { FilterButton } from '../FilterButton/FilterButton';
+import { useAttributionFilterOptions } from '../FilterButton/use-attribution-filter-options';
 
 export const TableFilterButton: React.FC = () => {
   const { attributions, loading } = useFilteredReportsAttributionsList();
+  const { filterProps } = useFilterProperties({ mode: 'reportTable' });
+  const [filters, setFilteredAttributions] =
+    useAttributionFiltersInReportView();
+  const { filterKeys, selectedLicense } = filters;
+  const filterOptions = useAttributionFilterOptions({
+    filterOptions: attributionFilterOptions,
+    filterProps,
+    filters,
+    setFilters: setFilteredAttributions,
+  });
+  const isFilterActive = !!filterKeys.length || !!selectedLicense;
 
   return (
     <FilterButton
-      mode="reportTable"
-      availableFilters={ATTRIBUTION_FILTERS}
+      options={filterOptions}
+      isActive={isFilterActive}
+      onClear={() =>
+        setFilteredAttributions((prev) => ({
+          ...prev,
+          filterKeys: [],
+          selectedLicense: '',
+        }))
+      }
       anchorPosition={'left'}
-      useFilteredData={useAttributionFiltersInReportView}
-      disabled={loading}
-      emptyAttributions={
-        !!attributions && Object.keys(attributions).length === 0
+      disabled={
+        loading ||
+        (!!attributions &&
+          Object.keys(attributions).length === 0 &&
+          !isFilterActive)
       }
     />
   );

--- a/src/Frontend/Components/ReportView/TableFilterButton.tsx
+++ b/src/Frontend/Components/ReportView/TableFilterButton.tsx
@@ -14,14 +14,14 @@ export const TableFilterButton: React.FC = () => {
   const { filterProps } = useFilterProperties({ mode: 'reportTable' });
   const [filters, setFilteredAttributions] =
     useAttributionFiltersInReportView();
-  const { filterKeys, selectedLicense } = filters;
+  const { filters: attributionFilters, selectedLicense } = filters;
   const filterOptions = useAttributionFilterOptions({
     filterOptions: attributionFilterOptions,
     filterProps,
     filters,
     setFilters: setFilteredAttributions,
   });
-  const isFilterActive = !!filterKeys.length || !!selectedLicense;
+  const isFilterActive = !!attributionFilters.length || !!selectedLicense;
 
   return (
     <FilterButton
@@ -30,7 +30,7 @@ export const TableFilterButton: React.FC = () => {
       onClear={() =>
         setFilteredAttributions((prev) => ({
           ...prev,
-          filterKeys: [],
+          filters: [],
           selectedLicense: '',
         }))
       }

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -18,9 +18,10 @@ import { usePanelSizes } from '../../state/variables/use-panel-sizes';
 import { useVariable } from '../../state/variables/use-variable';
 import { backend } from '../../util/backendClient';
 import { useDebouncedInput } from '../../util/use-debounced-input';
-import { useFilterProperties } from '../../util/use-filter-properties';
+import { useResourceTreeFilterProperties } from '../../util/use-filter-properties';
 import { FilterButton } from '../FilterButton/FilterButton';
 import { LicenseAutocomplete } from '../FilterButton/LicenseAutocomplete/LicenseAutocomplete';
+import { UnreviewedIcon } from '../Icons/Icons';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
 import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
@@ -53,41 +54,33 @@ export function ResourceBrowser() {
 
   // All resources
   const [
-    { selectedLicense: resourceTreeSelectedLicense },
+    { onlyUnreviewedFiles, selectedLicense: resourceTreeSelectedLicense },
     setResourceTreeFilters,
   ] = useResourceTreeFilters();
   const [searchAll, setSearchAll] = useVariable(ALL_RESOURCES_SEARCH, '');
   const debouncedSearchAll = useDebouncedInput(searchAll);
   const expandedIdsAll = useAppSelector(getExpandedIds);
-  const resourceTreeAttributionsWithSelectedLicense =
-    backend.listAttributions.useQuery(
-      {
-        external: false,
-        license: resourceTreeSelectedLicense,
-      },
-      { enabled: !!resourceTreeSelectedLicense },
-    );
-  const resourceTreeAttributionUuids = useMemo(
-    () =>
-      resourceTreeSelectedLicense
-        ? Object.keys(resourceTreeAttributionsWithSelectedLicense.data ?? {})
-        : undefined,
-    [
-      resourceTreeSelectedLicense,
-      resourceTreeAttributionsWithSelectedLicense.data,
-    ],
-  );
   const resourceTreeAll = backend.getResourceTree.useQuery(
     {
       expandedNodes: expandedIdsAll,
-      onAttributionUuids: resourceTreeAttributionUuids,
+      license: resourceTreeSelectedLicense,
+      onlyUnreviewedFiles,
       search: debouncedSearchAll,
       selectedResourcePath: selectedResourceId,
     },
     { placeholderData: keepPreviousData },
   );
-  const { filterProps } = useFilterProperties({ mode: 'resourceTree' });
-  const isResourceTreeFilterActive = !!resourceTreeSelectedLicense;
+  const unreviewedFileCountQuery =
+    backend.getResourceTreeUnreviewedCount.useQuery(
+      {
+        license: resourceTreeSelectedLicense,
+        search: debouncedSearchAll,
+      },
+      { placeholderData: keepPreviousData },
+    );
+  const { filterProps } = useResourceTreeFilterProperties({});
+  const isResourceTreeFilterActive =
+    onlyUnreviewedFiles || !!resourceTreeSelectedLicense;
   // Linked resources
   const [searchLinked, setSearchLinked] = useVariable(
     LINKED_RESOURCES_SEARCH,
@@ -126,6 +119,26 @@ export function ResourceBrowser() {
           <FilterButton
             options={[
               {
+                id: 'unreviewed',
+                selected: onlyUnreviewedFiles,
+                faded: !unreviewedFileCountQuery.data,
+                label:
+                  unreviewedFileCountQuery.data === undefined
+                    ? text.filters.unreviewed
+                    : `${text.filters.unreviewed} (${new Intl.NumberFormat().format(unreviewedFileCountQuery.data)})`,
+                icon: <UnreviewedIcon noTooltip />,
+                onAdd: () =>
+                  setResourceTreeFilters((prev) => ({
+                    ...prev,
+                    onlyUnreviewedFiles: true,
+                  })),
+                onDelete: () =>
+                  setResourceTreeFilters((prev) => ({
+                    ...prev,
+                    onlyUnreviewedFiles: false,
+                  })),
+              },
+              {
                 id: 'license',
                 selected: false,
                 focusContent: () => licenseInputRef.current?.focus(),
@@ -148,6 +161,7 @@ export function ResourceBrowser() {
             onClear={() =>
               setResourceTreeFilters((prev) => ({
                 ...prev,
+                onlyUnreviewedFiles: false,
                 selectedLicense: '',
               }))
             }

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { keepPreviousData } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { text } from '../../../shared/text';
@@ -18,7 +18,9 @@ import { usePanelSizes } from '../../state/variables/use-panel-sizes';
 import { useVariable } from '../../state/variables/use-variable';
 import { backend } from '../../util/backendClient';
 import { useDebouncedInput } from '../../util/use-debounced-input';
+import { useFilterProperties } from '../../util/use-filter-properties';
 import { FilterButton } from '../FilterButton/FilterButton';
+import { LicenseAutocomplete } from '../FilterButton/LicenseAutocomplete/LicenseAutocomplete';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
 import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
@@ -30,6 +32,7 @@ const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
 
 export function ResourceBrowser() {
   const { panelSizes, setPanelSizes } = usePanelSizes();
+  const licenseInputRef = useRef<HTMLInputElement>(null);
 
   const setWidth = useCallback(
     (width: number) => setPanelSizes({ resourceBrowserWidth: width }),
@@ -49,8 +52,10 @@ export function ResourceBrowser() {
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
   // All resources
-  const [resourceTreeFilters] = useResourceTreeFilters();
-  const { selectedLicense: resourceTreeSelectedLicense } = resourceTreeFilters;
+  const [
+    { selectedLicense: resourceTreeSelectedLicense },
+    setResourceTreeFilters,
+  ] = useResourceTreeFilters();
   const [searchAll, setSearchAll] = useVariable(ALL_RESOURCES_SEARCH, '');
   const debouncedSearchAll = useDebouncedInput(searchAll);
   const expandedIdsAll = useAppSelector(getExpandedIds);
@@ -81,7 +86,8 @@ export function ResourceBrowser() {
     },
     { placeholderData: keepPreviousData },
   );
-
+  const { filterProps } = useFilterProperties({ mode: 'resourceTree' });
+  const isResourceTreeFilterActive = !!resourceTreeSelectedLicense;
   // Linked resources
   const [searchLinked, setSearchLinked] = useVariable(
     LINKED_RESOURCES_SEARCH,
@@ -118,9 +124,33 @@ export function ResourceBrowser() {
         },
         headerActions: (
           <FilterButton
-            mode={'resourceTree'}
-            useFilteredData={useResourceTreeFilters}
-            availableFilters={[]}
+            options={[
+              {
+                id: 'license',
+                selected: false,
+                focusContent: () => licenseInputRef.current?.focus(),
+                label: (
+                  <LicenseAutocomplete
+                    inputRef={licenseInputRef}
+                    licenses={filterProps?.licenses ?? []}
+                    selectedLicense={resourceTreeSelectedLicense}
+                    setSelectedLicense={(license) =>
+                      setResourceTreeFilters((prev) => ({
+                        ...prev,
+                        selectedLicense: license || '',
+                      }))
+                    }
+                  />
+                ),
+              },
+            ]}
+            isActive={isResourceTreeFilterActive}
+            onClear={() =>
+              setResourceTreeFilters((prev) => ({
+                ...prev,
+                selectedLicense: '',
+              }))
+            }
             anchorPosition={'right'}
             badgeColor={'secondary'}
             triggerStyle={resourceBrowserFilterButtonStyle}

--- a/src/Frontend/Components/SelectMenu/SelectMenu.tsx
+++ b/src/Frontend/Components/SelectMenu/SelectMenu.tsx
@@ -27,6 +27,7 @@ export interface SelectMenuProps {
 export interface SelectMenuOption {
   faded?: boolean;
   icon?: React.ReactElement<unknown>;
+  focusContent?(): void;
   id: string;
   label: React.ReactNode;
   onAdd?(): void;
@@ -71,7 +72,10 @@ export const SelectMenu: React.FC<SelectMenuProps> = ({
 
   function renderVisibleOptions() {
     return visibleOptions.map(
-      ({ faded, label, icon, id, selected, onAdd, onDelete }, index) => {
+      (
+        { faded, label, icon, id, selected, onAdd, onDelete, focusContent },
+        index,
+      ) => {
         const isLabelString = typeof label === 'string';
         const toggleSelected = () => {
           if (multiple) {
@@ -92,7 +96,7 @@ export const SelectMenu: React.FC<SelectMenuProps> = ({
           <StyledMenuItem
             key={index}
             aria-selected={selected}
-            onClick={isLabelString ? toggleSelected : undefined}
+            onClick={isLabelString ? toggleSelected : focusContent}
             divider={index + 1 !== visibleOptions.length}
             disableRipple
             faded={faded}

--- a/src/Frontend/Components/SortButton/__tests__/SortButton.test.tsx
+++ b/src/Frontend/Components/SortButton/__tests__/SortButton.test.tsx
@@ -9,7 +9,7 @@ import userEvent from '@testing-library/user-event';
 import { text } from '../../../../shared/text';
 import {
   type AttributionFilters,
-  initialFilters,
+  initialAttributionFilters,
   type UseAttributionFilters,
 } from '../../../state/variables/use-filters';
 import { renderComponent } from '../../../test-helpers/render';
@@ -19,13 +19,13 @@ import type { SortOption } from '../useSortingOptions';
 describe('SortButton', () => {
   it('switches to selected sorting', async () => {
     let result: AttributionFilters;
-    const prev: AttributionFilters = initialFilters;
+    const prev: AttributionFilters = initialAttributionFilters;
     const setFilteredData = vi.fn((fn) => {
       result = fn(prev);
     });
     const sorting: SortOption = 'criticality';
     const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
+      initialAttributionFilters,
       setFilteredData,
     ];
     await renderComponent(<SortButton useFilteredData={useFilteredData} />);
@@ -40,7 +40,7 @@ describe('SortButton', () => {
 
   it('sort button is disabled when there are no attributions', async () => {
     const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
+      initialAttributionFilters,
       vi.fn(),
     ];
     await renderComponent(
@@ -52,7 +52,7 @@ describe('SortButton', () => {
 
   it('shows all sort options', async () => {
     const useFilteredData: UseAttributionFilters = () => [
-      initialFilters,
+      initialAttributionFilters,
       vi.fn(),
     ];
     await renderComponent(<SortButton useFilteredData={useFilteredData} />);

--- a/src/Frontend/shared-constants.ts
+++ b/src/Frontend/shared-constants.ts
@@ -9,7 +9,6 @@ import {
   type ProjectMetadata,
   type RawProjectConfig,
 } from '../shared/shared-types';
-import { text } from '../shared/text';
 
 export const ROOT_PATH = '/';
 
@@ -30,33 +29,5 @@ export const EMPTY_DISPLAY_PACKAGE_INFO: PackageInfo = {
   id: '',
   criticality: Criticality.None,
 };
-
-export const FILTERS = Object.values(text.filters);
-export type Filter = (typeof FILTERS)[number];
-export type FilterCounts = Partial<Record<Filter, number>>;
-
-export const SIGNAL_FILTERS = [
-  text.filters.firstParty,
-  text.filters.thirdParty,
-  text.filters.highConfidence,
-  text.filters.notExcludedFromNotice,
-  text.filters.notPreSelected,
-  text.filters.previouslyPreferred,
-] satisfies Array<Filter>;
-
-export const ATTRIBUTION_FILTERS = [
-  text.filters.firstParty,
-  text.filters.thirdParty,
-  text.filters.incompleteLegal,
-  text.filters.incompleteCoordinates,
-  text.filters.excludedFromNotice,
-  text.filters.lowConfidence,
-  text.filters.needsFollowUp,
-  text.filters.needsReview,
-  text.filters.preSelected,
-  text.filters.currentlyPreferred,
-  text.filters.previouslyPreferred,
-  text.filters.modifiedPreferred,
-] satisfies Array<Filter>;
 
 export const legacyOutputFileEnding = '_attributions.json';

--- a/src/Frontend/state/variables/use-filters.ts
+++ b/src/Frontend/state/variables/use-filters.ts
@@ -14,7 +14,7 @@ export const EXTERNAL_ATTRIBUTION_FILTERS = 'external-attribution-filters';
 export const RESOURCE_TREE_FILTERS = 'resource-tree-filters';
 
 export interface AttributionFilters {
-  filterKeys: Array<AttributionFilterKey>;
+  filters: Array<AttributionFilterKey>;
   search: string;
   selectedLicense: string;
   sorting: SortOption;
@@ -25,8 +25,8 @@ export interface ResourceTreeFilters {
   selectedLicense: string;
 }
 
-export const initialFilters: AttributionFilters = {
-  filterKeys: [],
+export const initialAttributionFilters: AttributionFilters = {
+  filters: [],
   search: '',
   selectedLicense: '',
   sorting: 'alphabetically',
@@ -49,21 +49,21 @@ export type SetAttributionFilters = (
 export function useManualAttributionFilters() {
   return useVariable<AttributionFilters>(
     MANUAL_ATTRIBUTION_FILTERS_AUDIT,
-    structuredClone(initialFilters),
+    structuredClone(initialAttributionFilters),
   );
 }
 
 export function useAttributionFiltersInReportView() {
   return useVariable<AttributionFilters>(
     MANUAL_ATTRIBUTION_FILTERS_REPORT,
-    structuredClone(initialFilters),
+    structuredClone(initialAttributionFilters),
   );
 }
 
 export function useExternalAttributionFilters() {
   return useVariable<AttributionFilters>(
     EXTERNAL_ATTRIBUTION_FILTERS,
-    structuredClone(initialFilters),
+    structuredClone(initialAttributionFilters),
   );
 }
 

--- a/src/Frontend/state/variables/use-filters.ts
+++ b/src/Frontend/state/variables/use-filters.ts
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import type { AttributionFilterKey } from '../../../shared/shared-constants';
 import type { SortOption } from '../../Components/SortButton/useSortingOptions';
-import type { Filter } from '../../shared-constants';
 import { useVariable } from './use-variable';
 
 export const MANUAL_ATTRIBUTION_FILTERS_AUDIT =
@@ -14,20 +14,27 @@ export const EXTERNAL_ATTRIBUTION_FILTERS = 'external-attribution-filters';
 export const RESOURCE_TREE_FILTERS = 'resource-tree-filters';
 
 export interface AttributionFilters {
-  filters: Array<Filter>;
+  filterKeys: Array<AttributionFilterKey>;
   search: string;
   selectedLicense: string;
   sorting: SortOption;
 }
 
 export const initialFilters: AttributionFilters = {
-  filters: [],
+  filterKeys: [],
   search: '',
   selectedLicense: '',
   sorting: 'alphabetically',
 };
 
 export type UseAttributionFilters = typeof useManualAttributionFilters;
+export type SetAttributionFilters = (
+  newValue:
+    | AttributionFilters
+    | ((
+        prev: AttributionFilters,
+      ) => AttributionFilters | Promise<AttributionFilters>),
+) => void;
 
 export function useManualAttributionFilters() {
   return useVariable<AttributionFilters>(

--- a/src/Frontend/state/variables/use-filters.ts
+++ b/src/Frontend/state/variables/use-filters.ts
@@ -20,11 +20,21 @@ export interface AttributionFilters {
   sorting: SortOption;
 }
 
+export interface ResourceTreeFilters {
+  onlyUnreviewedFiles: boolean;
+  selectedLicense: string;
+}
+
 export const initialFilters: AttributionFilters = {
   filterKeys: [],
   search: '',
   selectedLicense: '',
   sorting: 'alphabetically',
+};
+
+const initialResourceTreeFilters: ResourceTreeFilters = {
+  onlyUnreviewedFiles: false,
+  selectedLicense: '',
 };
 
 export type UseAttributionFilters = typeof useManualAttributionFilters;
@@ -58,8 +68,8 @@ export function useExternalAttributionFilters() {
 }
 
 export function useResourceTreeFilters() {
-  return useVariable<AttributionFilters>(
+  return useVariable<ResourceTreeFilters>(
     RESOURCE_TREE_FILTERS,
-    structuredClone(initialFilters),
+    structuredClone(initialResourceTreeFilters),
   );
 }

--- a/src/Frontend/util/use-attribution-lists.ts
+++ b/src/Frontend/util/use-attribution-lists.ts
@@ -25,7 +25,7 @@ export function useFilteredAttributionsList({
     ? useExternalAttributionFilters
     : useManualAttributionFilters;
 
-  const [{ filterKeys, search, selectedLicense, sorting }] = useFilters();
+  const [{ filters, search, selectedLicense, sorting }] = useFilters();
 
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
@@ -34,7 +34,7 @@ export function useFilteredAttributionsList({
 
   const attributionQuery = backend.listAttributions.useQuery({
     external,
-    filters: filterKeys,
+    filters,
     search,
     sort: sorting,
     license: selectedLicense,
@@ -63,11 +63,11 @@ export function useIsSelectedAttributionVisible() {
 }
 
 export function useFilteredReportsAttributionsList() {
-  const [{ filterKeys, selectedLicense }] = useAttributionFiltersInReportView();
+  const [{ filters, selectedLicense }] = useAttributionFiltersInReportView();
 
   const attributionQuery = backend.listAttributions.useQuery({
     external: false,
-    filters: filterKeys,
+    filters,
     resourcePathForRelationships: ROOT_PATH,
     license: selectedLicense,
   });

--- a/src/Frontend/util/use-attribution-lists.ts
+++ b/src/Frontend/util/use-attribution-lists.ts
@@ -25,7 +25,7 @@ export function useFilteredAttributionsList({
     ? useExternalAttributionFilters
     : useManualAttributionFilters;
 
-  const [{ filters, search, selectedLicense, sorting }] = useFilters();
+  const [{ filterKeys, search, selectedLicense, sorting }] = useFilters();
 
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
@@ -34,7 +34,7 @@ export function useFilteredAttributionsList({
 
   const attributionQuery = backend.listAttributions.useQuery({
     external,
-    filters,
+    filters: filterKeys,
     search,
     sort: sorting,
     license: selectedLicense,
@@ -63,11 +63,11 @@ export function useIsSelectedAttributionVisible() {
 }
 
 export function useFilteredReportsAttributionsList() {
-  const [{ filters, selectedLicense }] = useAttributionFiltersInReportView();
+  const [{ filterKeys, selectedLicense }] = useAttributionFiltersInReportView();
 
   const attributionQuery = backend.listAttributions.useQuery({
     external: false,
-    filters,
+    filters: filterKeys,
     resourcePathForRelationships: ROOT_PATH,
     license: selectedLicense,
   });

--- a/src/Frontend/util/use-filter-properties.ts
+++ b/src/Frontend/util/use-filter-properties.ts
@@ -30,7 +30,7 @@ export function useFilterProperties({
     reportTable: useAttributionFiltersInReportView,
   }[mode];
 
-  const [{ filterKeys, search, selectedLicense }] = useFilters();
+  const [{ filters, search, selectedLicense }] = useFilters();
 
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
@@ -40,7 +40,7 @@ export function useFilterProperties({
   const filterPropsQuery = backend.filterProperties.useQuery(
     {
       external: mode === 'external',
-      filters: filterKeys,
+      filters,
       search: mode === 'reportTable' ? undefined : search,
       license: mode === 'reportTable' ? undefined : selectedLicense,
       resourcePathForRelationships:

--- a/src/Frontend/util/use-filter-properties.ts
+++ b/src/Frontend/util/use-filter-properties.ts
@@ -11,13 +11,11 @@ import {
   useAttributionFiltersInReportView,
   useExternalAttributionFilters,
   useManualAttributionFilters,
-  useResourceTreeFilters,
 } from '../state/variables/use-filters';
 import { useUserSettings } from '../state/variables/use-user-setting';
 import { backend } from './backendClient';
 
-export type FilterPropsMode =
-  'external' | 'manual' | 'reportTable' | 'resourceTree';
+export type FilterPropsMode = 'external' | 'manual' | 'reportTable';
 
 export function useFilterProperties({
   mode,
@@ -30,7 +28,6 @@ export function useFilterProperties({
     manual: useManualAttributionFilters,
     external: useExternalAttributionFilters,
     reportTable: useAttributionFiltersInReportView,
-    resourceTree: useResourceTreeFilters,
   }[mode];
 
   const [{ filterKeys, search, selectedLicense }] = useFilters();
@@ -44,16 +41,10 @@ export function useFilterProperties({
     {
       external: mode === 'external',
       filters: filterKeys,
-      search:
-        mode === 'reportTable' || mode === 'resourceTree' ? undefined : search,
-      license:
-        mode === 'reportTable' || mode === 'resourceTree'
-          ? undefined
-          : selectedLicense,
+      search: mode === 'reportTable' ? undefined : search,
+      license: mode === 'reportTable' ? undefined : selectedLicense,
       resourcePathForRelationships:
-        mode === 'reportTable' || mode === 'resourceTree'
-          ? ROOT_PATH
-          : selectedResourceId,
+        mode === 'reportTable' ? ROOT_PATH : selectedResourceId,
       showResolved: mode === 'external' ? areHiddenSignalsVisible : undefined,
     },
     { enabled, placeholderData: keepPreviousData },
@@ -64,7 +55,6 @@ export function useFilterProperties({
       manual: 'all',
       external: 'sameOrDescendant',
       reportTable: 'descendant',
-      resourceTree: 'all',
     } as const
   )[mode];
 
@@ -72,4 +62,24 @@ export function useFilterProperties({
   const loading = filterPropsQuery.isLoading;
 
   return { filterProps, loading };
+}
+
+export function useResourceTreeFilterProperties({
+  enabled,
+}: {
+  enabled?: boolean;
+}) {
+  const filterPropsQuery = backend.filterProperties.useQuery(
+    {
+      external: false,
+      filters: [],
+      resourcePathForRelationships: ROOT_PATH,
+    },
+    { enabled, placeholderData: keepPreviousData },
+  );
+
+  return {
+    filterProps: filterPropsQuery.data?.all ?? null,
+    loading: filterPropsQuery.isLoading,
+  };
 }

--- a/src/Frontend/util/use-filter-properties.ts
+++ b/src/Frontend/util/use-filter-properties.ts
@@ -33,7 +33,7 @@ export function useFilterProperties({
     resourceTree: useResourceTreeFilters,
   }[mode];
 
-  const [{ filters, search, selectedLicense }] = useFilters();
+  const [{ filterKeys, search, selectedLicense }] = useFilters();
 
   const selectedResourceId = useAppSelector(getSelectedResourceId);
 
@@ -43,7 +43,7 @@ export function useFilterProperties({
   const filterPropsQuery = backend.filterProperties.useQuery(
     {
       external: mode === 'external',
-      filters,
+      filters: filterKeys,
       search:
         mode === 'reportTable' || mode === 'resourceTree' ? undefined : search,
       license:

--- a/src/e2e-tests/__tests__/filtering-resources.test.ts
+++ b/src/e2e-tests/__tests__/filtering-resources.test.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { faker, test } from '../utils';
+
+const [
+  externalResourceName,
+  preselectedResourceName,
+  reviewedMitResourceName,
+  reviewedApacheResourceName,
+] = faker.opossum.resourceNames({ count: 4 });
+const [externalAttributionId, externalPackageInfo] =
+  faker.opossum.rawAttribution();
+const [preselectedAttributionId, preselectedPackageInfo] =
+  faker.opossum.rawAttribution({ licenseName: 'MIT', preSelected: true });
+const [reviewedMitAttributionId, reviewedMitPackageInfo] =
+  faker.opossum.rawAttribution({ licenseName: 'MIT' });
+const [reviewedApacheAttributionId, reviewedApachePackageInfo] =
+  faker.opossum.rawAttribution({ licenseName: 'Apache-2.0' });
+
+test.use({
+  data: {
+    inputData: faker.opossum.inputData({
+      resources: faker.opossum.resources({
+        [externalResourceName]: 1,
+        [preselectedResourceName]: 1,
+        [reviewedMitResourceName]: 1,
+        [reviewedApacheResourceName]: 1,
+      }),
+      externalAttributions: faker.opossum.rawAttributions({
+        [externalAttributionId]: externalPackageInfo,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(externalResourceName)]: [externalAttributionId],
+      }),
+    }),
+    outputData: faker.opossum.outputData({
+      manualAttributions: faker.opossum.rawAttributions({
+        [preselectedAttributionId]: preselectedPackageInfo,
+        [reviewedMitAttributionId]: reviewedMitPackageInfo,
+        [reviewedApacheAttributionId]: reviewedApachePackageInfo,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(preselectedResourceName)]: [
+          preselectedAttributionId,
+        ],
+        [faker.opossum.filePath(reviewedMitResourceName)]: [
+          reviewedMitAttributionId,
+        ],
+        [faker.opossum.filePath(reviewedApacheResourceName)]: [
+          reviewedApacheAttributionId,
+        ],
+      }),
+    }),
+  },
+});
+
+test('filters the resource tree to unreviewed files', async ({
+  resourcesTree,
+}) => {
+  await resourcesTree.filterButton.click();
+  await resourcesTree.filters.unreviewed.click();
+  await resourcesTree.closeMenu();
+
+  await resourcesTree.assert.resourceIsVisible(externalResourceName);
+  await resourcesTree.assert.resourceIsVisible(preselectedResourceName);
+  await resourcesTree.assert.resourceIsHidden(reviewedMitResourceName);
+  await resourcesTree.assert.resourceIsHidden(reviewedApacheResourceName);
+});
+
+test('combines unreviewed and license filters in the resource tree', async ({
+  resourcesTree,
+}) => {
+  await resourcesTree.filterButton.click();
+  await resourcesTree.filters.unreviewed.click();
+  await resourcesTree.closeMenu();
+  await resourcesTree.filterButton.click();
+  await resourcesTree.selectLicenseName(preselectedPackageInfo.licenseName!);
+  await resourcesTree.closeMenu();
+  await resourcesTree.closeMenu();
+
+  await resourcesTree.assert.resourceIsHidden(externalResourceName);
+  await resourcesTree.assert.resourceIsVisible(preselectedResourceName);
+  await resourcesTree.assert.resourceIsHidden(reviewedMitResourceName);
+  await resourcesTree.assert.resourceIsHidden(reviewedApacheResourceName);
+});

--- a/src/e2e-tests/page-objects/ResourcesTree.ts
+++ b/src/e2e-tests/page-objects/ResourcesTree.ts
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import { text } from '../../shared/text';
+
 export class ResourcesTree {
   private readonly window: Page;
   private readonly node: Locator;
@@ -11,6 +13,7 @@ export class ResourcesTree {
   readonly filterButton: Locator;
   readonly filters: {
     readonly license: Locator;
+    readonly unreviewed: Locator;
   };
   readonly searchField: Locator;
   readonly clearSearchButton: Locator;
@@ -24,6 +27,9 @@ export class ResourcesTree {
     });
     this.filters = {
       license: window.getByLabel('license names'),
+      unreviewed: window.getByRole('menuitem', {
+        name: text.filters.unreviewed,
+      }),
     };
     this.searchField = this.header.getByRole('searchbox');
     this.clearSearchButton = this.header.getByLabel('clear search');

--- a/src/shared/shared-constants.ts
+++ b/src/shared/shared-constants.ts
@@ -4,6 +4,26 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { UserSettings } from './shared-types';
 
+export const ATTRIBUTION_FILTER_KEYS = [
+  'currentlyPreferred',
+  'excludedFromNotice',
+  'firstParty',
+  'highConfidence',
+  'incompleteCoordinates',
+  'incompleteLegal',
+  'lowConfidence',
+  'modifiedPreferred',
+  'needsFollowUp',
+  'needsReview',
+  'notExcludedFromNotice',
+  'notPreSelected',
+  'preSelected',
+  'previouslyPreferred',
+  'thirdParty',
+] as const;
+
+export type AttributionFilterKey = (typeof ATTRIBUTION_FILTER_KEYS)[number];
+
 export const DEFAULT_PANEL_SIZES: NonNullable<UserSettings['panelSizes']> = {
   resourceBrowserWidth: 340,
   packageListsWidth: 360,

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -334,6 +334,7 @@ export const text = {
     preSelected: 'Pre-selected',
     previouslyPreferred: 'Previously Preferred',
     thirdParty: 'Third Party',
+    unreviewed: 'Unreviewed',
   },
   sortings: {
     criticality: 'By Criticality',


### PR DESCRIPTION
### Summary of changes
- added unreviewed filter to resource tree
- refactored `FilterButton` to decouple it from the actual filter logic

### Context and reason for change
#3179
FilterButton had to know about all possible filters that could be used in it, with the display names being used as ids in the backend. This was already unclean, but especially so now that we use it not just for filtering attributions.
