### PR TITLE
perf: defer loading of linked resources

### DIFF
--- a/src/Frontend/Components/AttributionAction/useLinkedAttributionActionData.ts
+++ b/src/Frontend/Components/AttributionAction/useLinkedAttributionActionData.ts
@@ -10,7 +10,7 @@ import { useAppSelector } from '../../state/hooks';
 import { getSelectedResourceId } from '../../state/selectors/resource-selectors';
 import { backend } from '../../util/backendClient';
 import { useIsSelectedResourceReadonly } from '../../util/use-selected-resource';
-import { useLinkedResourcesTreeState } from '../ResourceBrowser/LinkedResourcesTree/useLinkedResourcesTreeState';
+import { useLinkedResourcesTree } from '../ResourceBrowser/LinkedResourcesTree/useLinkedResourcesTreeState';
 
 type AttributionSelectionSummary = Awaited<
   ReturnType<typeof backend.getAttributionSelectionSummary.query>
@@ -55,7 +55,7 @@ export function useLinkedAttributionActionData({
     { enabled: open && isQueryWideSelection },
   );
 
-  const linkedResourcesTreeState = useLinkedResourcesTreeState({
+  const { data: linkedResourcesTreeState } = useLinkedResourcesTree({
     onAttributionUuids: attributionIds,
     enabled:
       open &&

--- a/src/Frontend/Components/ConfirmAttributionActionPopup/ConfirmAttributionActionPopup.tsx
+++ b/src/Frontend/Components/ConfirmAttributionActionPopup/ConfirmAttributionActionPopup.tsx
@@ -36,7 +36,7 @@ interface Props {
   attributions: Attributions | undefined;
   localAction?: Action;
   globalAction: Action;
-  linkedResourcesTreeState: LinkedResourcesTreeState;
+  linkedResourcesTreeState: LinkedResourcesTreeState | undefined;
   mixedAttributionCount: number;
   isResourceInfoReady: boolean;
   isLocalActionAvailable: boolean | undefined;
@@ -122,12 +122,14 @@ export function ConfirmAttributionActionPopup({
               ? text.confirmAttributionActionPopup.editableLinkedResources
               : text.confirmAttributionActionPopup.linkedResources}
           </MuiTypography>
-          <LinkedResourcesTree
-            readOnly
-            disableHighlightSelected={!isLocalActionAvailable}
-            state={linkedResourcesTreeState}
-            sx={{ minHeight: '100px' }}
-          />
+          {linkedResourcesTreeState && (
+            <LinkedResourcesTree
+              readOnly
+              disableHighlightSelected={!isLocalActionAvailable}
+              state={linkedResourcesTreeState}
+              sx={{ minHeight: '100px' }}
+            />
+          )}
         </>
       )}
     </StyledConfirmAttributionActionPopup>

--- a/src/Frontend/Components/ResourceBrowser/LinkedResourcesTree/__tests__/LinkedResourcesTree.test.tsx
+++ b/src/Frontend/Components/ResourceBrowser/LinkedResourcesTree/__tests__/LinkedResourcesTree.test.tsx
@@ -9,7 +9,7 @@ import { getSelectedResourceId } from '../../../../state/selectors/resource-sele
 import { getParsedInputFileEnrichedWithTestData } from '../../../../test-helpers/general-test-helpers';
 import { renderComponent } from '../../../../test-helpers/render';
 import { LinkedResourcesTree } from '../LinkedResourcesTree';
-import { useLinkedResourcesTreeState } from '../useLinkedResourcesTreeState';
+import { useLinkedResourcesTree } from '../useLinkedResourcesTreeState';
 
 const testUuid = 'test-attribution-uuid';
 
@@ -36,12 +36,14 @@ const testData = getParsedInputFileEnrichedWithTestData({
 });
 
 function TestLinkedResourcesTree({
+  enabled = true,
   onAttributionUuids,
 }: {
+  enabled?: boolean;
   onAttributionUuids: Array<string>;
 }) {
-  const state = useLinkedResourcesTreeState({ onAttributionUuids });
-  return <LinkedResourcesTree state={state} />;
+  const { data } = useLinkedResourcesTree({ enabled, onAttributionUuids });
+  return data ? <LinkedResourcesTree state={data} /> : null;
 }
 
 describe('LinkedResourcesTree', () => {
@@ -55,6 +57,32 @@ describe('LinkedResourcesTree', () => {
       expect(screen.getByText('resource_1')).toBeInTheDocument();
     });
     expect(screen.getByText('resource_2')).toBeInTheDocument();
+  });
+
+  it('waits for enabled before loading linked resources', async () => {
+    const api = vi.mocked(window.electronAPI.api);
+    api.mockClear();
+    const { rerender } = await renderComponent(
+      <TestLinkedResourcesTree
+        enabled={false}
+        onAttributionUuids={[testUuid]}
+      />,
+      { data: testData },
+    );
+
+    expect(api).not.toHaveBeenCalledWith(
+      'getResourcePathsAndParentsForAttributions',
+      expect.anything(),
+    );
+
+    rerender(<TestLinkedResourcesTree onAttributionUuids={[testUuid]} />);
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith(
+        'getResourcePathsAndParentsForAttributions',
+        expect.objectContaining({ attributionUuids: [testUuid] }),
+      ),
+    );
   });
 
   it('dispatches selectedResourceId when a resource is clicked', async () => {

--- a/src/Frontend/Components/ResourceBrowser/LinkedResourcesTree/useLinkedResourcesTreeState.tsx
+++ b/src/Frontend/Components/ResourceBrowser/LinkedResourcesTree/useLinkedResourcesTreeState.tsx
@@ -5,28 +5,41 @@
 import { keepPreviousData, skipToken } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
+import type { ResourceTreeNodeData } from '../../../../ElectronBackend/api/resourceTree';
 import { useAppSelector } from '../../../state/hooks';
 import { getSelectedResourceId } from '../../../state/selectors/resource-selectors';
 import { backend } from '../../../util/backendClient';
 
-export type LinkedResourcesTreeState = ReturnType<
-  typeof useLinkedResourcesTreeState
->;
+export type LinkedResourcesTreeState = {
+  belowSelectedResource?: number;
+  count: number;
+  expandedIds: Array<string>;
+  setExpandedIds: (values: Array<string>) => void;
+  treeNodes: Array<ResourceTreeNodeData>;
+};
+
+export type LinkedResourcesTreeQueryProps = {
+  enabled?: boolean;
+  onAttributionUuids: Array<string>;
+  onlyWritable?: boolean;
+  search?: string;
+};
+
+export type LinkedResourcesTreeQueryResult = {
+  data: LinkedResourcesTreeState | undefined;
+  isError: boolean;
+  isLoading: boolean;
+};
 
 /**
  * Reusable hook to encapsulate the linked resource tree expanded id logic
  */
-export function useLinkedResourcesTreeState({
+export function useLinkedResourcesTree({
   onAttributionUuids,
   search,
   onlyWritable = false,
   enabled: enabledProp = true,
-}: {
-  onAttributionUuids: Array<string>;
-  search?: string;
-  onlyWritable?: boolean;
-  enabled?: boolean;
-}) {
+}: LinkedResourcesTreeQueryProps): LinkedResourcesTreeQueryResult {
   const selectedResourcePath = useAppSelector(getSelectedResourceId);
 
   const [expandedIds, setExpandedIds] = useState<{
@@ -87,18 +100,27 @@ export function useLinkedResourcesTreeState({
     { placeholderData: treeReady ? keepPreviousData : undefined },
   );
 
-  if (!treeReady || !resources.data) {
-    return undefined;
-  }
+  const state =
+    treeReady && resources.data
+      ? {
+          ...resources.data,
+          expandedIds: expandedIds.values,
+          setExpandedIds: (values: Array<string>) =>
+            setExpandedIds({
+              ownerKey,
+              source: expandedIds.source,
+              values,
+            }),
+        }
+      : undefined;
 
   return {
-    ...resources.data,
-    expandedIds: expandedIds.values,
-    setExpandedIds: (values: Array<string>) =>
-      setExpandedIds({
-        ownerKey,
-        source: expandedIds.source,
-        values,
-      }),
+    isError: enabled && (expansionPaths.isError || resources.isError),
+    isLoading:
+      enabled &&
+      !expansionPaths.isError &&
+      !resources.isError &&
+      (!treeReady || resources.isFetching),
+    data: state,
   };
 }

--- a/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
+++ b/src/Frontend/Components/ResourceBrowser/ResourceBrowser.tsx
@@ -2,15 +2,15 @@
 // SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 //
 // SPDX-License-Identifier: Apache-2.0
+import MuiLinearProgress from '@mui/material/LinearProgress';
 import { keepPreviousData } from '@tanstack/react-query';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { text } from '../../../shared/text';
 import { useAppSelector } from '../../state/hooks';
 import {
   getExpandedIds,
-  getSelectedAttributionId,
   getSelectedResourceId,
 } from '../../state/selectors/resource-selectors';
 import { useResourceTreeFilters } from '../../state/variables/use-filters';
@@ -24,9 +24,9 @@ import { LicenseAutocomplete } from '../FilterButton/LicenseAutocomplete/License
 import { UnreviewedIcon } from '../Icons/Icons';
 import { ResizePanels } from '../ResizePanels/ResizePanels';
 import { LinkedResourcesTree } from './LinkedResourcesTree/LinkedResourcesTree';
-import { useLinkedResourcesTreeState } from './LinkedResourcesTree/useLinkedResourcesTreeState';
 import { resourceBrowserFilterButtonStyle } from './ResourceBrowser.style';
 import { ResourcesTree } from './ResourcesTree/ResourcesTree';
+import { useLinkedResourcesPanelState } from './use-linked-resources-panel-state';
 
 const ALL_RESOURCES_SEARCH = 'all-resources-search';
 const LINKED_RESOURCES_SEARCH = 'linked-resources-search';
@@ -50,7 +50,6 @@ export function ResourceBrowser() {
     [setPanelSizes],
   );
 
-  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
   const selectedResourceId = useAppSelector(getSelectedResourceId);
   // All resources
   const [
@@ -98,12 +97,7 @@ export function ResourceBrowser() {
     '',
   );
   const debouncedSearchLinked = useDebouncedInput(searchLinked);
-  const onAttributionUuids = useMemo(
-    () => [selectedAttributionId],
-    [selectedAttributionId],
-  );
-  const linkedResourcesTreeState = useLinkedResourcesTreeState({
-    onAttributionUuids,
+  const linkedResourcesPanelState = useLinkedResourcesPanelState({
     search: debouncedSearchLinked,
   });
 
@@ -189,19 +183,30 @@ export function ResourceBrowser() {
           headerTestId: 'resources-tree-header',
         }}
         lowerPanel={{
-          title: linkedResourcesTreeState
+          title: linkedResourcesPanelState.treeState
             ? text.resourceBrowser.linkedResources(
-                linkedResourcesTreeState.belowSelectedResource ?? 0,
-                linkedResourcesTreeState.count,
+                linkedResourcesPanelState.treeState.belowSelectedResource ?? 0,
+                linkedResourcesPanelState.treeState.count,
               )
-            : '',
+            : text.resourceBrowser.linkedResourcesTitle,
           search: {
             value: searchLinked,
             setValue: setSearchLinked,
             channel: AllowedFrontendChannels.SearchLinkedResources,
           },
-          hidden: !linkedResourcesTreeState,
-          component: <LinkedResourcesTree state={linkedResourcesTreeState} />,
+          hidden: linkedResourcesPanelState.isHidden,
+          component: (
+            <>
+              {linkedResourcesPanelState.isLoading && (
+                <MuiLinearProgress data-testid={'linked-resources-loading'} />
+              )}
+              {linkedResourcesPanelState.treeState && (
+                <LinkedResourcesTree
+                  state={linkedResourcesPanelState.treeState}
+                />
+              )}
+            </>
+          ),
           headerTestId: 'linked-resources-tree-header',
         }}
       />

--- a/src/Frontend/Components/ResourceBrowser/__tests__/use-linked-resources-panel-state.test.ts
+++ b/src/Frontend/Components/ResourceBrowser/__tests__/use-linked-resources-panel-state.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { getLinkedResourcesPanelState } from '../use-linked-resources-panel-state';
+
+const treeState = {
+  belowSelectedResource: undefined,
+  count: 0,
+  expandedIds: [],
+  setExpandedIds: () => undefined,
+  treeNodes: [],
+};
+
+describe('getLinkedResourcesPanelState', () => {
+  it('hides the panel without a selected attribution', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: false,
+        hasSelectedAttribution: false,
+        isError: false,
+        isLoading: false,
+        treeState: undefined,
+      }),
+    ).toEqual({ isHidden: true, isLoading: false, treeState: undefined });
+  });
+
+  it('shows loading while attribution details are unavailable', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: false,
+        hasSelectedAttribution: true,
+        isError: false,
+        isLoading: false,
+        treeState: undefined,
+      }),
+    ).toEqual({ isHidden: false, isLoading: true, treeState: undefined });
+  });
+
+  it('returns loading while linked-resource queries are fetching', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: true,
+        hasSelectedAttribution: true,
+        isError: false,
+        isLoading: true,
+        treeState: undefined,
+      }),
+    ).toEqual({ isHidden: false, isLoading: true, treeState: undefined });
+  });
+
+  it('hides the panel when linked-resource data is unavailable after a failure', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: true,
+        hasSelectedAttribution: true,
+        isError: true,
+        isLoading: false,
+        treeState: undefined,
+      }),
+    ).toEqual({ isHidden: true, isLoading: false, treeState: undefined });
+  });
+
+  it('hides the panel when attribution details fail to load', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: false,
+        hasSelectedAttribution: true,
+        isError: true,
+        isLoading: false,
+        treeState: undefined,
+      }),
+    ).toEqual({ isHidden: true, isLoading: false, treeState: undefined });
+  });
+
+  it('keeps ready data available when a background refresh fails', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: true,
+        hasSelectedAttribution: true,
+        isError: true,
+        isLoading: false,
+        treeState,
+      }),
+    ).toEqual({ isHidden: false, isLoading: false, treeState });
+  });
+
+  it('returns ready data when linked-resource data is available', () => {
+    expect(
+      getLinkedResourcesPanelState({
+        attributionDetailsReady: true,
+        hasSelectedAttribution: true,
+        isError: false,
+        isLoading: false,
+        treeState,
+      }),
+    ).toEqual({ isHidden: false, isLoading: false, treeState });
+  });
+});

