### PR TITLE
fix: save output file even if it doesn't exist before

### DIFF
--- a/src/shared/write-file.ts
+++ b/src/shared/write-file.ts
@@ -43,7 +43,11 @@ export async function writeOpossumFile({
 }): Promise<string> {
   if (zip) {
     if (output) {
-      zip.updateFile(OUTPUT_FILE_NAME, toBuffer(output));
+      if (zip.getEntry(OUTPUT_FILE_NAME)) {
+        zip.updateFile(OUTPUT_FILE_NAME, toBuffer(output));
+      } else {
+        zip.addFile(OUTPUT_FILE_NAME, toBuffer(output));
+      }
     }
   } else {
     zip = new AdmZip();


### PR DESCRIPTION
When opening a file without an output.json, we skipped that while saving. This PR fixes that.
