### PR TITLE
feat: merge partially locked opossum files

### DIFF
--- a/src/ElectronBackend/api/__tests__/mergeOpossumFiles.test.ts
+++ b/src/ElectronBackend/api/__tests__/mergeOpossumFiles.test.ts
@@ -23,6 +23,7 @@ describe('mergeOpossumFiles', () => {
 
     await mergeOpossumFiles(
       {
+        ignoreReadonlyResourceOutputConflicts: true,
         saveFileParams,
         partitionPaths: ['/partitions/docs.opossum'],
       },
@@ -31,6 +32,7 @@ describe('mergeOpossumFiles', () => {
 
     expect(saveFile).toHaveBeenCalledWith(saveFileParams, opossumZip);
     expect(mergeOpossumArchives).toHaveBeenCalledWith({
+      ignoreReadonlyResourceOutputConflicts: true,
       inputPaths: ['/partitions/open.opossum', '/partitions/docs.opossum'],
       outputPath: '/partitions/open.opossum',
     });

--- a/src/ElectronBackend/api/__tests__/mergeOpossumFiles.test.ts
+++ b/src/ElectronBackend/api/__tests__/mergeOpossumFiles.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import AdmZip from 'adm-zip';
+
+import { mergeOpossumArchives } from '../../split/merge-opossum-files';
+import { mergeOpossumFiles } from '../mergeOpossumFiles';
+import { saveFile } from '../saveFile';
+
+vi.mock('../saveFile', () => ({ saveFile: vi.fn() }));
+vi.mock('../../split/merge-opossum-files', () => ({
+  mergeOpossumArchives: vi.fn(),
+}));
+
+describe('mergeOpossumFiles', () => {
+  it('saves the open project before merging it with the selected partitions', async () => {
+    const opossumZip = new AdmZip();
+    const saveFileParams = {
+      opossumFilePath: '/partitions/open.opossum',
+      projectId: 'project-id',
+    };
+
+    await mergeOpossumFiles(
+      {
+        saveFileParams,
+        partitionPaths: ['/partitions/docs.opossum'],
+      },
+      opossumZip,
+    );
+
+    expect(saveFile).toHaveBeenCalledWith(saveFileParams, opossumZip);
+    expect(mergeOpossumArchives).toHaveBeenCalledWith({
+      inputPaths: ['/partitions/open.opossum', '/partitions/docs.opossum'],
+      outputPath: '/partitions/open.opossum',
+    });
+  });
+});

--- a/src/ElectronBackend/api/mergeOpossumFiles.ts
+++ b/src/ElectronBackend/api/mergeOpossumFiles.ts
@@ -8,6 +8,7 @@ import { mergeOpossumArchives } from '../split/merge-opossum-files';
 import { saveFile, type SaveFileParams } from './saveFile';
 
 export interface MergeOpossumFilesParams {
+  ignoreReadonlyResourceOutputConflicts: boolean;
   saveFileParams: Omit<SaveFileParams, 'opossumFilePath'> & {
     opossumFilePath: string;
   };
@@ -15,23 +16,34 @@ export interface MergeOpossumFilesParams {
 }
 
 export interface MergeOpossumFilesFromPathsParams {
+  ignoreReadonlyResourceOutputConflicts: boolean;
   inputPaths: Array<string>;
   outputPath: string;
 }
 
 export async function mergeOpossumFilesFromPaths({
+  ignoreReadonlyResourceOutputConflicts,
   inputPaths,
   outputPath,
 }: MergeOpossumFilesFromPathsParams): Promise<void> {
-  await mergeOpossumArchives({ inputPaths, outputPath });
+  await mergeOpossumArchives({
+    ignoreReadonlyResourceOutputConflicts,
+    inputPaths,
+    outputPath,
+  });
 }
 
 export async function mergeOpossumFiles(
-  { saveFileParams, partitionPaths }: MergeOpossumFilesParams,
+  {
+    ignoreReadonlyResourceOutputConflicts,
+    saveFileParams,
+    partitionPaths,
+  }: MergeOpossumFilesParams,
   opossumZip: AdmZip,
 ): Promise<void> {
   await saveFile(saveFileParams, opossumZip);
   await mergeOpossumArchives({
+    ignoreReadonlyResourceOutputConflicts,
     inputPaths: [saveFileParams.opossumFilePath, ...partitionPaths],
     outputPath: saveFileParams.opossumFilePath,
   });

--- a/src/ElectronBackend/api/mergeOpossumFiles.ts
+++ b/src/ElectronBackend/api/mergeOpossumFiles.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import type AdmZip from 'adm-zip';
+
+import { mergeOpossumArchives } from '../split/merge-opossum-files';
+import { saveFile, type SaveFileParams } from './saveFile';
+
+export interface MergeOpossumFilesParams {
+  saveFileParams: Omit<SaveFileParams, 'opossumFilePath'> & {
+    opossumFilePath: string;
+  };
+  partitionPaths: Array<string>;
+}
+
+export interface MergeOpossumFilesFromPathsParams {
+  inputPaths: Array<string>;
+  outputPath: string;
+}
+
+export async function mergeOpossumFilesFromPaths({
+  inputPaths,
+  outputPath,
+}: MergeOpossumFilesFromPathsParams): Promise<void> {
+  await mergeOpossumArchives({ inputPaths, outputPath });
+}
+
+export async function mergeOpossumFiles(
+  { saveFileParams, partitionPaths }: MergeOpossumFilesParams,
+  opossumZip: AdmZip,
+): Promise<void> {
+  await saveFile(saveFileParams, opossumZip);
+  await mergeOpossumArchives({
+    inputPaths: [saveFileParams.opossumFilePath, ...partitionPaths],
+    outputPath: saveFileParams.opossumFilePath,
+  });
+}

--- a/src/ElectronBackend/api/mergeOpossumFiles.ts
+++ b/src/ElectronBackend/api/mergeOpossumFiles.ts
@@ -9,9 +9,7 @@ import { saveFile, type SaveFileParams } from './saveFile';
 
 export interface MergeOpossumFilesParams {
   ignoreReadonlyResourceOutputConflicts: boolean;
-  saveFileParams: Omit<SaveFileParams, 'opossumFilePath'> & {
-    opossumFilePath: string;
-  };
+  saveFileParams: SaveFileParams;
   partitionPaths: Array<string>;
 }
 

--- a/src/ElectronBackend/dbProcess/dbProcess.ts
+++ b/src/ElectronBackend/dbProcess/dbProcess.ts
@@ -45,6 +45,7 @@ interface SplitOpossumFileMessage {
 }
 
 interface MergeOpossumFilesMessage {
+  ignoreReadonlyResourceOutputConflicts: boolean;
   type: 'mergeOpossumFiles';
   projectId: string;
   inputFileChecksum?: string;
@@ -154,9 +155,19 @@ async function executeDbProcessMessage(
       if (!storedOpossumZip) {
         throw new Error('Cannot merge: no .opossum file is loaded');
       }
-      const { id: _, type: __, partitionPaths, ...saveFileParams } = msg;
+      const {
+        id: _,
+        type: __,
+        ignoreReadonlyResourceOutputConflicts,
+        partitionPaths,
+        ...saveFileParams
+      } = msg;
       await mergeOpossumFiles(
-        { saveFileParams, partitionPaths },
+        {
+          ignoreReadonlyResourceOutputConflicts,
+          saveFileParams,
+          partitionPaths,
+        },
         storedOpossumZip,
       );
       const loadResult = await loadFile(

--- a/src/ElectronBackend/dbProcess/dbProcess.ts
+++ b/src/ElectronBackend/dbProcess/dbProcess.ts
@@ -16,7 +16,10 @@ import {
   executeCommand,
 } from '../api/commands';
 import { exportFile } from '../api/exportCommands';
-import { mergeOpossumFiles } from '../api/mergeOpossumFiles';
+import {
+  mergeOpossumFiles,
+  mergeOpossumFilesFromPaths,
+} from '../api/mergeOpossumFiles';
 import { saveFile } from '../api/saveFile';
 import { splitOpossumFile } from '../api/splitOpossumFile';
 import {
@@ -53,6 +56,13 @@ interface MergeOpossumFilesMessage {
   partitionPaths: Array<string>;
 }
 
+interface MergeOpossumFilesFromPathsMessage {
+  ignoreReadonlyResourceOutputConflicts: boolean;
+  inputPaths: Array<string>;
+  outputPath: string;
+  type: 'mergeOpossumFilesFromPaths';
+}
+
 interface ExportFileMessage {
   type: 'exportFile';
   exportType: ExportType;
@@ -70,6 +80,7 @@ export type DbProcessPayload =
   | SaveFileMessage
   | SplitOpossumFileMessage
   | MergeOpossumFilesMessage
+  | MergeOpossumFilesFromPathsMessage
   | ExportFileMessage
   | ExecuteCommandMessage;
 
@@ -180,6 +191,21 @@ async function executeDbProcessMessage(
         );
       }
       storedOpossumZip = loadResult.opossumZip;
+      return undefined;
+    }
+    case 'mergeOpossumFilesFromPaths': {
+      const {
+        id: _,
+        type: __,
+        ignoreReadonlyResourceOutputConflicts,
+        inputPaths,
+        outputPath,
+      } = msg;
+      await mergeOpossumFilesFromPaths({
+        ignoreReadonlyResourceOutputConflicts,
+        inputPaths,
+        outputPath,
+      });
       return undefined;
     }
     case 'exportFile': {

--- a/src/ElectronBackend/dbProcess/dbProcess.ts
+++ b/src/ElectronBackend/dbProcess/dbProcess.ts
@@ -16,6 +16,7 @@ import {
   executeCommand,
 } from '../api/commands';
 import { exportFile } from '../api/exportCommands';
+import { mergeOpossumFiles } from '../api/mergeOpossumFiles';
 import { saveFile } from '../api/saveFile';
 import { splitOpossumFile } from '../api/splitOpossumFile';
 import {
@@ -43,6 +44,14 @@ interface SplitOpossumFileMessage {
   splitOpossumFilePath: string;
 }
 
+interface MergeOpossumFilesMessage {
+  type: 'mergeOpossumFiles';
+  projectId: string;
+  inputFileChecksum?: string;
+  opossumFilePath: string;
+  partitionPaths: Array<string>;
+}
+
 interface ExportFileMessage {
   type: 'exportFile';
   exportType: ExportType;
@@ -59,6 +68,7 @@ export type DbProcessPayload =
   | LoadFileMessage
   | SaveFileMessage
   | SplitOpossumFileMessage
+  | MergeOpossumFilesMessage
   | ExportFileMessage
   | ExecuteCommandMessage;
 
@@ -138,6 +148,27 @@ async function executeDbProcessMessage(
         },
         storedOpossumZip,
       );
+      return undefined;
+    }
+    case 'mergeOpossumFiles': {
+      if (!storedOpossumZip) {
+        throw new Error('Cannot merge: no .opossum file is loaded');
+      }
+      const { id: _, type: __, partitionPaths, ...saveFileParams } = msg;
+      await mergeOpossumFiles(
+        { saveFileParams, partitionPaths },
+        storedOpossumZip,
+      );
+      const loadResult = await loadFile(
+        saveFileParams.opossumFilePath,
+        onProgress,
+      );
+      if (!loadResult.ok) {
+        throw new Error(
+          `Could not reload merged archive: ${loadResult.error.message}`,
+        );
+      }
+      storedOpossumZip = loadResult.opossumZip;
       return undefined;
     }
     case 'exportFile': {

--- a/src/ElectronBackend/dbProcess/dbProcessClient.ts
+++ b/src/ElectronBackend/dbProcess/dbProcessClient.ts
@@ -136,10 +136,12 @@ export class DbProcessClient {
   }
 
   mergeOpossumFiles({
+    ignoreReadonlyResourceOutputConflicts,
     saveFileParams,
     partitionPaths,
   }: MergeOpossumFilesParams): Promise<void> {
     return this.request({
+      ignoreReadonlyResourceOutputConflicts,
       type: 'mergeOpossumFiles',
       ...saveFileParams,
       partitionPaths,

--- a/src/ElectronBackend/dbProcess/dbProcessClient.ts
+++ b/src/ElectronBackend/dbProcess/dbProcessClient.ts
@@ -11,7 +11,10 @@ import type {
   CommandParams,
   CommandReturn,
 } from '../api/commands';
-import type { MergeOpossumFilesParams } from '../api/mergeOpossumFiles';
+import type {
+  MergeOpossumFilesFromPathsParams,
+  MergeOpossumFilesParams,
+} from '../api/mergeOpossumFiles';
 import type { SaveFileParams } from '../api/saveFile';
 import type { SplitOpossumFileParams } from '../api/splitOpossumFile';
 import type { LoadFileIpcResult } from '../input/loadFile';
@@ -145,6 +148,19 @@ export class DbProcessClient {
       type: 'mergeOpossumFiles',
       ...saveFileParams,
       partitionPaths,
+    }) as Promise<void>;
+  }
+
+  mergeOpossumFilesFromPaths({
+    ignoreReadonlyResourceOutputConflicts,
+    inputPaths,
+    outputPath,
+  }: MergeOpossumFilesFromPathsParams): Promise<void> {
+    return this.request({
+      ignoreReadonlyResourceOutputConflicts,
+      inputPaths,
+      outputPath,
+      type: 'mergeOpossumFilesFromPaths',
     }) as Promise<void>;
   }
 

--- a/src/ElectronBackend/dbProcess/dbProcessClient.ts
+++ b/src/ElectronBackend/dbProcess/dbProcessClient.ts
@@ -11,6 +11,7 @@ import type {
   CommandParams,
   CommandReturn,
 } from '../api/commands';
+import type { MergeOpossumFilesParams } from '../api/mergeOpossumFiles';
 import type { SaveFileParams } from '../api/saveFile';
 import type { SplitOpossumFileParams } from '../api/splitOpossumFile';
 import type { LoadFileIpcResult } from '../input/loadFile';
@@ -131,6 +132,17 @@ export class DbProcessClient {
       ...saveFileParams,
       selectedFolderPaths,
       splitOpossumFilePath,
+    }) as Promise<void>;
+  }
+
+  mergeOpossumFiles({
+    saveFileParams,
+    partitionPaths,
+  }: MergeOpossumFilesParams): Promise<void> {
+    return this.request({
+      type: 'mergeOpossumFiles',
+      ...saveFileParams,
+      partitionPaths,
     }) as Promise<void>;
   }
 

--- a/src/ElectronBackend/input/parseFile.ts
+++ b/src/ElectronBackend/input/parseFile.ts
@@ -119,7 +119,7 @@ export async function parseOpossumFile(
   };
 }
 
-function parseReadonlyRules(content: string): Array<ReadonlyRule> {
+export function parseReadonlyRules(content: string): Array<ReadonlyRule> {
   const parsedContent = JSON.parse(content);
   jsonSchemaValidator.validate(
     parsedContent,
@@ -129,7 +129,7 @@ function parseReadonlyRules(content: string): Array<ReadonlyRule> {
   return parsedContent.readonlyRules as Array<ReadonlyRule>;
 }
 
-function parseOutputJsonContent(
+export function parseOutputJsonContent(
   fileContent: string,
   filePath: string,
 ): ParsedOpossumOutputFile {

--- a/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
+++ b/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
@@ -226,12 +226,13 @@ describe('mergeCurrentOpossumFilesListener', () => {
     await mergeCurrentOpossumFilesListener()(
       {} as Electron.IpcMainInvokeEvent,
       ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
+      false,
     );
 
     expect(mockMergeOpossumFiles).toHaveBeenCalledWith({
+      ignoreReadonlyResourceOutputConflicts: false,
       saveFileParams: {
         projectId: 'uuid_1',
-        inputFileChecksum: 'checksum_abc',
         opossumFilePath: '/my/file.opossum',
       },
       partitionPaths: [
@@ -245,9 +246,11 @@ describe('mergeCurrentOpossumFilesListener', () => {
     setGlobalBackendState({});
 
     await expect(
-      mergeCurrentOpossumFilesListener()({} as Electron.IpcMainInvokeEvent, [
-        '/partitions/docs.opossum',
-      ]),
+      mergeCurrentOpossumFilesListener()(
+        {} as Electron.IpcMainInvokeEvent,
+        ['/partitions/docs.opossum'],
+        false,
+      ),
     ).rejects.toThrow('No .opossum project is currently open.');
   });
 });
@@ -258,9 +261,11 @@ describe('mergeOpossumFilesFromPathsListener', () => {
       {} as Electron.IpcMainInvokeEvent,
       ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
       '/merged/project.opossum',
+      false,
     );
 
     expect(mergeOpossumFilesFromPaths).toHaveBeenCalledWith({
+      ignoreReadonlyResourceOutputConflicts: false,
       inputPaths: ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
       outputPath: '/merged/project.opossum',
     });

--- a/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
+++ b/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
@@ -7,7 +7,6 @@ import { type BrowserWindow, dialog, type WebContents } from 'electron';
 import type { Mock } from 'vitest';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
-import { mergeOpossumFilesFromPaths } from '../../api/mergeOpossumFiles';
 import { getMainDbClient } from '../../dbProcess/dbProcessClient';
 import { saveOpossumFileDialog } from '../dialogs';
 import { setGlobalBackendState } from '../globalBackendState';
@@ -41,10 +40,6 @@ vi.mock('../../dbProcess/dbProcessClient', () => ({
   getMainDbClient: vi.fn(),
 }));
 
-vi.mock('../../api/mergeOpossumFiles', () => ({
-  mergeOpossumFilesFromPaths: vi.fn(),
-}));
-
 vi.mock('../dialogs', () => ({
   saveOpossumFileDialog: vi.fn(),
 }));
@@ -52,11 +47,13 @@ vi.mock('../dialogs', () => ({
 const mockSaveFile = vi.fn();
 const mockSplitOpossumFile = vi.fn();
 const mockMergeOpossumFiles = vi.fn();
+const mockMergeOpossumFilesFromPaths = vi.fn();
 
 (getMainDbClient as Mock).mockReturnValue({
   saveFile: mockSaveFile,
   splitOpossumFile: mockSplitOpossumFile,
   mergeOpossumFiles: mockMergeOpossumFiles,
+  mergeOpossumFilesFromPaths: mockMergeOpossumFilesFromPaths,
 });
 
 describe('saveFileListener', () => {
@@ -66,6 +63,7 @@ describe('saveFileListener', () => {
       saveFile: mockSaveFile,
       splitOpossumFile: mockSplitOpossumFile,
       mergeOpossumFiles: mockMergeOpossumFiles,
+      mergeOpossumFilesFromPaths: mockMergeOpossumFilesFromPaths,
     });
   });
 
@@ -264,7 +262,7 @@ describe('mergeOpossumFilesFromPathsListener', () => {
       false,
     );
 
-    expect(mergeOpossumFilesFromPaths).toHaveBeenCalledWith({
+    expect(mockMergeOpossumFilesFromPaths).toHaveBeenCalledWith({
       ignoreReadonlyResourceOutputConflicts: false,
       inputPaths: ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
       outputPath: '/merged/project.opossum',

--- a/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
+++ b/src/ElectronBackend/main/__tests__/get-save-file-listener.test.ts
@@ -7,10 +7,13 @@ import { type BrowserWindow, dialog, type WebContents } from 'electron';
 import type { Mock } from 'vitest';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
+import { mergeOpossumFilesFromPaths } from '../../api/mergeOpossumFiles';
 import { getMainDbClient } from '../../dbProcess/dbProcessClient';
 import { saveOpossumFileDialog } from '../dialogs';
 import { setGlobalBackendState } from '../globalBackendState';
 import {
+  mergeCurrentOpossumFilesListener,
+  mergeOpossumFilesFromPathsListener,
   saveFileListener,
   selectSplitDestinationListener,
   splitCurrentOpossumFileListener,
@@ -38,16 +41,22 @@ vi.mock('../../dbProcess/dbProcessClient', () => ({
   getMainDbClient: vi.fn(),
 }));
 
+vi.mock('../../api/mergeOpossumFiles', () => ({
+  mergeOpossumFilesFromPaths: vi.fn(),
+}));
+
 vi.mock('../dialogs', () => ({
   saveOpossumFileDialog: vi.fn(),
 }));
 
 const mockSaveFile = vi.fn();
 const mockSplitOpossumFile = vi.fn();
+const mockMergeOpossumFiles = vi.fn();
 
 (getMainDbClient as Mock).mockReturnValue({
   saveFile: mockSaveFile,
   splitOpossumFile: mockSplitOpossumFile,
+  mergeOpossumFiles: mockMergeOpossumFiles,
 });
 
 describe('saveFileListener', () => {
@@ -56,6 +65,7 @@ describe('saveFileListener', () => {
     (getMainDbClient as Mock).mockReturnValue({
       saveFile: mockSaveFile,
       splitOpossumFile: mockSplitOpossumFile,
+      mergeOpossumFiles: mockMergeOpossumFiles,
     });
   });
 
@@ -200,5 +210,59 @@ describe('splitCurrentOpossumFileListener', () => {
       '/my/file-source.opossum',
     );
     expect(selectedPath).toBe('/partitions/source-partition.opossum');
+  });
+});
+
+describe('mergeCurrentOpossumFilesListener', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setGlobalBackendState({
+      opossumFilePath: '/my/file.opossum',
+      projectId: 'uuid_1',
+    });
+  });
+
+  it('merges the provided partitions into the currently open archive', async () => {
+    await mergeCurrentOpossumFilesListener()(
+      {} as Electron.IpcMainInvokeEvent,
+      ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
+    );
+
+    expect(mockMergeOpossumFiles).toHaveBeenCalledWith({
+      saveFileParams: {
+        projectId: 'uuid_1',
+        inputFileChecksum: 'checksum_abc',
+        opossumFilePath: '/my/file.opossum',
+      },
+      partitionPaths: [
+        '/partitions/docs.opossum',
+        '/partitions/frontend.opossum',
+      ],
+    });
+  });
+
+  it('rejects merging when no .opossum project is open', async () => {
+    setGlobalBackendState({});
+
+    await expect(
+      mergeCurrentOpossumFilesListener()({} as Electron.IpcMainInvokeEvent, [
+        '/partitions/docs.opossum',
+      ]),
+    ).rejects.toThrow('No .opossum project is currently open.');
+  });
+});
+
+describe('mergeOpossumFilesFromPathsListener', () => {
+  it('forwards the selected archive paths without requiring an open project', async () => {
+    await mergeOpossumFilesFromPathsListener(
+      {} as Electron.IpcMainInvokeEvent,
+      ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
+      '/merged/project.opossum',
+    );
+
+    expect(mergeOpossumFilesFromPaths).toHaveBeenCalledWith({
+      inputPaths: ['/partitions/docs.opossum', '/partitions/frontend.opossum'],
+      outputPath: '/merged/project.opossum',
+    });
   });
 });

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -18,6 +18,7 @@ import {
   type SplitFileResult,
 } from '../../shared/shared-types';
 import { text } from '../../shared/text';
+import { mergeOpossumFilesFromPaths } from '../api/mergeOpossumFiles';
 import { getMainDbClient } from '../dbProcess/dbProcessClient';
 import {
   sendListenerErrorToFrontend,
@@ -105,6 +106,34 @@ export const splitCurrentOpossumFileListener =
       return { status: 'error', message };
     }
   };
+
+export const mergeCurrentOpossumFilesListener =
+  () =>
+  async (
+    _: Electron.IpcMainInvokeEvent,
+    partitionPaths: Array<string>,
+  ): Promise<void> => {
+    const globalBackendState = getGlobalBackendState();
+    if (!globalBackendState.projectId || !globalBackendState.opossumFilePath) {
+      throw new Error('No .opossum project is currently open.');
+    }
+
+    await getMainDbClient().mergeOpossumFiles({
+      saveFileParams: {
+        projectId: globalBackendState.projectId,
+        opossumFilePath: globalBackendState.opossumFilePath,
+      },
+      partitionPaths,
+    });
+  };
+
+export async function mergeOpossumFilesFromPathsListener(
+  _: Electron.IpcMainInvokeEvent,
+  inputPaths: Array<string>,
+  outputPath: string,
+): Promise<void> {
+  await mergeOpossumFilesFromPaths({ inputPaths, outputPath });
+}
 
 export const selectSplitDestinationListener =
   (_mainWindow: BrowserWindow) =>

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -112,6 +112,7 @@ export const mergeCurrentOpossumFilesListener =
   async (
     _: Electron.IpcMainInvokeEvent,
     partitionPaths: Array<string>,
+    ignoreReadonlyResourceOutputConflicts: boolean,
   ): Promise<void> => {
     const globalBackendState = getGlobalBackendState();
     if (!globalBackendState.projectId || !globalBackendState.opossumFilePath) {
@@ -119,6 +120,7 @@ export const mergeCurrentOpossumFilesListener =
     }
 
     await getMainDbClient().mergeOpossumFiles({
+      ignoreReadonlyResourceOutputConflicts,
       saveFileParams: {
         projectId: globalBackendState.projectId,
         opossumFilePath: globalBackendState.opossumFilePath,
@@ -131,8 +133,13 @@ export async function mergeOpossumFilesFromPathsListener(
   _: Electron.IpcMainInvokeEvent,
   inputPaths: Array<string>,
   outputPath: string,
+  ignoreReadonlyResourceOutputConflicts: boolean,
 ): Promise<void> {
-  await mergeOpossumFilesFromPaths({ inputPaths, outputPath });
+  await mergeOpossumFilesFromPaths({
+    ignoreReadonlyResourceOutputConflicts,
+    inputPaths,
+    outputPath,
+  });
 }
 
 export const selectSplitDestinationListener =

--- a/src/ElectronBackend/main/listeners.ts
+++ b/src/ElectronBackend/main/listeners.ts
@@ -18,7 +18,6 @@ import {
   type SplitFileResult,
 } from '../../shared/shared-types';
 import { text } from '../../shared/text';
-import { mergeOpossumFilesFromPaths } from '../api/mergeOpossumFiles';
 import { getMainDbClient } from '../dbProcess/dbProcessClient';
 import {
   sendListenerErrorToFrontend,
@@ -135,7 +134,7 @@ export async function mergeOpossumFilesFromPathsListener(
   outputPath: string,
   ignoreReadonlyResourceOutputConflicts: boolean,
 ): Promise<void> {
-  await mergeOpossumFilesFromPaths({
+  await getMainDbClient().mergeOpossumFilesFromPaths({
     ignoreReadonlyResourceOutputConflicts,
     inputPaths,
     outputPath,

--- a/src/ElectronBackend/main/setUpIpcHandling.ts
+++ b/src/ElectronBackend/main/setUpIpcHandling.ts
@@ -11,7 +11,9 @@ import {
   exportFileListener,
   importFileConvertAndLoadListener,
   importFileSelectSaveLocationListener,
+  mergeCurrentOpossumFilesListener,
   mergeFileAndLoadListener,
+  mergeOpossumFilesFromPathsListener,
   openFileListener,
   openLinkListener,
   saveFileListener,
@@ -52,6 +54,14 @@ export function setupIpcHandling(
     selectSplitDestinationListener(window),
   );
   ipcMain.handle(IpcChannel.SplitFile, splitCurrentOpossumFileListener(window));
+  ipcMain.handle(
+    IpcChannel.MergeOpossumFiles,
+    mergeCurrentOpossumFilesListener(),
+  );
+  ipcMain.handle(
+    IpcChannel.MergeOpossumFilesFromPaths,
+    mergeOpossumFilesFromPathsListener,
+  );
   ipcMain.handle(IpcChannel.ExportFile, exportFileListener(window));
   ipcMain.handle(IpcChannel.StopLoading, () =>
     new ProcessingStatusUpdater(window.webContents).endProcessing(),

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -53,6 +53,14 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke(IpcChannel.SelectSplitDestination, splitPath),
   splitFile: (splitPaths, splitOpossumFilePath) =>
     ipcRenderer.invoke(IpcChannel.SplitFile, splitPaths, splitOpossumFilePath),
+  mergeOpossumFiles: (partitionPaths) =>
+    ipcRenderer.invoke(IpcChannel.MergeOpossumFiles, partitionPaths),
+  mergeOpossumFilesFromPaths: (inputPaths, outputPath) =>
+    ipcRenderer.invoke(
+      IpcChannel.MergeOpossumFilesFromPaths,
+      inputPaths,
+      outputPath,
+    ),
   saveFile: () => ipcRenderer.invoke(IpcChannel.SaveFile),
   exportFile: (exportType) =>
     ipcRenderer.invoke(IpcChannel.ExportFile, exportType),

--- a/src/ElectronBackend/preload.ts
+++ b/src/ElectronBackend/preload.ts
@@ -53,13 +53,22 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke(IpcChannel.SelectSplitDestination, splitPath),
   splitFile: (splitPaths, splitOpossumFilePath) =>
     ipcRenderer.invoke(IpcChannel.SplitFile, splitPaths, splitOpossumFilePath),
-  mergeOpossumFiles: (partitionPaths) =>
-    ipcRenderer.invoke(IpcChannel.MergeOpossumFiles, partitionPaths),
-  mergeOpossumFilesFromPaths: (inputPaths, outputPath) =>
+  mergeOpossumFiles: (partitionPaths, ignoreReadonlyResourceOutputConflicts) =>
+    ipcRenderer.invoke(
+      IpcChannel.MergeOpossumFiles,
+      partitionPaths,
+      ignoreReadonlyResourceOutputConflicts,
+    ),
+  mergeOpossumFilesFromPaths: (
+    inputPaths,
+    outputPath,
+    ignoreReadonlyResourceOutputConflicts,
+  ) =>
     ipcRenderer.invoke(
       IpcChannel.MergeOpossumFilesFromPaths,
       inputPaths,
       outputPath,
+      ignoreReadonlyResourceOutputConflicts,
     ),
   saveFile: () => ipcRenderer.invoke(IpcChannel.SaveFile),
   exportFile: (exportType) =>

--- a/src/ElectronBackend/split/__tests__/merge-opossum-files.test.ts
+++ b/src/ElectronBackend/split/__tests__/merge-opossum-files.test.ts
@@ -203,7 +203,43 @@ describe('mergeOpossumArchives', () => {
     ]);
   });
 
-  it('keeps readonly resource output from the first archive', async () => {
+  it('rejects conflicting readonly resource attribution mappings', async () => {
+    const firstPath = await createArchive({
+      output: output({
+        attributions: { other: 'first-other', shared: 'first-shared' },
+      }),
+      readonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
+      ],
+    });
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await expect(
+      mergeOpossumArchives({
+        inputPaths: [
+          firstPath,
+          await createArchive({
+            output: output({
+              attributions: {
+                other: 'second-other',
+                shared: 'second-shared',
+              },
+            }),
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/frontend', readonly: false },
+            ],
+          }),
+        ],
+        outputPath,
+      }),
+    ).rejects.toThrow(
+      "readonly resource output for paths: '/other/', '/shared/'",
+    );
+  });
+
+  it('uses the first archive readonly resource output when conflicts are ignored', async () => {
     const firstPath = await createArchive({
       output: output({ attributions: { shared: 'first-shared' } }),
       readonlyRules: [
@@ -214,6 +250,7 @@ describe('mergeOpossumArchives', () => {
     const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
 
     await mergeOpossumArchives({
+      ignoreReadonlyResourceOutputConflicts: true,
       inputPaths: [
         firstPath,
         await createArchive({
@@ -233,6 +270,35 @@ describe('mergeOpossumArchives', () => {
         'first-shared': { packageName: 'first-shared' },
       },
     });
+  });
+
+  it('rejects conflicting readonly manual attribution payloads', async () => {
+    const firstOutput = output({ attributions: { shared: 'shared' } });
+    const secondOutput = output({ attributions: { shared: 'shared' } });
+    secondOutput.manualAttributions.shared = { packageName: 'updated-shared' };
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await expect(
+      mergeOpossumArchives({
+        inputPaths: [
+          await createArchive({
+            output: firstOutput,
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/docs', readonly: false },
+            ],
+          }),
+          await createArchive({
+            output: secondOutput,
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/frontend', readonly: false },
+            ],
+          }),
+        ],
+        outputPath,
+      }),
+    ).rejects.toThrow("readonly resource output for paths: '/shared/'");
   });
 
   it('rejects archives with different project IDs', async () => {

--- a/src/ElectronBackend/split/__tests__/merge-opossum-files.test.ts
+++ b/src/ElectronBackend/split/__tests__/merge-opossum-files.test.ts
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import AdmZip from 'adm-zip';
+
+import type { ReadonlyRule } from '../../../shared/shared-types';
+import { writeOpossumFile } from '../../../shared/write-file';
+import {
+  INPUT_FILE_NAME,
+  SPLIT_INFO_FILE_NAME,
+} from '../../../shared/write-file-utils';
+import { faker } from '../../../testing/Faker';
+import { parseOpossumFile } from '../../input/parseFile';
+import type {
+  ParsedOpossumInputFile,
+  ParsedOpossumOutputFile,
+} from '../../types/types';
+import {
+  mergeOpossumArchives,
+  MergeOpossumFilesError,
+} from '../merge-opossum-files';
+import { splitOpossumArchive } from '../split-opossum-file';
+
+const input: ParsedOpossumInputFile = {
+  metadata: { fileCreationDate: 'today', projectId: 'project-id' },
+  resources: {
+    docs: { 'README.md': 1 },
+    frontend: { 'App.tsx': 1 },
+  },
+  externalAttributions: {},
+  resourcesToAttributions: {},
+};
+
+describe('mergeOpossumArchives', () => {
+  it('merges complementary partitions into an editable archive', async () => {
+    const sourcePath = await createArchive({
+      output: output({
+        attributions: {
+          docs: 'stale-docs',
+          frontend: 'source-frontend',
+        },
+        resolved: ['source-resolved'],
+      }),
+      readonlyRules: [{ path: '/docs', readonly: true }],
+      additionalFile: 'source data',
+    });
+    const selectedPath = await createArchive({
+      output: output({
+        attributions: { docs: 'selected-docs' },
+        resolved: ['selected-resolved'],
+      }),
+      readonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
+      ],
+    });
+    const outputPath = sourcePath;
+
+    await mergeOpossumArchives({
+      inputPaths: [sourcePath, selectedPath],
+      outputPath,
+    });
+
+    const parsed = await parseMergedArchive(outputPath);
+    expect(parsed.readonlyRules).toEqual([]);
+    expect(parsed.output).toMatchObject({
+      resourcesToAttributions: {
+        '/docs/': ['selected-docs'],
+        '/frontend/': ['source-frontend'],
+      },
+      manualAttributions: {
+        'selected-docs': { packageName: 'selected-docs' },
+        'source-frontend': { packageName: 'source-frontend' },
+      },
+    });
+    expect(parsed.output?.resolvedExternalAttributions).toEqual([
+      'source-resolved',
+      'selected-resolved',
+    ]);
+    expect(parsed.output?.manualAttributions).not.toHaveProperty('stale-docs');
+    expect(new AdmZip(outputPath).readAsText('additional-data.txt')).toBe(
+      'source data',
+    );
+  });
+
+  it('merges consecutively split archives in any order', async () => {
+    const sourcePath = await createArchive({
+      output: output({
+        attributions: {
+          backend: 'initial-backend',
+          docs: 'initial-docs',
+          frontend: 'initial-frontend',
+        },
+      }),
+      readonlyRules: [],
+    });
+    const docsPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+    const firstSplit = await splitOpossumArchive({
+      paths: {
+        sourceOpossumFilePath: sourcePath,
+        selectedFolderPaths: ['/docs'],
+        splitOpossumFilePath: docsPath,
+      },
+      sourceZip: new AdmZip(sourcePath),
+      readonlyRules: [],
+    });
+    const frontendPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+    await splitOpossumArchive({
+      paths: {
+        sourceOpossumFilePath: sourcePath,
+        selectedFolderPaths: ['/frontend'],
+        splitOpossumFilePath: frontendPath,
+      },
+      sourceZip: new AdmZip(sourcePath),
+      readonlyRules: firstSplit.sourceReadonlyRules,
+    });
+
+    const updatedSourcePath = await copyArchiveWithOutput(
+      sourcePath,
+      output({
+        attributions: {
+          backend: 'updated-backend',
+          docs: 'stale-source-docs',
+          frontend: 'stale-source-frontend',
+        },
+      }),
+    );
+    const updatedDocsPath = await copyArchiveWithOutput(
+      docsPath,
+      output({
+        attributions: {
+          backend: 'stale-docs-backend',
+          docs: 'updated-docs',
+          frontend: 'stale-docs-frontend',
+        },
+      }),
+    );
+    const updatedFrontendPath = await copyArchiveWithOutput(
+      frontendPath,
+      output({
+        attributions: {
+          backend: 'stale-frontend-backend',
+          docs: 'stale-frontend-docs',
+          frontend: 'updated-frontend',
+        },
+      }),
+    );
+
+    const expectedOutput = output({
+      attributions: {
+        backend: 'updated-backend',
+        docs: 'updated-docs',
+        frontend: 'updated-frontend',
+      },
+    });
+    for (const inputPaths of getPermutations([
+      updatedSourcePath,
+      updatedDocsPath,
+      updatedFrontendPath,
+    ])) {
+      const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+      await mergeOpossumArchives({ inputPaths, outputPath });
+
+      const parsed = await parseMergedArchive(outputPath);
+      expect(parsed.readonlyRules).toEqual([]);
+      expect(parsed.output?.resourcesToAttributions).toEqual(
+        expectedOutput.resourcesToAttributions,
+      );
+      expect(parsed.output?.manualAttributions).toEqual(
+        expectedOutput.manualAttributions,
+      );
+    }
+  });
+
+  it('keeps split metadata when the merged partitions do not cover all resources', async () => {
+    const firstPath = await createArchive({
+      readonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
+      ],
+    });
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await mergeOpossumArchives({
+      inputPaths: [
+        firstPath,
+        await createArchive({
+          readonlyRules: [
+            { path: '/', readonly: true },
+            { path: '/frontend', readonly: false },
+          ],
+        }),
+      ],
+      outputPath,
+    });
+
+    expect(getReadonlyRules(outputPath)).toEqual([
+      { path: '/', readonly: true },
+      { path: '/docs', readonly: false },
+      { path: '/frontend', readonly: false },
+    ]);
+  });
+
+  it('keeps readonly resource output from the first archive', async () => {
+    const firstPath = await createArchive({
+      output: output({ attributions: { shared: 'first-shared' } }),
+      readonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
+      ],
+    });
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await mergeOpossumArchives({
+      inputPaths: [
+        firstPath,
+        await createArchive({
+          output: output({ attributions: { shared: 'second-shared' } }),
+          readonlyRules: [
+            { path: '/', readonly: true },
+            { path: '/frontend', readonly: false },
+          ],
+        }),
+      ],
+      outputPath,
+    });
+
+    expect((await parseMergedArchive(outputPath)).output).toMatchObject({
+      resourcesToAttributions: { '/shared/': ['first-shared'] },
+      manualAttributions: {
+        'first-shared': { packageName: 'first-shared' },
+      },
+    });
+  });
+
+  it('rejects archives with different project IDs', async () => {
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await expect(
+      mergeOpossumArchives({
+        inputPaths: [
+          await createArchive({
+            readonlyRules: [{ path: '/docs', readonly: true }],
+          }),
+          await createArchive({
+            projectId: 'other-project-id',
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/docs', readonly: false },
+            ],
+          }),
+        ],
+        outputPath,
+      }),
+    ).rejects.toThrow('same project ID');
+  });
+
+  it('does not parse input.json while merging', async () => {
+    const sourcePath = await createArchive({
+      inputContent: '{invalid json',
+      readonlyRules: [{ path: '/docs', readonly: true }],
+    });
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await mergeOpossumArchives({
+      inputPaths: [
+        sourcePath,
+        await createArchive({
+          readonlyRules: [
+            { path: '/', readonly: true },
+            { path: '/docs', readonly: false },
+          ],
+        }),
+      ],
+      outputPath,
+    });
+
+    expect(new AdmZip(outputPath).getEntry('output.json')).toBeDefined();
+  });
+
+  it('rejects overlapping editable partitions', async () => {
+    const outputPath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+
+    await expect(
+      mergeOpossumArchives({
+        inputPaths: [
+          await createArchive({
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/docs', readonly: false },
+            ],
+          }),
+          await createArchive({
+            readonlyRules: [
+              { path: '/', readonly: true },
+              { path: '/docs', readonly: false },
+            ],
+          }),
+        ],
+        outputPath,
+      }),
+    ).rejects.toBeInstanceOf(MergeOpossumFilesError);
+  });
+});
+
+async function createArchive({
+  additionalFile,
+  inputContent,
+  output: archiveOutput,
+  projectId = input.metadata.projectId,
+  readonlyRules,
+}: {
+  additionalFile?: string;
+  inputContent?: string;
+  output?: ParsedOpossumOutputFile;
+  projectId?: string;
+  readonlyRules: Array<ReadonlyRule>;
+}): Promise<string> {
+  const archivePath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+  const archiveInput = { ...input, metadata: { projectId } };
+  const outputWithProjectId: ParsedOpossumOutputFile = archiveOutput
+    ? {
+        ...archiveOutput,
+        metadata: {
+          ...archiveOutput.metadata,
+          projectId,
+        },
+      }
+    : {
+        metadata: { fileCreationDate: 'today', projectId },
+        manualAttributions: {},
+        resourcesToAttributions: {},
+        resolvedExternalAttributions: [],
+      };
+  const zip = new AdmZip();
+  zip.addFile(
+    INPUT_FILE_NAME,
+    Buffer.from(inputContent ?? JSON.stringify(archiveInput)),
+  );
+  if (additionalFile) {
+    zip.addFile('additional-data.txt', Buffer.from(additionalFile));
+  }
+  await writeOpossumFile({
+    output: outputWithProjectId,
+    path: archivePath,
+    readonlyRules,
+    zip,
+  });
+  return archivePath;
+}
+
+function getPermutations<T>(values: Array<T>): Array<Array<T>> {
+  if (values.length === 0) {
+    return [[]];
+  }
+  return values.flatMap((value, index) =>
+    getPermutations(values.filter((_, otherIndex) => otherIndex !== index)).map(
+      (permutation) => [value, ...permutation],
+    ),
+  );
+}
+
+async function copyArchiveWithOutput(
+  sourcePath: string,
+  archiveOutput: ParsedOpossumOutputFile,
+): Promise<string> {
+  const archivePath = faker.outputPath(`${faker.string.uuid()}.opossum`);
+  const sourceZip = new AdmZip(sourcePath);
+  const zip = new AdmZip();
+  for (const entry of sourceZip.getEntries()) {
+    zip.addFile(entry.entryName, entry.getData());
+  }
+  await writeOpossumFile({
+    output: archiveOutput,
+    path: archivePath,
+    zip,
+  });
+  return archivePath;
+}
+
+function output({
+  attributions,
+  resolved = [],
+}: {
+  attributions: Record<string, string>;
+  resolved?: Array<string>;
+}): ParsedOpossumOutputFile {
+  return {
+    metadata: {
+      fileCreationDate: 'today',
+      projectId: input.metadata.projectId,
+    },
+    manualAttributions: Object.fromEntries(
+      Object.values(attributions).map((attributionUuid) => [
+        attributionUuid,
+        { packageName: attributionUuid },
+      ]),
+    ),
+    resourcesToAttributions: Object.fromEntries(
+      Object.entries(attributions).map(([directory, attributionUuid]) => [
+        `/${directory}/`,
+        [attributionUuid],
+      ]),
+    ),
+    resolvedExternalAttributions: resolved,
+  };
+}
+
+async function parseMergedArchive(filePath: string) {
+  const parsed = await parseOpossumFile(filePath);
+  if ('type' in parsed) {
+    throw new Error(parsed.message);
+  }
+  return parsed;
+}
+
+function getReadonlyRules(filePath: string): Array<ReadonlyRule> {
+  return JSON.parse(new AdmZip(filePath).readAsText(SPLIT_INFO_FILE_NAME))
+    .readonlyRules as Array<ReadonlyRule>;
+}

--- a/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
+++ b/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  createSplitRules,
+  getReadonlyRuleMap,
+  getReadonlyState,
+  mergeReadonlyRules,
+  MergeReadonlyRulesError,
+} from '../readonly-rules';
+
+describe('getReadonlyState', () => {
+  it('uses the closest matching rule and defaults to editable', () => {
+    const rulesByPath = getReadonlyRuleMap([
+      { path: '/', readonly: true },
+      { path: '/frontend', readonly: false },
+      { path: '/frontend/generated', readonly: true },
+    ]);
+
+    expect(getReadonlyState('/docs', rulesByPath)).toBe(true);
+    expect(getReadonlyState('/frontend/App.tsx', rulesByPath)).toBe(false);
+    expect(getReadonlyState('/frontend/generated/file.ts', rulesByPath)).toBe(
+      true,
+    );
+    expect(getReadonlyState('/unknown', getReadonlyRuleMap([]))).toBe(false);
+  });
+});
+
+describe('mergeReadonlyRules', () => {
+  it('merges complementary partitions into an editable result', () => {
+    expect(
+      mergeReadonlyRules([
+        [{ path: '/docs', readonly: true }],
+        [
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+      ]),
+    ).toEqual([]);
+  });
+
+  it('retains readonly paths that are not editable in any partition', () => {
+    expect(
+      mergeReadonlyRules([
+        [
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+        [
+          { path: '/', readonly: true },
+          { path: '/frontend', readonly: false },
+        ],
+      ]),
+    ).toEqual([
+      { path: '/', readonly: true },
+      { path: '/docs', readonly: false },
+      { path: '/frontend', readonly: false },
+    ]);
+  });
+
+  it('keeps only necessary nested overrides', () => {
+    expect(
+      mergeReadonlyRules([
+        [
+          { path: '/', readonly: true },
+          { path: '/frontend', readonly: false },
+          { path: '/frontend/components', readonly: true },
+        ],
+        [
+          { path: '/', readonly: true },
+          { path: '/frontend/components', readonly: false },
+        ],
+      ]),
+    ).toEqual([
+      { path: '/', readonly: true },
+      { path: '/frontend', readonly: false },
+    ]);
+  });
+
+  it('retains a readonly nested override below an editable path', () => {
+    expect(
+      mergeReadonlyRules([
+        [
+          { path: '/', readonly: true },
+          { path: '/src', readonly: false },
+          { path: '/src/generated', readonly: true },
+        ],
+        [{ path: '/', readonly: true }],
+      ]),
+    ).toEqual([
+      { path: '/', readonly: true },
+      { path: '/src', readonly: false },
+      { path: '/src/generated', readonly: true },
+    ]);
+  });
+
+  it('keeps a fully readonly result', () => {
+    expect(
+      mergeReadonlyRules([
+        [{ path: '/', readonly: true }],
+        [{ path: '/', readonly: true }],
+      ]),
+    ).toEqual([{ path: '/', readonly: true }]);
+  });
+
+  it('returns rules in canonical path order', () => {
+    expect(
+      mergeReadonlyRules([
+        [
+          { path: '/docs/nested', readonly: true },
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+        [
+          { path: '/frontend', readonly: false },
+          { path: '/', readonly: true },
+        ],
+      ]),
+    ).toEqual([
+      { path: '/', readonly: true },
+      { path: '/docs', readonly: false },
+      { path: '/frontend', readonly: false },
+      { path: '/docs/nested', readonly: true },
+    ]);
+  });
+
+  it('merges several source partitions in any order', () => {
+    const firstSplit = createSplitRules([], ['/docs']);
+    const secondSplit = createSplitRules(firstSplit.sourceReadonlyRules, [
+      '/frontend',
+    ]);
+
+    expectMergesInAnyOrder([
+      secondSplit.sourceReadonlyRules,
+      firstSplit.splitReadonlyRules,
+      secondSplit.splitReadonlyRules,
+    ]);
+  });
+
+  it('merges nested partitions in any order', () => {
+    const firstSplit = createSplitRules([], ['/frontend']);
+    const secondSplit = createSplitRules(firstSplit.splitReadonlyRules, [
+      '/frontend/components',
+    ]);
+
+    expectMergesInAnyOrder([
+      firstSplit.sourceReadonlyRules,
+      secondSplit.sourceReadonlyRules,
+      secondSplit.splitReadonlyRules,
+    ]);
+  });
+
+  it('rejects an empty list of archives', () => {
+    expect(() => mergeReadonlyRules([])).toThrow(MergeReadonlyRulesError);
+    expect(() => mergeReadonlyRules([])).toThrow(
+      'At least one archive is required',
+    );
+  });
+
+  it('rejects an archive without readonly rules', () => {
+    expect(() =>
+      mergeReadonlyRules([[{ path: '/', readonly: true }], []]),
+    ).toThrow(MergeReadonlyRulesError);
+    expect(() =>
+      mergeReadonlyRules([[{ path: '/', readonly: true }], []]),
+    ).toThrow('All archives must contain readonly rules');
+  });
+
+  it.each([
+    {
+      readonlyRulesByPartition: [
+        [{ path: '/', readonly: false }],
+        [{ path: '/', readonly: false }],
+      ],
+      overlappingPath: '/',
+    },
+    {
+      readonlyRulesByPartition: [
+        [
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+        [
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+      ],
+      overlappingPath: '/docs',
+    },
+    {
+      readonlyRulesByPartition: [
+        [
+          { path: '/', readonly: true },
+          { path: '/docs', readonly: false },
+        ],
+        [
+          { path: '/', readonly: true },
+          { path: '/docs/nested', readonly: false },
+        ],
+      ],
+      overlappingPath: '/docs/nested',
+    },
+  ])(
+    'rejects invalid rule sets at $overlappingPath',
+    ({ readonlyRulesByPartition, overlappingPath }) => {
+      expect(() => mergeReadonlyRules(readonlyRulesByPartition)).toThrow(
+        MergeReadonlyRulesError,
+      );
+      expect(() => mergeReadonlyRules(readonlyRulesByPartition)).toThrow(
+        `'${overlappingPath}'`,
+      );
+    },
+  );
+});
+
+describe('split and merge', () => {
+  it('retains nested readonly overrides in the selected partition', () => {
+    const currentReadonlyRules = [
+      { path: '/', readonly: true },
+      { path: '/frontend', readonly: false },
+      { path: '/frontend/components', readonly: true },
+      { path: '/frontend/components/vendor', readonly: false },
+    ];
+
+    const { sourceReadonlyRules, splitReadonlyRules } = createSplitRules(
+      currentReadonlyRules,
+      ['/frontend'],
+    );
+
+    expect(splitReadonlyRules).toEqual(currentReadonlyRules);
+    expect(
+      mergeReadonlyRules([sourceReadonlyRules, splitReadonlyRules]),
+    ).toEqual(currentReadonlyRules);
+  });
+
+  it.each([
+    {
+      currentReadonlyRules: [],
+      selectedPaths: ['/docs'],
+    },
+    {
+      currentReadonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/frontend', readonly: false },
+      ],
+      selectedPaths: ['/frontend/components'],
+    },
+    {
+      currentReadonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/frontend', readonly: false },
+        { path: '/frontend/components', readonly: true },
+      ],
+      selectedPaths: ['/frontend'],
+    },
+    {
+      currentReadonlyRules: [
+        { path: '/', readonly: true },
+        { path: '/docs', readonly: false },
+        { path: '/frontend', readonly: false },
+      ],
+      selectedPaths: ['/docs', '/frontend/components'],
+    },
+  ])(
+    'restores the original rules after splitting $selectedPaths',
+    ({ currentReadonlyRules, selectedPaths }) => {
+      const { sourceReadonlyRules, splitReadonlyRules } = createSplitRules(
+        currentReadonlyRules,
+        selectedPaths,
+      );
+
+      expect(
+        mergeReadonlyRules([sourceReadonlyRules, splitReadonlyRules]),
+      ).toEqual(currentReadonlyRules);
+    },
+  );
+});
+
+function expectMergesInAnyOrder(
+  readonlyRulesByPartition: Array<Array<{ path: string; readonly: boolean }>>,
+): void {
+  for (const permutation of getPermutations(readonlyRulesByPartition)) {
+    expect(mergeReadonlyRules(permutation)).toEqual([]);
+  }
+}
+
+function getPermutations<T>(values: Array<T>): Array<Array<T>> {
+  if (values.length === 0) {
+    return [[]];
+  }
+  return values.flatMap((value, index) =>
+    getPermutations(values.filter((_, otherIndex) => otherIndex !== index)).map(
+      (permutation) => [value, ...permutation],
+    ),
+  );
+}

--- a/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
+++ b/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
@@ -31,11 +31,11 @@ describe('mergeReadonlyRules', () => {
   it('merges complementary partitions into an editable result', () => {
     expect(
       mergeReadonlyRules([
-        [{ path: '/docs', readonly: true }],
-        [
+        getReadonlyRuleMap([{ path: '/docs', readonly: true }]),
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
+        ]),
       ]),
     ).toEqual([]);
   });
@@ -43,14 +43,14 @@ describe('mergeReadonlyRules', () => {
   it('retains readonly paths that are not editable in any partition', () => {
     expect(
       mergeReadonlyRules([
-        [
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
-        [
+        ]),
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/frontend', readonly: false },
-        ],
+        ]),
       ]),
     ).toEqual([
       { path: '/', readonly: true },
@@ -62,15 +62,15 @@ describe('mergeReadonlyRules', () => {
   it('keeps only necessary nested overrides', () => {
     expect(
       mergeReadonlyRules([
-        [
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/frontend', readonly: false },
           { path: '/frontend/components', readonly: true },
-        ],
-        [
+        ]),
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/frontend/components', readonly: false },
-        ],
+        ]),
       ]),
     ).toEqual([
       { path: '/', readonly: true },
@@ -81,12 +81,12 @@ describe('mergeReadonlyRules', () => {
   it('retains a readonly nested override below an editable path', () => {
     expect(
       mergeReadonlyRules([
-        [
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/src', readonly: false },
           { path: '/src/generated', readonly: true },
-        ],
-        [{ path: '/', readonly: true }],
+        ]),
+        getReadonlyRuleMap([{ path: '/', readonly: true }]),
       ]),
     ).toEqual([
       { path: '/', readonly: true },
@@ -98,8 +98,8 @@ describe('mergeReadonlyRules', () => {
   it('keeps a fully readonly result', () => {
     expect(
       mergeReadonlyRules([
-        [{ path: '/', readonly: true }],
-        [{ path: '/', readonly: true }],
+        getReadonlyRuleMap([{ path: '/', readonly: true }]),
+        getReadonlyRuleMap([{ path: '/', readonly: true }]),
       ]),
     ).toEqual([{ path: '/', readonly: true }]);
   });
@@ -107,15 +107,15 @@ describe('mergeReadonlyRules', () => {
   it('returns rules in canonical path order', () => {
     expect(
       mergeReadonlyRules([
-        [
+        getReadonlyRuleMap([
           { path: '/docs/nested', readonly: true },
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
-        [
+        ]),
+        getReadonlyRuleMap([
           { path: '/frontend', readonly: false },
           { path: '/', readonly: true },
-        ],
+        ]),
       ]),
     ).toEqual([
       { path: '/', readonly: true },
@@ -131,11 +131,13 @@ describe('mergeReadonlyRules', () => {
       '/frontend',
     ]);
 
-    expectMergesInAnyOrder([
-      secondSplit.sourceReadonlyRules,
-      firstSplit.splitReadonlyRules,
-      secondSplit.splitReadonlyRules,
-    ]);
+    expectMergesInAnyOrder(
+      [
+        secondSplit.sourceReadonlyRules,
+        firstSplit.splitReadonlyRules,
+        secondSplit.splitReadonlyRules,
+      ].map(getReadonlyRuleMap),
+    );
   });
 
   it('merges nested partitions in any order', () => {
@@ -144,11 +146,13 @@ describe('mergeReadonlyRules', () => {
       '/frontend/components',
     ]);
 
-    expectMergesInAnyOrder([
-      firstSplit.sourceReadonlyRules,
-      secondSplit.sourceReadonlyRules,
-      secondSplit.splitReadonlyRules,
-    ]);
+    expectMergesInAnyOrder(
+      [
+        firstSplit.sourceReadonlyRules,
+        secondSplit.sourceReadonlyRules,
+        secondSplit.splitReadonlyRules,
+      ].map(getReadonlyRuleMap),
+    );
   });
 
   it('rejects an empty list of archives', () => {
@@ -160,54 +164,60 @@ describe('mergeReadonlyRules', () => {
 
   it('rejects an archive without readonly rules', () => {
     expect(() =>
-      mergeReadonlyRules([[{ path: '/', readonly: true }], []]),
+      mergeReadonlyRules([
+        getReadonlyRuleMap([{ path: '/', readonly: true }]),
+        new Map(),
+      ]),
     ).toThrow(MergeReadonlyRulesError);
     expect(() =>
-      mergeReadonlyRules([[{ path: '/', readonly: true }], []]),
+      mergeReadonlyRules([
+        getReadonlyRuleMap([{ path: '/', readonly: true }]),
+        new Map(),
+      ]),
     ).toThrow('All archives must contain readonly rules');
   });
 
   it.each([
     {
-      readonlyRulesByPartition: [
-        [{ path: '/', readonly: false }],
-        [{ path: '/', readonly: false }],
+      readonlyRuleMaps: [
+        getReadonlyRuleMap([{ path: '/', readonly: false }]),
+        getReadonlyRuleMap([{ path: '/', readonly: false }]),
       ],
       overlappingPath: '/',
     },
     {
-      readonlyRulesByPartition: [
-        [
+      readonlyRuleMaps: [
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
-        [
+        ]),
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
+        ]),
       ],
       overlappingPath: '/docs',
     },
     {
-      readonlyRulesByPartition: [
-        [
+      readonlyRuleMaps: [
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs', readonly: false },
-        ],
-        [
+        ]),
+        getReadonlyRuleMap([
           { path: '/', readonly: true },
           { path: '/docs/nested', readonly: false },
-        ],
+        ]),
       ],
       overlappingPath: '/docs/nested',
     },
   ])(
     'rejects invalid rule sets at $overlappingPath',
-    ({ readonlyRulesByPartition, overlappingPath }) => {
-      expect(() => mergeReadonlyRules(readonlyRulesByPartition)).toThrow(
+    ({ readonlyRuleMaps, overlappingPath }) => {
+      expect(() => mergeReadonlyRules(readonlyRuleMaps)).toThrow(
         MergeReadonlyRulesError,
       );
-      expect(() => mergeReadonlyRules(readonlyRulesByPartition)).toThrow(
+      expect(() => mergeReadonlyRules(readonlyRuleMaps)).toThrow(
         `'${overlappingPath}'`,
       );
     },
@@ -230,7 +240,9 @@ describe('split and merge', () => {
 
     expect(splitReadonlyRules).toEqual(currentReadonlyRules);
     expect(
-      mergeReadonlyRules([sourceReadonlyRules, splitReadonlyRules]),
+      mergeReadonlyRules(
+        [sourceReadonlyRules, splitReadonlyRules].map(getReadonlyRuleMap),
+      ),
     ).toEqual(currentReadonlyRules);
   });
 
@@ -271,16 +283,18 @@ describe('split and merge', () => {
       );
 
       expect(
-        mergeReadonlyRules([sourceReadonlyRules, splitReadonlyRules]),
+        mergeReadonlyRules(
+          [sourceReadonlyRules, splitReadonlyRules].map(getReadonlyRuleMap),
+        ),
       ).toEqual(currentReadonlyRules);
     },
   );
 });
 
 function expectMergesInAnyOrder(
-  readonlyRulesByPartition: Array<Array<{ path: string; readonly: boolean }>>,
+  readonlyRuleMaps: Array<Map<string, boolean>>,
 ): void {
-  for (const permutation of getPermutations(readonlyRulesByPartition)) {
+  for (const permutation of getPermutations(readonlyRuleMaps)) {
     expect(mergeReadonlyRules(permutation)).toEqual([]);
   }
 }

--- a/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
+++ b/src/ElectronBackend/split/__tests__/readonly-rules.test.ts
@@ -120,8 +120,8 @@ describe('mergeReadonlyRules', () => {
     ).toEqual([
       { path: '/', readonly: true },
       { path: '/docs', readonly: false },
-      { path: '/frontend', readonly: false },
       { path: '/docs/nested', readonly: true },
+      { path: '/frontend', readonly: false },
     ]);
   });
 

--- a/src/ElectronBackend/split/merge-opossum-files.ts
+++ b/src/ElectronBackend/split/merge-opossum-files.ts
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import AdmZip from 'adm-zip';
+import fs from 'fs';
+import path from 'path';
+
+import type { ReadonlyRule } from '../../shared/shared-types';
+import { writeOpossumFile } from '../../shared/write-file';
+import {
+  INPUT_FILE_NAME,
+  OPOSSUM_FILE_EXTENSION,
+  OUTPUT_FILE_NAME,
+  SPLIT_INFO_FILE_NAME,
+} from '../../shared/write-file-utils';
+import { parseOutputJsonContent, parseReadonlyRules } from '../input/parseFile';
+import type { ParsedOpossumOutputFile } from '../types/types';
+import {
+  getReadonlyRuleMap,
+  getReadonlyState,
+  mergeReadonlyRules as mergePureReadonlyRules,
+  MergeReadonlyRulesError,
+} from './readonly-rules';
+
+export interface MergeOpossumArchivesArgs {
+  inputPaths: Array<string>;
+  outputPath: string;
+}
+
+interface MergeArchive {
+  output: ParsedOpossumOutputFile;
+  readonlyRules: Array<ReadonlyRule>;
+  readonlyRulesByPath: Map<string, boolean>;
+  zip: AdmZip;
+}
+
+export class MergeOpossumFilesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MergeOpossumFilesError';
+  }
+}
+
+export async function mergeOpossumArchives({
+  inputPaths,
+  outputPath,
+}: MergeOpossumArchivesArgs): Promise<void> {
+  validatePaths(inputPaths, outputPath);
+  const archives = inputPaths.map(readMergeArchive);
+  validateProjectIds(archives);
+
+  const readonlyRules = mergeReadonlyRules(archives);
+  const output = mergeOutput(archives);
+
+  await writeOpossumFile({
+    path: outputPath,
+    zip: new AdmZip(archives[0].zip.toBuffer()),
+    output,
+    readonlyRules,
+  });
+}
+
+function readMergeArchive(filePath: string): MergeArchive {
+  let zip: AdmZip;
+  try {
+    zip = new AdmZip(filePath);
+  } catch (error) {
+    throw new MergeOpossumFilesError(
+      `Cannot merge '${filePath}': ${getErrorMessage(error)}`,
+    );
+  }
+
+  if (!zip.getEntry(INPUT_FILE_NAME)) {
+    throw new MergeOpossumFilesError(
+      `Cannot merge '${filePath}': archive does not contain input.json`,
+    );
+  }
+  const outputEntry = zip.getEntry(OUTPUT_FILE_NAME);
+  if (!outputEntry) {
+    throw new MergeOpossumFilesError(
+      `Cannot merge '${filePath}': archive does not contain output.json`,
+    );
+  }
+
+  try {
+    const readonlyRulesEntry = zip.getEntry(SPLIT_INFO_FILE_NAME);
+    const readonlyRules = readonlyRulesEntry
+      ? parseReadonlyRules(readonlyRulesEntry.getData().toString('utf-8'))
+      : [];
+    return {
+      output: parseOutputJsonContent(
+        outputEntry.getData().toString('utf-8'),
+        filePath,
+      ),
+      readonlyRules,
+      readonlyRulesByPath: getReadonlyRuleMap(readonlyRules),
+      zip,
+    };
+  } catch (error) {
+    throw new MergeOpossumFilesError(
+      `Cannot merge '${filePath}': ${getErrorMessage(error)}`,
+    );
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function validatePaths(inputPaths: Array<string>, outputPath: string): void {
+  if (inputPaths.length < 2) {
+    throw new MergeOpossumFilesError('Select at least two .opossum archives');
+  }
+  const resolvedInputPaths = inputPaths.map((inputPath) =>
+    path.resolve(inputPath),
+  );
+  if (new Set(resolvedInputPaths).size !== inputPaths.length) {
+    throw new MergeOpossumFilesError('Input archives must be unique');
+  }
+  if (path.extname(outputPath) !== OPOSSUM_FILE_EXTENSION) {
+    throw new MergeOpossumFilesError(
+      'Output archive must use the .opossum extension',
+    );
+  }
+  if (!fs.existsSync(path.dirname(path.resolve(outputPath)))) {
+    throw new MergeOpossumFilesError('Output directory does not exist');
+  }
+}
+
+function validateProjectIds(archives: Array<MergeArchive>): void {
+  const projectId = archives[0].output.metadata.projectId;
+  if (
+    archives.some((archive) => archive.output.metadata.projectId !== projectId)
+  ) {
+    throw new MergeOpossumFilesError(
+      'All input archives must have the same project ID',
+    );
+  }
+}
+
+function mergeReadonlyRules(
+  archives: Array<MergeArchive>,
+): Array<ReadonlyRule> {
+  try {
+    return mergePureReadonlyRules(
+      archives.map((archive) => archive.readonlyRules),
+    );
+  } catch (error) {
+    if (error instanceof MergeReadonlyRulesError) {
+      throw new MergeOpossumFilesError(error.message);
+    }
+    throw error;
+  }
+}
+
+function mergeOutput(archives: Array<MergeArchive>): ParsedOpossumOutputFile {
+  const manualAttributions: ParsedOpossumOutputFile['manualAttributions'] = {};
+  const resourcesToAttributions: ParsedOpossumOutputFile['resourcesToAttributions'] =
+    {};
+  const { outputJsonResourcePaths, referencedAttributionUuids } =
+    getOutputJsonResourcePathsAndReferencedAttributionUuids(archives);
+
+  for (const outputJsonResourcePath of outputJsonResourcePaths) {
+    const editableArchive = findEditableArchive(
+      getResourcePath(outputJsonResourcePath),
+      archives,
+    );
+    // TODO: Validate that all archives agree on readonly resource output.
+    const outputArchive = editableArchive ?? archives[0];
+    const attributionUuids =
+      outputArchive.output.resourcesToAttributions[outputJsonResourcePath];
+    if (!attributionUuids) {
+      continue;
+    }
+    resourcesToAttributions[outputJsonResourcePath] = attributionUuids;
+    for (const attributionUuid of attributionUuids) {
+      const attribution =
+        outputArchive.output.manualAttributions[attributionUuid];
+      if (attribution) {
+        manualAttributions[attributionUuid] = attribution;
+      }
+    }
+  }
+
+  const rootEditableArchive = findEditableArchive('/', archives);
+  const unlinkedAttributions =
+    rootEditableArchive?.output.manualAttributions ??
+    archives[0].output.manualAttributions;
+  for (const [attributionUuid, attribution] of Object.entries(
+    unlinkedAttributions,
+  )) {
+    if (!referencedAttributionUuids.has(attributionUuid)) {
+      manualAttributions[attributionUuid] = attribution;
+    }
+  }
+
+  return {
+    ...archives[0].output,
+    manualAttributions,
+    resourcesToAttributions,
+    resolvedExternalAttributions: Array.from(
+      new Set(
+        archives.flatMap(
+          (archive) => archive.output.resolvedExternalAttributions ?? [],
+        ),
+      ),
+    ),
+  };
+}
+
+function findEditableArchive(
+  resourcePath: string,
+  archives: Array<MergeArchive>,
+): MergeArchive | undefined {
+  return archives.find(
+    (archive) => !getReadonlyState(resourcePath, archive.readonlyRulesByPath),
+  );
+}
+
+function getResourcePath(outputJsonResourcePath: string): string {
+  if (outputJsonResourcePath === '/') {
+    return outputJsonResourcePath;
+  }
+  return outputJsonResourcePath.replace(/\/$/, '');
+}
+
+function getOutputJsonResourcePathsAndReferencedAttributionUuids(
+  archives: Array<MergeArchive>,
+): {
+  outputJsonResourcePaths: Set<string>;
+  referencedAttributionUuids: Set<string>;
+} {
+  const outputJsonResourcePaths = new Set<string>();
+  const referencedAttributionUuids = new Set<string>();
+
+  for (const archive of archives) {
+    for (const [outputJsonResourcePath, attributionUuids] of Object.entries(
+      archive.output.resourcesToAttributions,
+    )) {
+      outputJsonResourcePaths.add(outputJsonResourcePath);
+      for (const attributionUuid of attributionUuids) {
+        referencedAttributionUuids.add(attributionUuid);
+      }
+    }
+  }
+
+  return { outputJsonResourcePaths, referencedAttributionUuids };
+}

--- a/src/ElectronBackend/split/merge-opossum-files.ts
+++ b/src/ElectronBackend/split/merge-opossum-files.ts
@@ -32,7 +32,6 @@ export interface MergeOpossumArchivesArgs {
 
 interface MergeArchive {
   output: ParsedOpossumOutputFile;
-  readonlyRules: Array<ReadonlyRule>;
   readonlyRulesByPath: Map<string, boolean>;
   zip: AdmZip;
 }
@@ -96,7 +95,6 @@ function readMergeArchive(filePath: string): MergeArchive {
         outputEntry.getData().toString('utf-8'),
         filePath,
       ),
-      readonlyRules,
       readonlyRulesByPath: getReadonlyRuleMap(readonlyRules),
       zip,
     };
@@ -147,7 +145,7 @@ function mergeReadonlyRules(
 ): Array<ReadonlyRule> {
   try {
     return mergePureReadonlyRules(
-      archives.map((archive) => archive.readonlyRules),
+      archives.map((archive) => archive.readonlyRulesByPath),
     );
   } catch (error) {
     if (error instanceof MergeReadonlyRulesError) {

--- a/src/ElectronBackend/split/merge-opossum-files.ts
+++ b/src/ElectronBackend/split/merge-opossum-files.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import AdmZip from 'adm-zip';
 import fs from 'fs';
+import { isDeepStrictEqual } from 'node:util';
 import path from 'path';
 
 import type { ReadonlyRule } from '../../shared/shared-types';
@@ -24,6 +25,7 @@ import {
 } from './readonly-rules';
 
 export interface MergeOpossumArchivesArgs {
+  ignoreReadonlyResourceOutputConflicts?: boolean;
   inputPaths: Array<string>;
   outputPath: string;
 }
@@ -43,6 +45,7 @@ export class MergeOpossumFilesError extends Error {
 }
 
 export async function mergeOpossumArchives({
+  ignoreReadonlyResourceOutputConflicts = false,
   inputPaths,
   outputPath,
 }: MergeOpossumArchivesArgs): Promise<void> {
@@ -51,7 +54,7 @@ export async function mergeOpossumArchives({
   validateProjectIds(archives);
 
   const readonlyRules = mergeReadonlyRules(archives);
-  const output = mergeOutput(archives);
+  const output = mergeOutput(archives, ignoreReadonlyResourceOutputConflicts);
 
   await writeOpossumFile({
     path: outputPath,
@@ -154,19 +157,29 @@ function mergeReadonlyRules(
   }
 }
 
-function mergeOutput(archives: Array<MergeArchive>): ParsedOpossumOutputFile {
+function mergeOutput(
+  archives: Array<MergeArchive>,
+  ignoreReadonlyResourceOutputConflicts: boolean,
+): ParsedOpossumOutputFile {
   const manualAttributions: ParsedOpossumOutputFile['manualAttributions'] = {};
   const resourcesToAttributions: ParsedOpossumOutputFile['resourcesToAttributions'] =
     {};
   const { outputJsonResourcePaths, referencedAttributionUuids } =
     getOutputJsonResourcePathsAndReferencedAttributionUuids(archives);
+  const readonlyResourceOutputConflicts: Array<string> = [];
 
   for (const outputJsonResourcePath of outputJsonResourcePaths) {
     const editableArchive = findEditableArchive(
       getResourcePath(outputJsonResourcePath),
       archives,
     );
-    // TODO: Validate that all archives agree on readonly resource output.
+    if (
+      !ignoreReadonlyResourceOutputConflicts &&
+      !editableArchive &&
+      !hasEqualReadonlyResourceOutput(outputJsonResourcePath, archives)
+    ) {
+      readonlyResourceOutputConflicts.push(outputJsonResourcePath);
+    }
     const outputArchive = editableArchive ?? archives[0];
     const attributionUuids =
       outputArchive.output.resourcesToAttributions[outputJsonResourcePath];
@@ -195,6 +208,12 @@ function mergeOutput(archives: Array<MergeArchive>): ParsedOpossumOutputFile {
     }
   }
 
+  if (readonlyResourceOutputConflicts.length > 0) {
+    throw new MergeOpossumFilesError(
+      `Input archives disagree on readonly resource output for paths: ${readonlyResourceOutputConflicts.map((path) => `'${path}'`).join(', ')}`,
+    );
+  }
+
   return {
     ...archives[0].output,
     manualAttributions,
@@ -207,6 +226,37 @@ function mergeOutput(archives: Array<MergeArchive>): ParsedOpossumOutputFile {
       ),
     ),
   };
+}
+
+function hasEqualReadonlyResourceOutput(
+  outputJsonResourcePath: string,
+  archives: Array<MergeArchive>,
+): boolean {
+  const [firstArchive, ...otherArchives] = archives;
+  const attributionUuids =
+    firstArchive.output.resourcesToAttributions[outputJsonResourcePath];
+
+  for (const archive of otherArchives) {
+    if (
+      !isDeepStrictEqual(
+        archive.output.resourcesToAttributions[outputJsonResourcePath],
+        attributionUuids,
+      )
+    ) {
+      return false;
+    }
+    for (const attributionUuid of attributionUuids ?? []) {
+      if (
+        !isDeepStrictEqual(
+          archive.output.manualAttributions[attributionUuid],
+          firstArchive.output.manualAttributions[attributionUuid],
+        )
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 function findEditableArchive(

--- a/src/ElectronBackend/split/merge-opossum-files.ts
+++ b/src/ElectronBackend/split/merge-opossum-files.ts
@@ -194,12 +194,12 @@ function mergeOutput(
     }
   }
 
+  // We don't expect unlinked attributions to occur, but the data model does not prevent it.
+  // We have no way of resolving conflicts between them, so we simply choose one archive as the authority.
   const rootEditableArchive = findEditableArchive('/', archives);
-  const unlinkedAttributions =
-    rootEditableArchive?.output.manualAttributions ??
-    archives[0].output.manualAttributions;
+  const unlinkedAttributionSourceArchive = rootEditableArchive ?? archives[0];
   for (const [attributionUuid, attribution] of Object.entries(
-    unlinkedAttributions,
+    unlinkedAttributionSourceArchive.output.manualAttributions,
   )) {
     if (!referencedAttributionUuids.has(attributionUuid)) {
       manualAttributions[attributionUuid] = attribution;

--- a/src/ElectronBackend/split/readonly-rules.ts
+++ b/src/ElectronBackend/split/readonly-rules.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import path from 'path';
+
+import type { ReadonlyRule } from '../../shared/shared-types';
+
+export class MergeReadonlyRulesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MergeReadonlyRulesError';
+  }
+}
+
+export function getReadonlyRuleMap(
+  readonlyRules: Array<ReadonlyRule>,
+): Map<string, boolean> {
+  return new Map(readonlyRules.map((rule) => [rule.path, rule.readonly]));
+}
+
+export function getReadonlyState(
+  resourcePath: string,
+  rulesByPath: Map<string, boolean>,
+): boolean {
+  let currentPath = resourcePath;
+  while (true) {
+    const readonly = rulesByPath.get(currentPath);
+    if (readonly !== undefined) {
+      return readonly;
+    }
+    if (currentPath === '/') {
+      return false;
+    }
+    currentPath = path.posix.dirname(currentPath);
+  }
+}
+
+export function createSplitRules(
+  existingReadonlyRules: Array<ReadonlyRule>,
+  selectedPaths: Array<string>,
+): {
+  sourceReadonlyRules: Array<ReadonlyRule>;
+  splitReadonlyRules: Array<ReadonlyRule>;
+} {
+  return {
+    sourceReadonlyRules: createSourceReadonlyRules(
+      existingReadonlyRules,
+      selectedPaths,
+    ),
+    splitReadonlyRules: createSplitReadonlyRules(
+      existingReadonlyRules,
+      selectedPaths,
+    ),
+  };
+}
+
+function createSplitReadonlyRules(
+  currentReadonlyRules: Array<ReadonlyRule>,
+  selectedPaths: Array<string>,
+): Array<ReadonlyRule> {
+  return [
+    { path: '/', readonly: true },
+    ...selectedPaths.map((path) => ({ path, readonly: false })),
+    ...currentReadonlyRules.filter((rule) =>
+      selectedPaths.some((selectedPath) =>
+        isDescendant(rule.path, selectedPath),
+      ),
+    ),
+  ];
+}
+
+function createSourceReadonlyRules(
+  currentReadonlyRules: Array<ReadonlyRule>,
+  selectedPaths: Array<string>,
+): Array<ReadonlyRule> {
+  const selectedPathsWithCurrentRule = selectedPaths.filter((selectedPath) =>
+    currentReadonlyRules.some((rule) => rule.path === selectedPath),
+  );
+
+  return [
+    ...currentReadonlyRules,
+    ...selectedPaths.map((path) => ({ path, readonly: true })),
+  ].filter(
+    (rule) =>
+      !selectedPathsWithCurrentRule.includes(rule.path) &&
+      !selectedPaths.some((selectedPath) =>
+        isDescendant(rule.path, selectedPath),
+      ),
+  );
+}
+
+export function mergeReadonlyRules(
+  readonlyRulesByArchive: Array<Array<ReadonlyRule>>,
+): Array<ReadonlyRule> {
+  if (readonlyRulesByArchive.length === 0) {
+    throw new MergeReadonlyRulesError('At least one archive is required');
+  }
+  if (
+    readonlyRulesByArchive.some((readonlyRules) => readonlyRules.length === 0)
+  ) {
+    throw new MergeReadonlyRulesError(
+      'All archives must contain readonly rules',
+    );
+  }
+  const rulesByPathByArchive = readonlyRulesByArchive.map(getReadonlyRuleMap);
+  const candidatePaths = Array.from(
+    new Set([
+      '/',
+      ...readonlyRulesByArchive.flatMap((rules) =>
+        rules.map((rule) => rule.path),
+      ),
+    ]),
+  );
+
+  const mergedRules: Array<ReadonlyRule> = [];
+  for (const resourcePath of candidatePaths) {
+    const readonly = getMergedReadonlyState(resourcePath, rulesByPathByArchive);
+    const parentReadonly =
+      resourcePath === '/'
+        ? false
+        : getMergedReadonlyState(
+            path.posix.dirname(resourcePath),
+            rulesByPathByArchive,
+          );
+    if (readonly !== parentReadonly) {
+      mergedRules.push({ path: resourcePath, readonly });
+    }
+  }
+
+  return mergedRules.sort((first, second) =>
+    comparePaths(first.path, second.path),
+  );
+}
+
+function getMergedReadonlyState(
+  resourcePath: string,
+  rulesByPathByArchive: Array<Map<string, boolean>>,
+): boolean {
+  const editableArchiveCount = rulesByPathByArchive.filter(
+    (rulesByPath) => !getReadonlyState(resourcePath, rulesByPath),
+  ).length;
+  if (editableArchiveCount > 1) {
+    throw new MergeReadonlyRulesError(
+      `Input archives overlap on editable path '${resourcePath}'`,
+    );
+  }
+  return editableArchiveCount === 0;
+}
+
+function comparePaths(firstPath: string, secondPath: string): number {
+  const depthDifference = getPathDepth(firstPath) - getPathDepth(secondPath);
+  return depthDifference === 0
+    ? firstPath.localeCompare(secondPath)
+    : depthDifference;
+}
+
+function getPathDepth(resourcePath: string): number {
+  return resourcePath.split('/').filter(Boolean).length;
+}
+
+export function isDescendant(
+  resourcePath: string,
+  ancestorPath: string,
+): boolean {
+  return resourcePath.startsWith(`${ancestorPath}/`);
+}

--- a/src/ElectronBackend/split/readonly-rules.ts
+++ b/src/ElectronBackend/split/readonly-rules.ts
@@ -91,24 +91,21 @@ function createSourceReadonlyRules(
 }
 
 export function mergeReadonlyRules(
-  readonlyRulesByArchive: Array<Array<ReadonlyRule>>,
+  rulesByPathByArchive: Array<Map<string, boolean>>,
 ): Array<ReadonlyRule> {
-  if (readonlyRulesByArchive.length === 0) {
+  if (rulesByPathByArchive.length === 0) {
     throw new MergeReadonlyRulesError('At least one archive is required');
   }
-  if (
-    readonlyRulesByArchive.some((readonlyRules) => readonlyRules.length === 0)
-  ) {
+  if (rulesByPathByArchive.some((rulesByPath) => rulesByPath.size === 0)) {
     throw new MergeReadonlyRulesError(
       'All archives must contain readonly rules',
     );
   }
-  const rulesByPathByArchive = readonlyRulesByArchive.map(getReadonlyRuleMap);
   const candidatePaths = Array.from(
     new Set([
       '/',
-      ...readonlyRulesByArchive.flatMap((rules) =>
-        rules.map((rule) => rule.path),
+      ...rulesByPathByArchive.flatMap((rulesByPath) =>
+        Array.from(rulesByPath.keys()),
       ),
     ]),
   );

--- a/src/ElectronBackend/split/readonly-rules.ts
+++ b/src/ElectronBackend/split/readonly-rules.ts
@@ -126,7 +126,7 @@ export function mergeReadonlyRules(
   }
 
   return mergedRules.sort((first, second) =>
-    comparePaths(first.path, second.path),
+    first.path.localeCompare(second.path),
   );
 }
 
@@ -143,17 +143,6 @@ function getMergedReadonlyState(
     );
   }
   return editableArchiveCount === 0;
-}
-
-function comparePaths(firstPath: string, secondPath: string): number {
-  const depthDifference = getPathDepth(firstPath) - getPathDepth(secondPath);
-  return depthDifference === 0
-    ? firstPath.localeCompare(secondPath)
-    : depthDifference;
-}
-
-function getPathDepth(resourcePath: string): number {
-  return resourcePath.split('/').filter(Boolean).length;
 }
 
 export function isDescendant(

--- a/src/ElectronBackend/split/split-opossum-file.ts
+++ b/src/ElectronBackend/split/split-opossum-file.ts
@@ -13,6 +13,12 @@ import {
   OPOSSUM_FILE_EXTENSION,
 } from '../../shared/write-file-utils';
 import { getDb } from '../db/db';
+import {
+  createSplitRules,
+  getReadonlyRuleMap,
+  getReadonlyState,
+  isDescendant,
+} from './readonly-rules';
 
 interface SplitOpossumArchivePaths {
   sourceOpossumFilePath: string;
@@ -141,9 +147,7 @@ export async function validateSelectedFolderPaths(
     );
   }
 
-  const rulesByPath = new Map(
-    readonlyRules.map((rule) => [rule.path, rule.readonly]),
-  );
+  const rulesByPath = getReadonlyRuleMap(readonlyRules);
   for (const selectedPath of selectedFolderPaths) {
     if (!isCanonicalNonRootPath(selectedPath)) {
       throw new SplitOpossumFileError(
@@ -171,77 +175,6 @@ export async function validateSelectedFolderPaths(
   }
 
   await validateResourcesExist(selectedFolderPaths);
-}
-
-function createSplitRules(
-  existingReadonlyRules: Array<ReadonlyRule>,
-  selectedPaths: Array<string>,
-): {
-  sourceReadonlyRules: Array<ReadonlyRule>;
-  splitReadonlyRules: Array<ReadonlyRule>;
-} {
-  return {
-    sourceReadonlyRules: createSourceReadonlyRules(
-      existingReadonlyRules,
-      selectedPaths,
-    ),
-    splitReadonlyRules: createSplitReadonlyRules(
-      existingReadonlyRules,
-      selectedPaths,
-    ),
-  };
-}
-
-function createSplitReadonlyRules(
-  currentReadonlyRules: Array<ReadonlyRule>,
-  selectedPaths: Array<string>,
-): Array<ReadonlyRule> {
-  return [
-    { path: '/', readonly: true },
-    ...selectedPaths.map((path) => ({ path, readonly: false })),
-    ...currentReadonlyRules.filter((rule) =>
-      selectedPaths.some((selectedPath) =>
-        isDescendant(rule.path, selectedPath),
-      ),
-    ),
-  ];
-}
-
-function createSourceReadonlyRules(
-  currentReadonlyRules: Array<ReadonlyRule>,
-  selectedPaths: Array<string>,
-): Array<ReadonlyRule> {
-  const selectedPathsWithCurrentRule = selectedPaths.filter((selectedPath) =>
-    currentReadonlyRules.some((rule) => rule.path === selectedPath),
-  );
-
-  return [
-    ...currentReadonlyRules,
-    ...selectedPaths.map((path) => ({ path, readonly: true })),
-  ].filter(
-    (rule) =>
-      !selectedPathsWithCurrentRule.includes(rule.path) &&
-      !selectedPaths.some((selectedPath) =>
-        isDescendant(rule.path, selectedPath),
-      ),
-  );
-}
-
-function getReadonlyState(
-  resourcePath: string,
-  rulesByPath: Map<string, boolean>,
-): boolean {
-  let currentPath = resourcePath;
-  while (true) {
-    const readonly = rulesByPath.get(currentPath);
-    if (readonly !== undefined) {
-      return readonly;
-    }
-    if (currentPath === '/') {
-      return false;
-    }
-    currentPath = path.posix.dirname(currentPath);
-  }
 }
 
 async function writeSplitArchives({
@@ -277,8 +210,4 @@ function isCanonicalNonRootPath(resourcePath: string): boolean {
     !resourcePath.endsWith('/') &&
     resourcePath !== '/'
   );
-}
-
-function isDescendant(path: string, ancestorPath: string): boolean {
-  return path.startsWith(`${ancestorPath}/`);
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -12,6 +12,8 @@ export enum IpcChannel {
   MergeFileAndLoad = 'merge-file-and-load',
   SelectSplitDestination = 'select-split-destination',
   SplitFile = 'split-file',
+  MergeOpossumFiles = 'merge-opossum-files',
+  MergeOpossumFilesFromPaths = 'merge-opossum-files-from-paths',
   OpenLink = 'open-link',
   SaveFile = 'save-file',
   ExportFile = 'export-file',

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -268,10 +268,14 @@ export interface ElectronAPI {
     splitPaths: Array<string>,
     splitOpossumFilePath: string,
   ) => Promise<SplitFileResult>;
-  mergeOpossumFiles: (partitionPaths: Array<string>) => Promise<void>;
+  mergeOpossumFiles: (
+    partitionPaths: Array<string>,
+    ignoreReadonlyResourceOutputConflicts?: boolean,
+  ) => Promise<void>;
   mergeOpossumFilesFromPaths: (
     inputPaths: Array<string>,
     outputPath: string,
+    ignoreReadonlyResourceOutputConflicts?: boolean,
   ) => Promise<void>;
   saveFile: () => void;
   exportFile: (exportType: ExportType) => Promise<void>;

--- a/src/shared/shared-types.ts
+++ b/src/shared/shared-types.ts
@@ -268,6 +268,11 @@ export interface ElectronAPI {
     splitPaths: Array<string>,
     splitOpossumFilePath: string,
   ) => Promise<SplitFileResult>;
+  mergeOpossumFiles: (partitionPaths: Array<string>) => Promise<void>;
+  mergeOpossumFilesFromPaths: (
+    inputPaths: Array<string>,
+    outputPath: string,
+  ) => Promise<void>;
   saveFile: () => void;
   exportFile: (exportType: ExportType) => Promise<void>;
   /**

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -29,6 +29,8 @@ if (typeof window !== 'undefined') {
     mergeFileAndLoad: vi.fn(),
     selectSplitDestination: vi.fn(),
     splitFile: vi.fn(),
+    mergeOpossumFiles: vi.fn(),
+    mergeOpossumFilesFromPaths: vi.fn(),
     saveFile: vi.fn(),
     exportFile: vi.fn(),
     stopLoading: vi.fn(),


### PR DESCRIPTION
### Summary of changes

* backend functionality for merging split files back together
* checks for conflicts in purely readonly path
  * provides a boolean flag to ignore this
  * intended workflow: run into conflicts -> warn in UI -> user can say proceed anyway -> retry with flag set

### Context and reason for change
#3197
No UI yet, that will be done in #3198 (inlcuding things like progress updates)
