### PR TITLE
chore(knip): remove obsolete codesign ignoreBinaries entry

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -6,5 +6,5 @@
     "src/ElectronBackend/db/generated/databaseTypes.ts": ["types"]
   },
   "ignoreDependencies": ["dpdm", "better-sqlite3-electron"],
-  "ignoreBinaries": ["tools/*", "spdx", "reuse", "licenses", "codesign"]
+  "ignoreBinaries": ["tools/*", "spdx", "reuse", "licenses"]
 }


### PR DESCRIPTION
Knip emits a configuration hint:

```
codesign    knip.json  Remove from ignoreBinaries
```

This removes `codesign` from the `ignoreBinaries` list in `knip.json` as it is no longer needed there.

## Why `codesign` no longer needs to be ignored

**History of `codesign` in the repo:**

1. **Initially added** in commit `1fc05c62` (April 2025) when knip was first introduced — `codesign` was placed in `ignoreBinaries` alongside `ship-mac`, `tools/*`, `spdx`, `reuse`, and `licenses`.

2. **At that time**, `codesign` was invoked from the `ship-mac:arm64` yarn script (originally moved there from a GitHub Action in commit `64a886e1`, Feb 2025). Knip detected `codesign` as an unlisted binary in package.json scripts (because it's a system binary on macOS, not an npm package) and would flag it as an issue unless ignored.

3. **Knip v6.7.0** (commit `a60e7c19`, PR #3137) upgraded knip. Newer versions of knip added `codesign` to its built-in `IGNORED_GLOBAL_BINARIES` set (`node_modules/knip/dist/constants.js:44`), a hardcoded list of common system binaries (like `bash`, `cat`, `cp`, `curl`, `docker`, etc.) that are silently ignored by default.

**Conclusion:** Because knip now ships `codesign` in its global ignore list (`constants.js:44`), the explicit entry in `knip.json` became redundant — knip never reports `codesign` as an unused binary issue anymore, so the local override never matches anything and is flagged as a removable configuration hint. This is purely a knip tooling change, not a change to how OpossumUI uses `codesign` (it's still used in the `ship-mac:arm64` script at `package.json:146`).

Note: the `ship-mac` entry was removed earlier (commit `2137aa39`) for the same reason — knip added `ship-mac`-style binaries to its global list, or the script was removed. In our case, the `codesign` entry just lagged behind until knip v6.7.0 added it to the global set.