### PR TITLE
Use signals for license filter on resource tree

### DIFF
--- a/src/ElectronBackend/api/__tests__/resourceTree.test.ts
+++ b/src/ElectronBackend/api/__tests__/resourceTree.test.ts
@@ -506,7 +506,7 @@ describe('getResourceTree', () => {
   });
 
   describe('license filtering', () => {
-    it('only shows resources linked to matching signals once', async () => {
+    it('only shows resources linked to matching external attributions once', async () => {
       const firstMitUuid = 'first-mit-uuid';
       const secondMitUuid = 'second-mit-uuid';
       const apacheUuid = 'apache-uuid';

--- a/src/ElectronBackend/api/__tests__/resourceTree.test.ts
+++ b/src/ElectronBackend/api/__tests__/resourceTree.test.ts
@@ -506,7 +506,7 @@ describe('getResourceTree', () => {
   });
 
   describe('license filtering', () => {
-    it('only shows resources linked to matching manual attributions once', async () => {
+    it('only shows resources linked to matching signals once', async () => {
       const firstMitUuid = 'first-mit-uuid';
       const secondMitUuid = 'second-mit-uuid';
       const apacheUuid = 'apache-uuid';
@@ -516,7 +516,7 @@ describe('getResourceTree', () => {
           linked: { 'file.ts': 1 },
           unlinked: { 'other.ts': 1 },
         },
-        manualAttributions: makeAttributionData(
+        externalAttributions: makeAttributionData(
           {
             [firstMitUuid]: {
               packageName: 'first MIT package',
@@ -546,7 +546,10 @@ describe('getResourceTree', () => {
 
       const { result } = await getResourceTree({
         expandedNodes: 'expandAll',
-        license: 'MIT',
+        licenseFilter: {
+          licenseName: 'MIT',
+          external: true,
+        },
       });
 
       expect(result.count).toBe(1);
@@ -555,6 +558,51 @@ describe('getResourceTree', () => {
       expect(labels).toContain('file.ts');
       expect(labels).not.toContain('unlinked');
       expect(labels).not.toContain('other.ts');
+    });
+
+    it('filters resources by manual attribution license when requested', async () => {
+      await initializeDbWithTestData({
+        resources: {
+          attribution: { 'file.ts': 1 },
+          signal: { 'file.ts': 1 },
+        },
+        externalAttributions: makeAttributionData(
+          {
+            'signal-uuid': {
+              packageName: 'signal',
+              criticality: Criticality.None,
+              id: 'signal-uuid',
+              licenseName: 'MIT',
+            },
+          },
+          { '/signal/file.ts': ['signal-uuid'] },
+        ),
+        manualAttributions: makeAttributionData(
+          {
+            'attribution-uuid': {
+              packageName: 'attribution',
+              criticality: Criticality.None,
+              id: 'attribution-uuid',
+              licenseName: 'MIT',
+            },
+          },
+          { '/attribution/file.ts': ['attribution-uuid'] },
+        ),
+      });
+
+      const { result } = await getResourceTree({
+        expandedNodes: 'expandAll',
+        licenseFilter: {
+          licenseName: 'MIT',
+          external: false,
+        },
+      });
+
+      expect(result.treeNodes.map((node) => node.labelText)).toEqual([
+        '/',
+        'attribution',
+        'file.ts',
+      ]);
     });
   });
 
@@ -741,7 +789,7 @@ describe('getResourceTree', () => {
       ]);
     });
 
-    it('applies license and unreviewed filtering to the displayed tree', async () => {
+    it('filters the displayed tree by signal license', async () => {
       await initializeDbWithTestData({
         resources: {
           src: {
@@ -756,6 +804,7 @@ describe('getResourceTree', () => {
               packageName: 'external',
               criticality: Criticality.None,
               id: 'external-uuid',
+              licenseName: 'MIT',
             },
           },
           { '/src/external.ts': ['external-uuid'] },
@@ -785,7 +834,10 @@ describe('getResourceTree', () => {
 
       const { result } = await getResourceTree({
         expandedNodes: 'expandAll',
-        license: 'MIT',
+        licenseFilter: {
+          licenseName: 'MIT',
+          external: true,
+        },
         onlyUnreviewedFiles: true,
       });
 
@@ -793,7 +845,7 @@ describe('getResourceTree', () => {
       expect(result.treeNodes.map((node) => node.labelText)).toEqual([
         '/',
         'src',
-        'preselected-mit.ts',
+        'external.ts',
       ]);
     });
 
@@ -808,6 +860,7 @@ describe('getResourceTree', () => {
               packageName: 'external',
               criticality: Criticality.None,
               id: 'external-uuid',
+              licenseName: 'MIT',
             },
           },
           { '/src/external.ts': ['external-uuid'] },
@@ -819,7 +872,7 @@ describe('getResourceTree', () => {
               criticality: Criticality.None,
               id: 'preselected-uuid',
               preSelected: true,
-              licenseName: 'MIT',
+              licenseName: 'Apache-2.0',
             },
             'manual-uuid': {
               packageName: 'manual',
@@ -847,8 +900,22 @@ describe('getResourceTree', () => {
       ).resolves.toEqual({ result: 0 });
 
       await expect(
-        getResourceTreeUnreviewedCount({ license: 'MIT' }),
+        getResourceTreeUnreviewedCount({
+          licenseFilter: {
+            licenseName: 'MIT',
+            external: true,
+          },
+        }),
       ).resolves.toEqual({ result: 1 });
+
+      await expect(
+        getResourceTreeUnreviewedCount({
+          licenseFilter: {
+            licenseName: 'MIT',
+            external: false,
+          },
+        }),
+      ).resolves.toEqual({ result: 0 });
     });
   });
 

--- a/src/ElectronBackend/api/resourceTree.ts
+++ b/src/ElectronBackend/api/resourceTree.ts
@@ -28,19 +28,23 @@ export type ResourceTreeNodeData = Awaited<
 
 const FILTERED_RESOURCE_TEMP_TABLE = 'filtered_resources';
 type FilteredTable = { filtered_resources: { id: number } };
+type LicenseFilter = {
+  licenseName: string;
+  external: boolean;
+};
 
 export function getResourceTree({
   search,
   expandedNodes,
   onlyUnreviewedFiles,
-  license,
+  licenseFilter,
   onAttributionUuids,
   selectedResourcePath,
 }: {
   search?: string;
   expandedNodes: Array<string> | 'expandAll';
   onlyUnreviewedFiles?: boolean;
-  license?: string;
+  licenseFilter?: LicenseFilter;
   onAttributionUuids?: Array<string>;
   selectedResourcePath?: string;
 }) {
@@ -48,7 +52,7 @@ export function getResourceTree({
     .transaction()
     .execute(async (trx) => {
       const hasActiveFilters = Boolean(
-        search || license || onAttributionUuids || onlyUnreviewedFiles,
+        search || licenseFilter || onAttributionUuids || onlyUnreviewedFiles,
       );
       /*
        * FILTERED_RESOURCE_TEMP_TABLE contains the resources included by the active filters.
@@ -58,7 +62,7 @@ export function getResourceTree({
       let dropTempTable;
       if (hasActiveFilters) {
         const filterQuery = getFilteredResourcesQuery(trx, {
-          license,
+          licenseFilter,
           onlyUnreviewedFiles,
           onAttributionUuids,
           search,
@@ -257,11 +261,11 @@ export function getResourceTree({
 }
 
 export async function getResourceTreeUnreviewedCount({
-  license,
+  licenseFilter,
   onAttributionUuids,
   search,
 }: {
-  license?: string;
+  licenseFilter?: LicenseFilter;
   onAttributionUuids?: Array<string>;
   search?: string;
 }) {
@@ -271,7 +275,7 @@ export async function getResourceTreeUnreviewedCount({
       const count = await trx
         .selectFrom(
           getFilteredResourcesQuery(trx, {
-            license,
+            licenseFilter,
             onlyUnreviewedFiles: true,
             onAttributionUuids,
             search,
@@ -287,12 +291,12 @@ export async function getResourceTreeUnreviewedCount({
 function getFilteredResourcesQuery(
   trx: Transaction<DB>,
   {
-    license,
+    licenseFilter,
     onlyUnreviewedFiles,
     onAttributionUuids,
     search,
   }: {
-    license?: string;
+    licenseFilter?: LicenseFilter;
     onlyUnreviewedFiles?: boolean;
     onAttributionUuids?: Array<string>;
     search?: string;
@@ -304,7 +308,7 @@ function getFilteredResourcesQuery(
     query = query.where('r.path', 'like', `%${search}%`);
   }
 
-  if (license) {
+  if (licenseFilter) {
     query = query.where('r.id', 'in', (eb) =>
       eb
         .selectFrom('attribution as a')
@@ -314,11 +318,11 @@ function getFilteredResourcesQuery(
           'a.uuid',
         )
         .select('rta.resource_id')
-        .where('a.is_external', '=', 0)
+        .where('a.is_external', '=', Number(licenseFilter.external))
         .where(
           'a.canonical_license_name',
           '=',
-          toCanonicalLicenseName(license),
+          toCanonicalLicenseName(licenseFilter.licenseName),
         ),
     );
   }

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -30,7 +30,7 @@ import { ResourcesTree } from './ResourcesTree/ResourcesTree';
 
 const ALL_RESOURCES_SEARCH = 'all-resources-search';
 const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
-const isLicenseFilterBasedOnExternalAttributions = false;
+const IS_LICENSE_FILTER_BASED_ON_EXTERNAL_ATTRIBUTIONS = true;
 
 export function ResourceBrowser() {
   const { panelSizes, setPanelSizes } = usePanelSizes();
@@ -64,7 +64,7 @@ export function ResourceBrowser() {
   const resourceTreeLicenseFilter = resourceTreeSelectedLicense
     ? {
         licenseName: resourceTreeSelectedLicense,
-        external: isLicenseFilterBasedOnExternalAttributions,
+        external: IS_LICENSE_FILTER_BASED_ON_EXTERNAL_ATTRIBUTIONS,
       }
     : undefined;
   const resourceTreeAll = backend.getResourceTree.useQuery(
@@ -86,7 +86,7 @@ export function ResourceBrowser() {
       { placeholderData: keepPreviousData },
     );
   const { filterProps } = useResourceTreeFilterProperties({
-    external: isLicenseFilterBasedOnExternalAttributions,
+    external: IS_LICENSE_FILTER_BASED_ON_EXTERNAL_ATTRIBUTIONS,
   });
   const isResourceTreeFilterActive =
     onlyUnreviewedFiles || !!resourceTreeSelectedLicense;

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -30,6 +30,7 @@ import { ResourcesTree } from './ResourcesTree/ResourcesTree';
 
 const ALL_RESOURCES_SEARCH = 'all-resources-search';
 const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
+const isLicenseFilterBasedOnExternalAttributions = false;
 
 export function ResourceBrowser() {
   const { panelSizes, setPanelSizes } = usePanelSizes();
@@ -60,10 +61,16 @@ export function ResourceBrowser() {
   const [searchAll, setSearchAll] = useVariable(ALL_RESOURCES_SEARCH, '');
   const debouncedSearchAll = useDebouncedInput(searchAll);
   const expandedIdsAll = useAppSelector(getExpandedIds);
+  const resourceTreeLicenseFilter = resourceTreeSelectedLicense
+    ? {
+        licenseName: resourceTreeSelectedLicense,
+        external: isLicenseFilterBasedOnExternalAttributions,
+      }
+    : undefined;
   const resourceTreeAll = backend.getResourceTree.useQuery(
     {
       expandedNodes: expandedIdsAll,
-      license: resourceTreeSelectedLicense,
+      licenseFilter: resourceTreeLicenseFilter,
       onlyUnreviewedFiles,
       search: debouncedSearchAll,
       selectedResourcePath: selectedResourceId,
@@ -73,12 +80,14 @@ export function ResourceBrowser() {
   const unreviewedFileCountQuery =
     backend.getResourceTreeUnreviewedCount.useQuery(
       {
-        license: resourceTreeSelectedLicense,
+        licenseFilter: resourceTreeLicenseFilter,
         search: debouncedSearchAll,
       },
       { placeholderData: keepPreviousData },
     );
-  const { filterProps } = useResourceTreeFilterProperties({});
+  const { filterProps } = useResourceTreeFilterProperties({
+    external: isLicenseFilterBasedOnExternalAttributions,
+  });
   const isResourceTreeFilterActive =
     onlyUnreviewedFiles || !!resourceTreeSelectedLicense;
   // Linked resources

--- a/src/Frontend/util/use-filter-properties.ts
+++ b/src/Frontend/util/use-filter-properties.ts
@@ -66,12 +66,14 @@ export function useFilterProperties({
 
 export function useResourceTreeFilterProperties({
   enabled,
+  external,
 }: {
   enabled?: boolean;
+  external: boolean;
 }) {
   const filterPropsQuery = backend.filterProperties.useQuery(
     {
-      external: false,
+      external,
       filters: [],
       resourcePathForRelationships: ROOT_PATH,
     },

--- a/src/e2e-tests/__tests__/filtering-resources.test.ts
+++ b/src/e2e-tests/__tests__/filtering-resources.test.ts
@@ -11,7 +11,7 @@ const [
   reviewedApacheResourceName,
 ] = faker.opossum.resourceNames({ count: 4 });
 const [externalAttributionId, externalPackageInfo] =
-  faker.opossum.rawAttribution();
+  faker.opossum.rawAttribution({ licenseName: 'MIT' });
 const [preselectedAttributionId, preselectedPackageInfo] =
   faker.opossum.rawAttribution({ licenseName: 'MIT', preSelected: true });
 const [reviewedMitAttributionId, reviewedMitPackageInfo] =
@@ -69,19 +69,19 @@ test('filters the resource tree to unreviewed files', async ({
   await resourcesTree.assert.resourceIsHidden(reviewedApacheResourceName);
 });
 
-test('combines unreviewed and license filters in the resource tree', async ({
+test('combines unreviewed and external attribution license filters in the resource tree', async ({
   resourcesTree,
 }) => {
   await resourcesTree.filterButton.click();
   await resourcesTree.filters.unreviewed.click();
   await resourcesTree.closeMenu();
   await resourcesTree.filterButton.click();
-  await resourcesTree.selectLicenseName(preselectedPackageInfo.licenseName!);
+  await resourcesTree.selectLicenseName(externalPackageInfo.licenseName!);
   await resourcesTree.closeMenu();
   await resourcesTree.closeMenu();
 
-  await resourcesTree.assert.resourceIsHidden(externalResourceName);
-  await resourcesTree.assert.resourceIsVisible(preselectedResourceName);
+  await resourcesTree.assert.resourceIsVisible(externalResourceName);
+  await resourcesTree.assert.resourceIsHidden(preselectedResourceName);
   await resourcesTree.assert.resourceIsHidden(reviewedMitResourceName);
   await resourcesTree.assert.resourceIsHidden(reviewedApacheResourceName);
 });

--- a/src/e2e-tests/__tests__/interacting-with-resources.test.ts
+++ b/src/e2e-tests/__tests__/interacting-with-resources.test.ts
@@ -22,6 +22,9 @@ const [attributionId2, packageInfo2] = faker.opossum.rawAttribution({
 const [attributionId3, packageInfo3] = faker.opossum.rawAttribution({
   licenseName: 'BSD-3-Clause',
 });
+const [attributionId4, packageInfo4] = faker.opossum.rawAttribution({
+  licenseName: 'MIT',
+});
 
 test.use({
   data: {
@@ -44,6 +47,16 @@ test.use({
           attributionId2,
         ],
         [faker.opossum.filePath(resourceName7)]: [attributionId3],
+      }),
+    }),
+    outputData: faker.opossum.outputData({
+      manualAttributions: faker.opossum.rawAttributions({
+        [attributionId4]: packageInfo4,
+      }),
+      resourcesToAttributions: faker.opossum.resourcesToAttributions({
+        [faker.opossum.filePath(resourceName4, resourceName5, resourceName6)]: [
+          attributionId4,
+        ],
       }),
     }),
   },
@@ -166,18 +179,9 @@ test('shows only resources matching search', async ({
   await resourcesTree.assert.resourceIsVisible(resourceName4);
 });
 
-test('shows only resources matching selected manual attribution license', async ({
+test('shows only resources matching selected external attribution license', async ({
   resourcesTree,
-  signalsPanel,
 }) => {
-  await resourcesTree.goto(resourceName1, resourceName2, resourceName3);
-  await signalsPanel.packageCard.click(packageInfo1);
-  await signalsPanel.linkButton.click();
-
-  await resourcesTree.goto(resourceName4, resourceName5, resourceName6);
-  await signalsPanel.packageCard.click(packageInfo2);
-  await signalsPanel.linkButton.click();
-
   await resourcesTree.gotoRoot();
   await resourcesTree.filterButton.click();
   await resourcesTree.selectLicenseName(packageInfo1.licenseName!);

--- a/src/e2e-tests/__tests__/interacting-with-resources.test.ts
+++ b/src/e2e-tests/__tests__/interacting-with-resources.test.ts
@@ -4,17 +4,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import { faker, test } from '../utils';
 
+const SELECTED_LICENSE = 'MIT';
 const [
-  resourceName1,
-  resourceName2,
-  resourceName3,
-  resourceName4,
-  resourceName5,
-  resourceName6,
-  resourceName7,
-] = faker.opossum.resourceNames({ count: 7 });
+  resourceWithExternalSelectedLicense,
+  nestedResourceWithExternalSelectedLicense,
+  leafResourceWithExternalSelectedLicense,
+  resourceWithExternalDifferentLicense,
+  nestedResourceWithExternalDifferentLicense,
+  leafResourceWithExternalDifferentLicense,
+  anotherResourceWithExternalDifferentLicense,
+  resourceWithManualSelectedLicense,
+] = faker.opossum.resourceNames({ count: 8 });
 const [attributionId1, packageInfo1] = faker.opossum.rawAttribution({
-  licenseName: 'MIT',
+  licenseName: SELECTED_LICENSE,
 });
 const [attributionId2, packageInfo2] = faker.opossum.rawAttribution({
   licenseName: 'Apache-2.0',
@@ -23,16 +25,25 @@ const [attributionId3, packageInfo3] = faker.opossum.rawAttribution({
   licenseName: 'BSD-3-Clause',
 });
 const [attributionId4, packageInfo4] = faker.opossum.rawAttribution({
-  licenseName: 'MIT',
+  licenseName: SELECTED_LICENSE,
 });
 
 test.use({
   data: {
     inputData: faker.opossum.inputData({
       resources: faker.opossum.resources({
-        [resourceName1]: { [resourceName2]: { [resourceName3]: 1 } },
-        [resourceName4]: { [resourceName5]: { [resourceName6]: 1 } },
-        [resourceName7]: 1,
+        [resourceWithExternalSelectedLicense]: {
+          [nestedResourceWithExternalSelectedLicense]: {
+            [leafResourceWithExternalSelectedLicense]: 1,
+          },
+        },
+        [resourceWithExternalDifferentLicense]: {
+          [nestedResourceWithExternalDifferentLicense]: {
+            [leafResourceWithExternalDifferentLicense]: 1,
+          },
+        },
+        [anotherResourceWithExternalDifferentLicense]: 1,
+        [resourceWithManualSelectedLicense]: 1,
       }),
       externalAttributions: faker.opossum.rawAttributions({
         [attributionId1]: packageInfo1,
@@ -40,13 +51,19 @@ test.use({
         [attributionId3]: packageInfo3,
       }),
       resourcesToAttributions: faker.opossum.resourcesToAttributions({
-        [faker.opossum.filePath(resourceName1, resourceName2, resourceName3)]: [
-          attributionId1,
+        [faker.opossum.filePath(
+          resourceWithExternalSelectedLicense,
+          nestedResourceWithExternalSelectedLicense,
+          leafResourceWithExternalSelectedLicense,
+        )]: [attributionId1],
+        [faker.opossum.filePath(
+          resourceWithExternalDifferentLicense,
+          nestedResourceWithExternalDifferentLicense,
+          leafResourceWithExternalDifferentLicense,
+        )]: [attributionId2],
+        [faker.opossum.filePath(anotherResourceWithExternalDifferentLicense)]: [
+          attributionId3,
         ],
-        [faker.opossum.filePath(resourceName4, resourceName5, resourceName6)]: [
-          attributionId2,
-        ],
-        [faker.opossum.filePath(resourceName7)]: [attributionId3],
       }),
     }),
     outputData: faker.opossum.outputData({
@@ -54,7 +71,7 @@ test.use({
         [attributionId4]: packageInfo4,
       }),
       resourcesToAttributions: faker.opossum.resourcesToAttributions({
-        [faker.opossum.filePath(resourceName4, resourceName5, resourceName6)]: [
+        [faker.opossum.filePath(resourceWithManualSelectedLicense)]: [
           attributionId4,
         ],
       }),
@@ -65,19 +82,44 @@ test.use({
 test('shows expected resources as user browses through resources', async ({
   resourcesTree,
 }) => {
-  await resourcesTree.assert.resourceIsVisible(resourceName1);
-  await resourcesTree.assert.resourceIsVisible(resourceName4);
-  await resourcesTree.assert.resourceIsVisible(resourceName7);
-  await resourcesTree.assert.resourceIsHidden(resourceName2);
-  await resourcesTree.assert.resourceIsHidden(resourceName3);
-  await resourcesTree.assert.resourceIsHidden(resourceName5);
-  await resourcesTree.assert.resourceIsHidden(resourceName6);
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    anotherResourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithManualSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    nestedResourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    leafResourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    nestedResourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    leafResourceWithExternalDifferentLicense,
+  );
 
-  await resourcesTree.goto(resourceName4);
-  await resourcesTree.assert.resourceIsVisible(resourceName5);
-  await resourcesTree.assert.resourceIsVisible(resourceName6);
-  await resourcesTree.assert.resourceIsHidden(resourceName2);
-  await resourcesTree.assert.resourceIsHidden(resourceName3);
+  await resourcesTree.goto(resourceWithExternalDifferentLicense);
+  await resourcesTree.assert.resourceIsVisible(
+    nestedResourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    leafResourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    nestedResourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    leafResourceWithExternalSelectedLicense,
+  );
 });
 
 test('cycles through resources as user clicks on progress bar', async ({
@@ -119,41 +161,60 @@ test('shows expected breadcrumbs as user navigates through browser history', asy
   await pathBar.assert.goBackButtonIsDisabled();
   await pathBar.assert.goForwardButtonIsDisabled();
 
-  await resourcesTree.goto(resourceName1, resourceName2, resourceName3);
+  await resourcesTree.goto(
+    resourceWithExternalSelectedLicense,
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
+  );
   await pathBar.assert.goBackButtonIsEnabled();
   await pathBar.assert.goForwardButtonIsDisabled();
   await pathBar.assert.breadcrumbsAreVisible(
-    resourceName1,
-    resourceName2,
-    resourceName3,
+    resourceWithExternalSelectedLicense,
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
   );
 
   await pathBar.goBackButton.click();
   await pathBar.assert.goForwardButtonIsEnabled();
-  await pathBar.assert.breadcrumbsAreVisible(resourceName1, resourceName2);
-  await pathBar.assert.breadcrumbsAreHidden(resourceName3);
+  await pathBar.assert.breadcrumbsAreVisible(
+    resourceWithExternalSelectedLicense,
+    nestedResourceWithExternalSelectedLicense,
+  );
+  await pathBar.assert.breadcrumbsAreHidden(
+    leafResourceWithExternalSelectedLicense,
+  );
 
   await pathBar.goForwardButton.click();
   await pathBar.assert.breadcrumbsAreVisible(
-    resourceName1,
-    resourceName2,
-    resourceName3,
+    resourceWithExternalSelectedLicense,
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
   );
 
-  await pathBar.clickOnBreadcrumb(resourceName1);
-  await pathBar.assert.breadcrumbsAreVisible(resourceName1);
-  await pathBar.assert.breadcrumbsAreHidden(resourceName2, resourceName3);
+  await pathBar.clickOnBreadcrumb(resourceWithExternalSelectedLicense);
+  await pathBar.assert.breadcrumbsAreVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await pathBar.assert.breadcrumbsAreHidden(
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
+  );
 
   await window.keyboard.press(`${modKey}+ArrowLeft`);
   await pathBar.assert.breadcrumbsAreVisible(
-    resourceName1,
-    resourceName2,
-    resourceName3,
+    resourceWithExternalSelectedLicense,
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
   );
 
   await window.keyboard.press(`${modKey}+ArrowRight`);
-  await pathBar.assert.breadcrumbsAreVisible(resourceName1);
-  await pathBar.assert.breadcrumbsAreHidden(resourceName2, resourceName3);
+  await pathBar.assert.breadcrumbsAreVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await pathBar.assert.breadcrumbsAreHidden(
+    nestedResourceWithExternalSelectedLicense,
+    leafResourceWithExternalSelectedLicense,
+  );
 });
 
 test('shows only resources matching search', async ({
@@ -161,22 +222,38 @@ test('shows only resources matching search', async ({
   window,
   modKey,
 }) => {
-  await resourcesTree.assert.resourceIsVisible(resourceName1);
-  await resourcesTree.assert.resourceIsVisible(resourceName4);
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalDifferentLicense,
+  );
 
-  await resourcesTree.searchField.fill(resourceName4);
-  await resourcesTree.assert.resourceIsHidden(resourceName1);
-  await resourcesTree.assert.resourceIsVisible(resourceName4);
+  await resourcesTree.searchField.fill(resourceWithExternalDifferentLicense);
+  await resourcesTree.assert.resourceIsHidden(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalDifferentLicense,
+  );
 
   await resourcesTree.clearSearchButton.click();
-  await resourcesTree.assert.resourceIsVisible(resourceName1);
-  await resourcesTree.assert.resourceIsVisible(resourceName4);
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalDifferentLicense,
+  );
 
   await resourcesTree.gotoRoot();
   await window.keyboard.press(`${modKey}+F`);
-  await window.keyboard.type(resourceName4);
-  await resourcesTree.assert.resourceIsHidden(resourceName1);
-  await resourcesTree.assert.resourceIsVisible(resourceName4);
+  await window.keyboard.type(resourceWithExternalDifferentLicense);
+  await resourcesTree.assert.resourceIsHidden(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalDifferentLicense,
+  );
 });
 
 test('shows only resources matching selected external attribution license', async ({
@@ -184,11 +261,20 @@ test('shows only resources matching selected external attribution license', asyn
 }) => {
   await resourcesTree.gotoRoot();
   await resourcesTree.filterButton.click();
-  await resourcesTree.selectLicenseName(packageInfo1.licenseName!);
+  await resourcesTree.selectLicenseName(SELECTED_LICENSE);
   await resourcesTree.closeMenu();
   await resourcesTree.closeMenu();
 
-  await resourcesTree.assert.resourceIsVisible(resourceName1);
-  await resourcesTree.assert.resourceIsHidden(resourceName4);
-  await resourcesTree.assert.resourceIsHidden(resourceName7);
+  await resourcesTree.assert.resourceIsVisible(
+    resourceWithExternalSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    resourceWithManualSelectedLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    resourceWithExternalDifferentLicense,
+  );
+  await resourcesTree.assert.resourceIsHidden(
+    anotherResourceWithExternalDifferentLicense,
+  );
 });


### PR DESCRIPTION
### Summary of changes
- Base resource license filter on signals instead of attributions
- small refactoring to make this setting explicit

### Context and reason for change

Feedback from Indira
