### PR TITLE
fix: always re-fetch state in file menu click handler

### DIFF
--- a/src/ElectronBackend/main/__tests__/menu.test.ts
+++ b/src/ElectronBackend/main/__tests__/menu.test.ts
@@ -8,6 +8,7 @@ import electron, {
 } from 'electron';
 import type { Mock } from 'vitest';
 
+import { AllowedFrontendChannels } from '../../../shared/ipc-channels';
 import { text } from '../../../shared/text';
 import { setGlobalBackendState } from '../globalBackendState';
 import { createMenu } from '../menu';
@@ -123,5 +124,29 @@ describe('create menu', () => {
       ({ label }) => label === text.menu.fileSubmenu.merge,
     );
     expect(mergeMenu?.enabled).toBe(true);
+  });
+
+  it('uses the currently loaded file when the merge menu is clicked', async () => {
+    await UserSettingsService.init();
+    const send = vi.fn();
+    const mainWindow = {
+      webContents: { send },
+    } as unknown as BrowserWindow;
+    setGlobalBackendState({ opossumFilePath: '/tmp/file-a.opossum' });
+
+    const fileMenu = await getFileMenu(mainWindow, vi.fn(), false);
+    const items = fileMenu.submenu as Array<MenuItemConstructorOptions>;
+    const mergeMenu = items.find(
+      ({ label }) => label === text.menu.fileSubmenu.merge,
+    );
+
+    setGlobalBackendState({ opossumFilePath: '/tmp/file-b.opossum' });
+    mergeMenu?.click?.({} as Electron.MenuItem, mainWindow, {});
+
+    expect(send).toHaveBeenCalledWith(
+      AllowedFrontendChannels.ShowMergeOpossumFilesDialog,
+      true,
+      '/tmp/file-b.opossum',
+    );
   });
 });

--- a/src/ElectronBackend/main/menu/fileMenu.ts
+++ b/src/ElectronBackend/main/menu/fileMenu.ts
@@ -148,19 +148,20 @@ function getImportFileMenuItemId(fileType: FileType): string {
 }
 
 function getMerge(mainWindow: BrowserWindow): MenuItemConstructorOptions {
-  const globalBackendState = getGlobalBackendState();
-  const enabled = !globalBackendState.frontendPopupOpen;
+  const enabled = !getGlobalBackendState().frontendPopupOpen;
 
   return {
     icon: getIconBasedOnTheme('icons/merge-white.png', 'icons/merge-black.png'),
     label: text.menu.fileSubmenu.merge,
     id: menuItemIds.mergeOpossumFiles,
-    click: () =>
+    click: () => {
+      const globalBackendState = getGlobalBackendState();
       mainWindow.webContents.send(
         AllowedFrontendChannels.ShowMergeOpossumFilesDialog,
         isFileLoaded(globalBackendState),
         globalBackendState.opossumFilePath,
-      ),
+      );
+    },
     enabled,
   };
 }


### PR DESCRIPTION
### Summary of changes

Always re-fetch state in file menu click handler

### Context and reason for change

This could lead to stale backend state being used in the click handler, see e.g. https://github.com/opossum-tool/OpossumUI/actions/runs/34283946400
We already do this for the other click handlers. 
