### PR TITLE
test: fix flaky e2e tests

### DIFF
--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
@@ -102,7 +102,7 @@ export const PackagesPanel = ({
 
   const [multiSelectedAttributionIds, setMultiSelectedAttributionIds] =
     useState<Array<string>>([]);
-  const [activeRelation, setActiveRelation] = useState<Relation>('children');
+  const [activeRelation, setActiveRelation] = useState<Relation | null>(null);
   const { filterProps } = useFilterProperties({
     mode: external ? 'external' : 'manual',
   });
@@ -192,13 +192,13 @@ export const PackagesPanel = ({
     effectiveSelectedIds,
   );
 
-  // reset multi-selected IDs when selected resource changes
+  // reset resource-dependent state when the selected resource changes
   useEffect(() => {
-    if (
-      selectedResourceId !== previousSelectedResourceId &&
-      multiSelectedAttributionIds.length
-    ) {
-      setMultiSelectedAttributionIds([]);
+    if (selectedResourceId !== previousSelectedResourceId) {
+      if (multiSelectedAttributionIds.length) {
+        setMultiSelectedAttributionIds([]);
+      }
+      setActiveRelation(null);
     }
   }, [
     multiSelectedAttributionIds.length,
@@ -223,12 +223,13 @@ export const PackagesPanel = ({
   // reset active relation when active relation no longer exists
   useEffect(() => {
     if (
+      !loading &&
       availableRelations?.length &&
       (!activeRelation || !availableRelations.includes(activeRelation))
     ) {
       setActiveRelation(availableRelations[0]);
     }
-  }, [activeRelation, availableRelations]);
+  }, [activeRelation, availableRelations, loading]);
 
   // switch to the tab of a newly selected attribution
   useEffect(() => {
@@ -238,9 +239,8 @@ export const PackagesPanel = ({
   }, [selectedAttributionRelation]);
 
   const childrenProps: PackagesPanelChildrenProps = {
-    activeAttributionIds: groupedIds
-      ? (groupedIds[activeRelation] ?? [])
-      : null,
+    activeAttributionIds:
+      groupedIds && activeRelation ? (groupedIds[activeRelation] ?? []) : null,
     activeRelation,
     attributionIds,
     attributions,

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
@@ -2,13 +2,16 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { Attributions } from '../../../../../shared/shared-types';
 import { text } from '../../../../../shared/text';
 import { faker } from '../../../../../testing/Faker';
-import { setSelectedAttributionId } from '../../../../state/actions/resource-actions/audit-view-simple-actions';
+import {
+  setSelectedAttributionId,
+  setSelectedResourceId,
+} from '../../../../state/actions/resource-actions/audit-view-simple-actions';
 import { setVariable } from '../../../../state/actions/variables-actions/variables-actions';
 import type { Action } from '../../../../state/configure-store';
 import { ATTRIBUTION_IDS_FOR_REPLACEMENT } from '../../../../state/variables/use-attribution-ids-for-replacement';
@@ -346,6 +349,26 @@ describe('PackagesPanel', () => {
     ).toHaveAttribute('aria-selected', 'false');
     expect(
       screen.getByRole('tab', { name: new RegExp(text.relations.unrelated) }),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('selects the first available tab after a resource change', async () => {
+    const packageInfo1 = faker.opossum.packageInfo({ relation: 'resource' });
+    const packageInfo2 = faker.opossum.packageInfo({ relation: 'unrelated' });
+    const { store } = await renderPackagesPanel({
+      attributions: faker.opossum.attributions({
+        [packageInfo1.id]: packageInfo1,
+        [packageInfo2.id]: packageInfo2,
+      }),
+    });
+
+    await userEvent.click(
+      screen.getByRole('tab', { name: new RegExp(text.relations.unrelated) }),
+    );
+    await act(() => store.dispatch(setSelectedResourceId('/next-resource')));
+
+    expect(
+      screen.getByRole('tab', { name: new RegExp(text.relations.resource) }),
     ).toHaveAttribute('aria-selected', 'true');
   });
 

--- a/src/e2e-tests/page-objects/AttributionsPanel.ts
+++ b/src/e2e-tests/page-objects/AttributionsPanel.ts
@@ -181,8 +181,10 @@ export class AttributionsPanel {
 
   async selectLicenseName(licenseName: string) {
     await this.filters.license.fill(licenseName);
-    await this.window.keyboard.press('ArrowUp');
-    await this.window.keyboard.press('Enter');
+    await this.window
+      .getByRole('option', { name: licenseName, exact: true })
+      .click();
+    await expect(this.filters.license).toHaveValue(licenseName);
   }
 
   async selectIncompleteCoordinates(value: string) {

--- a/src/e2e-tests/page-objects/ResourcesTree.ts
+++ b/src/e2e-tests/page-objects/ResourcesTree.ts
@@ -70,7 +70,9 @@ export class ResourcesTree {
 
   async selectLicenseName(licenseName: string): Promise<void> {
     await this.filters.license.fill(licenseName);
-    await this.window.keyboard.press('ArrowUp');
-    await this.window.keyboard.press('Enter');
+    await this.window
+      .getByRole('option', { name: licenseName, exact: true })
+      .click();
+    await expect(this.filters.license).toHaveValue(licenseName);
   }
 }


### PR DESCRIPTION
### Summary of changes
- fix flakiness when selecting license in e2e tests
- always select the first attribution tab after resource changes

### Context and reason for change
See failures: https://github.com/opossum-tool/OpossumUI/actions/runs/30005786580/job/89201326127#step:9:156
