### PR TITLE
test: ensure unique short license names

### DIFF
--- a/src/testing/Faker.ts
+++ b/src/testing/Faker.ts
@@ -67,6 +67,8 @@ type _TupleOf<
 > = L['length'] extends N ? L : _TupleOf<N, T, [T, ...L]>;
 
 class OpossumModule {
+  private static nextLicenseId = 0;
+
   public static metadata(
     props: Partial<ProjectMetadata> = {},
   ): ProjectMetadata {
@@ -253,11 +255,14 @@ class OpossumModule {
     props?: Partial<RawFrequentLicense>,
   ): RawFrequentLicense {
     const fullName = faker.commerce.productName();
+    const acronym = fullName.match(/\b([A-Z])/g)!.join('');
+    // ensure a unique shortName
+    const shortName = `${acronym}-${OpossumModule.nextLicenseId++}`;
 
     return {
       defaultText: faker.lorem.sentences(),
       fullName,
-      shortName: fullName.match(/\b([A-Z])/g)!.join(''),
+      shortName,
       ...props,
     };
   }


### PR DESCRIPTION
We rely on short license names being unique, but the acronyms we use in our test data have a realistic chance of collision (see https://github.com/opossum-tool/OpossumUI/actions/runs/31693829300/job/94426931575)