### PR TITLE
fix: destroy the db to reset it to fix EBUSY errors on e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,3 @@ yarn-error.log*
 
 dev.db
 dev.db-journal
-local-reuse.js
-.local-pre-commit/pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ yarn-error.log*
 
 dev.db
 dev.db-journal
+local-reuse.js
+.local-pre-commit/pre-commit

--- a/src/ElectronBackend/db/db.ts
+++ b/src/ElectronBackend/db/db.ts
@@ -42,9 +42,7 @@ function openDb() {
 }
 
 export async function resetDb() {
-  if (db) {
-    await db.destroy()
-  }
+  await db?.destroy()
   db = openDb();
 }
 

--- a/src/ElectronBackend/db/db.ts
+++ b/src/ElectronBackend/db/db.ts
@@ -41,7 +41,10 @@ function openDb() {
   });
 }
 
-export function resetDb() {
+export async function resetDb() {
+  if (db) {
+    await db.destroy()
+  }
   db = openDb();
 }
 

--- a/src/ElectronBackend/db/db.ts
+++ b/src/ElectronBackend/db/db.ts
@@ -42,7 +42,7 @@ function openDb() {
 }
 
 export async function resetDb() {
-  await db?.destroy()
+  await db?.destroy();
   db = openDb();
 }
 

--- a/src/ElectronBackend/db/initializeDb.ts
+++ b/src/ElectronBackend/db/initializeDb.ts
@@ -130,7 +130,7 @@ const ATTRIBUTION_INDEX_COLUMNS = [
 ] as const satisfies ReadonlyArray<keyof DB['attribution']>;
 
 export async function initializeDb(inputFile: ParsedFileContent) {
-  resetDb();
+  await resetDb();
   await getDb()
     .transaction()
     .execute(async (trx) => {


### PR DESCRIPTION
### Summary of changes

- src/ElectronBackend/db/db.ts — `resetDb()` is now async. It awaits `db.destroy()` on any existing connection before opening a new one, properly releasing the file handle.
- src/ElectronBackend/db/initializeDb.ts — `initializeDb()` now awaits `resetDb()`.

### Context and reason for change

Problem: On Windows, `resetDb()` opened a new SQLite connection without closing the old one. The lingering connection kept a file handle on the .opossum file, causing EBUSY errors when e2e tests reset/reopened the database.