--- a/src/Frontend/Components/ResourceBrowser/use-linked-resources-panel-state.ts
+++ b/src/Frontend/Components/ResourceBrowser/use-linked-resources-panel-state.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Meta Platforms, Inc. and its affiliates
+// SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+import { useMemo } from 'react';
+
+import { useAppSelector } from '../../state/hooks';
+import {
+  getAttributionSelectionPendingResourceId,
+  getSelectedAttributionId,
+  getSelectedResourceId,
+} from '../../state/selectors/resource-selectors';
+import { useSelectedAttribution } from '../../util/use-selected-attribution';
+import {
+  type LinkedResourcesTreeState,
+  useLinkedResourcesTree,
+} from './LinkedResourcesTree/useLinkedResourcesTreeState';
+
+export type LinkedResourcesPanelState = {
+  isHidden: boolean;
+  isLoading: boolean;
+  treeState: LinkedResourcesTreeState | undefined;
+};
+
+type GetLinkedResourcesPanelStateParams = {
+  attributionDetailsReady: boolean;
+  hasSelectedAttribution: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  treeState: LinkedResourcesTreeState | undefined;
+};
+
+export function getLinkedResourcesPanelState({
+  attributionDetailsReady,
+  hasSelectedAttribution,
+  isError,
+  isLoading,
+  treeState,
+}: GetLinkedResourcesPanelStateParams): LinkedResourcesPanelState {
+  return {
+    isHidden: !hasSelectedAttribution || (isError && !treeState),
+    isLoading:
+      hasSelectedAttribution &&
+      !isError &&
+      (!attributionDetailsReady || isLoading || !treeState),
+    treeState,
+  };
+}
+
+export function useLinkedResourcesPanelState({
+  search,
+}: {
+  search?: string;
+} = {}): LinkedResourcesPanelState {
+  const selectedAttributionId = useAppSelector(getSelectedAttributionId);
+  const selectedResourceId = useAppSelector(getSelectedResourceId);
+  const attributionSelectionPendingResourceId = useAppSelector(
+    getAttributionSelectionPendingResourceId,
+  );
+  const {
+    isError: isAttributionError,
+    isPending: isAttributionPending,
+    packageInfo: selectedAttribution,
+  } = useSelectedAttribution();
+  const onAttributionUuids = useMemo(
+    () => [selectedAttributionId],
+    [selectedAttributionId],
+  );
+  const attributionDetailsReady =
+    !selectedAttributionId ||
+    (attributionSelectionPendingResourceId !== selectedResourceId &&
+      !isAttributionPending &&
+      !isAttributionError &&
+      selectedAttribution?.id === selectedAttributionId);
+  const linkedResourcesTreeQuery = useLinkedResourcesTree({
+    enabled: attributionDetailsReady,
+    onAttributionUuids,
+    search,
+  });
+
+  return getLinkedResourcesPanelState({
+    attributionDetailsReady,
+    hasSelectedAttribution: !!selectedAttributionId,
+    isError: isAttributionError || linkedResourcesTreeQuery.isError,
+    isLoading: linkedResourcesTreeQuery.isLoading,
+    treeState: linkedResourcesTreeQuery.data,
+  });
+}

