### PR TITLE
test: make wait for saving changes more robust

### DIFF
--- a/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
+++ b/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
@@ -13,6 +13,7 @@ import { EMPTY_DISPLAY_PACKAGE_INFO } from '../../shared-constants';
 import { initializePackageInfoEditing } from '../../state/actions/resource-actions/all-views-simple-actions';
 import { useAppDispatch, useAppSelector } from '../../state/hooks';
 import {
+  getIsPackageInfoDirty,
   getSelectedAttributionId,
   getSelectedResourceId,
   getTemporaryDisplayPackageInfo,
@@ -50,6 +51,7 @@ const classes = {
 export function AttributionDetails() {
   const dispatch = useAppDispatch();
   const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const isPackageInfoDirty = useAppSelector(getIsPackageInfoDirty);
 
   const temporaryDisplayPackageInfo = useAppSelector(
     getTemporaryDisplayPackageInfo,
@@ -125,7 +127,11 @@ export function AttributionDetails() {
   }
 
   return (
-    <MuiBox aria-label={'attribution column'} sx={classes.root}>
+    <MuiBox
+      aria-label={'attribution column'}
+      data-dirty={isPackageInfoDirty}
+      sx={classes.root}
+    >
       {isSelectedAttributionLoading && (
         <MuiLinearProgress
           data-testid={'attribution-details-loading'}

--- a/src/Frontend/Components/AttributionDetails/__tests__/AttributionDetails.test.tsx
+++ b/src/Frontend/Components/AttributionDetails/__tests__/AttributionDetails.test.tsx
@@ -1185,6 +1185,10 @@ describe('AttributionDetails', () => {
     await waitFor(() =>
       expect(getIsPackageInfoDirty(store.getState())).toBe(true),
     );
+    expect(screen.getByLabelText('attribution column')).toHaveAttribute(
+      'data-dirty',
+      'true',
+    );
   });
 
   it('sets isPackageInfoDirty to false when temp matches stored', async () => {
@@ -1208,6 +1212,10 @@ describe('AttributionDetails', () => {
 
     await waitFor(() =>
       expect(getIsPackageInfoDirty(store.getState())).toBe(false),
+    );
+    expect(screen.getByLabelText('attribution column')).toHaveAttribute(
+      'data-dirty',
+      'false',
     );
   });
 });

--- a/src/e2e-tests/page-objects/AttributionDetails.ts
+++ b/src/e2e-tests/page-objects/AttributionDetails.ts
@@ -72,11 +72,9 @@ export class AttributionDetails {
   }
 
   async saveChanges(): Promise<void> {
-    const progressIndicator = this.saveButton.getByRole('progressbar');
-
+    await expect(this.node).toHaveAttribute('data-dirty', 'true');
     await this.saveButton.click();
-    await expect(this.saveButton).toBeDisabled();
-    await expect(progressIndicator).toBeHidden();
+    await expect(this.node).toHaveAttribute('data-dirty', 'false');
   }
 
   public assert = {


### PR DESCRIPTION
### Summary of changes

Make wait for saving to finish more robust

### Context and reason for change
Before, it was possible for the assertions to finish before the save had actually completed (all of them were true before saving had started). See https://github.com/opossum-tool/OpossumUI/actions/runs/31494815870
