### PR TITLE
fix: keep auditing option trigger stable while loading

### DIFF
--- a/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
+++ b/src/Frontend/Components/AttributionDetails/AttributionDetails.tsx
@@ -142,6 +142,7 @@ export function AttributionDetails() {
         packageInfo={temporaryDisplayPackageInfo}
         onEdit={isEditable ? confirmEditWasPreferred : undefined}
         dimmed={pickerMode.isActive}
+        keepAddButtonVisibleWhenDisabled={isSelectedAttributionLoading}
       />
       {!isSelectedAttributionLoading && (
         <ButtonRow

--- a/src/Frontend/Components/AttributionDetails/__tests__/AttributionDetails.test.tsx
+++ b/src/Frontend/Components/AttributionDetails/__tests__/AttributionDetails.test.tsx
@@ -107,6 +107,9 @@ describe('AttributionDetails', () => {
     expect(
       screen.getByLabelText(text.attributionColumn.packageName),
     ).toHaveAttribute('readonly');
+    expect(
+      screen.getByRole('button', { name: text.auditingOptions.add }),
+    ).toHaveAttribute('aria-disabled', 'true');
     expect(container).not.toHaveTextContent(text.attributionColumn.save);
   });
 

--- a/src/Frontend/Components/AttributionForm/AttributionForm.tsx
+++ b/src/Frontend/Components/AttributionForm/AttributionForm.tsx
@@ -54,6 +54,7 @@ interface AttributionFormProps {
   label?: string;
   config?: AttributionFormConfig;
   dimmed?: boolean;
+  keepAddButtonVisibleWhenDisabled?: boolean;
   sectionPrefix?: string;
 }
 
@@ -64,6 +65,7 @@ export function AttributionForm({
   variant = 'default',
   config,
   dimmed,
+  keepAddButtonVisibleWhenDisabled,
   sectionPrefix = '',
 }: AttributionFormProps) {
   const dispatch = useAppDispatch();
@@ -80,7 +82,11 @@ export function AttributionForm({
       aria-label={label}
     >
       {!isDiff && (
-        <AuditingOptions packageInfo={packageInfo} isEditable={!!onEdit} />
+        <AuditingOptions
+          packageInfo={packageInfo}
+          isEditable={!!onEdit}
+          keepAddButtonVisibleWhenDisabled={keepAddButtonVisibleWhenDisabled}
+        />
       )}
       <MuiDivider variant={'middle'}>
         <MuiTypography>

--- a/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.tsx
+++ b/src/Frontend/Components/AttributionForm/AuditingOptions/AuditingOptions.tsx
@@ -22,12 +22,14 @@ const classes = {
 interface Props {
   packageInfo: PackageInfo;
   isEditable: boolean;
+  keepAddButtonVisibleWhenDisabled?: boolean;
   sx?: SxProps<Theme>;
 }
 
 export const AuditingOptions: React.FC<Props> = ({
   packageInfo,
   isEditable,
+  keepAddButtonVisibleWhenDisabled,
   sx,
 }) => {
   const options = useAuditingOptions({ packageInfo, isEditable });
@@ -56,7 +58,7 @@ export const AuditingOptions: React.FC<Props> = ({
 
   function renderTriggerButton() {
     return (
-      hasUnselectedInteractiveOption && (
+      (hasUnselectedInteractiveOption || keepAddButtonVisibleWhenDisabled) && (
         <MuiChip
           label={text.auditingOptions.add}
           color={'primary'}


### PR DESCRIPTION
## Summary

- keep the Add Auditing Option chip mounted while a newly selected attribution is loading
- disable the chip during the existing read-only loading state
- add regression coverage for the stable disabled control

## Root cause

AttributionDetails intentionally makes the form read-only while attribution data is loading. AuditingOptions derived whether to render its trigger from editability, so the transient read-only state removed the chip and then added it back when loading completed.

## User impact

Switching between editable attributions no longer makes the Add Auditing Option control disappear and reappear. The control remains visible but disabled until editing is safe again.

## Validation

- focused AttributionDetails regression test
- TypeScript checks for frontend and Electron backend
- ESLint on all changed files
- Prettier check on all changed files
- `git diff --check`

The broader AttributionDetails test file was also run: 30 tests passed, while two unrelated pre-existing tests exceeded their 5-second local timeout. The focused regression test passes independently.

Closes #3256

## Disclosure

This contribution was prepared with AI assistance under human-directed scope and was source-verified and tested before submission.
