### PR TITLE
fix: prevent resource tree side panel from jumping

### DIFF
--- a/src/Frontend/Components/ResizePanels/ResizePanels.tsx
+++ b/src/Frontend/Components/ResizePanels/ResizePanels.tsx
@@ -136,7 +136,6 @@ export const ResizePanels: React.FC<ResizePanelsProps> = ({
       }}
       sx={{
         display: 'flex',
-        flex: 1,
         flexDirection: 'column',
         minHeight: 0,
         transition: isResizing ? undefined : TRANSITION,


### PR DESCRIPTION
`flex: 1` caused the side panel to consume available space while resources loaded
