### PR TITLE
fix: preserve nested readonly rules in partitions

### DIFF
--- a/src/ElectronBackend/split/__tests__/split-opossum-file.test.ts
+++ b/src/ElectronBackend/split/__tests__/split-opossum-file.test.ts
@@ -102,24 +102,29 @@ describe('splitOpossumArchive', () => {
     ]);
   });
 
-  it('removes readonly rules below a selected folder in the source', async () => {
+  it('preserves readonly overrides below a selected folder', async () => {
     const { source, selected } = await splitArchive({
       selectedFolderPaths: ['/frontend'],
       readonlyRules: [
         { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
         { path: '/frontend', readonly: false },
         { path: '/frontend/components', readonly: true },
       ],
     });
 
-    expect(source).toEqual([{ path: '/', readonly: true }]);
+    expect(source).toEqual([
+      { path: '/', readonly: true },
+      { path: '/docs', readonly: false },
+    ]);
     expect(selected).toEqual([
       { path: '/', readonly: true },
       { path: '/frontend', readonly: false },
+      { path: '/frontend/components', readonly: true },
     ]);
   });
 
-  it('removes descendant rules below a selected folder without a rule of its own', async () => {
+  it('moves descendant rules when the selected folder has no explicit rule', async () => {
     const { source, selected } = await splitArchive({
       selectedFolderPaths: ['/frontend'],
       readonlyRules: [{ path: '/frontend/components', readonly: true }],
@@ -129,6 +134,7 @@ describe('splitOpossumArchive', () => {
     expect(selected).toEqual([
       { path: '/', readonly: true },
       { path: '/frontend', readonly: false },
+      { path: '/frontend/components', readonly: true },
     ]);
   });
 

--- a/src/ElectronBackend/split/split-opossum-file.ts
+++ b/src/ElectronBackend/split/split-opossum-file.ts
@@ -180,16 +180,25 @@ function createSplitRules(
       existingReadonlyRules,
       selectedPaths,
     ),
-    selectedReadonlyRules: createSelectedReadonlyRules(selectedPaths),
+    selectedReadonlyRules: createSelectedReadonlyRules(
+      existingReadonlyRules,
+      selectedPaths,
+    ),
   };
 }
 
 function createSelectedReadonlyRules(
+  currentReadonlyRules: Array<ReadonlyRule>,
   selectedPaths: Array<string>,
 ): Array<ReadonlyRule> {
   return [
     { path: '/', readonly: true },
     ...selectedPaths.map((path) => ({ path, readonly: false })),
+    ...currentReadonlyRules.filter((rule) =>
+      selectedPaths.some((selectedPath) =>
+        isDescendant(rule.path, selectedPath),
+      ),
+    ),
   ];
 }
 


### PR DESCRIPTION
Fixed a bug in the splitting logic, where the new partition dropped pre-existing readonly rules nested under one of the selected folders
