### PR TITLE
fix: prevent delayed unsaved popup after resource navigation

### DIFF
--- a/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
+++ b/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
@@ -14,7 +14,6 @@ import {
   setIsPackageInfoDirty,
   setTemporaryDisplayPackageInfo,
 } from '../../state/actions/resource-actions/all-views-simple-actions';
-import { setSelectedAttributionId } from '../../state/actions/resource-actions/audit-view-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
   getSelectedAttributionId,
@@ -89,30 +88,7 @@ export function AttributionDetails() {
   const isSelectedAttributionVisible =
     !!attributions?.[selectedAttributionId] ||
     !!signals?.[selectedAttributionId];
-  const selectedAttributionList = selectedAttributionIsExternal
-    ? signals
-    : attributions;
 
-  useEffect(() => {
-    const replacementAttribution = selectedAttributionList
-      ? Object.values(selectedAttributionList)[0]
-      : undefined;
-
-    if (
-      selectedAttributionId &&
-      selectedAttributionIsExternal !== null &&
-      selectedAttributionIsExternal !== undefined &&
-      !selectedAttributionList?.[selectedAttributionId] &&
-      replacementAttribution
-    ) {
-      dispatch(setSelectedAttributionId(replacementAttribution.id));
-    }
-  }, [
-    dispatch,
-    selectedAttributionId,
-    selectedAttributionIsExternal,
-    selectedAttributionList,
-  ]);
   const compareToOriginal = useCompareToOriginal(temporaryDisplayPackageInfo);
 
   const wasPreferred =

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/PackagesPanel.tsx
@@ -11,7 +11,7 @@ import {
   intersection,
   isEqual,
 } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Attributions, Relation } from '../../../../shared/shared-types';
 import { text } from '../../../../shared/text';
@@ -20,6 +20,7 @@ import {
   PICKER_MODE_DISABLED_OPACITY,
 } from '../../../shared-styles';
 import { changeAttributionFiltersOrOpenUnsavedPopup } from '../../../state/actions/popup-actions/popup-actions';