--- a/src/Frontend/util/use-selected-attribution.ts
+++ b/src/Frontend/util/use-selected-attribution.ts
@@ -21,6 +21,7 @@ export function useSelectedAttribution() {
 
   if (!selectedAttributionId) {
     return {
+      isError: false,
       isExternal: null,
       isPending: false,
       packageInfo: null,
@@ -28,6 +29,7 @@ export function useSelectedAttribution() {
   }
 
   return {
+    isError: selectedAttributionData.isError,
     isExternal: selectedAttributionData.data?.isExternal,
     isReadonly:
       selectedAttributionData.data?.packageInfo.resourceAccess === 'readonly',

--- a/src/performance-tests/playwright/resource-performance-workflows.ts
+++ b/src/performance-tests/playwright/resource-performance-workflows.ts
@@ -27,6 +27,7 @@ export async function runResourceWorkflows({
   runScenario,
   signalsPanel,
   topBar,
+  window,
 }: PerformanceWorkflowContext): Promise<void> {
   const expandAndSelectScenario = model.scenarios.expandAndSelect;
   const expandAndSelectAnchors = expandAndSelectScenario.anchors;
@@ -36,6 +37,7 @@ export async function runResourceWorkflows({
   const attributionFilter = model.scenarios.attributionFilter;
   const signalSearch = model.scenarios.signalSearch;
   const signalSort = model.scenarios.signalSort;
+  const highFanout = model.scenarios.highFanout;
 
   await runScenario({
     id: 'expand-and-select-resource',
@@ -101,6 +103,43 @@ export async function runResourceWorkflows({
       await resourcesTree.assert.resourceIsVisible(
         expandAndSelectAnchors.targetResourceName,
       );
+    },
+  });
+
+  await runScenario({
+    id: 'open-high-fanout-attribution-details',
+    title: 'open high-fanout attribution details before linked resources',
+    setup: async () => {
+      await navigateToResource({
+        anchor: highFanout.resource,
+        assertEditable: false,
+        attributionDetails,
+        attributionsPanel,
+        resourcesTree,
+        signalsPanel,
+      });
+      await Promise.all([
+        signalsPanel.packageCard.assert.isVisible(
+          highFanout.external.packageInfo,
+        ),
+        window
+          .locator('[data-testid="linked-resources-loading"]')
+          .waitFor({ state: 'hidden' }),
+      ]);
+    },
+    execute: async () => {
+      await signalsPanel.packageCard.click(highFanout.external.packageInfo);
+      await Promise.all([
+        attributionDetails.attributionForm.assert.matchesPackageInfo(
+          highFanout.external.packageInfo,
+        ),
+        attributionDetails.assert.loadingIndicatorIsHidden(),
+      ]);
+    },
+    teardown: async () => {
+      await window
+        .locator('[data-testid="linked-resources-loading"]')
+        .waitFor({ state: 'hidden' });
     },
   });
 

--- a/src/shared/text.ts
+++ b/src/shared/text.ts
@@ -259,6 +259,7 @@ export const text = {
     splitHere: 'Split here',
     linkedResources: (selectedResources: number, totalCount: number) =>
       `Linked Resources (${new Intl.NumberFormat().format(selectedResources)} / ${new Intl.NumberFormat().format(totalCount)})`,
+    linkedResourcesTitle: 'Linked Resources',
     hasHighlyCriticalSignals: 'Has highly critical signals',
     hasMediumCriticalSignals: 'Has medium critical signals',
     hasSignals: 'Has signals',


### PR DESCRIPTION
### Summary of changes

Defer loading of linked resources until after package details

### Context and reason for change

#3101

Loading linked resources can be costly, loading package details is fast and probably more immediately interesting to the user


### How can the changes be tested

Run the new scenario `PERFORMANCE_SCENARIOS=open-high-fanout-attribution-details yarn performance:measure:large` and observe how this takes the time from ~1500ms to <200ms
