### PR TITLE
feat: make split here target initially visible

### DIFF
--- a/src/Frontend/Components/SplitDialog/MultiResourcePicker.tsx
+++ b/src/Frontend/Components/SplitDialog/MultiResourcePicker.tsx
@@ -15,6 +15,7 @@ import type { ResourceTreeNodeData } from '../../../ElectronBackend/api/resource
 import { text } from '../../../shared/text';
 import { ROOT_PATH } from '../../shared-constants';
 import { readonlyStyle } from '../../shared-styles';
+import { getParents } from '../../state/helpers/get-parents';
 import { backend } from '../../util/backendClient';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { ReadonlyIcon } from '../Icons/Icons';
@@ -45,8 +46,13 @@ export function MultiResourcePicker({
   onSelectionChange,
 }: MultiResourcePickerProps) {
   const [selectedPaths, setSelectedPaths] = useState(initialSelectedPaths);
-  const [expandedPaths, setExpandedPaths] = useState<Array<string>>([
-    ROOT_PATH,
+  const [expandedPaths, setExpandedPaths] = useState<Array<string>>(() => [
+    ...new Set([
+      ROOT_PATH,
+      ...initialSelectedPaths.flatMap((selectedPath) =>
+        getParents(selectedPath),
+      ),
+    ]),
   ]);
   const resourceTree = backend.getResourceTree.useQuery(
     {

--- a/src/Frontend/Components/SplitDialog/MultiResourcePicker.tsx
+++ b/src/Frontend/Components/SplitDialog/MultiResourcePicker.tsx
@@ -9,7 +9,7 @@ import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutl
 import MuiChip from '@mui/material/Chip';
 import MuiTypography from '@mui/material/Typography';
 import { keepPreviousData } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import type { ResourceTreeNodeData } from '../../../ElectronBackend/api/resourceTree';
 import { text } from '../../../shared/text';
@@ -54,6 +54,10 @@ export function MultiResourcePicker({
       ),
     ]),
   ]);
+  const initiallySelectedPath = initialSelectedPaths[0];
+  const scrollToResource = useCallback((element: HTMLDivElement | null) => {
+    element?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, []);
   const resourceTree = backend.getResourceTree.useQuery(
     {
       expandedNodes: expandedPaths,
@@ -63,7 +67,6 @@ export function MultiResourcePicker({
   const resources = (resourceTree.data?.treeNodes ?? []).filter(
     (resource) => resource.id !== ROOT_PATH,
   );
-
   function updateSelectedPaths(path: string) {
     const nextSelectedPaths = selectedPaths.includes(path)
       ? selectedPaths.filter((selectedPath) => selectedPath !== path)
@@ -112,6 +115,8 @@ export function MultiResourcePicker({
               selectedPaths,
               updateSelectedPaths,
               toggleExpanded,
+              initiallySelectedPath,
+              scrollToResource,
             ),
           )
         )}
@@ -144,6 +149,8 @@ function renderResource(
   selectedPaths: Array<string>,
   updateSelectedPaths: (path: string) => void,
   toggleExpanded: (resource: ResourceTreeNodeData) => Promise<void>,
+  initiallySelectedPath: string | undefined,
+  scrollToInitiallySelectedResource: (element: HTMLDivElement | null) => void,
 ) {
   const path = removeTrailingSlash(resource.id);
   const selectedExplicitly = selectedPaths.includes(path);
@@ -158,6 +165,11 @@ function renderResource(
   return (
     <ResourceRow
       key={resource.id}
+      ref={
+        path === initiallySelectedPath
+          ? scrollToInitiallySelectedResource
+          : undefined
+      }
       resourceLevel={resource.level}
       selectedByAncestor={selectedByAncestor}
     >

--- a/src/Frontend/Components/SplitDialog/__tests__/multi-resource-picker.test.tsx
+++ b/src/Frontend/Components/SplitDialog/__tests__/multi-resource-picker.test.tsx
@@ -46,6 +46,21 @@ describe('MultiResourcePicker', () => {
     expect(screen.getByText('second.ts')).toBeInTheDocument();
   });
 
+  it('expands ancestors of initially selected resources', async () => {
+    await renderComponent(
+      <MultiResourcePicker
+        initialSelectedPaths={['/src/single/first.ts']}
+        open={true}
+        onSelectionChange={vi.fn()}
+      />,
+      { data },
+    );
+
+    expect(await screen.findByText('single')).toBeInTheDocument();
+    expect(screen.getByText('first.ts')).toBeInTheDocument();
+    expect(screen.getByText('second.ts')).toBeInTheDocument();
+  });
+
   it('normalizes selections and visually includes descendants', async () => {
     const onSelectionChange = vi.fn();
     await renderPicker(onSelectionChange);

--- a/src/Frontend/Components/SplitDialog/__tests__/multi-resource-picker.test.tsx
+++ b/src/Frontend/Components/SplitDialog/__tests__/multi-resource-picker.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { text } from '../../../../shared/text';
 import { getParsedInputFileEnrichedWithTestData } from '../../../test-helpers/general-test-helpers';
@@ -47,6 +47,8 @@ describe('MultiResourcePicker', () => {
   });
 
   it('expands ancestors of initially selected resources', async () => {
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+
     await renderComponent(
       <MultiResourcePicker
         initialSelectedPaths={['/src/single/first.ts']}
@@ -59,6 +61,12 @@ describe('MultiResourcePicker', () => {
     expect(await screen.findByText('single')).toBeInTheDocument();
     expect(screen.getByText('first.ts')).toBeInTheDocument();
     expect(screen.getByText('second.ts')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'center',
+        behavior: 'smooth',
+      }),
+    );
   });
 
   it('normalizes selections and visually includes descendants', async () => {


### PR DESCRIPTION
### Summary of changes
Auto expand and scroll to the split-here target in the split dialog

### Context and reason for change
When the target is nested or in a long list of files, it's awkward to have to search for it
