### PR TITLE
test: wait for stable state before interacting

### DIFF
--- a/src/Frontend/Components/VirtualizedTree/VirtualizedTree.tsx
+++ b/src/Frontend/Components/VirtualizedTree/VirtualizedTree.tsx
@@ -53,7 +53,8 @@ export function VirtualizedTree({
           onSelect={onSelect}
           onContextMenu={onContextMenu}
           readOnly={readOnly}
-          selected={selected || resource.id === contextMenuNodeId}
+          selected={selected}
+          highlighted={selected || resource.id === contextMenuNodeId}
           focused={focused}
           resource={resource}
         />

--- a/src/Frontend/Components/VirtualizedTree/VirtualizedTreeNode/VirtualizedTreeNode.tsx
+++ b/src/Frontend/Components/VirtualizedTree/VirtualizedTreeNode/VirtualizedTreeNode.tsx
@@ -81,6 +81,7 @@ interface VirtualizedTreeNodeProps extends TreeNode {
   onToggle: (nodeIdsToExpand: Array<string>) => void;
   readOnly?: boolean;
   selected: boolean;
+  highlighted: boolean;
   focused: boolean;
 }
 
@@ -92,6 +93,7 @@ export function VirtualizedTreeNode({
   onToggle,
   readOnly,
   selected,
+  highlighted,
   focused,
 }: VirtualizedTreeNodeProps) {
   const marginRight =
@@ -119,6 +121,7 @@ export function VirtualizedTreeNode({
     <MuiBox
       role={'treeitem'}
       aria-label={resource.labelText}
+      aria-selected={selected}
       data-resource-path={resource.id}
       sx={classes.listNode}
       onClick={handleClick}
@@ -153,9 +156,9 @@ export function VirtualizedTreeNode({
         className={'tree-node-selected-indicator'}
         sx={{
           ...classes.treeNodeSelectedIndicator,
-          display: selected ? 'block' : 'none',
+          display: highlighted ? 'block' : 'none',
           // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-          opacity: selected ? 1 : 0.5,
+          opacity: highlighted ? 1 : 0.5,
           cursor: handleClick ? 'pointer' : 'default',
         }}
       />

--- a/src/e2e-tests/__tests__/creating-attributions.test.ts
+++ b/src/e2e-tests/__tests__/creating-attributions.test.ts
@@ -69,7 +69,7 @@ test('creates a new third-party attribution', async ({
     newPackageInfo,
   );
 
-  await resourcesTree.goto(resourceName2);
+  await resourcesTree.clickResource(resourceName2);
   await notSavedPopup.assert.isVisible();
 
   await notSavedPopup.cancelButton.click();

--- a/src/e2e-tests/page-objects/AttributionForm.ts
+++ b/src/e2e-tests/page-objects/AttributionForm.ts
@@ -11,9 +11,13 @@ import { text } from '../../shared/text';
 
 class ValidationDisplay {
   readonly node: Locator;
+  readonly collapse: Locator;
   readonly expandButton: Locator;
   constructor(parentLocator: Locator) {
     this.node = parentLocator.getByTestId('validation-display');
+    this.collapse = parentLocator.locator('.MuiCollapse-root', {
+      has: parentLocator.page().getByTestId('validation-display'),
+    });
     this.expandButton = this.node.getByLabel('expand messages');
   }
   public assert = {
@@ -28,6 +32,8 @@ class ValidationDisplay {
     },
   };
   public clickSuggestion = async (suggestionText: string): Promise<void> => {
+    // Scrolling during expansion can shift the suggestion before the click lands.
+    await expect(this.collapse).toHaveClass(/MuiCollapse-entered/);
     await this.node.getByText(suggestionText, { exact: true }).click();
   };
 }

--- a/src/e2e-tests/page-objects/ResourcesTree.ts
+++ b/src/e2e-tests/page-objects/ResourcesTree.ts
@@ -16,6 +16,7 @@ export class ResourcesTree {
   private readonly node: Locator;
   private readonly header: Locator;
   private readonly filterMenu: Locator;
+  private readonly loadingIndicators: Locator;
   readonly filterButton: Locator;
   readonly filters: {
     readonly license: Locator;
@@ -28,6 +29,11 @@ export class ResourcesTree {
     this.window = window;
     this.node = window.getByTestId('resources-tree');
     this.header = window.getByTestId('resources-tree-header');
+    this.loadingIndicators = window
+      .getByTestId('attributions-panel')
+      .getByTestId('loading')
+      .or(window.getByTestId('signals-panel').getByTestId('loading'))
+      .or(window.getByTestId('attribution-details-loading'));
     this.filterButton = this.header.getByLabel('filter button', {
       exact: true,
     });
@@ -157,35 +163,29 @@ export class ResourcesTree {
       .getByLabel('path bar')
       .getByText('Home', { exact: true })
       .click();
+    await expect(
+      this.window.getByLabel('path bar').getByRole('listitem'),
+    ).toHaveText(['Home']);
+    await expect(this.loadingIndicators).toHaveCount(0);
   }
 
   async goto(...resourceNames: Array<string>): Promise<void> {
     for (const resourceName of resourceNames) {
-      await this.node.getByText(resourceName, { exact: true }).click();
+      await this.clickResource(resourceName);
+      await expect(this.getResourceByName(resourceName)).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+      await expect(this.loadingIndicators).toHaveCount(0);
     }
+  }
+
+  async clickResource(resourceName: string): Promise<void> {
+    await this.getResourceByName(resourceName).click();
   }
 
   async focusResource(resourceName: string): Promise<void> {
     await this.getResourceByName(resourceName).focus();
-  }
-
-  async gotoPath(resourceNames: ReadonlyArray<string>): Promise<void> {
-    const firstResource = this.getResourceByName(resourceNames[0]);
-    if (!(await firstResource.isVisible())) {
-      await this.gotoRoot();
-    }
-
-    for (const [index, resourceName] of resourceNames.entries()) {
-      const resource = this.getResourceByName(resourceName);
-      await expect(resource).toBeVisible();
-      const nextResourceName = resourceNames[index + 1];
-      if (
-        nextResourceName === undefined ||
-        !(await this.getResourceByName(nextResourceName).isVisible())
-      ) {
-        await resource.click();
-      }
-    }
   }
 
   async openContextMenu(resourceName: string): Promise<void> {


### PR DESCRIPTION
### Summary of changes

* wait for loading to finish after navigating
  * mark selected resource as `aria-selected`
* wait for animation to finish in autocomplete

### Context and reason for change

`scrolls a selected attribution into view after report navigation` was flaky because of the loading, see https://github.com/opossum-tool/OpossumUI/actions/runs/34456776590/job/102804906024?pr=3299

See https://github.com/opossum-tool/OpossumUI/actions/runs/34458060725/attempts/1 for the animation flake