+import { setSelectedAttributionId } from '../../../state/actions/resource-actions/audit-view-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../../state/hooks';
 import {
   getSelectedAttributionId,
@@ -37,6 +38,7 @@ import { getRelationPriority } from '../../../util/sort-attributions';
 import { useFilteredAttributionsList } from '../../../util/use-attribution-lists';
 import { useFilterProperties } from '../../../util/use-filter-properties';
 import { usePrevious } from '../../../util/use-previous';
+import { useSelectedAttributionIsExternal } from '../../../util/use-selected-attribution';
 import { Checkbox } from '../../Checkbox/Checkbox';
 import { FilterButton } from '../../FilterButton/FilterButton';
 import { useAttributionFilterOptions } from '../../FilterButton/use-attribution-filter-options';
@@ -97,7 +99,9 @@ export const PackagesPanel = ({
 }: Props) => {
   const dispatch = useAppDispatch();
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const selectedAttributionIsExternal = useSelectedAttributionIsExternal();
   const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const lastResourceIdWithAutoSelectionRef = useRef(selectedResourceId);
   const previousSelectedResourceId = usePrevious(selectedResourceId);
 
   const [multiSelectedAttributionIds, setMultiSelectedAttributionIds] =
@@ -110,6 +114,60 @@ export const PackagesPanel = ({
   const { filters: attributionFilters, valueFilters } = filters;
   const { attributions, loading } = useFilteredAttributionsList({ external });
   const selectedAttribution = attributions?.[selectedAttributionId];
+  const groupedIds = useMemo(
+    () =>
+      attributions &&
+      _groupBy(
+        _orderBy(
+          Object.keys(attributions),
+          (id) => getRelationPriority(attributions[id].relation),
+          'desc',
+        ),
+        (id) => attributions[id].relation || 'unrelated',
+      ),
+    [attributions],
+  );
+
+  // Automatic attribution selection
+  useEffect(() => {
+    if (loading || !attributions) {
+      return;
+    }
+
+    if (
+      !external &&
+      lastResourceIdWithAutoSelectionRef.current !== selectedResourceId
+    ) {
+      lastResourceIdWithAutoSelectionRef.current = selectedResourceId;
+      const closestAttributionId =
+        groupedIds?.resource?.[0] ?? groupedIds?.parents?.[0];
+
+      dispatch(setSelectedAttributionId(closestAttributionId ?? ''));
+      return;
+    }
+
+    const replacementAttribution = attributions
+      ? Object.values(attributions)[0]
+      : undefined;
+
+    if (
+      selectedAttributionId &&
+      selectedAttributionIsExternal === external &&
+      !attributions?.[selectedAttributionId] &&
+      replacementAttribution
+    ) {
+      dispatch(setSelectedAttributionId(replacementAttribution.id));
+    }
+  }, [
+    attributions,
+    dispatch,
+    external,
+    groupedIds,
+    loading,
+    selectedAttributionId,
+    selectedAttributionIsExternal,
+    selectedResourceId,
+  ]);
   const setFiltersWithUnsavedCheck = useCallback(
     (nextFilters: AttributionFilters) => {
       if (selectedAttribution) {
@@ -139,19 +197,6 @@ export const PackagesPanel = ({
 
   const attributionIds = attributions && Object.keys(attributions);
 
-  const groupedIds = useMemo(
-    () =>
-      attributions &&
-      _groupBy(
-        _orderBy(
-          Object.keys(attributions),
-          (id) => getRelationPriority(attributions[id].relation),
-          'desc',
-        ),
-        (id) => attributions[id].relation || 'unrelated',
-      ),
-    [attributions],
-  );
   const availableRelations =
     groupedIds && (Object.keys(groupedIds) as Array<Relation> | null);
   const selectedAttributionRelation =

--- a/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
+++ b/src/Frontend/Components/AttributionPanels/PackagesPanel/__tests__/PackagesPanel.test.tsx
@@ -2,15 +2,17 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { Attributions } from '../../../../../shared/shared-types';
 import { text } from '../../../../../shared/text';
 import { faker } from '../../../../../testing/Faker';
+import { closePopupAndUnsetTargets } from '../../../../state/actions/popup-actions/popup-actions';
 import {
   setSelectedAttributionId,
   setSelectedResourceId,
+  setTargetSelectedResourceId,
 } from '../../../../state/actions/resource-actions/audit-view-simple-actions';
 import { setVariable } from '../../../../state/actions/variables-actions/variables-actions';
 import type { Action } from '../../../../state/configure-store';
@@ -18,6 +20,7 @@ import { ATTRIBUTION_IDS_FOR_REPLACEMENT } from '../../../../state/variables/use
 import { initialAttributionFilters } from '../../../../state/variables/use-filters';
 import { renderComponent } from '../../../../test-helpers/render';
 import { useFilteredAttributionsList } from '../../../../util/use-attribution-lists';
+import { useSelectedAttributionIsExternal } from '../../../../util/use-selected-attribution';
 import {
   PackagesPanel,
   type PackagesPanelChildrenProps,
@@ -25,6 +28,10 @@ import {
 
 vi.mock('../../../../util/use-attribution-lists', () => ({
   useFilteredAttributionsList: vi.fn(),
+}));
+
+vi.mock('../../../../util/use-selected-attribution', () => ({
+  useSelectedAttributionIsExternal: vi.fn(),
 }));
 
 function mockAttributions(attributions: Attributions) {
@@ -44,6 +51,7 @@ function renderPackagesPanel({
   actions?: Array<Action>;
 }) {
   mockAttributions(attributions);
+  vi.mocked(useSelectedAttributionIsExternal).mockReturnValue(false);
   return renderComponent(
     <PackagesPanel
       external={false}
@@ -75,6 +83,71 @@ function rerenderPackagesPanel(
 }
 
 describe('PackagesPanel', () => {
+  it('selects the attribution on the selected resource', async () => {
+    const resourceAttribution = faker.opossum.packageInfo({
+      relation: 'resource',
+    });
+    const unrelatedAttribution = faker.opossum.packageInfo({
+      relation: 'unrelated',
+    });
+    const { store } = await renderPackagesPanel({
+      attributions: faker.opossum.attributions({
+        [resourceAttribution.id]: resourceAttribution,
+        [unrelatedAttribution.id]: unrelatedAttribution,
+      }),
+    });
+
+    await act(() => store.dispatch(setSelectedResourceId('/another-resource')));
+
+    await waitFor(() => {
+      expect(store.getState().resourceState.selectedAttributionId).toBe(
+        resourceAttribution.id,
+      );
+    });
+  });
+
+  it('does not auto-select when a resource navigation is cancelled', async () => {
+    const selectedAttribution = faker.opossum.packageInfo({
+      relation: 'unrelated',
+    });
+    const resourceAttribution = faker.opossum.packageInfo({
+      relation: 'resource',
+    });
+    const { store } = await renderPackagesPanel({
+      attributions: faker.opossum.attributions({
+        [selectedAttribution.id]: selectedAttribution,
+        [resourceAttribution.id]: resourceAttribution,
+      }),
+      actions: [
+        setSelectedAttributionId(selectedAttribution.id),
+        setTargetSelectedResourceId('/cancelled-resource'),
+      ],
+    });
+
+    act(() => store.dispatch(closePopupAndUnsetTargets()));
+
+    expect(store.getState().resourceState.selectedAttributionId).toBe(
+      selectedAttribution.id,
+    );
+  });
+
+  it('selects the first visible manual attribution when the selection is filtered out', async () => {
+    const selectedAttribution = faker.opossum.packageInfo();
+    const replacementAttribution = faker.opossum.packageInfo();
+    const { store } = await renderPackagesPanel({
+      attributions: faker.opossum.attributions({
+        [replacementAttribution.id]: replacementAttribution,
+      }),
+      actions: [setSelectedAttributionId(selectedAttribution.id)],
+    });
+
+    await waitFor(() => {
+      expect(store.getState().resourceState.selectedAttributionId).toBe(
+        replacementAttribution.id,
+      );
+    });
+  });
+
   it('enables select-all checkbox when there are attribution IDs', async () => {
     await renderPackagesPanel({ attributions: faker.opossum.attributions() });
 

--- a/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTree.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourcesTree/ResourcesTree.tsx
@@ -7,14 +7,8 @@ import { remove } from 'lodash-es';
 import { useCallback, useEffect } from 'react';
 
 import type { ResourceTreeNodeData } from '../../../../ElectronBackend/api/resourceTree';
-import {
-  EMPTY_DISPLAY_PACKAGE_INFO,
-  ROOT_PATH,
-} from '../../../shared-constants';
-import {
-  changeSelectedAttributionOrOpenUnsavedPopup,
-  setSelectedResourceIdOrOpenUnsavedPopup,
-} from '../../../state/actions/popup-actions/popup-actions';
+import { ROOT_PATH } from '../../../shared-constants';
+import { setSelectedResourceIdOrOpenUnsavedPopup } from '../../../state/actions/popup-actions/popup-actions';
 import {
   setExpandedIds,
   setSelectedResourceId,
@@ -24,7 +18,6 @@ import {
   getExpandedIds,
   getSelectedResourceId,
 } from '../../../state/selectors/resource-selectors';
-import { backend } from '../../../util/backendClient';
 import { VirtualizedTree } from '../../VirtualizedTree/VirtualizedTree';
 import { ResourcesTreeNode } from './ResourcesTreeNode/ResourcesTreeNode';
 
@@ -60,17 +53,8 @@ export const ResourcesTree = ({ resources, sx }: Props) => {
   );
 
   const handleSelect = useCallback(
-    async (nodeId: string) => {
+    (nodeId: string) => {
       dispatch(setSelectedResourceIdOrOpenUnsavedPopup(nodeId));
-      const attributionToAutoselect =
-        await backend.getManualAttributionOnResourceOrAncestor.query({
-          resourcePath: nodeId,
-        });
-      dispatch(
-        changeSelectedAttributionOrOpenUnsavedPopup(
-          attributionToAutoselect || EMPTY_DISPLAY_PACKAGE_INFO,
-        ),
-      );
     },
     [dispatch],
   );


### PR DESCRIPTION
The tree previously triggered a second unsaved-changes check after its asynchronous attribution lookup completed. This could open a delayed popup after the original resource-navigation popup had been cancelled, causing unrelated E2E interactions to time out. Example: https://github.com/opossum-tool/OpossumUI/actions/runs/30076489731

Now autoselecting is owned centrally instead of being scattered across multiple places.
