### PR TITLE
test: immediately fail on unstubbed dialog call

### DIFF
--- a/src/e2e-tests/utils/dialog.ts
+++ b/src/e2e-tests/utils/dialog.ts
@@ -4,6 +4,38 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ElectronApplication } from '@playwright/test';
 
+const DIALOG_STUB_STATE_KEY = '__opossumE2EDialogStubState';
+
+interface DialogStubState {
+  unexpectedDialogCalls: Array<string>;
+}
+
+export async function installDefaultSyncDialogStubs(
+  app: ElectronApplication,
+): Promise<void> {
+  await app.evaluate(({ dialog }, stateKey) => {
+    const state: DialogStubState = { unexpectedDialogCalls: [] };
+    Reflect.set(dialog, stateKey, state);
+    Reflect.set(dialog, 'showOpenDialogSync', () => {
+      state.unexpectedDialogCalls.push('showOpenDialogSync');
+      return undefined;
+    });
+    Reflect.set(dialog, 'showSaveDialogSync', () => {
+      state.unexpectedDialogCalls.push('showSaveDialogSync');
+      return undefined;
+    });
+  }, DIALOG_STUB_STATE_KEY);
+}
+
+export async function getUnexpectedSyncDialogCalls(
+  app: ElectronApplication,
+): Promise<Array<string>> {
+  return app.evaluate(({ dialog }, stateKey) => {
+    const state = Reflect.get(dialog, stateKey) as DialogStubState | undefined;
+    return state?.unexpectedDialogCalls ?? [];
+  }, DIALOG_STUB_STATE_KEY);
+}
+
 export async function stubOpenDialogSync(
   app: ElectronApplication,
   value: Array<string> | undefined,

--- a/src/e2e-tests/utils/fixtures.ts
+++ b/src/e2e-tests/utils/fixtures.ts
@@ -40,6 +40,10 @@ import { ResourcesTree } from '../page-objects/ResourcesTree';
 import { SignalsPanel } from '../page-objects/SignalsPanel';
 import { SplitDialog } from '../page-objects/SplitDialog';
 import { TopBar } from '../page-objects/TopBar';
+import {
+  getUnexpectedSyncDialogCalls,
+  installDefaultSyncDialogStubs,
+} from './dialog';
 
 const LOAD_TIMEOUT = 15000;
 
@@ -122,6 +126,7 @@ export const test = base.extend<{
         RESET: '1',
       },
     });
+    await installDefaultSyncDialogStubs(app);
 
     // Capture main process stdout/stderr for debugging
     const mainProcessLogs: Array<string> = [];
@@ -146,6 +151,8 @@ export const test = base.extend<{
 
     await use(Object.assign(window, { app }));
 
+    const unexpectedDialogCalls = await getUnexpectedSyncDialogCalls(app);
+
     // Write main process logs to artifacts
     if (mainProcessLogs.length > 0) {
       fs.writeFileSync(
@@ -162,6 +169,12 @@ export const test = base.extend<{
       ),
     });
     await app.close();
+
+    if (unexpectedDialogCalls.length > 0) {
+      throw new Error(
+        `Unexpected unstubbed native dialog call${unexpectedDialogCalls.length === 1 ? '' : 's'}: ${unexpectedDialogCalls.join(', ')}`,
+      );
+    }
   },
   debug: async ({ window: _ }, use, info) => {
     await use(() => {


### PR DESCRIPTION
Previously, this resulted in a teardown timeout because the app could not be closed